### PR TITLE
[ML] Better handle almost periodic data in time series anomaly detection

### DIFF
--- a/include/maths/common/CLbfgs.h
+++ b/include/maths/common/CLbfgs.h
@@ -301,7 +301,8 @@ private:
 
         double smin;
         double fmin;
-        CSolvers::globalMinimize(probes, f_, smin, fmin);
+        double fsd;
+        CSolvers::globalMinimize(probes, f_, smin, fmin, fsd);
         xs = m_X - smin * step;
         fs = f(xs);
     }

--- a/include/maths/common/CLowessDetail.h
+++ b/include/maths/common/CLowessDetail.h
@@ -89,11 +89,12 @@ void CLowess<N>::fit(TDoubleDoublePrVec data, std::size_t numberFolds) {
 
     double kmax;
     double likelihoodMax;
+    double likelihoodStandardDeviation;
     CSolvers::globalMaximize(K,
                              [&](double k) -> double {
                                  return this->likelihood(trainingMasks, testingMasks, k);
                              },
-                             kmax, likelihoodMax);
+                             kmax, likelihoodMax, likelihoodStandardDeviation);
     LOG_TRACE(<< "kmax = " << kmax << " likelihood(kmax) = " << likelihoodMax);
 
     m_K = kmax;
@@ -137,8 +138,9 @@ typename CLowess<N>::TDoubleDoublePr CLowess<N>::minimum() const {
     X.push_back(xb);
     double xmin;
     double fmin;
+    double fsd;
     CSolvers::globalMinimize(
-        X, [this](double x) -> double { return this->predict(x); }, xmin, fmin);
+        X, [this](double x) -> double { return this->predict(x); }, xmin, fmin, fsd);
 
     // Refine.
     double range{(xb - xa) / static_cast<double>(X.size())};
@@ -152,7 +154,7 @@ typename CLowess<N>::TDoubleDoublePr CLowess<N>::minimum() const {
     double xcand;
     double fcand;
     CSolvers::globalMinimize(
-        X, [this](double x) -> double { return this->predict(x); }, xcand, fcand);
+        X, [this](double x) -> double { return this->predict(x); }, xcand, fcand, fsd);
 
     if (fcand < fmin) {
         xmin = xcand;

--- a/include/maths/common/CModel.h
+++ b/include/maths/common/CModel.h
@@ -56,7 +56,8 @@ public:
                  double decayRate,
                  double minimumSeasonalVarianceScale,
                  core_t::TTime minimumTimeToDetectChange,
-                 core_t::TTime maximumTimeToTestForChange);
+                 core_t::TTime maximumTimeToTestForChange,
+                 core_t::TTime maximumSeasonalJitter);
 
     //! Get the bucket length.
     core_t::TTime bucketLength() const;
@@ -82,6 +83,13 @@ public:
     //! Get the maximum time to test for a change point in the model.
     core_t::TTime maximumTimeToTestForChange() const;
 
+    //! Get the maximum random jitter we tolerate in seasonal patterns.
+    //!
+    //! \note We treat as normal any time shift of seasonal patterns which is
+    //! smaller than this amount. We also check for larger time shift change
+    //! points, such as when daylight saving and do report anomalies for these.
+    core_t::TTime maximumSeasonalJitter() const;
+
 private:
     //! The data bucketing length.
     core_t::TTime m_BucketLength;
@@ -95,6 +103,8 @@ private:
     core_t::TTime m_MinimumTimeToDetectChange;
     //! The maximum time permitted to test for a change in the model.
     core_t::TTime m_MaximumTimeToTestForChange;
+    //! The maximum random jitter we tolerate in seasonal patterns.
+    core_t::TTime m_MaximumSeasonalJitter;
 };
 
 //! \brief The extra parameters needed by CModel::addSamples.

--- a/include/maths/time_series/CTimeSeriesDecomposition.h
+++ b/include/maths/time_series/CTimeSeriesDecomposition.h
@@ -167,10 +167,14 @@ public:
                   double minimumScale,
                   const TWriteForecastResult& writer) override;
 
-    //! Detrend \p value by the prediction of the modelled features at \p time.
+    //! Remove the prediction of the modelled features at \p time from \p value.
     //!
     //! \note That detrending preserves the time series mean.
-    double detrend(core_t::TTime time, double value, double confidence, int components = E_All) const override;
+    double detrend(core_t::TTime time,
+                   double value,
+                   double confidence,
+                   core_t::TTime maximumTimeShift = 0,
+                   int components = E_All) const override;
 
     //! Get the mean variance of the baseline.
     double meanVariance() const override;

--- a/include/maths/time_series/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/time_series/CTimeSeriesDecompositionDetail.h
@@ -782,6 +782,7 @@ public:
                      std::size_t size,
                      double decayRate,
                      double bucketLength,
+                     core_t::TTime maxTimeShiftPerPeriod,
                      common::CSplineTypes::EBoundaryCondition boundaryCondition,
                      core_t::TTime startTime,
                      core_t::TTime endTime,

--- a/include/maths/time_series/CTimeSeriesDecompositionInterface.h
+++ b/include/maths/time_series/CTimeSeriesDecompositionInterface.h
@@ -149,12 +149,13 @@ public:
                           double minimumScale,
                           const TWriteForecastResult& writer) = 0;
 
-    //! Detrend \p value by the prediction of the modelled features at \p time.
+    //! Remove the prediction of the modelled features at \p time from \p value.
     //!
     //! \note That detrending preserves the time series mean.
     virtual double detrend(core_t::TTime time,
                            double value,
                            double confidence,
+                           core_t::TTime maximumTimeShift = 0,
                            int components = E_All) const = 0;
 
     //! Get the mean variance of the baseline.

--- a/include/maths/time_series/CTimeSeriesDecompositionStub.h
+++ b/include/maths/time_series/CTimeSeriesDecompositionStub.h
@@ -80,7 +80,11 @@ public:
                   const TWriteForecastResult& writer) override;
 
     //! Returns \p value.
-    double detrend(core_t::TTime time, double value, double confidence, int components = E_All) const override;
+    double detrend(core_t::TTime time,
+                   double value,
+                   double confidence,
+                   core_t::TTime maximumTimeShift = 0,
+                   int components = E_All) const override;
 
     //! Returns 0.0.
     double meanVariance() const override;

--- a/include/maths/time_series/CTimeSeriesModel.h
+++ b/include/maths/time_series/CTimeSeriesModel.h
@@ -16,6 +16,7 @@
 #include <maths/common/CModel.h>
 #include <maths/common/CMultivariatePrior.h>
 
+#include <maths/time_series/CTimeSeriesMultibucketFeaturesFwd.h>
 #include <maths/time_series/ImportExport.h>
 
 #include <boost/array.hpp>
@@ -36,8 +37,6 @@ namespace time_series {
 class CDecayRateController;
 class CTimeSeriesDecompositionInterface;
 class CTimeSeriesAnomalyModel;
-template<typename>
-class CTimeSeriesMultibucketFeature;
 
 //! \brief A CModel implementation for modeling a univariate time series.
 class MATHS_TIME_SERIES_EXPORT CUnivariateTimeSeriesModel : public common::CModel {
@@ -48,7 +47,7 @@ public:
     using TDoubleWeightsAry = maths_t::TDoubleWeightsAry;
     using TDecompositionPtr = std::shared_ptr<CTimeSeriesDecompositionInterface>;
     using TDecayRateController2Ary = std::array<CDecayRateController, 2>;
-    using TMultibucketFeature = CTimeSeriesMultibucketFeature<double>;
+    using TMultibucketFeature = CTimeSeriesMultibucketScalarFeature;
 
 public:
     //! \param[in] params The model parameters.
@@ -211,11 +210,9 @@ public:
     //@}
 
 private:
-    using TTimeDoublePr = std::pair<core_t::TTime, double>;
-    using TSizeVec = std::vector<std::size_t>;
     using TDouble1Vec = core::CSmallVector<double, 1>;
     using TDouble1VecVec = std::vector<TDouble1Vec>;
-    using TDouble2VecWeightsAryVec = std::vector<TDouble2VecWeightsAry>;
+    using TTimeDouble2VecSizeTrVecDoublePr = std::pair<TTimeDouble2VecSizeTrVec, double>;
     using TMultibucketFeaturePtr = std::unique_ptr<TMultibucketFeature>;
     using TDecayRateController2AryPtr = std::unique_ptr<TDecayRateController2Ary>;
     using TPriorPtr = std::shared_ptr<common::CPrior>;
@@ -234,6 +231,11 @@ private:
     //! Update the trend with \p samples.
     EUpdateResult updateTrend(const common::CModelAddSamplesParams& params,
                               const TTimeDouble2VecSizeTrVec& samples);
+
+    //! Update the residual models.
+    TTimeDouble2VecSizeTrVecDoublePr
+    updateResidualModels(const common::CModelAddSamplesParams& params,
+                         TTimeDouble2VecSizeTrVec samples);
 
     //! Update the various model decay rates based on the prediction errors
     //! for \p samples.
@@ -529,7 +531,7 @@ public:
     using TDecompositionPtr = std::shared_ptr<CTimeSeriesDecompositionInterface>;
     using TDecompositionPtr10Vec = core::CSmallVector<TDecompositionPtr, 10>;
     using TDecayRateController2Ary = std::array<CDecayRateController, 2>;
-    using TMultibucketFeature = CTimeSeriesMultibucketFeature<TDouble10Vec>;
+    using TMultibucketFeature = CTimeSeriesMultibucketVectorFeature;
 
 public:
     //! \param[in] params The model parameters.
@@ -690,9 +692,6 @@ public:
 private:
     using TDouble1Vec = core::CSmallVector<double, 1>;
     using TDouble1VecVec = std::vector<TDouble1Vec>;
-    using TDouble2VecWeightsAryVec = std::vector<TDouble2VecWeightsAry>;
-    using TVector = common::CVector<common::CFloatStorage>;
-    using TVectorMeanAccumulator = common::CBasicStatistics::SSampleMean<TVector>::TAccumulator;
     using TMultibucketFeaturePtr = std::unique_ptr<TMultibucketFeature>;
     using TDecayRateController2AryPtr = std::unique_ptr<TDecayRateController2Ary>;
     using TMultivariatePriorPtr = std::unique_ptr<common::CMultivariatePrior>;
@@ -702,6 +701,10 @@ private:
     //! Update the trend with \p samples.
     EUpdateResult updateTrend(const common::CModelAddSamplesParams& params,
                               const TTimeDouble2VecSizeTrVec& samples);
+
+    //! Update the residual models.
+    void updateResidualModels(const common::CModelAddSamplesParams& params,
+                              TTimeDouble2VecSizeTrVec samples);
 
     //! Update the various model decay rates based on the prediction errors
     //! for \p samples.

--- a/include/maths/time_series/CTimeSeriesMultibucketFeatureSerialiser.h
+++ b/include/maths/time_series/CTimeSeriesMultibucketFeatureSerialiser.h
@@ -12,6 +12,7 @@
 #ifndef INCLUDED_ml_maths_time_series_CTimeSeriesMultibucketFeatureSerialiser_h
 #define INCLUDED_ml_maths_time_series_CTimeSeriesMultibucketFeatureSerialiser_h
 
+#include <maths/time_series/CTimeSeriesMultibucketFeaturesFwd.h>
 #include <maths/time_series/ImportExport.h>
 
 #include <memory>
@@ -24,12 +25,7 @@ class CStatePersistInserter;
 class CStateRestoreTraverser;
 }
 namespace maths {
-namespace common {
-struct SModelRestoreParams;
-}
 namespace time_series {
-template<typename>
-class CTimeSeriesMultibucketFeature;
 
 //! \brief Reflection for CTimeSeriesMultibucketFeature sub-classes.
 //!
@@ -46,29 +42,28 @@ class CTimeSeriesMultibucketFeature;
 class MATHS_TIME_SERIES_EXPORT CTimeSeriesMultibucketFeatureSerialiser {
 public:
     using TDouble10Vec = core::CSmallVector<double, 10>;
-    using TUnivariateFeature = CTimeSeriesMultibucketFeature<double>;
-    using TMultivariateFeature = CTimeSeriesMultibucketFeature<TDouble10Vec>;
-    using TUnivariateFeaturePtr = std::unique_ptr<TUnivariateFeature>;
-    using TMultivariateFeaturePtr = std::unique_ptr<TMultivariateFeature>;
+    using TScalarFeature = CTimeSeriesMultibucketScalarFeature;
+    using TVectorFeature = CTimeSeriesMultibucketVectorFeature;
+    using TScalarFeaturePtr = std::unique_ptr<TScalarFeature>;
+    using TVectorFeaturePtr = std::unique_ptr<TVectorFeature>;
 
 public:
     //! Construct the appropriate CTimeSeriesMultibucketFeature sub-class
     //! from its state document representation. Sets \p result to NULL on
     //! failure.
-    bool operator()(TUnivariateFeaturePtr& result, core::CStateRestoreTraverser& traverser) const;
+    bool operator()(TScalarFeaturePtr& result, core::CStateRestoreTraverser& traverser) const;
 
     //! Construct the appropriate CTimeSeriesMultibucketFeature sub-class
     //! from its state document representation. Sets \p result to NULL on
     //! failure.
-    bool operator()(TMultivariateFeaturePtr& result,
-                    core::CStateRestoreTraverser& traverser) const;
+    bool operator()(TVectorFeaturePtr& result, core::CStateRestoreTraverser& traverser) const;
 
     //! Persist \p feature by passing information to the supplied inserter
-    void operator()(const TUnivariateFeaturePtr& feature,
+    void operator()(const TScalarFeaturePtr& feature,
                     core::CStatePersistInserter& inserter) const;
 
     //! Persist \p feature by passing information to the supplied inserter
-    void operator()(const TMultivariateFeaturePtr& feature,
+    void operator()(const TVectorFeaturePtr& feature,
                     core::CStatePersistInserter& inserter) const;
 };
 }

--- a/include/maths/time_series/CTimeSeriesMultibucketFeatures.h
+++ b/include/maths/time_series/CTimeSeriesMultibucketFeatures.h
@@ -12,45 +12,46 @@
 #ifndef INCLUDED_ml_maths_time_series_CTimeSeriesMultibucketFeatures_h
 #define INCLUDED_ml_maths_time_series_CTimeSeriesMultibucketFeatures_h
 
-#include <core/CPersistUtils.h>
+#include <core/CMemory.h>
 #include <core/CSmallVector.h>
-#include <core/CTriple.h>
 #include <core/CoreTypes.h>
-#include <core/RestoreMacros.h>
 
 #include <maths/common/CBasicStatistics.h>
 #include <maths/common/CBasicStatisticsPersist.h>
-#include <maths/common/CChecksum.h>
-#include <maths/common/CLinearAlgebra.h>
-#include <maths/common/CLinearAlgebraTools.h>
-#include <maths/common/CTypeTraits.h>
+#include <maths/common/CLinearAlgebraFwd.h>
 #include <maths/common/MathsTypes.h>
+
+#include <maths/time_series/CTimeSeriesMultibucketFeaturesFwd.h>
+#include <maths/time_series/ImportExport.h>
 
 #include <boost/circular_buffer.hpp>
 
+#include <cmath>
+#include <cstdint>
 #include <memory>
-#include <numeric>
-#include <tuple>
-#include <type_traits>
-#include <utility>
 
 namespace ml {
+namespace core {
+class CStatePersistInserter;
+class CStateRestoreTraverser;
+}
 namespace maths {
 namespace time_series {
 
 //! \brief Defines features on collections of time series values.
 //!
 //! DESCRIPTION:\n
-//! The intention of these is to provide useful features for performing
-//! anomaly detection. Specifically, unusual values of certain properties
-//! of extended intervals of a time series are often the most interesting
-//! events in a time series from a user's perspective.
+//! The intention of these is to provide useful features for performing anomaly
+//! detection. Specifically, unusual values of certain properties of extended
+//! intervals of a time series are often the most interesting events in a time
+//! series from a user's perspective.
 template<typename T>
 class CTimeSeriesMultibucketFeature {
 public:
-    using TT1Vec = core::CSmallVector<T, 1>;
-    using TWeightsAry1Vec = core::CSmallVector<maths_t::TWeightsAry<T>, 1>;
-    using TT1VecTWeightAry1VecPr = std::pair<TT1Vec, TWeightsAry1Vec>;
+    using Type = T;
+    using TType1Vec = core::CSmallVector<Type, 1>;
+    using TWeightsAry1Vec = core::CSmallVector<maths_t::TWeightsAry<Type>, 1>;
+    using TType1VecTWeightAry1VecPr = std::pair<TType1Vec, TWeightsAry1Vec>;
     using TPtr = std::unique_ptr<CTimeSeriesMultibucketFeature>;
 
 public:
@@ -60,7 +61,7 @@ public:
     virtual TPtr clone() const = 0;
 
     //! Get the feature value.
-    virtual TT1VecTWeightAry1VecPr value() const = 0;
+    virtual const TType1VecTWeightAry1VecPr& value() const = 0;
 
     //! Get the correlation of this feature with the bucket value.
     virtual double correlationWithBucketValue() const = 0;
@@ -71,11 +72,11 @@ public:
     //! Update the window with \p values at \p time.
     virtual void add(core_t::TTime time,
                      core_t::TTime bucketLength,
-                     const TT1Vec& values,
+                     const TType1Vec& values,
                      const TWeightsAry1Vec& weights) = 0;
 
     //! Compute a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const = 0;
+    virtual std::uint64_t checksum(std::uint64_t seed = 0) const = 0;
 
     //! Debug the memory used by this object.
     virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const = 0;
@@ -91,246 +92,128 @@ public:
 
     //! Persist by passing information to \p inserter.
     virtual void acceptPersistInserter(core::CStatePersistInserter& inserter) const = 0;
-
-protected:
-    //! Return weight.
-    static common::CFloatStorage minweight(double weight) { return weight; }
-    //! Return the minimum weight.
-    template<std::size_t N>
-    static common::CFloatStorage minweight(const core::CSmallVector<double, N>& weight) {
-        return *std::min_element(weight.begin(), weight.end());
-    }
-
-    //! Univariate implementation returns \p value.
-    template<typename U, typename V>
-    static V conformable(const U& /*x*/, V value) {
-        return value;
-    }
-    //! Multivariate implementation returns the \p value scalar multiple
-    //! of the one vector which is conformable with \p x.
-    template<typename U, typename V>
-    static common::CVector<V> conformable(const common::CVector<U>& x, V value) {
-        return common::CVector<V>(x.dimension(), value);
-    }
-
-    //! Univariate implementation returns 1.
-    template<typename U>
-    static std::size_t dimension(const U& /*x*/) {
-        return 1;
-    }
-    //! Multivariate implementation returns the dimension of \p x.
-    template<typename U>
-    static std::size_t dimension(const common::CVector<U>& x) {
-        return x.dimension();
-    }
-
-    //! Univariate implementation returns \p x.
-    template<typename U>
-    static double toVector(const U& x) {
-        return x;
-    }
-    //! Multivariate implementation returns \p x as the VECTOR type.
-    template<typename U>
-    static T toVector(const common::CVector<U>& x) {
-        return x.template toVector<T>();
-    }
 };
 
-//! \brief A weighted mean of a sliding window of time series values.
-template<typename T>
-class CTimeSeriesMultibucketMean final : public CTimeSeriesMultibucketFeature<T> {
+template<typename T, typename STORAGE>
+class CTimeSeriesMultibucketMeanImpl;
+
+//! \brief A scalar valued multi-bucket mean feature.
+class MATHS_TIME_SERIES_EXPORT CTimeSeriesMultibucketScalarMean final
+    : public CTimeSeriesMultibucketScalarFeature {
 public:
-    using TT1Vec = typename CTimeSeriesMultibucketFeature<T>::TT1Vec;
-    using TWeightsAry1Vec = typename CTimeSeriesMultibucketFeature<T>::TWeightsAry1Vec;
-    using TT1VecTWeightAry1VecPr = typename CTimeSeriesMultibucketFeature<T>::TT1VecTWeightAry1VecPr;
-    using TPtr = typename CTimeSeriesMultibucketFeature<T>::TPtr;
+    using Type = CTimeSeriesMultibucketScalarFeature::Type;
 
 public:
-    explicit CTimeSeriesMultibucketMean(std::size_t length = 0)
-        : m_SlidingWindow(length) {}
-    ~CTimeSeriesMultibucketMean() override = default;
+    explicit CTimeSeriesMultibucketScalarMean(std::size_t length = 0);
+    CTimeSeriesMultibucketScalarMean(const CTimeSeriesMultibucketScalarMean& other);
+    ~CTimeSeriesMultibucketScalarMean() override;
+
+    CTimeSeriesMultibucketScalarMean(CTimeSeriesMultibucketScalarMean&&) noexcept;
+    CTimeSeriesMultibucketScalarMean& operator=(CTimeSeriesMultibucketScalarMean&&) noexcept;
+    CTimeSeriesMultibucketScalarMean& operator=(const CTimeSeriesMultibucketScalarMean&);
 
     //! Clone this feature.
-    TPtr clone() const override {
-        return std::make_unique<CTimeSeriesMultibucketMean>(*this);
-    }
+    TPtr clone() const override;
 
-    //! Get the feature value and weight.
-    TT1VecTWeightAry1VecPr value() const override {
-        if (4 * m_SlidingWindow.size() >= 3 * m_SlidingWindow.capacity()) {
-            return {{this->mean()}, {maths_t::countWeight(this->count())}};
-        }
-        return {{}, {}};
-    }
+    //! Get the feature value.
+    const TType1VecTWeightAry1VecPr& value() const override;
 
     //! Get the correlation of this feature with the bucket value.
-    double correlationWithBucketValue() const override {
-        // This follows from the weighting applied to values in the
-        // window and linearity of expectation.
-        double r{WINDOW_GEOMETRIC_WEIGHT * WINDOW_GEOMETRIC_WEIGHT};
-        double length{static_cast<double>(m_SlidingWindow.size())};
-        return length == 0.0 ? 0.0 : std::sqrt((1.0 - r) / (1.0 - std::pow(r, length)));
-    }
+    double correlationWithBucketValue() const override;
 
     //! Clear the feature state.
-    void clear() override { m_SlidingWindow.clear(); }
+    void clear() override;
 
-    //! Add \p values and \p time.
+    //! Update the window with \p values at \p time.
     void add(core_t::TTime time,
              core_t::TTime bucketLength,
-             const TT1Vec& values,
-             const TWeightsAry1Vec& weights) override {
-        // Remove any old samples.
-        core_t::TTime cutoff{time - this->windowInterval(bucketLength)};
-        while (m_SlidingWindow.size() > 0 && m_SlidingWindow.front().first < cutoff) {
-            m_SlidingWindow.pop_front();
-        }
-        if (values.size() > 0) {
-            using TStorage1Vec = core::CSmallVector<TStorage, 1>;
-
-            // Get the scales to apply to each value.
-            TStorage1Vec scales;
-            scales.reserve(weights.size());
-            for (const auto& weight : weights) {
-                using std::sqrt;
-                scales.push_back(sqrt(TStorage(maths_t::countVarianceScale(weight)) *
-                                      TStorage(maths_t::seasonalVarianceScale(weight))));
-            }
-
-            // Add the next sample.
-            TFloatMeanAccumulator next{this->conformable(TStorage(values[0]), 0.0f)};
-            for (std::size_t i = 0; i < values.size(); ++i) {
-                auto weight = maths_t::countForUpdate(weights[i]);
-                next.add(TStorage(values[i]) / scales[i], this->minweight(weight));
-            }
-            m_SlidingWindow.push_back({time, next});
-        }
-    }
+             const TType1Vec& values,
+             const TWeightsAry1Vec& weights) override;
 
     //! Compute a checksum for this object.
-    uint64_t checksum(uint64_t seed = 0) const override {
-        seed = common::CChecksum::calculate(seed, m_SlidingWindow.capacity());
-        return common::CChecksum::calculate(seed, m_SlidingWindow);
-    }
+    std::uint64_t checksum(std::uint64_t seed = 0) const override;
 
     //! Debug the memory used by this object.
-    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
-        mem->setName("CTimeSeriesMultibucketMean");
-        core::CMemoryDebug::dynamicSize("m_SlidingWindow", m_SlidingWindow, mem);
-    }
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 
     //! Get the static size of object.
-    std::size_t staticSize() const override { return sizeof(*this); }
+    std::size_t staticSize() const override;
 
     //! Get the memory used by this object.
-    std::size_t memoryUsage() const override {
-        return core::CMemory::dynamicSize(m_SlidingWindow);
-    }
+    std::size_t memoryUsage() const override;
 
     //! Initialize reading state from \p traverser.
-    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override {
-        do {
-            const std::string& name{traverser.name()};
-            RESTORE_SETUP_TEARDOWN(CAPACITY_TAG, std::size_t capacity,
-                                   core::CStringUtils::stringToType(traverser.value(), capacity),
-                                   m_SlidingWindow.set_capacity(capacity))
-            RESTORE(SLIDING_WINDOW_TAG,
-                    core::CPersistUtils::restore(SLIDING_WINDOW_TAG, m_SlidingWindow, traverser))
-        } while (traverser.next());
-        return true;
-    }
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override;
 
     //! Persist by passing information to \p inserter.
-    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override {
-        inserter.insertValue(CAPACITY_TAG, m_SlidingWindow.capacity());
-        core::CPersistUtils::persist(SLIDING_WINDOW_TAG, m_SlidingWindow, inserter);
-    }
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
 
 private:
-    using TDoubleDoublePr = std::pair<double, double>;
-    using TStorage =
-        typename std::conditional<std::is_arithmetic<T>::value, common::CFloatStorage, common::CVector<common::CFloatStorage>>::type;
-    using TFloatMeanAccumulator =
-        typename common::CBasicStatistics::SSampleMean<TStorage>::TAccumulator;
-    using TDoubleMeanAccumulator = typename common::SPromoted<TFloatMeanAccumulator>::Type;
-    using TTimeFloatMeanAccumulatorPr = std::pair<core_t::TTime, TFloatMeanAccumulator>;
-    using TTimeFloatMeanAccumulatorPrCBuf = boost::circular_buffer<TTimeFloatMeanAccumulatorPr>;
+    using TImpl = CTimeSeriesMultibucketMeanImpl<Type, common::CFloatStorage>;
+    using TImplPtr = std::unique_ptr<TImpl>;
 
 private:
-    //! The geometric weight applied to the window.
-    constexpr static const double WINDOW_GEOMETRIC_WEIGHT = 0.9;
-    //! The state tags.
-    static const std::string CAPACITY_TAG;
-    static const std::string SLIDING_WINDOW_TAG;
-
-private:
-    //! Get the length of the window given \p bucketLength.
-    core_t::TTime windowInterval(core_t::TTime bucketLength) const {
-        return static_cast<core_t::TTime>(m_SlidingWindow.capacity()) * bucketLength;
-    }
-
-    //! Compute the weighted mean of the values in the window.
-    T mean() const {
-        return evaluateOnWindow(
-            [](const TFloatMeanAccumulator& value) {
-                return common::CBasicStatistics::mean(value);
-            },
-            [](const TFloatMeanAccumulator& value) {
-                return common::CBasicStatistics::count(value);
-            });
-    }
-
-    //! Compute the weighted count of the values in the window.
-    T count() const {
-        return evaluateOnWindow(
-            [&](const TFloatMeanAccumulator& value) {
-                return this->conformable(
-                    common::CBasicStatistics::mean(value),
-                    static_cast<double>(common::CBasicStatistics::count(value)));
-            },
-            [](const TFloatMeanAccumulator&) { return 1.0; });
-    }
-
-    //! Compute the weighted mean of \p function on the sliding window.
-    template<typename VALUE, typename WEIGHT>
-    T evaluateOnWindow(VALUE value, WEIGHT weight) const {
-        double latest, earliest;
-        std::tie(earliest, latest) = this->range();
-        double n{static_cast<double>(m_SlidingWindow.size())};
-        double scale{(n - 1.0) * (latest == earliest ? 1.0 : 1.0 / (latest - earliest))};
-        auto i = m_SlidingWindow.begin();
-        TDoubleMeanAccumulator mean{this->conformable(value(i->second), 0.0)};
-        for (double last{earliest}; i != m_SlidingWindow.end(); ++i) {
-            double dt{static_cast<double>(i->first) - last};
-            last = static_cast<double>(i->first);
-            mean.age(std::pow(WINDOW_GEOMETRIC_WEIGHT, scale * dt));
-            mean.add(value(i->second), weight(i->second));
-        }
-        return this->toVector(common::CBasicStatistics::mean(mean));
-    }
-
-    //! Compute the time range of window.
-    TDoubleDoublePr range() const {
-        auto range =
-            std::accumulate(m_SlidingWindow.begin(), m_SlidingWindow.end(),
-                            common::CBasicStatistics::CMinMax<double>(),
-                            [](common::CBasicStatistics::CMinMax<double> partial,
-                               const TTimeFloatMeanAccumulatorPr& value) {
-                                partial.add(static_cast<double>(value.first));
-                                return partial;
-                            });
-        return {range.min(), range.max()};
-    }
-
-private:
-    //! The window values.
-    TTimeFloatMeanAccumulatorPrCBuf m_SlidingWindow;
+    TImplPtr m_Impl;
 };
 
-template<typename T>
-const std::string CTimeSeriesMultibucketMean<T>::CAPACITY_TAG{"a"};
-template<typename T>
-const std::string CTimeSeriesMultibucketMean<T>::SLIDING_WINDOW_TAG{"b"};
+//! \brief A vector valued multi-bucket mean feature.
+class MATHS_TIME_SERIES_EXPORT CTimeSeriesMultibucketVectorMean final
+    : public CTimeSeriesMultibucketVectorFeature {
+public:
+    using Type = CTimeSeriesMultibucketVectorFeature::Type;
+
+public:
+    explicit CTimeSeriesMultibucketVectorMean(std::size_t length = 0);
+    CTimeSeriesMultibucketVectorMean(const CTimeSeriesMultibucketVectorMean& other);
+    ~CTimeSeriesMultibucketVectorMean() override;
+
+    CTimeSeriesMultibucketVectorMean(CTimeSeriesMultibucketVectorMean&&) noexcept;
+    CTimeSeriesMultibucketVectorMean& operator=(CTimeSeriesMultibucketVectorMean&&) noexcept;
+    CTimeSeriesMultibucketVectorMean& operator=(const CTimeSeriesMultibucketVectorMean&);
+
+    //! Clone this feature.
+    TPtr clone() const override;
+
+    //! Get the raw feature value.
+    const TType1VecTWeightAry1VecPr& value() const override;
+
+    //! Get the correlation of this feature with the bucket value.
+    double correlationWithBucketValue() const override;
+
+    //! Clear the feature state.
+    void clear() override;
+
+    //! Update the window with \p values at \p time.
+    void add(core_t::TTime time,
+             core_t::TTime bucketLength,
+             const TType1Vec& values,
+             const TWeightsAry1Vec& weights) override;
+
+    //! Compute a checksum for this object.
+    std::uint64_t checksum(std::uint64_t seed = 0) const override;
+
+    //! Debug the memory used by this object.
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
+
+    //! Get the static size of object.
+    std::size_t staticSize() const override;
+
+    //! Get the memory used by this object.
+    std::size_t memoryUsage() const override;
+
+    //! Initialize reading state from \p traverser.
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override;
+
+    //! Persist by passing information to \p inserter.
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
+
+private:
+    using TImpl = CTimeSeriesMultibucketMeanImpl<Type, common::CVector<common::CFloatStorage>>;
+    using TImplPtr = std::unique_ptr<TImpl>;
+
+private:
+    TImplPtr m_Impl;
+};
 }
 }
 }

--- a/include/maths/time_series/CTimeSeriesTestForSeasonality.h
+++ b/include/maths/time_series/CTimeSeriesTestForSeasonality.h
@@ -109,6 +109,9 @@ public:
     //! Get the desired component size.
     std::size_t size() const;
 
+    //! Check if the component is one of \p periods.
+    bool isOneOf(int periods) const;
+
     //! Get a seasonal time for the specified results.
     //!
     //! \warning The caller owns the returned object.
@@ -119,6 +122,9 @@ public:
 
     //! Get the end time of the initial values.
     core_t::TTime initialValuesEndTime() const;
+
+    //! Get the bucket length of the window used to find the component.
+    core_t::TTime bucketLength() const;
 
     //! Get the values to use to initialize the component.
     const TFloatMeanAccumulatorVec& initialValues() const;
@@ -643,7 +649,7 @@ private:
     TSizeVec m_ModelledPeriodsSizes;
     TBoolVec m_ModelledPeriodsTestable;
     TFloatMeanAccumulatorVec m_Values;
-    // The follow are member data to avoid repeatedly reinitialising.
+    // The following are member data to avoid repeatedly recreating.
     mutable TAmplitudeVec m_Amplitudes;
     mutable TSeasonalComponentVec m_Periods;
     mutable TSeasonalComponentVec m_CandidatePeriods;

--- a/include/model/CAnomalyDetectorModelConfig.h
+++ b/include/model/CAnomalyDetectorModelConfig.h
@@ -158,6 +158,9 @@ public:
     //! The default maximum time to test for a change point in a time series.
     static const core_t::TTime DEFAULT_MAXIMUM_TIME_TO_TEST_FOR_CHANGE;
 
+    //! The default maximum random jitter we tolerate in seasonal patterns.
+    static const core_t::TTime DEFAULT_MAXIMUM_SEASONAL_JITTER;
+
     //! The default number of time buckets used to generate multibucket features
     //! for anomaly detection.
     static const std::size_t MULTIBUCKET_FEATURES_WINDOW_LENGTH;

--- a/include/model/ModelTypes.h
+++ b/include/model/ModelTypes.h
@@ -18,6 +18,8 @@
 
 #include <maths/common/MathsTypes.h>
 
+#include <maths/time_series/CTimeSeriesMultibucketFeaturesFwd.h>
+
 #include <model/ImportExport.h>
 
 #include <functional>
@@ -26,12 +28,6 @@
 #include <utility>
 
 namespace ml {
-namespace maths {
-namespace time_series {
-template<typename>
-class CTimeSeriesMultibucketFeature;
-}
-}
 namespace model {
 class CInfluenceCalculator;
 struct SModelParams;
@@ -46,9 +42,9 @@ using TDouble2Vec1Vec = core::CSmallVector<TDouble2Vec, 1>;
 using TDouble1VecDouble1VecPr = std::pair<TDouble1Vec, TDouble1Vec>;
 using TInfluenceCalculatorCPtr = std::shared_ptr<const model::CInfluenceCalculator>;
 using TUnivariateMultibucketFeaturePtr =
-    std::unique_ptr<maths::time_series::CTimeSeriesMultibucketFeature<double>>;
+    std::unique_ptr<maths::time_series::CTimeSeriesMultibucketScalarFeature>;
 using TMultivariateMultibucketFeaturePtr =
-    std::unique_ptr<maths::time_series::CTimeSeriesMultibucketFeature<TDouble10Vec>>;
+    std::unique_ptr<maths::time_series::CTimeSeriesMultibucketVectorFeature>;
 
 //! The types of model available.
 //!

--- a/include/model/SModelParams.h
+++ b/include/model/SModelParams.h
@@ -100,6 +100,9 @@ struct MODEL_EXPORT SModelParams {
     //! The maximum time to test for a change point in a time series.
     core_t::TTime s_MaximumTimeToTestForChange;
 
+    //! The maximum random jitter we tolerate in seasonal patterns.
+    core_t::TTime s_MaximumSeasonalJitter;
+
     //! The number of time buckets used to generate multibucket features for anomaly
     //! detection.
     std::size_t s_MultibucketFeaturesWindowLength;

--- a/lib/maths/common/CModel.cc
+++ b/lib/maths/common/CModel.cc
@@ -35,7 +35,7 @@ const double EFFECTIVE_COUNT[]{1.0,  0.8,  0.7,  0.65, 0.6,
 //! Get the parameters for the stub model.
 CModelParams stubParameters() {
     return CModelParams{
-        0, 1.0, 0.0, 0.0, 6 * core::constants::HOUR, core::constants::DAY};
+        0, 1.0, 0.0, 0.0, 6 * core::constants::HOUR, core::constants::DAY, 15 * core::constants::MINUTE};
 }
 }
 
@@ -46,11 +46,15 @@ CModelParams::CModelParams(core_t::TTime bucketLength,
                            double decayRate,
                            double minimumSeasonalVarianceScale,
                            core_t::TTime minimumTimeToDetectChange,
-                           core_t::TTime maximumTimeToTestForChange)
-    : m_BucketLength(bucketLength), m_LearnRate(learnRate), m_DecayRate(decayRate),
-      m_MinimumSeasonalVarianceScale(minimumSeasonalVarianceScale),
-      m_MinimumTimeToDetectChange(std::max(minimumTimeToDetectChange, 6 * bucketLength)),
-      m_MaximumTimeToTestForChange(std::max(maximumTimeToTestForChange, 12 * bucketLength)) {
+                           core_t::TTime maximumTimeToTestForChange,
+                           core_t::TTime maximumSeasonalJitter)
+    : m_BucketLength{bucketLength}, m_LearnRate{learnRate}, m_DecayRate{decayRate},
+      m_MinimumSeasonalVarianceScale{minimumSeasonalVarianceScale},
+      m_MinimumTimeToDetectChange{std::max(minimumTimeToDetectChange, 6 * bucketLength)},
+      m_MaximumTimeToTestForChange{std::max(maximumTimeToTestForChange, 12 * bucketLength)},
+      m_MaximumSeasonalJitter{maximumSeasonalJitter > 0
+                                  ? std::max(maximumSeasonalJitter, bucketLength / 4)
+                                  : 0} {
 }
 
 core_t::TTime CModelParams::bucketLength() const {
@@ -83,6 +87,10 @@ core_t::TTime CModelParams::minimumTimeToDetectChange() const {
 
 core_t::TTime CModelParams::maximumTimeToTestForChange() const {
     return m_MaximumTimeToTestForChange;
+}
+
+core_t::TTime CModelParams::maximumSeasonalJitter() const {
+    return m_MaximumSeasonalJitter;
 }
 
 //////// CModelAddSamplesParams ////////

--- a/lib/maths/common/CPrior.cc
+++ b/lib/maths/common/CPrior.cc
@@ -294,7 +294,9 @@ double CPrior::adjustOffsetWithCost(const TDouble1Vec& samples,
             trialOffsets.push_back(offset);
         }
         double likelihood;
-        CSolvers::globalMinimize(trialOffsets, cost, offset, likelihood);
+        double likelihoodStandardDeviation;
+        CSolvers::globalMinimize(trialOffsets, cost, offset, likelihood,
+                                 likelihoodStandardDeviation);
         LOG_TRACE(<< "samples = " << core::CContainerPrinter::print(samples)
                   << ", offset = " << offset << ", likelihood = " << likelihood);
     }

--- a/lib/maths/common/unittest/CModelTest.cc
+++ b/lib/maths/common/unittest/CModelTest.cc
@@ -32,9 +32,13 @@ BOOST_AUTO_TEST_CASE(testAll) {
         double learnRate{0.5};
         double decayRate{0.001};
         double minimumSeasonalVarianceScale{0.3};
-        maths::common::CModelParams params(
-            bucketLength, learnRate, decayRate, minimumSeasonalVarianceScale,
-            6 * core::constants::HOUR, core::constants::DAY);
+        maths::common::CModelParams params{bucketLength,
+                                           learnRate,
+                                           decayRate,
+                                           minimumSeasonalVarianceScale,
+                                           6 * core::constants::HOUR,
+                                           core::constants::DAY,
+                                           15 * core::constants::MINUTE};
         BOOST_REQUIRE_EQUAL(bucketLength, params.bucketLength());
         BOOST_REQUIRE_EQUAL(learnRate, params.learnRate());
         BOOST_REQUIRE_EQUAL(decayRate, params.decayRate());
@@ -42,6 +46,7 @@ BOOST_AUTO_TEST_CASE(testAll) {
                             params.minimumSeasonalVarianceScale());
         BOOST_REQUIRE_EQUAL(6 * core::constants::HOUR, params.minimumTimeToDetectChange());
         BOOST_REQUIRE_EQUAL(core::constants::DAY, params.maximumTimeToTestForChange());
+        BOOST_REQUIRE_EQUAL(15 * core::constants::MINUTE, params.maximumSeasonalJitter());
     }
     {
         maths_t::TDouble2VecWeightsAry weight1(maths_t::CUnitWeights::unit<TDouble2Vec>(2));

--- a/lib/maths/time_series/CSeasonalComponent.cc
+++ b/lib/maths/time_series/CSeasonalComponent.cc
@@ -23,51 +23,55 @@
 #include <maths/common/CIntegerTools.h>
 #include <maths/common/CLeastSquaresOnlineRegressionDetail.h>
 #include <maths/common/CSampling.h>
+#include <maths/common/CSolvers.h>
 
 #include <maths/time_series/CSeasonalTime.h>
 
 #include <cmath>
-#include <limits>
 #include <vector>
 
 namespace ml {
 namespace maths {
 namespace time_series {
 namespace {
-
 using TDoubleDoublePr = maths_t::TDoubleDoublePr;
-
 const core::TPersistenceTag DECOMPOSITION_COMPONENT_TAG{"a", "decomposition_component"};
 const core::TPersistenceTag RNG_TAG{"b", "rng"};
 const core::TPersistenceTag BUCKETING_TAG{"c", "bucketing"};
 const core::TPersistenceTag LAST_INTERPOLATION_TAG{"d", "last_interpolation_time"};
+const core::TPersistenceTag TOTAL_SHIFT_TAG{"e", "total_shift"};
+const core::TPersistenceTag CURRENT_MEAN_SHIFT_TAG{"f", "current_mean"};
+const core::TPersistenceTag MAX_TIME_SHIFT_PER_PERIOD_TAG{"g", "max_time_shift_per_period"};
 const std::string EMPTY_STRING;
 }
 
 CSeasonalComponent::CSeasonalComponent(const CSeasonalTime& time,
                                        std::size_t maxSize,
                                        double decayRate,
-                                       double minimumBucketLength,
+                                       double minBucketLength,
+                                       core_t::TTime maxTimeShiftPerPeriod,
                                        common::CSplineTypes::EBoundaryCondition boundaryCondition,
                                        common::CSplineTypes::EType valueInterpolationType,
                                        common::CSplineTypes::EType varianceInterpolationType)
     : CDecompositionComponent{maxSize, boundaryCondition,
                               valueInterpolationType, varianceInterpolationType},
-      m_Bucketing{time, decayRate, minimumBucketLength},
-      m_LastInterpolationTime{2 * (std::numeric_limits<core_t::TTime>::min() / 3)} {
+      m_Bucketing{time, decayRate, minBucketLength},
+      m_MaxTimeShiftPerPeriod{common::CBasicStatistics::min(
+          maxTimeShiftPerPeriod,
+          static_cast<core_t::TTime>(minBucketLength / 2.0 + 0.5),
+          static_cast<core_t::TTime>(0.1 * static_cast<double>(time.period()) + 0.5))} {
 }
 
 CSeasonalComponent::CSeasonalComponent(double decayRate,
-                                       double minimumBucketLength,
+                                       double minBucketLength,
                                        core::CStateRestoreTraverser& traverser,
                                        common::CSplineTypes::EType valueInterpolationType,
                                        common::CSplineTypes::EType varianceInterpolationType)
     : CDecompositionComponent{0, common::CSplineTypes::E_Periodic,
-                              valueInterpolationType, varianceInterpolationType},
-      m_LastInterpolationTime{2 * (std::numeric_limits<core_t::TTime>::min() / 3)} {
-    if (traverser.traverseSubLevel(
-            std::bind(&CSeasonalComponent::acceptRestoreTraverser, this, decayRate,
-                      minimumBucketLength, std::placeholders::_1)) == false) {
+                              valueInterpolationType, varianceInterpolationType} {
+    if (traverser.traverseSubLevel([&](core::CStateRestoreTraverser& traverser_) {
+            return this->acceptRestoreTraverser(decayRate, minBucketLength, traverser_);
+        }) == false) {
         traverser.setBadState();
     }
 }
@@ -77,25 +81,32 @@ void CSeasonalComponent::swap(CSeasonalComponent& other) {
     std::swap(m_Rng, other.m_Rng);
     m_Bucketing.swap(other.m_Bucketing);
     std::swap(m_LastInterpolationTime, other.m_LastInterpolationTime);
+    std::swap(m_MaxTimeShiftPerPeriod, other.m_MaxTimeShiftPerPeriod);
+    std::swap(m_TotalShift, other.m_TotalShift);
+    std::swap(m_CurrentMeanShift, other.m_CurrentMeanShift);
 }
 
 bool CSeasonalComponent::acceptRestoreTraverser(double decayRate,
-                                                double minimumBucketLength,
+                                                double minBucketLength,
                                                 core::CStateRestoreTraverser& traverser) {
     bool restoredBucketing{false};
     do {
         const std::string& name{traverser.name()};
         RESTORE(DECOMPOSITION_COMPONENT_TAG,
-                traverser.traverseSubLevel(std::bind(
-                    &CDecompositionComponent::acceptRestoreTraverser,
-                    static_cast<CDecompositionComponent*>(this), std::placeholders::_1)))
+                traverser.traverseSubLevel([this](core::CStateRestoreTraverser& traverser_) {
+                    return this->CDecompositionComponent::acceptRestoreTraverser(traverser_);
+                }))
         RESTORE(RNG_TAG, m_Rng.fromString(traverser.value()))
         RESTORE_SETUP_TEARDOWN(BUCKETING_TAG,
                                CSeasonalComponentAdaptiveBucketing bucketing(
-                                   decayRate, minimumBucketLength, traverser),
+                                   decayRate, minBucketLength, traverser),
                                restoredBucketing = (traverser.haveBadState() == false),
                                m_Bucketing.swap(bucketing))
         RESTORE_BUILT_IN(LAST_INTERPOLATION_TAG, m_LastInterpolationTime)
+        RESTORE_BUILT_IN(MAX_TIME_SHIFT_PER_PERIOD_TAG, m_MaxTimeShiftPerPeriod)
+        RESTORE_BUILT_IN(TOTAL_SHIFT_TAG, m_TotalShift)
+        RESTORE(CURRENT_MEAN_SHIFT_TAG,
+                m_CurrentMeanShift.fromDelimited(traverser.value()))
     } while (traverser.next());
 
     if (restoredBucketing == false) {
@@ -107,15 +118,17 @@ bool CSeasonalComponent::acceptRestoreTraverser(double decayRate,
 }
 
 void CSeasonalComponent::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
-    inserter.insertLevel(DECOMPOSITION_COMPONENT_TAG,
-                         std::bind(&CDecompositionComponent::acceptPersistInserter,
-                                   static_cast<const CDecompositionComponent*>(this),
-                                   std::placeholders::_1));
+    inserter.insertLevel(DECOMPOSITION_COMPONENT_TAG, [this](core::CStatePersistInserter& inserter_) {
+        this->CDecompositionComponent::acceptPersistInserter(inserter_);
+    });
     inserter.insertValue(RNG_TAG, m_Rng.toString());
-    inserter.insertLevel(BUCKETING_TAG,
-                         std::bind(&CSeasonalComponentAdaptiveBucketing::acceptPersistInserter,
-                                   &m_Bucketing, std::placeholders::_1));
+    inserter.insertLevel(BUCKETING_TAG, [this](core::CStatePersistInserter& inserter_) {
+        m_Bucketing.acceptPersistInserter(inserter_);
+    });
     inserter.insertValue(LAST_INTERPOLATION_TAG, m_LastInterpolationTime);
+    inserter.insertValue(MAX_TIME_SHIFT_PER_PERIOD_TAG, m_MaxTimeShiftPerPeriod);
+    inserter.insertValue(TOTAL_SHIFT_TAG, m_TotalShift);
+    inserter.insertValue(CURRENT_MEAN_SHIFT_TAG, m_CurrentMeanShift.toDelimited());
 }
 
 bool CSeasonalComponent::initialized() const {
@@ -181,8 +194,12 @@ void CSeasonalComponent::linearScale(core_t::TTime time, double scale) {
 }
 
 void CSeasonalComponent::add(core_t::TTime time, double value, double weight, double gradientLearnRate) {
-    double predicted{common::CBasicStatistics::mean(this->value(this->jitter(time), 0.0))};
-    m_Bucketing.add(time, value, predicted, weight, gradientLearnRate);
+    core_t::TTime shift;
+    double shiftWeight;
+    std::tie(shift, shiftWeight) = this->likelyShift(time, value);
+    m_CurrentMeanShift.add(static_cast<double>(shift), weight * shiftWeight);
+    double prediction{common::CBasicStatistics::mean(this->value(this->jitter(time), 0.0))};
+    m_Bucketing.add(time + m_TotalShift, value, prediction, weight, gradientLearnRate);
 }
 
 bool CSeasonalComponent::shouldInterpolate(core_t::TTime time) const {
@@ -207,6 +224,11 @@ void CSeasonalComponent::interpolate(core_t::TTime time, bool refine) {
         this->CDecompositionComponent::interpolate(knots, values, variances);
     }
     m_LastInterpolationTime = time_.startOfPeriod(time);
+    m_TotalShift += static_cast<core_t::TTime>(
+        common::CBasicStatistics::mean(m_CurrentMeanShift) + 0.5);
+    m_TotalShift = m_TotalShift % this->time().period();
+    m_CurrentMeanShift = TFloatMeanAccumulator{};
+    LOG_TRACE(<< "total shift = " << m_TotalShift);
     LOG_TRACE(<< "last interpolation time = " << m_LastInterpolationTime);
 }
 
@@ -231,6 +253,7 @@ const CSeasonalComponentAdaptiveBucketing& CSeasonalComponent::bucketing() const
 }
 
 TDoubleDoublePr CSeasonalComponent::value(core_t::TTime time, double confidence) const {
+    time += m_TotalShift;
     double offset{this->time().periodic(time)};
     double n{m_Bucketing.count(time)};
     return this->CDecompositionComponent::value(offset, n, confidence);
@@ -293,6 +316,7 @@ double CSeasonalComponent::delta(core_t::TTime time,
 }
 
 TDoubleDoublePr CSeasonalComponent::variance(core_t::TTime time, double confidence) const {
+    time += m_TotalShift;
     double offset{this->time().periodic(time)};
     double n{m_Bucketing.count(time)};
     return this->CDecompositionComponent::variance(offset, n, confidence);
@@ -309,7 +333,8 @@ bool CSeasonalComponent::covariances(core_t::TTime time, TMatrix& result) const 
         return false;
     }
 
-    if (auto r = m_Bucketing.regression(time)) {
+    time += m_TotalShift;
+    if (const auto* r = m_Bucketing.regression(time)) {
         double variance{common::CBasicStatistics::mean(this->variance(time, 0.0))};
         return r->covariances(variance, result);
     }
@@ -332,7 +357,10 @@ bool CSeasonalComponent::slopeAccurate(core_t::TTime time) const {
 std::uint64_t CSeasonalComponent::checksum(std::uint64_t seed) const {
     seed = this->CDecompositionComponent::checksum(seed);
     seed = common::CChecksum::calculate(seed, m_Bucketing);
-    return common::CChecksum::calculate(seed, m_LastInterpolationTime);
+    seed = common::CChecksum::calculate(seed, m_LastInterpolationTime);
+    seed = common::CChecksum::calculate(seed, m_MaxTimeShiftPerPeriod);
+    seed = common::CChecksum::calculate(seed, m_TotalShift);
+    return common::CChecksum::calculate(seed, m_CurrentMeanShift);
 }
 
 void CSeasonalComponent::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
@@ -344,6 +372,51 @@ void CSeasonalComponent::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsage
 std::size_t CSeasonalComponent::memoryUsage() const {
     return core::CMemory::dynamicSize(m_Bucketing) +
            core::CMemory::dynamicSize(this->splines());
+}
+
+CSeasonalComponent::TTimeDoublePr CSeasonalComponent::likelyShift(core_t::TTime maxTimeShift,
+                                                                  core_t::TTime time,
+                                                                  const TLossFunc& loss) {
+    if (maxTimeShift == 0) {
+        return {0, 0.0};
+    }
+
+    std::array<double, 7> times;
+    double range{2 * static_cast<double>(maxTimeShift)};
+    double step{range / static_cast<double>(times.size() - 1)};
+    times[0] = static_cast<double>(time) - range / 2.0;
+    for (std::size_t i = 1; i < times.size(); ++i) {
+        times[i] = times[i - 1] + step;
+    }
+
+    double shiftedTime;
+    double lossAtShiftedTime;
+    double lossStandardDeviation;
+    common::CSolvers::globalMinimize(times, loss, shiftedTime,
+                                     lossAtShiftedTime, lossStandardDeviation);
+    LOG_TRACE(<< "shift = " << static_cast<core_t::TTime>(shiftedTime + 0.5) - time
+              << ", loss(shift) = " << lossAtShiftedTime
+              << ", sd(loss) = " << lossStandardDeviation);
+
+    return {static_cast<core_t::TTime>(shiftedTime + 0.5), lossStandardDeviation};
+}
+
+CSeasonalComponent::TTimeDoublePr
+CSeasonalComponent::likelyShift(core_t::TTime time, double value) const {
+
+    double range{2 * static_cast<double>(m_MaxTimeShiftPerPeriod)};
+
+    // If the change due to the shift is small compared to the prediction
+    // error force it to zero.
+    double noise{0.2 * std::sqrt(this->meanVariance()) / range};
+    auto loss = [&](double offset) {
+        return std::fabs(common::CBasicStatistics::mean(this->value(
+                             time + static_cast<core_t::TTime>(offset + 0.5), 0.0)) -
+                         value) +
+               noise * std::fabs(offset);
+    };
+
+    return likelyShift(m_MaxTimeShiftPerPeriod, 0, loss);
 }
 
 core_t::TTime CSeasonalComponent::jitter(core_t::TTime time) {

--- a/lib/maths/time_series/CTimeSeriesDecompositionStub.cc
+++ b/lib/maths/time_series/CTimeSeriesDecompositionStub.cc
@@ -80,6 +80,7 @@ void CTimeSeriesDecompositionStub::forecast(core_t::TTime /*startTime*/,
 double CTimeSeriesDecompositionStub::detrend(core_t::TTime /*time*/,
                                              double value,
                                              double /*confidence*/,
+                                             core_t::TTime /*maximumTimeShift*/,
                                              int /*components*/) const {
     return value;
 }

--- a/lib/maths/time_series/CTimeSeriesModel.cc
+++ b/lib/maths/time_series/CTimeSeriesModel.cc
@@ -623,7 +623,7 @@ CUnivariateTimeSeriesModel::CUnivariateTimeSeriesModel(
                                           params.decayRate())
                                     : nullptr),
       m_Correlations(nullptr) {
-    if (controllers) {
+    if (controllers != nullptr) {
         m_Controllers = std::make_unique<TDecayRateController2Ary>(*controllers);
     }
 }
@@ -701,13 +701,6 @@ CUnivariateTimeSeriesModel::addSamples(const common::CModelAddSamplesParams& par
         return E_Success;
     }
 
-    TSizeVec valueorder(samples.size());
-    std::iota(valueorder.begin(), valueorder.end(), 0);
-    std::stable_sort(valueorder.begin(), valueorder.end(),
-                     [&samples](std::size_t lhs, std::size_t rhs) {
-                         return samples[lhs].second < samples[rhs].second;
-                     });
-
     // Update the data characteristics.
     m_IsNonNegative = params.isNonNegative();
     maths_t::EDataType type{params.type()};
@@ -719,57 +712,8 @@ CUnivariateTimeSeriesModel::addSamples(const common::CModelAddSamplesParams& par
 
     EUpdateResult result{this->updateTrend(params, samples)};
 
-    for (auto& sample : samples) {
-        sample.second[0] = m_TrendModel->detrend(sample.first, sample.second[0], 0.0);
-    }
-
-    // Removing the trend can change the order of values due to the time
-    // differences so we need to re-sort here.
-    std::stable_sort(valueorder.begin(), valueorder.end(),
-                     [&samples](std::size_t lhs, std::size_t rhs) {
-                         return samples[lhs].second < samples[rhs].second;
-                     });
-
-    // Compute the current bucket residual samples.
-    TDouble1Vec samples_;
-    maths_t::TDoubleWeightsAry1Vec weights_;
-    samples_.reserve(samples.size());
-    weights_.reserve(samples.size());
-    TMeanAccumulator averageTime_;
-    for (auto i : valueorder) {
-        core_t::TTime time{samples[i].first};
-        auto weight = unpack(params.priorWeights()[i]);
-        samples_.push_back(samples[i].second[0]);
-        weights_.push_back(weight);
-        averageTime_.add(static_cast<double>(time), maths_t::countForUpdate(weight));
-    }
-    core_t::TTime averageTime{
-        static_cast<core_t::TTime>(common::CBasicStatistics::mean(averageTime_))};
-
-    // Update the residual model.
-    m_ResidualModel->addSamples(samples_, weights_);
-    m_ResidualModel->propagateForwardsByTime(params.propagationInterval());
-
-    // Update the multi-bucket residual feature model.
-    if (m_MultibucketFeatureModel != nullptr) {
-        TDouble2Vec seasonalWeight;
-        for (auto i : valueorder) {
-            core_t::TTime time{samples[i].first};
-            this->seasonalWeight(0.0, time, seasonalWeight);
-            maths_t::setSeasonalVarianceScale(seasonalWeight[0], weights_[i]);
-        }
-        m_MultibucketFeature->add(averageTime, this->params().bucketLength(),
-                                  samples_, weights_);
-
-        TDouble1Vec feature;
-        maths_t::TDoubleWeightsAry1Vec featureWeight;
-        std::tie(feature, featureWeight) = m_MultibucketFeature->value();
-
-        if (feature.size() > 0) {
-            m_MultibucketFeatureModel->addSamples(feature, featureWeight);
-            m_MultibucketFeatureModel->propagateForwardsByTime(params.propagationInterval());
-        }
-    }
+    auto[residuals, decayRateMultiplier] =
+        this->updateResidualModels(params, std::move(samples));
 
     // Age the anomaly model. Note that update requires the probability
     // to be calculated. This is expensive to compute and so unlike our
@@ -778,12 +722,9 @@ CUnivariateTimeSeriesModel::addSamples(const common::CModelAddSamplesParams& par
         m_AnomalyModel->propagateForwardsByTime(params.propagationInterval());
     }
 
-    // Perform model decay control.
-    double multiplier{this->updateDecayRates(params, averageTime, samples_)};
-
     // Add the samples to the correlation models if there are any.
     if (m_Correlations != nullptr) {
-        m_Correlations->addSamples(m_Id, params, samples, multiplier);
+        m_Correlations->addSamples(m_Id, params, residuals, decayRateMultiplier);
     }
 
     return result;
@@ -846,7 +787,8 @@ void CUnivariateTimeSeriesModel::detrend(const TTime2Vec1Vec& time,
     }
 
     if (value[0].size() == 1) {
-        value[0][0] = m_TrendModel->detrend(time[0][0], value[0][0], confidenceInterval);
+        value[0][0] = m_TrendModel->detrend(time[0][0], value[0][0], confidenceInterval,
+                                            this->params().maximumSeasonalJitter());
     } else {
         TSize1Vec correlated;
         TSize2Vec1Vec variables;
@@ -857,11 +799,12 @@ void CUnivariateTimeSeriesModel::detrend(const TTime2Vec1Vec& time,
             for (std::size_t i = 0; i < variables.size(); ++i) {
                 if (!value[i].empty()) {
                     value[i][variables[i][0]] = m_TrendModel->detrend(
-                        time[i][variables[i][0]], value[i][variables[i][0]], confidenceInterval);
+                        time[i][variables[i][0]], value[i][variables[i][0]],
+                        confidenceInterval, this->params().maximumSeasonalJitter());
                     value[i][variables[i][1]] =
                         correlatedTimeSeriesModels[i]->m_TrendModel->detrend(
                             time[i][variables[i][1]], value[i][variables[i][1]],
-                            confidenceInterval);
+                            confidenceInterval, this->params().maximumSeasonalJitter());
                 }
             }
         }
@@ -881,7 +824,7 @@ CUnivariateTimeSeriesModel::predict(core_t::TTime time,
         if (m_Correlations->correlationModels(m_Id, correlated, variables,
                                               correlationModel, correlatedModel)) {
             double sample{correlatedModel[0]->m_TrendModel->detrend(
-                time, correlatedValue[0].second, 0.0)};
+                time, correlatedValue[0].second, 0.0, this->params().maximumSeasonalJitter())};
             TSize10Vec marginalize{variables[0][1]};
             TSizeDoublePr10Vec condition{{variables[0][1], sample}};
             const common::CMultivariatePrior* joint{correlationModel[0].first};
@@ -900,7 +843,8 @@ CUnivariateTimeSeriesModel::predict(core_t::TTime time,
     }
 
     if (hint.size() == 1) {
-        hint[0] = m_TrendModel->detrend(time, hint[0], 0.0);
+        hint[0] = m_TrendModel->detrend(time, hint[0], 0.0,
+                                        this->params().maximumSeasonalJitter());
     }
 
     double median{
@@ -1011,11 +955,13 @@ bool CUnivariateTimeSeriesModel::uncorrelatedProbability(
     TDouble4Vec probabilities;
     common::SModelProbabilityResult::TFeatureProbability4Vec featureProbabilities;
 
-    double pl, pu;
+    double pl;
+    double pu;
     maths_t::ETail tail;
     core_t::TTime time{time_[0][0]};
     TDouble1Vec sample{m_TrendModel->detrend(time, value[0][0],
-                                             params.seasonalConfidenceInterval())};
+                                             params.seasonalConfidenceInterval(),
+                                             this->params().maximumSeasonalJitter())};
     if (m_ResidualModel->probabilityOfLessLikelySamples(calculation, sample,
                                                         weights, pl, pu, tail)) {
         LOG_TRACE(<< "P(" << sample << " | weight = " << weights
@@ -1033,9 +979,8 @@ bool CUnivariateTimeSeriesModel::uncorrelatedProbability(
     double correlation{0.0};
     if (m_MultibucketFeatureModel != nullptr && params.useMultibucketFeatures()) {
         double pMultiBucket{1.0};
-        TDouble1Vec feature;
-        std::tie(feature, std::ignore) = m_MultibucketFeature->value();
-        if (feature.size() > 0) {
+        const TDouble1Vec& feature = m_MultibucketFeature->value().first;
+        if (feature.empty() == false) {
             for (auto calculation_ : expand(calculation)) {
                 maths_t::ETail dummy;
                 if (m_MultibucketFeatureModel->probabilityOfLessLikelySamples(
@@ -1104,7 +1049,8 @@ bool CUnivariateTimeSeriesModel::correlatedProbability(
     TDouble10Vec1Vec sample{TDouble10Vec(2)};
     maths_t::TDouble10VecWeightsAry1Vec weights{
         maths_t::CUnitWeights::unit<TDouble10Vec>(2)};
-    TDouble10Vec2Vec pli, pui;
+    TDouble10Vec2Vec pli;
+    TDouble10Vec2Vec pui;
     TTail10Vec ti;
     core_t::TTime mostAnomalousTime{0};
     double mostAnomalousSample{0.0};
@@ -1139,9 +1085,11 @@ bool CUnivariateTimeSeriesModel::correlatedProbability(
             const auto& correlationModel = correlationModels[correlateIndex].first;
 
             sample[0][0] = trendModels[0]->detrend(
-                time[i][0], value[i][0], params.seasonalConfidenceInterval());
+                time[i][0], value[i][0], params.seasonalConfidenceInterval(),
+                this->params().maximumSeasonalJitter());
             sample[0][1] = trendModels[1]->detrend(
-                time[i][1], value[i][1], params.seasonalConfidenceInterval());
+                time[i][1], value[i][1], params.seasonalConfidenceInterval(),
+                this->params().maximumSeasonalJitter());
             weights[0] = CMultivariateTimeSeriesModel::unpack(params.weights()[i]);
 
             if (correlationModel->probabilityOfLessLikelySamples(
@@ -1229,7 +1177,8 @@ void CUnivariateTimeSeriesModel::countWeights(core_t::TTime time,
 
     TDouble2Vec seasonalWeight;
     this->seasonalWeight(0.0, time, seasonalWeight);
-    double sample{m_TrendModel->detrend(time, value[0], 0.0)};
+    double sample{m_TrendModel->detrend(time, value[0], 0.0,
+                                        this->params().maximumSeasonalJitter())};
     auto weights = maths_t::CUnitWeights::UNIT;
     maths_t::setCount(std::min(residualCountWeight / trendCountWeight, 1.0), weights);
     maths_t::setSeasonalVarianceScale(seasonalWeight[0], weights);
@@ -1510,7 +1459,7 @@ CUnivariateTimeSeriesModel::EUpdateResult
 CUnivariateTimeSeriesModel::updateTrend(const common::CModelAddSamplesParams& params,
                                         const TTimeDouble2VecSizeTrVec& samples) {
 
-    const TDouble2VecWeightsAryVec& weights = params.trendWeights();
+    const auto& weights = params.trendWeights();
     const auto& modelAnnotationCallback = params.annotationCallback();
 
     for (const auto& sample : samples) {
@@ -1523,7 +1472,7 @@ CUnivariateTimeSeriesModel::updateTrend(const common::CModelAddSamplesParams& pa
     // Time order is not a total order, for example if the data are polled
     // the times of all samples will be the same. So break ties using the
     // sample value.
-    TSizeVec timeorder(samples.size());
+    TSize1Vec timeorder(samples.size());
     std::iota(timeorder.begin(), timeorder.end(), 0);
     std::stable_sort(timeorder.begin(), timeorder.end(),
                      [&samples](std::size_t lhs, std::size_t rhs) {
@@ -1555,6 +1504,66 @@ CUnivariateTimeSeriesModel::updateTrend(const common::CModelAddSamplesParams& pa
     }
 
     return result;
+}
+
+CUnivariateTimeSeriesModel::TTimeDouble2VecSizeTrVecDoublePr
+CUnivariateTimeSeriesModel::updateResidualModels(const common::CModelAddSamplesParams& params,
+                                                 TTimeDouble2VecSizeTrVec samples) {
+
+    for (auto& residual : samples) {
+        residual.second[0] = m_TrendModel->detrend(residual.first, residual.second[0], 0.0);
+    }
+
+    // We add the samples in value order since it makes clustering more stable.
+    TSize1Vec valueorder(samples.size());
+    std::iota(valueorder.begin(), valueorder.end(), 0);
+    std::stable_sort(valueorder.begin(), valueorder.end(),
+                     [&](std::size_t lhs, std::size_t rhs) {
+                         return samples[lhs].second < samples[rhs].second;
+                     });
+
+    TDouble1Vec residuals;
+    maths_t::TDoubleWeightsAry1Vec weights;
+    TMeanAccumulator averageTimeAccumulator;
+    weights.reserve(samples.size());
+    residuals.reserve(samples.size());
+
+    for (auto i : valueorder) {
+        core_t::TTime time{samples[i].first};
+        auto weight = unpack(params.priorWeights()[i]);
+        residuals.push_back(samples[i].second[0]);
+        weights.push_back(weight);
+        averageTimeAccumulator.add(static_cast<double>(time),
+                                   maths_t::countForUpdate(weight));
+    }
+    core_t::TTime averageTime{static_cast<core_t::TTime>(
+        common::CBasicStatistics::mean(averageTimeAccumulator))};
+
+    m_ResidualModel->addSamples(residuals, weights);
+    m_ResidualModel->propagateForwardsByTime(params.propagationInterval());
+
+    if (m_MultibucketFeatureModel != nullptr) {
+        TDouble2Vec seasonalWeight;
+        for (std::size_t i = 0; i < valueorder.size(); ++i) {
+            core_t::TTime time{samples[i].first};
+            this->seasonalWeight(0.0, time, seasonalWeight);
+            maths_t::setSeasonalVarianceScale(seasonalWeight[0], weights[i]);
+        }
+
+        m_MultibucketFeature->add(averageTime, this->params().bucketLength(),
+                                  residuals, weights);
+
+        const auto & [ feature, featureWeight ] = m_MultibucketFeature->value();
+
+        if (feature.empty() == false) {
+            m_MultibucketFeatureModel->addSamples(feature, featureWeight);
+            m_MultibucketFeatureModel->propagateForwardsByTime(params.propagationInterval());
+        }
+    }
+
+    double decayRateMultiplier{this->updateDecayRates(params, averageTime, residuals)};
+
+    return {std::move(samples), decayRateMultiplier};
 }
 
 double CUnivariateTimeSeriesModel::updateDecayRates(const common::CModelAddSamplesParams& params,
@@ -1898,9 +1907,9 @@ void CTimeSeriesCorrelations::refresh(const CTimeSeriesCorrelateModelAllocator& 
         }
 
         if (allocator.areAllocationsAllowed()) {
-            for (std::size_t i = 0u,
-                             nextChunk = std::min(allocator.maxNumberCorrelations(),
-                                                  initial + allocator.chunkSize());
+            for (std::size_t i = 0, nextChunk =
+                                        std::min(allocator.maxNumberCorrelations(),
+                                                 initial + allocator.chunkSize());
                  m_CorrelationDistributionModels.size() < allocator.maxNumberCorrelations() &&
                  i < missing.size() &&
                  (m_CorrelationDistributionModels.size() <= initial ||
@@ -2102,7 +2111,7 @@ bool CTimeSeriesCorrelations::correlationModels(std::size_t id,
     variables.reserve(correlated.size());
     correlationModels.reserve(correlated.size());
     correlatedTimeSeriesModels.reserve(correlated.size());
-    std::size_t end{0u};
+    std::size_t end{0};
     for (auto correlate : correlated) {
         auto i = m_CorrelationDistributionModels.find({id, correlate});
         TSize2Vec variable{0, 1};
@@ -2124,7 +2133,7 @@ bool CTimeSeriesCorrelations::correlationModels(std::size_t id,
             continue;
         }
         correlated[end] = correlate;
-        correlationModels.push_back({i->second.first.get(), variable[0]});
+        correlationModels.emplace_back(i->second.first.get(), variable[0]);
         variables.push_back(std::move(variable));
         ++end;
     }
@@ -2166,7 +2175,7 @@ CMultivariateTimeSeriesModel::CMultivariateTimeSeriesModel(
                                           params.bucketLength(),
                                           params.decayRate())
                                     : nullptr) {
-    if (controllers) {
+    if (controllers != nullptr) {
         m_Controllers = std::make_unique<TDecayRateController2Ary>(*controllers);
     }
     for (std::size_t d = 0; d < this->dimension(); ++d) {
@@ -2186,7 +2195,7 @@ CMultivariateTimeSeriesModel::CMultivariateTimeSeriesModel(const CMultivariateTi
       m_AnomalyModel(other.m_AnomalyModel != nullptr
                          ? std::make_unique<CTimeSeriesAnomalyModel>(*other.m_AnomalyModel)
                          : nullptr) {
-    if (other.m_Controllers) {
+    if (other.m_Controllers != nullptr) {
         m_Controllers = std::make_unique<TDecayRateController2Ary>(*other.m_Controllers);
     }
     m_TrendModel.reserve(other.m_TrendModel.size());
@@ -2245,12 +2254,12 @@ CMultivariateTimeSeriesModel::addSamples(const common::CModelAddSamplesParams& p
         return E_Success;
     }
 
-    TSizeVec valueorder(samples.size());
-    std::iota(valueorder.begin(), valueorder.end(), 0);
-    std::stable_sort(valueorder.begin(), valueorder.end(),
-                     [&samples](std::size_t lhs, std::size_t rhs) {
-                         return samples[lhs].second < samples[rhs].second;
-                     });
+    std::size_t dimension{this->dimension()};
+    samples.erase(std::remove_if(samples.begin(), samples.end(),
+                                 [&](const auto& sample) {
+                                     return sample.second.size() != dimension;
+                                 }),
+                  samples.end());
 
     // Update the data characteristics.
     m_IsNonNegative = params.isNonNegative();
@@ -2265,68 +2274,7 @@ CMultivariateTimeSeriesModel::addSamples(const common::CModelAddSamplesParams& p
 
     EUpdateResult result{this->updateTrend(params, samples)};
 
-    std::size_t dimension{this->dimension()};
-    for (auto& sample : samples) {
-        if (sample.second.size() != dimension) {
-            LOG_ERROR(<< "Unexpected sample dimension: '" << sample.second.size()
-                      << " != " << dimension << "' discarding");
-        } else {
-            core_t::TTime time{sample.first};
-            for (std::size_t d = 0; d < dimension; ++d) {
-                sample.second[d] = m_TrendModel[d]->detrend(time, sample.second[d], 0.0);
-            }
-        }
-    }
-    // Removing the trend can change the order of values due to the time
-    // differences so we need to re-sort here.
-    std::stable_sort(valueorder.begin(), valueorder.end(),
-                     [&samples](std::size_t lhs, std::size_t rhs) {
-                         return samples[lhs].second < samples[rhs].second;
-                     });
-
-    TDouble10Vec1Vec samples_;
-    maths_t::TDouble10VecWeightsAry1Vec weights_;
-    TDouble10Vec1Vec scales_;
-    samples_.reserve(samples.size());
-    weights_.reserve(samples.size());
-    TMeanAccumulator averageTime_;
-    TDouble2Vec seasonalWeight;
-    for (auto i : valueorder) {
-        core_t::TTime time{samples[i].first};
-        auto weight = unpack(params.priorWeights()[i]);
-        this->seasonalWeight(0.0, time, seasonalWeight);
-        samples_.push_back(samples[i].second);
-        weights_.push_back(weight);
-        scales_.push_back(sqrt(TVector(maths_t::countVarianceScale(weight)) * TVector(seasonalWeight))
-                              .toVector<TDouble10Vec>());
-        averageTime_.add(static_cast<double>(time));
-    }
-    core_t::TTime averageTime{
-        static_cast<core_t::TTime>(common::CBasicStatistics::mean(averageTime_))};
-
-    // Update the residual models.
-    m_ResidualModel->addSamples(samples_, weights_);
-    m_ResidualModel->propagateForwardsByTime(params.propagationInterval());
-
-    // Update the multi-bucket residual feature model.
-    if (m_MultibucketFeatureModel != nullptr) {
-        for (auto i : valueorder) {
-            core_t::TTime time{samples[i].first};
-            this->seasonalWeight(0.0, time, seasonalWeight);
-            maths_t::setSeasonalVarianceScale(TDouble10Vec(seasonalWeight), weights_[i]);
-        }
-        m_MultibucketFeature->add(averageTime, this->params().bucketLength(),
-                                  samples_, weights_);
-
-        TDouble10Vec1Vec feature;
-        maths_t::TDouble10VecWeightsAry1Vec featureWeight;
-        std::tie(feature, featureWeight) = m_MultibucketFeature->value();
-
-        if (feature.size() > 0) {
-            m_MultibucketFeatureModel->addSamples(feature, featureWeight);
-            m_MultibucketFeatureModel->propagateForwardsByTime(params.propagationInterval());
-        }
-    }
+    this->updateResidualModels(params, std::move(samples));
 
     // Age the anomaly model. Note that update requires the probability
     // to be calculated. This is expensive to compute and so unlike our
@@ -2334,9 +2282,6 @@ CMultivariateTimeSeriesModel::addSamples(const common::CModelAddSamplesParams& p
     if (m_AnomalyModel != nullptr) {
         m_AnomalyModel->propagateForwardsByTime(params.propagationInterval());
     }
-
-    // Perform model decay control.
-    this->updateDecayRates(params, averageTime, samples_);
 
     return result;
 }
@@ -2382,7 +2327,8 @@ void CMultivariateTimeSeriesModel::detrend(const TTime2Vec1Vec& time_,
     std::size_t dimension{this->dimension()};
     core_t::TTime time{time_[0][0]};
     for (std::size_t d = 0; d < dimension; ++d) {
-        value[0][d] = m_TrendModel[d]->detrend(time, value[0][d], confidenceInterval);
+        value[0][d] = m_TrendModel[d]->detrend(time, value[0][d], confidenceInterval,
+                                               this->params().maximumSeasonalJitter());
     }
 }
 
@@ -2396,7 +2342,8 @@ CMultivariateTimeSeriesModel::predict(core_t::TTime time,
 
     if (hint.size() == dimension) {
         for (std::size_t d = 0; d < dimension; ++d) {
-            hint[d] = m_TrendModel[d]->detrend(time, hint[d], 0.0);
+            hint[d] = m_TrendModel[d]->detrend(
+                time, hint[d], 0.0, this->params().maximumSeasonalJitter());
         }
     }
 
@@ -2509,7 +2456,8 @@ bool CMultivariateTimeSeriesModel::probability(const common::CModelProbabilityPa
     TDouble10Vec1Vec sample{TDouble10Vec(dimension)};
     for (std::size_t d = 0; d < dimension; ++d) {
         sample[0][d] = m_TrendModel[d]->detrend(
-            time, value[0][d], params.seasonalConfidenceInterval());
+            time, value[0][d], params.seasonalConfidenceInterval(),
+            this->params().maximumSeasonalJitter());
     }
     maths_t::TDouble10VecWeightsAry1Vec weights{unpack(params.weights()[0])};
 
@@ -2550,12 +2498,12 @@ bool CMultivariateTimeSeriesModel::probability(const common::CModelProbabilityPa
         tail[i] = tail_[0];
 
         if (m_MultibucketFeatureModel != nullptr && params.useMultibucketFeatures()) {
-            TDouble10Vec1Vec feature;
-            std::tie(feature, std::ignore) = m_MultibucketFeature->value();
-            if (feature.size() > 0) {
+            const TDouble10Vec1Vec& feature = m_MultibucketFeature->value().first;
+            if (feature.empty() == false) {
                 TDouble10Vec2Vec pMultiBucket[2]{{{1.0}, {1.0}}, {{1.0}, {1.0}}};
                 for (auto calculation_ : expand(calculation)) {
-                    TDouble10Vec2Vec pl, pu;
+                    TDouble10Vec2Vec pl;
+                    TDouble10Vec2Vec pu;
                     TTail10Vec dummy;
                     if (m_MultibucketFeatureModel->probabilityOfLessLikelySamples(
                             calculation_, feature,
@@ -2650,7 +2598,8 @@ void CMultivariateTimeSeriesModel::countWeights(core_t::TTime time,
     TDouble2Vec countVarianceScales(dimension, 1.0);
     TDouble10Vec sample(dimension);
     for (std::size_t d = 0; d < dimension; ++d) {
-        sample[d] = m_TrendModel[d]->detrend(time, value[d], 0.0);
+        sample[d] = m_TrendModel[d]->detrend(
+            time, value[d], 0.0, this->params().maximumSeasonalJitter());
         if (m_TrendModel[d]->seasonalComponents().size() == 0) {
             trendCountWeights[d] /= countVarianceScale;
             countVarianceScales[d] = countVarianceScale;
@@ -2911,7 +2860,7 @@ CMultivariateTimeSeriesModel::EUpdateResult
 CMultivariateTimeSeriesModel::updateTrend(const common::CModelAddSamplesParams& params,
                                           const TTimeDouble2VecSizeTrVec& samples) {
 
-    const TDouble2VecWeightsAryVec& weights = params.trendWeights();
+    const auto& weights = params.trendWeights();
     const auto& modelAnnotationCallback = params.annotationCallback();
 
     std::size_t dimension{this->dimension()};
@@ -2927,7 +2876,7 @@ CMultivariateTimeSeriesModel::updateTrend(const common::CModelAddSamplesParams& 
     // Time order is not a total order, for example if the data are polled
     // the times of all samples will be the same. So break ties using the
     // sample value.
-    TSizeVec timeorder(samples.size());
+    TSize1Vec timeorder(samples.size());
     std::iota(timeorder.begin(), timeorder.end(), 0);
     std::stable_sort(timeorder.begin(), timeorder.end(),
                      [&samples](std::size_t lhs, std::size_t rhs) {
@@ -2965,6 +2914,65 @@ CMultivariateTimeSeriesModel::updateTrend(const common::CModelAddSamplesParams& 
     }
 
     return result;
+}
+
+void CMultivariateTimeSeriesModel::updateResidualModels(const common::CModelAddSamplesParams& params,
+                                                        TTimeDouble2VecSizeTrVec samples) {
+
+    std::size_t dimension{this->dimension()};
+
+    for (auto& residual : samples) {
+        core_t::TTime time{residual.first};
+        for (std::size_t d = 0; d < dimension; ++d) {
+            residual.second[d] = m_TrendModel[d]->detrend(time, residual.second[d], 0.0);
+        }
+    }
+
+    // We add the samples in value order since it makes clustering more stable.
+    TSize1Vec valueorder(samples.size());
+    std::iota(valueorder.begin(), valueorder.end(), 0);
+    std::stable_sort(valueorder.begin(), valueorder.end(),
+                     [&](std::size_t lhs, std::size_t rhs) {
+                         return samples[lhs].second < samples[rhs].second;
+                     });
+
+    TDouble10Vec1Vec residuals;
+    maths_t::TDouble10VecWeightsAry1Vec weights;
+    samples.reserve(samples.size());
+    weights.reserve(samples.size());
+    TMeanAccumulator averageTimeAccumulator;
+    for (auto i : valueorder) {
+        core_t::TTime time{samples[i].first};
+        auto weight = unpack(params.priorWeights()[i]);
+        residuals.push_back(samples[i].second);
+        weights.push_back(weight);
+        averageTimeAccumulator.add(static_cast<double>(time));
+    }
+    core_t::TTime averageTime{static_cast<core_t::TTime>(
+        common::CBasicStatistics::mean(averageTimeAccumulator))};
+
+    m_ResidualModel->addSamples(residuals, weights);
+    m_ResidualModel->propagateForwardsByTime(params.propagationInterval());
+
+    if (m_MultibucketFeatureModel != nullptr) {
+        TDouble2Vec seasonalWeight;
+        for (std::size_t i = 0; i < valueorder.size(); ++i) {
+            core_t::TTime time{samples[valueorder[i]].first};
+            this->seasonalWeight(0.0, time, seasonalWeight);
+            maths_t::setSeasonalVarianceScale(TDouble10Vec(seasonalWeight), weights[i]);
+        }
+        m_MultibucketFeature->add(averageTime, this->params().bucketLength(),
+                                  residuals, weights);
+
+        const auto & [ feature, featureWeight ] = m_MultibucketFeature->value();
+
+        if (feature.empty() == false) {
+            m_MultibucketFeatureModel->addSamples(feature, featureWeight);
+            m_MultibucketFeatureModel->propagateForwardsByTime(params.propagationInterval());
+        }
+    }
+
+    this->updateDecayRates(params, averageTime, residuals);
 }
 
 void CMultivariateTimeSeriesModel::updateDecayRates(const common::CModelAddSamplesParams& params,

--- a/lib/maths/time_series/CTimeSeriesMultibucketFeatureSerialiser.cc
+++ b/lib/maths/time_series/CTimeSeriesMultibucketFeatureSerialiser.cc
@@ -27,54 +27,54 @@ const std::string MULTIVARIATE_MEAN_TAG{"b"};
 }
 
 bool CTimeSeriesMultibucketFeatureSerialiser::
-operator()(TUnivariateFeaturePtr& result, core::CStateRestoreTraverser& traverser) const {
+operator()(TScalarFeaturePtr& result, core::CStateRestoreTraverser& traverser) const {
     do {
         const std::string& name{traverser.name()};
         RESTORE_SETUP_TEARDOWN(
             UNIVARIATE_MEAN_TAG,
-            result = std::make_unique<CTimeSeriesMultibucketMean<double>>(),
-            traverser.traverseSubLevel(
-                std::bind<bool>(&TUnivariateFeature::acceptRestoreTraverser,
-                                result.get(), std::placeholders::_1)),
+            result = std::make_unique<CTimeSeriesMultibucketScalarMean>(),
+            traverser.traverseSubLevel([&](core::CStateRestoreTraverser& traverser_) {
+                return result->acceptRestoreTraverser(traverser_);
+            }),
             /**/)
     } while (traverser.next());
     return true;
 }
 
 bool CTimeSeriesMultibucketFeatureSerialiser::
-operator()(TMultivariateFeaturePtr& result, core::CStateRestoreTraverser& traverser) const {
+operator()(TVectorFeaturePtr& result, core::CStateRestoreTraverser& traverser) const {
     do {
         const std::string& name{traverser.name()};
         RESTORE_SETUP_TEARDOWN(
             MULTIVARIATE_MEAN_TAG,
-            result = std::make_unique<CTimeSeriesMultibucketMean<TDouble10Vec>>(),
-            traverser.traverseSubLevel(
-                std::bind<bool>(&TMultivariateFeature::acceptRestoreTraverser,
-                                result.get(), std::placeholders::_1)),
+            result = std::make_unique<CTimeSeriesMultibucketVectorMean>(),
+            traverser.traverseSubLevel([&](core::CStateRestoreTraverser& traverser_) {
+                return result->acceptRestoreTraverser(traverser_);
+            }),
             /**/)
     } while (traverser.next());
     return true;
 }
 
 void CTimeSeriesMultibucketFeatureSerialiser::
-operator()(const TUnivariateFeaturePtr& feature, core::CStatePersistInserter& inserter) const {
-    if (dynamic_cast<const CTimeSeriesMultibucketMean<double>*>(feature.get()) != nullptr) {
-        inserter.insertLevel(UNIVARIATE_MEAN_TAG,
-                             std::bind(&TUnivariateFeature::acceptPersistInserter,
-                                       feature.get(), std::placeholders::_1));
+operator()(const TScalarFeaturePtr& feature, core::CStatePersistInserter& inserter) const {
+    if (dynamic_cast<const CTimeSeriesMultibucketScalarMean*>(feature.get()) != nullptr) {
+        inserter.insertLevel(UNIVARIATE_MEAN_TAG, [&](core::CStatePersistInserter& inserter_) {
+            feature->acceptPersistInserter(inserter_);
+        });
     } else {
-        LOG_ERROR(<< "Feature with type '" << typeid(feature).name() << "' has no defined name");
+        LOG_ERROR(<< "Unknown feature with type '" << typeid(feature).name());
     }
 }
 
 void CTimeSeriesMultibucketFeatureSerialiser::
-operator()(const TMultivariateFeaturePtr& feature, core::CStatePersistInserter& inserter) const {
-    if (dynamic_cast<const CTimeSeriesMultibucketMean<TDouble10Vec>*>(feature.get()) != nullptr) {
-        inserter.insertLevel(MULTIVARIATE_MEAN_TAG,
-                             std::bind(&TMultivariateFeature::acceptPersistInserter,
-                                       feature.get(), std::placeholders::_1));
+operator()(const TVectorFeaturePtr& feature, core::CStatePersistInserter& inserter) const {
+    if (dynamic_cast<const CTimeSeriesMultibucketVectorMean*>(feature.get()) != nullptr) {
+        inserter.insertLevel(MULTIVARIATE_MEAN_TAG, [&](core::CStatePersistInserter& inserter_) {
+            feature->acceptPersistInserter(inserter_);
+        });
     } else {
-        LOG_ERROR(<< "Feature with type '" << typeid(feature).name() << "' has no defined name");
+        LOG_ERROR(<< "Unknown feature with type '" << typeid(feature).name());
     }
 }
 }

--- a/lib/maths/time_series/CTimeSeriesMultibucketFeatures.cc
+++ b/lib/maths/time_series/CTimeSeriesMultibucketFeatures.cc
@@ -1,0 +1,399 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#include <maths/time_series/CTimeSeriesMultibucketFeatures.h>
+
+#include <core/CPersistUtils.h>
+#include <core/CSmallVector.h>
+#include <core/CoreTypes.h>
+#include <core/RestoreMacros.h>
+
+#include <maths/common/CBasicStatistics.h>
+#include <maths/common/CBasicStatisticsPersist.h>
+#include <maths/common/CChecksum.h>
+#include <maths/common/CLinearAlgebra.h>
+#include <maths/common/CLinearAlgebraTools.h>
+#include <maths/common/CSolvers.h>
+#include <maths/common/CTypeTraits.h>
+#include <maths/common/MathsTypes.h>
+
+#include <maths/time_series/CSeasonalComponent.h>
+
+#include <boost/circular_buffer.hpp>
+
+#include <memory>
+#include <numeric>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace ml {
+namespace maths {
+namespace time_series {
+namespace {
+
+common::CFloatStorage minWeight(double weight) {
+    return weight;
+}
+template<std::size_t N>
+common::CFloatStorage minWeight(const core::CSmallVector<double, N>& weight) {
+    return *std::min_element(weight.begin(), weight.end());
+}
+
+template<typename U, typename V>
+V conformable(const U& /*x*/, V value) {
+    return value;
+}
+template<typename U, typename V>
+common::CVector<V> conformable(const common::CVector<U>& x, V value) {
+    return common::CVector<V>(x.dimension(), value);
+}
+
+const std::string CAPACITY_TAG{"a"};
+const std::string SLIDING_WINDOW_TAG{"b"};
+const std::string VALUE_AND_WEIGHT_TAG{"c"};
+}
+
+template<typename T, typename STORAGE>
+class CTimeSeriesMultibucketMeanImpl {
+public:
+    using TDoubleDoublePr = std::pair<double, double>;
+    using Type = T;
+    using TFeature = CTimeSeriesMultibucketFeature<T>;
+    using TType1Vec = typename TFeature::TType1Vec;
+    using TWeightsAry1Vec = typename TFeature::TWeightsAry1Vec;
+    using TType1VecTWeightAry1VecPr = typename TFeature::TType1VecTWeightAry1VecPr;
+    using TFloatMeanAccumulator =
+        typename common::CBasicStatistics::SSampleMean<STORAGE>::TAccumulator;
+    using TValueFunc = std::function<STORAGE(const TFloatMeanAccumulator&)>;
+    using TWeightFunc = std::function<double(const TFloatMeanAccumulator&)>;
+
+public:
+    explicit CTimeSeriesMultibucketMeanImpl(std::size_t length = 0)
+        : m_SlidingWindow(length) {}
+
+    const TType1VecTWeightAry1VecPr& value() const { return m_ValueAndWeight; }
+
+    double correlationWithBucketValue() const {
+        // This follows from the weighting applied to values in the window and
+        // linearity of expectation.
+        double r{WINDOW_GEOMETRIC_WEIGHT * WINDOW_GEOMETRIC_WEIGHT};
+        double length{static_cast<double>(m_SlidingWindow.size())};
+        return length == 0.0 ? 0.0 : std::sqrt((1.0 - r) / (1.0 - std::pow(r, length)));
+    }
+
+    void clear() {
+        m_SlidingWindow.clear();
+        m_ValueAndWeight = TType1VecTWeightAry1VecPr{};
+    }
+
+    void add(core_t::TTime time,
+             core_t::TTime bucketLength,
+             const TType1Vec& values,
+             const TWeightsAry1Vec& weights) {
+
+        // Remove any old samples.
+        core_t::TTime cutoff{time - this->windowInterval(bucketLength)};
+        while (m_SlidingWindow.size() > 0 && m_SlidingWindow.front().first < cutoff) {
+            m_SlidingWindow.pop_front();
+        }
+
+        if (values.size() > 0) {
+            using TStorage1Vec = core::CSmallVector<STORAGE, 1>;
+
+            // Get the scales to apply to each value.
+            TStorage1Vec scales;
+            scales.reserve(weights.size());
+            for (const auto& weight : weights) {
+                using std::sqrt;
+                scales.push_back(sqrt(STORAGE{maths_t::countVarianceScale(weight)} *
+                                      STORAGE{maths_t::seasonalVarianceScale(weight)}));
+            }
+
+            // Add the next sample.
+            TFloatMeanAccumulator next{conformable(STORAGE(values[0]), 0.0F)};
+            for (std::size_t i = 0; i < values.size(); ++i) {
+                auto weight = maths_t::countForUpdate(weights[i]);
+                next.add(STORAGE(values[i]) / scales[i], minWeight(weight));
+            }
+            m_SlidingWindow.push_back({time, next});
+        }
+
+        if (this->sufficientData()) {
+            m_ValueAndWeight.first.assign({this->windowValue()});
+            m_ValueAndWeight.second.assign({maths_t::countWeight(this->windowCount())});
+        } else {
+            m_ValueAndWeight = TType1VecTWeightAry1VecPr{};
+        }
+    }
+
+    std::uint64_t checksum(std::uint64_t seed = 0) const {
+        seed = common::CChecksum::calculate(seed, m_SlidingWindow.capacity());
+        seed = common::CChecksum::calculate(seed, m_SlidingWindow);
+        return common::CChecksum::calculate(seed, m_ValueAndWeight);
+    }
+
+    void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
+        core::CMemoryDebug::dynamicSize("m_SlidingWindow", m_SlidingWindow, mem);
+        core::CMemoryDebug::dynamicSize("m_ValueAndWeight", m_ValueAndWeight, mem);
+    }
+
+    std::size_t memoryUsage() const {
+        return core::CMemory::dynamicSize(m_SlidingWindow) +
+               core::CMemory::dynamicSize(m_ValueAndWeight);
+    }
+
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
+        do {
+            const std::string& name{traverser.name()};
+            RESTORE_SETUP_TEARDOWN(CAPACITY_TAG, std::size_t capacity,
+                                   core::CStringUtils::stringToType(traverser.value(), capacity),
+                                   m_SlidingWindow.set_capacity(capacity))
+            RESTORE(SLIDING_WINDOW_TAG,
+                    core::CPersistUtils::restore(SLIDING_WINDOW_TAG, m_SlidingWindow, traverser))
+            RESTORE(VALUE_AND_WEIGHT_TAG,
+                    core::CPersistUtils::restore(VALUE_AND_WEIGHT_TAG, m_ValueAndWeight, traverser))
+        } while (traverser.next());
+        return true;
+    }
+
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+        inserter.insertValue(CAPACITY_TAG, m_SlidingWindow.capacity());
+        core::CPersistUtils::persist(SLIDING_WINDOW_TAG, m_SlidingWindow, inserter);
+        core::CPersistUtils::persist(VALUE_AND_WEIGHT_TAG, m_ValueAndWeight, inserter);
+    }
+
+private:
+    using TDoubleMeanAccumulator = typename common::SPromoted<TFloatMeanAccumulator>::Type;
+    using TTimeFloatMeanAccumulatorPr = std::pair<core_t::TTime, TFloatMeanAccumulator>;
+    using TTimeFloatMeanAccumulatorPrCBuf = boost::circular_buffer<TTimeFloatMeanAccumulatorPr>;
+
+private:
+    //! The geometric weight applied to the window.
+    constexpr static const double WINDOW_GEOMETRIC_WEIGHT{0.9};
+
+private:
+    bool sufficientData() const {
+        return 4 * m_SlidingWindow.size() >= 3 * m_SlidingWindow.capacity();
+    }
+
+    //! Get the length of the window given \p bucketLength.
+    core_t::TTime windowInterval(core_t::TTime bucketLength) const {
+        return static_cast<core_t::TTime>(m_SlidingWindow.capacity()) * bucketLength;
+    }
+
+    //! Compute the window value using \p value to extract individual values.
+    Type windowValue() const {
+        auto valueFunc = [&](const TFloatMeanAccumulator& x) {
+            return common::CBasicStatistics::mean(x);
+        };
+        auto weightFunc = [](const TFloatMeanAccumulator& x) {
+            return static_cast<double>(common::CBasicStatistics::count(x));
+        };
+        return this->evaluateOnWindow(valueFunc, weightFunc);
+    }
+
+    //! Compute the window count.
+    Type windowCount() const {
+        auto countFunc = [&](const TFloatMeanAccumulator& x) {
+            return conformable(common::CBasicStatistics::mean(x),
+                               common::CBasicStatistics::count(x));
+        };
+        auto weightFunc = [](const TFloatMeanAccumulator&) { return 1.0; };
+        return this->evaluateOnWindow(countFunc, weightFunc);
+    }
+
+    //! Compute the weighted mean of \p value on the sliding window.
+    Type evaluateOnWindow(const TValueFunc& valueFunc, const TWeightFunc& weightFunc) const {
+        double latest;
+        double earliest;
+        std::tie(earliest, latest) = this->windowTimeRange();
+        double n{static_cast<double>(m_SlidingWindow.size())};
+        double scale{(n - 1.0) * (latest == earliest ? 1.0 : 1.0 / (latest - earliest))};
+        auto i = m_SlidingWindow.begin();
+        TDoubleMeanAccumulator mean{conformable(valueFunc(i->second), 0.0)};
+        for (double last{earliest}; i != m_SlidingWindow.end(); ++i) {
+            double dt{static_cast<double>(i->first) - last};
+            last = static_cast<double>(i->first);
+            mean.age(std::pow(WINDOW_GEOMETRIC_WEIGHT, scale * dt));
+            mean.add(valueFunc(i->second), weightFunc(i->second));
+        }
+        return this->toVector(common::CBasicStatistics::mean(mean));
+    }
+
+    //! Compute the time range of window.
+    TDoubleDoublePr windowTimeRange() const {
+        auto range =
+            std::accumulate(m_SlidingWindow.begin(), m_SlidingWindow.end(),
+                            common::CBasicStatistics::CMinMax<double>(),
+                            [](common::CBasicStatistics::CMinMax<double> partial,
+                               const TTimeFloatMeanAccumulatorPr& value) {
+                                partial.add(static_cast<double>(value.first));
+                                return partial;
+                            });
+        return {range.min(), range.max()};
+    }
+
+    template<typename U>
+    static double toVector(const U& x) {
+        return x;
+    }
+    template<typename U>
+    static T toVector(const common::CVector<U>& x) {
+        return x.template toVector<T>();
+    }
+
+private:
+    TTimeFloatMeanAccumulatorPrCBuf m_SlidingWindow;
+    TType1VecTWeightAry1VecPr m_ValueAndWeight;
+};
+
+CTimeSeriesMultibucketScalarMean::CTimeSeriesMultibucketScalarMean(std::size_t length)
+    : m_Impl{std::make_unique<TImpl>(length)} {
+}
+
+CTimeSeriesMultibucketScalarMean::CTimeSeriesMultibucketScalarMean(const CTimeSeriesMultibucketScalarMean& other)
+    : m_Impl{std::make_unique<TImpl>(*other.m_Impl)} {
+}
+
+CTimeSeriesMultibucketScalarMean::~CTimeSeriesMultibucketScalarMean() = default;
+CTimeSeriesMultibucketScalarMean::CTimeSeriesMultibucketScalarMean(
+    CTimeSeriesMultibucketScalarMean&&) noexcept = default;
+
+CTimeSeriesMultibucketScalarMean& CTimeSeriesMultibucketScalarMean::
+operator=(CTimeSeriesMultibucketScalarMean&&) noexcept = default;
+CTimeSeriesMultibucketScalarMean& CTimeSeriesMultibucketScalarMean::
+operator=(const CTimeSeriesMultibucketScalarMean& other) {
+    if (this != &other) {
+        CTimeSeriesMultibucketScalarMean tmp{*this};
+        *this = std::move(tmp);
+    }
+    return *this;
+}
+
+CTimeSeriesMultibucketScalarMean::TPtr CTimeSeriesMultibucketScalarMean::clone() const {
+    return std::make_unique<CTimeSeriesMultibucketScalarMean>(*this);
+}
+
+const CTimeSeriesMultibucketScalarMean::TType1VecTWeightAry1VecPr&
+CTimeSeriesMultibucketScalarMean::value() const {
+    return m_Impl->value();
+}
+
+double CTimeSeriesMultibucketScalarMean::correlationWithBucketValue() const {
+    return m_Impl->correlationWithBucketValue();
+}
+
+void CTimeSeriesMultibucketScalarMean::clear() {
+    m_Impl->clear();
+}
+
+void CTimeSeriesMultibucketScalarMean::add(core_t::TTime time,
+                                           core_t::TTime bucketLength,
+                                           const TType1Vec& values,
+                                           const TWeightsAry1Vec& weights) {
+    m_Impl->add(time, bucketLength, values, weights);
+}
+
+std::uint64_t CTimeSeriesMultibucketScalarMean::checksum(std::uint64_t seed) const {
+    return m_Impl->checksum(seed);
+}
+
+void CTimeSeriesMultibucketScalarMean::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
+    mem->setName("CTimeSeriesMultibucketScalarMean");
+    core::CMemoryDebug::dynamicSize("m_Impl", m_Impl, mem);
+}
+
+std::size_t CTimeSeriesMultibucketScalarMean::staticSize() const {
+    return sizeof(*this);
+}
+
+std::size_t CTimeSeriesMultibucketScalarMean::memoryUsage() const {
+    return core::CMemory::dynamicSize(m_Impl);
+}
+
+bool CTimeSeriesMultibucketScalarMean::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
+    return m_Impl->acceptRestoreTraverser(traverser);
+}
+
+void CTimeSeriesMultibucketScalarMean::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+    m_Impl->acceptPersistInserter(inserter);
+}
+
+CTimeSeriesMultibucketVectorMean::CTimeSeriesMultibucketVectorMean(std::size_t length)
+    : m_Impl{std::make_unique<TImpl>(length)} {
+}
+
+CTimeSeriesMultibucketVectorMean::CTimeSeriesMultibucketVectorMean(const CTimeSeriesMultibucketVectorMean& other)
+    : m_Impl{std::make_unique<TImpl>(*other.m_Impl)} {
+}
+
+CTimeSeriesMultibucketVectorMean::~CTimeSeriesMultibucketVectorMean() = default;
+CTimeSeriesMultibucketVectorMean::CTimeSeriesMultibucketVectorMean(
+    CTimeSeriesMultibucketVectorMean&&) noexcept = default;
+
+CTimeSeriesMultibucketVectorMean& CTimeSeriesMultibucketVectorMean::
+operator=(CTimeSeriesMultibucketVectorMean&&) noexcept = default;
+CTimeSeriesMultibucketVectorMean& CTimeSeriesMultibucketVectorMean::
+operator=(const CTimeSeriesMultibucketVectorMean& other) {
+    if (this != &other) {
+        CTimeSeriesMultibucketVectorMean tmp{*this};
+        *this = std::move(tmp);
+    }
+    return *this;
+}
+
+CTimeSeriesMultibucketVectorMean::TPtr CTimeSeriesMultibucketVectorMean::clone() const {
+    return std::make_unique<CTimeSeriesMultibucketVectorMean>(*this);
+}
+
+const CTimeSeriesMultibucketVectorMean::TType1VecTWeightAry1VecPr&
+CTimeSeriesMultibucketVectorMean::value() const {
+    return m_Impl->value();
+}
+
+double CTimeSeriesMultibucketVectorMean::correlationWithBucketValue() const {
+    return m_Impl->correlationWithBucketValue();
+}
+
+void CTimeSeriesMultibucketVectorMean::clear() {
+    m_Impl->clear();
+}
+
+void CTimeSeriesMultibucketVectorMean::add(core_t::TTime time,
+                                           core_t::TTime bucketLength,
+                                           const TType1Vec& values,
+                                           const TWeightsAry1Vec& weights) {
+    m_Impl->add(time, bucketLength, values, weights);
+}
+
+std::uint64_t CTimeSeriesMultibucketVectorMean::checksum(std::uint64_t seed) const {
+    return m_Impl->checksum(seed);
+}
+
+void CTimeSeriesMultibucketVectorMean::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
+    mem->setName("CTimeSeriesMultibucketVectorMean");
+    core::CMemoryDebug::dynamicSize("m_Impl", m_Impl, mem);
+}
+
+std::size_t CTimeSeriesMultibucketVectorMean::staticSize() const {
+    return sizeof(*this);
+}
+
+std::size_t CTimeSeriesMultibucketVectorMean::memoryUsage() const {
+    return core::CMemory::dynamicSize(m_Impl);
+}
+
+bool CTimeSeriesMultibucketVectorMean::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
+    return m_Impl->acceptRestoreTraverser(traverser);
+}
+
+void CTimeSeriesMultibucketVectorMean::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
+    m_Impl->acceptPersistInserter(inserter);
+}
+}
+}
+}

--- a/lib/maths/time_series/CTimeSeriesTestForSeasonality.cc
+++ b/lib/maths/time_series/CTimeSeriesTestForSeasonality.cc
@@ -113,6 +113,10 @@ std::size_t CNewSeasonalComponentSummary::size() const {
     return m_Size;
 }
 
+bool CNewSeasonalComponentSummary::isOneOf(int periods) const {
+    return (m_PeriodDescriptor & periods) != 0;
+}
+
 CNewSeasonalComponentSummary::TSeasonalTimeUPtr
 CNewSeasonalComponentSummary::seasonalTime() const {
     auto interval = [this](std::size_t i) {
@@ -172,6 +176,10 @@ core_t::TTime CNewSeasonalComponentSummary::initialValuesStartTime() const {
 core_t::TTime CNewSeasonalComponentSummary::initialValuesEndTime() const {
     return m_InitialValuesStartTime +
            static_cast<core_t::TTime>(m_InitialValues.size()) * m_BucketLength;
+}
+
+core_t::TTime CNewSeasonalComponentSummary::bucketLength() const {
+    return m_BucketLength;
 }
 
 const CNewSeasonalComponentSummary::TFloatMeanAccumulatorVec&
@@ -280,7 +288,7 @@ bool CTimeSeriesTestForSeasonality::canTestModelledComponent(
     const CSeasonalTime& component) {
     std::size_t minimumPeriodInBuckets{
         std::max(buckets(bucketLength, minimumPeriod), minimumResolution)};
-    return 10 * (component.period() % bucketLength) < component.period() &&
+    return 100 * (component.period() % bucketLength) < component.period() &&
            canTestPeriod(values, minimumPeriodInBuckets,
                          toPeriod(bucketsStartTime, bucketLength, component));
 }

--- a/lib/maths/time_series/Makefile
+++ b/lib/maths/time_series/Makefile
@@ -40,6 +40,7 @@ CTimeSeriesDecompositionDetail.cc \
 CTimeSeriesDecompositionStateSerialiser.cc \
 CTimeSeriesDecompositionStub.cc \
 CTimeSeriesModel.cc \
+CTimeSeriesMultibucketFeatures.cc \
 CTimeSeriesMultibucketFeatureSerialiser.cc \
 CTimeSeriesSegmentation.cc \
 CTimeSeriesTestForChange.cc \

--- a/lib/maths/time_series/unittest/CForecastTest.cc
+++ b/lib/maths/time_series/unittest/CForecastTest.cc
@@ -128,7 +128,8 @@ maths::common::CModelParams params(core_t::TTime bucketLength) {
                                        DECAY_RATE,
                                        minimumSeasonalVarianceScale,
                                        6 * core::constants::HOUR,
-                                       core::constants::DAY};
+                                       core::constants::DAY,
+                                       15 * core::constants::MINUTE};
 }
 
 maths::time_series::CUnivariateTimeSeriesModel::TDecayRateController2Ary decayRateControllers() {
@@ -331,8 +332,8 @@ BOOST_AUTO_TEST_CASE(testDailyVaryingLongTermTrend) {
     test.bucketLength(bucketLength)
         .daysToLearn(98)
         .noiseVariance(9.0)
-        .maximumPercentageOutOfBounds(5.0)
-        .maximumError(0.04)
+        .maximumPercentageOutOfBounds(5.5)
+        .maximumError(0.045)
         .run(trend);
 }
 

--- a/lib/maths/time_series/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/time_series/unittest/CTimeSeriesDecompositionTest.cc
@@ -70,7 +70,8 @@ public:
     static const bool ENABLED{false};
 
 public:
-    CDebugGenerator(const std::string& file = "results.py") : m_File(file) {}
+    explicit CDebugGenerator(std::string file = "results.py")
+        : m_File{std::move(file)} {}
 
     ~CDebugGenerator() {
         if (ENABLED) {
@@ -1068,7 +1069,8 @@ BOOST_FIXTURE_TEST_CASE(testSpikeyDataProblemCase, CTestFixture) {
         double value = timeseries[i].second;
         double variance = model.marginalLikelihoodVariance();
 
-        double lb, ub;
+        double lb;
+        double ub;
         maths_t::ETail tail;
         model.probabilityOfLessLikelySamples(
             maths_t::E_TwoSided, {decomposition.detrend(time, value, 0.0)},
@@ -1594,21 +1596,23 @@ BOOST_FIXTURE_TEST_CASE(testLongTermTrendAndPeriodicity, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testNonDiurnal, CTestFixture) {
+
     // Test the accuracy of the modeling of some non-daily or weekly
     // seasonal components.
+
     test::CRandomNumbers rng;
 
     LOG_DEBUG(<< "Hourly");
     for (auto pad : {0 * DAY, 28 * DAY}) {
 
-        double periodic[]{10.0, 1.0, 0.5, 0.5, 1.0, 5.0,
-                          2.0,  1.0, 0.5, 0.5, 1.0, 6.0};
+        TDoubleVec periodicPattern{10.0, 1.0, 0.5, 0.5, 1.0, 5.0,
+                                   2.0,  1.0, 0.5, 0.5, 1.0, 6.0};
 
-        TDoubleVec trend{TDoubleVec(pad / FIVE_MINS, 0.0)};
+        TDoubleVec trend(pad / FIVE_MINS, 0.0);
         TTimeVec times;
         for (core_t::TTime time = 0; time < pad + 21 * DAY; time += FIVE_MINS) {
             times.push_back(time);
-            trend.push_back(periodic[(time / FIVE_MINS) % 12]);
+            trend.push_back(periodicPattern[(time / FIVE_MINS) % 12]);
         }
 
         TDoubleVec noise;
@@ -1619,11 +1623,11 @@ BOOST_FIXTURE_TEST_CASE(testNonDiurnal, CTestFixture) {
         maths::time_series::CTimeSeriesDecomposition decomposition(0.01, FIVE_MINS);
         CDebugGenerator debug("hourly." + core::CStringUtils::typeToString(pad) + ".py");
 
-        double totalSumResidual = 0.0;
-        double totalMaxResidual = 0.0;
-        double totalSumValue = 0.0;
-        double totalMaxValue = 0.0;
-        core_t::TTime lastHour = times[0] + 3 * DAY;
+        double totalSumResidual{0.0};
+        double totalMaxResidual{0.0};
+        double totalSumValue{0.0};
+        double totalMaxValue{0.0};
+        core_t::TTime lastHour{times[0] + 3 * DAY};
 
         for (std::size_t i = 0; i < times.size(); ++i) {
             decomposition.addPoint(times[i], trend[i] + noise[i]);
@@ -1633,19 +1637,19 @@ BOOST_FIXTURE_TEST_CASE(testNonDiurnal, CTestFixture) {
                 LOG_TRACE(<< "Processing hour " << times[i] / HOUR);
 
                 if (times[i] > startTesting) {
-                    double sumResidual = 0.0;
-                    double maxResidual = 0.0;
-                    double sumValue = 0.0;
-                    double maxValue = 0.0;
+                    double sumResidual{0.0};
+                    double maxResidual{0.0};
+                    double sumValue{0.0};
+                    double maxValue{0.0};
 
                     for (std::size_t j = i - 12; j < i; ++j) {
-                        TDoubleDoublePr prediction = decomposition.value(times[j], 70.0);
-                        double residual = std::fabs(trend[j] - mean(prediction));
+                        double prediction{mean(decomposition.value(times[j], 70.0))};
+                        double residual{std::fabs(trend[j] - prediction)};
                         sumResidual += residual;
                         maxResidual = std::max(maxResidual, residual);
                         sumValue += std::fabs(trend[j]);
                         maxValue = std::max(maxValue, std::fabs(trend[j]));
-                        debug.addPrediction(times[j], mean(prediction), residual);
+                        debug.addPrediction(times[j], prediction, residual);
                     }
 
                     LOG_TRACE(<< "'sum residual' / 'sum value' = "
@@ -1658,8 +1662,8 @@ BOOST_FIXTURE_TEST_CASE(testNonDiurnal, CTestFixture) {
                     totalSumValue += sumValue;
                     totalMaxValue += maxValue;
 
-                    BOOST_TEST_REQUIRE(sumResidual / sumValue < 0.58);
-                    BOOST_TEST_REQUIRE(maxResidual / maxValue < 0.58);
+                    BOOST_TEST_REQUIRE(sumResidual / sumValue < 0.60);
+                    BOOST_TEST_REQUIRE(maxResidual / maxValue < 0.60);
                 }
                 lastHour += HOUR;
             }
@@ -1676,14 +1680,14 @@ BOOST_FIXTURE_TEST_CASE(testNonDiurnal, CTestFixture) {
     {
         const core_t::TTime length = 20 * DAY;
 
-        double periodic[]{10.0, 8.0, 5.5, 2.5, 2.0, 5.0,
-                          2.0,  1.0, 1.5, 3.5, 4.0, 7.0};
+        TDoubleVec periodicPattern{10.0, 8.0, 5.5, 2.5, 2.0, 5.0,
+                                   2.0,  1.0, 1.5, 3.5, 4.0, 7.0};
 
         TTimeVec times;
         TDoubleVec trend;
         for (core_t::TTime time = 0; time < length; time += TEN_MINS) {
             times.push_back(time);
-            trend.push_back(periodic[(time / 4 / HOUR) % 12]);
+            trend.push_back(periodicPattern[(time / 4 / HOUR) % 12]);
         }
 
         TDoubleVec noise;
@@ -1693,11 +1697,11 @@ BOOST_FIXTURE_TEST_CASE(testNonDiurnal, CTestFixture) {
         maths::time_series::CTimeSeriesDecomposition decomposition(0.01, TEN_MINS);
         CDebugGenerator debug("two_day.py");
 
-        double totalSumResidual = 0.0;
-        double totalMaxResidual = 0.0;
-        double totalSumValue = 0.0;
-        double totalMaxValue = 0.0;
-        core_t::TTime lastTwoDay = times[0] + 3 * DAY;
+        double totalSumResidual{0.0};
+        double totalMaxResidual{0.0};
+        double totalSumValue{0.0};
+        double totalMaxValue{0.0};
+        core_t::TTime lastTwoDay{times[0] + 3 * DAY};
 
         for (std::size_t i = 0; i < times.size(); ++i) {
             decomposition.addPoint(times[i], trend[i] + noise[i]);
@@ -1707,19 +1711,19 @@ BOOST_FIXTURE_TEST_CASE(testNonDiurnal, CTestFixture) {
                 LOG_TRACE(<< "Processing two days " << times[i] / 2 * DAY);
 
                 if (times[i] > startTesting) {
-                    double sumResidual = 0.0;
-                    double maxResidual = 0.0;
-                    double sumValue = 0.0;
-                    double maxValue = 0.0;
+                    double sumResidual{0.0};
+                    double maxResidual{0.0};
+                    double sumValue{0.0};
+                    double maxValue{0.0};
 
                     for (std::size_t j = i - 288; j < i; ++j) {
-                        TDoubleDoublePr prediction = decomposition.value(times[j], 70.0);
-                        double residual = std::fabs(trend[j] - mean(prediction));
+                        double prediction{mean(decomposition.value(times[j], 70.0))};
+                        double residual{std::fabs(trend[j] - prediction)};
                         sumResidual += residual;
                         maxResidual = std::max(maxResidual, residual);
                         sumValue += std::fabs(trend[j]);
                         maxValue = std::max(maxValue, std::fabs(trend[j]));
-                        debug.addPrediction(times[j], mean(prediction), residual);
+                        debug.addPrediction(times[j], prediction, residual);
                     }
 
                     LOG_TRACE(<< "'sum residual' / 'sum value' = "
@@ -1745,6 +1749,119 @@ BOOST_FIXTURE_TEST_CASE(testNonDiurnal, CTestFixture) {
         BOOST_TEST_REQUIRE(totalSumResidual / totalSumValue < 0.09);
         BOOST_TEST_REQUIRE(totalMaxResidual / totalMaxValue < 0.20);
     }
+}
+
+BOOST_FIXTURE_TEST_CASE(testPrecession, CTestFixture) {
+
+    // Test the case the period is not a multiple of the bucket length.
+
+    test::CRandomNumbers rng;
+
+    TDoubleVec noise{0.0};
+    TDoubleVec delta{0.0};
+    double period{3600.0};
+
+    for (std::size_t t = 0; t < 5; ++t) {
+        rng.generateUniformSamples(0, 120, 1, delta);
+        delta[0] = std::floor(delta[0]);
+        LOG_DEBUG(<< "period = " << 3600.0 + delta[0]);
+
+        maths::time_series::CTimeSeriesDecomposition decomposition(0.048, FIVE_MINS);
+        CDebugGenerator debug{"period_" + std::to_string(period + delta[0]) + ".py"};
+
+        double sumResidual{0.0};
+        double maxResidual{0.0};
+        double sumValue{0.0};
+        double maxValue{0.0};
+
+        for (core_t::TTime time = 0; time < WEEK; time += FIVE_MINS) {
+            double trend{2.0 + std::sin(boost::math::double_constants::two_pi *
+                                        static_cast<double>(time) /
+                                        static_cast<double>(period + delta[0]))};
+            rng.generateNormalSamples(0.0, 0.1, 1, noise);
+            decomposition.addPoint(time, trend + noise[0]);
+            if (decomposition.initialized()) {
+                double prediction{mean(decomposition.value(time, 0.0))};
+                double residual{decomposition.detrend(time, trend, 0.0, FIVE_MINS)};
+                sumResidual += std::fabs(residual);
+                maxResidual = std::max(maxResidual, std::fabs(residual));
+                sumValue += std::fabs(trend);
+                maxValue = std::max(maxValue, std::fabs(trend));
+                debug.addValue(time, trend);
+                debug.addPrediction(time, prediction, trend - prediction);
+            }
+        }
+
+        LOG_DEBUG(<< "'sum residual' / 'sum value' = " << sumResidual / sumValue);
+        LOG_DEBUG(<< "'max residual' / 'max value' = " << maxResidual / maxValue);
+        BOOST_TEST_REQUIRE(sumResidual / sumValue < 0.01);
+        BOOST_TEST_REQUIRE(maxResidual / maxValue < 0.15);
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(testRandomShifts, CTestFixture) {
+
+    // Test small sporadic random time shifts.
+
+    test::CRandomNumbers rng;
+
+    TDoubleVec noise{0.0};
+    double period{3600.0};
+
+    double shift{0.0};
+    TDoubleVec u01{0.0};
+
+    auto trend = [&] {
+        auto period_ = static_cast<core_t::TTime>(period);
+        TDoubleVec periodicPattern{10.0, 1.0, 0.5, 0.5, 1.0, 1.0,
+                                   2.0,  1.0, 0.5, 0.5, 1.0, 6.0};
+        return [periodicPattern, period_, &shift](core_t::TTime time) {
+            auto offset = (time + static_cast<core_t::TTime>(shift)) % period_;
+            auto i = (12 * offset) / period_;
+            auto j = (i + 1) % 12;
+
+            return maths::common::CTools::linearlyInterpolate(
+                0.0, 1.0, periodicPattern[i], periodicPattern[j],
+                static_cast<double>(offset % (period_ / 12)));
+        };
+    }();
+
+    maths::time_series::CTimeSeriesDecomposition decomposition(0.048, FIVE_MINS);
+    CDebugGenerator debug{"shifting.py"};
+
+    double sumResidual{0.0};
+    double maxResidual{0.0};
+    double sumValue{0.0};
+    double maxValue{0.0};
+
+    for (core_t::TTime time = 0; time < 3 * WEEK; time += FIVE_MINS) {
+        rng.generateNormalSamples(0.0, 0.1, 1, noise);
+
+        decomposition.addPoint(time, trend(time) + noise[0]);
+        if (decomposition.initialized()) {
+            double prediction{mean(decomposition.value(time, 0.0))};
+            double residual{decomposition.detrend(time, trend(time), 0.0, FIVE_MINS)};
+            sumResidual += residual;
+            maxResidual = std::max(maxResidual, std::fabs(residual));
+            sumValue += std::fabs(trend(time));
+            maxValue = std::max(maxValue, std::fabs(trend(time)));
+            debug.addValue(time, trend(time));
+            debug.addPrediction(time, prediction, trend(time) - prediction);
+        }
+
+        rng.generateUniformSamples(0.0, 1.0, 1, u01);
+        if (u01[0] < 0.001) {
+            TDoubleVec shift_;
+            rng.generateUniformSamples(0, static_cast<double>(FIVE_MINS), 1, shift_);
+            shift += std::floor(shift_[0] + 0.5);
+        }
+    }
+
+    LOG_DEBUG(<< "'sum residual' / 'sum value' = " << sumResidual / sumValue);
+    LOG_DEBUG(<< "'max residual' / 'max value' = " << maxResidual / maxValue);
+
+    BOOST_TEST_REQUIRE(sumResidual / sumValue < 0.025);
+    BOOST_TEST_REQUIRE(maxResidual / maxValue < 0.4);
 }
 
 BOOST_FIXTURE_TEST_CASE(testYearly, CTestFixture) {
@@ -2026,7 +2143,7 @@ BOOST_FIXTURE_TEST_CASE(testComponentLifecycle, CTestFixture) {
         debug.addPrediction(time, prediction, trend(time) + noise[0] - prediction);
     }
 
-    TDoubleVec bounds{0.01, 0.013, 0.22, 0.02};
+    TDoubleVec bounds{0.013, 0.013, 0.25, 0.02};
     for (std::size_t i = 0; i < 4; ++i) {
         double error{maths::common::CBasicStatistics::mean(errors[i])};
         LOG_DEBUG(<< "error = " << error);
@@ -2163,15 +2280,15 @@ BOOST_FIXTURE_TEST_CASE(testFastAndSlowSeasonality, CTestFixture) {
 
         double prediction{mean(decomposition.value(time, 0.0))};
         debug.addPrediction(time, prediction, trend(time) + noise[0] - prediction);
-
         if (time > 4 * DAY) {
-            double error{(std::fabs(trend(time) - prediction)) / trend(time)};
-            BOOST_TEST_REQUIRE(error < 0.75);
+            double error{(std::fabs(decomposition.detrend(time, trend(time), 0.0, FIVE_MINS))) /
+                         std::fabs(trend(time))};
+            BOOST_TEST_REQUIRE(error < 0.25);
             meanError.add(error);
         }
     }
 
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.06);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.01);
 
     // We should be modelling both seasonalities.
     BOOST_TEST_REQUIRE(2, decomposition.seasonalComponents().size());

--- a/lib/model/CAnomalyDetectorModelConfig.cc
+++ b/lib/model/CAnomalyDetectorModelConfig.cc
@@ -78,6 +78,8 @@ const core_t::TTime
     CAnomalyDetectorModelConfig::DEFAULT_MINIMUM_TIME_TO_DETECT_CHANGE(core::constants::DAY);
 const core_t::TTime
     CAnomalyDetectorModelConfig::DEFAULT_MAXIMUM_TIME_TO_TEST_FOR_CHANGE(2 * core::constants::DAY);
+const core_t::TTime
+    CAnomalyDetectorModelConfig::DEFAULT_MAXIMUM_SEASONAL_JITTER(15 * core::constants::MINUTE);
 const std::size_t CAnomalyDetectorModelConfig::MULTIBUCKET_FEATURES_WINDOW_LENGTH(12);
 const double CAnomalyDetectorModelConfig::MAXIMUM_MULTI_BUCKET_IMPACT_MAGNITUDE(5.0);
 const double CAnomalyDetectorModelConfig::DEFAULT_MAXIMUM_UPDATES_PER_BUCKET(1.0);

--- a/lib/model/CForecastModelPersist.cc
+++ b/lib/model/CForecastModelPersist.cc
@@ -128,7 +128,8 @@ bool CForecastModelPersist::CRestore::nextModel(TMathsModelPtr& model,
                     m_ModelParams.s_DecayRate,
                     m_MinimumSeasonalVarianceScale,
                     m_ModelParams.s_MinimumTimeToDetectChange,
-                    m_ModelParams.s_MaximumTimeToTestForChange};
+                    m_ModelParams.s_MaximumTimeToTestForChange,
+                    m_ModelParams.s_MaximumSeasonalJitter};
 
                 maths::common::SModelRestoreParams params{
                     modelParams,

--- a/lib/model/CModelFactory.cc
+++ b/lib/model/CModelFactory.cc
@@ -85,7 +85,8 @@ CModelFactory::defaultFeatureModel(model_t::EFeature feature,
                                        m_ModelParams.s_DecayRate,
                                        minimumSeasonalVarianceScale,
                                        m_ModelParams.s_MinimumTimeToDetectChange,
-                                       m_ModelParams.s_MaximumTimeToTestForChange};
+                                       m_ModelParams.s_MaximumTimeToTestForChange,
+                                       m_ModelParams.s_MaximumSeasonalJitter};
 
     std::size_t dimension{model_t::dimension(feature)};
 

--- a/lib/model/ModelTypes.cc
+++ b/lib/model/ModelTypes.cc
@@ -1195,8 +1195,7 @@ univariateMultibucketFeature(model_t::EFeature feature, std::size_t windowLength
         case E_IndividualInfoContentByBucketAndPerson:
         case E_IndividualLowInfoContentByBucketAndPerson:
         case E_IndividualHighInfoContentByBucketAndPerson:
-            return std::make_unique<maths::time_series::CTimeSeriesMultibucketMean<double>>(
-                windowLength);
+            return std::make_unique<maths::time_series::CTimeSeriesMultibucketScalarMean>(windowLength);
         case E_IndividualTotalBucketCountByPerson:
         case E_IndividualIndicatorOfBucketPerson:
         case E_IndividualTimeOfDayByBucketAndPerson:
@@ -1224,8 +1223,7 @@ univariateMultibucketFeature(model_t::EFeature feature, std::size_t windowLength
         case E_IndividualMinVelocityByPerson:
         case E_IndividualMaxByPerson:
         case E_IndividualMaxVelocityByPerson:
-            return std::make_unique<maths::time_series::CTimeSeriesMultibucketMean<double>>(
-                windowLength);
+            return std::make_unique<maths::time_series::CTimeSeriesMultibucketScalarMean>(windowLength);
         case E_IndividualMeanLatLongByPerson:
             break;
 

--- a/lib/model/SModelParams.cc
+++ b/lib/model/SModelParams.cc
@@ -38,6 +38,7 @@ SModelParams::SModelParams(core_t::TTime bucketLength)
       s_ComponentSize(CAnomalyDetectorModelConfig::DEFAULT_COMPONENT_SIZE),
       s_MinimumTimeToDetectChange(CAnomalyDetectorModelConfig::DEFAULT_MINIMUM_TIME_TO_DETECT_CHANGE),
       s_MaximumTimeToTestForChange(CAnomalyDetectorModelConfig::DEFAULT_MAXIMUM_TIME_TO_TEST_FOR_CHANGE),
+      s_MaximumSeasonalJitter(CAnomalyDetectorModelConfig::DEFAULT_MAXIMUM_SEASONAL_JITTER),
       s_MultibucketFeaturesWindowLength(CAnomalyDetectorModelConfig::MULTIBUCKET_FEATURES_WINDOW_LENGTH),
       s_MultivariateByFields(false),
       s_CorrelationModelsOverhead(CAnomalyDetectorModelConfig::DEFAULT_CORRELATION_MODELS_OVERHEAD),

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -853,14 +853,15 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatedTrend, CTestFixture) {
     TMinAccumulatorVec probabilities{TMinAccumulator{4}, TMinAccumulator{4},
                                      TMinAccumulator{4}, TMinAccumulator{4}};
 
-    SModelParams params(bucketLength);
+    SModelParams params{bucketLength};
     params.s_DecayRate = 0.0002;
     params.s_LearnRate = 1.0;
     params.s_MinimumModeFraction = CAnomalyDetectorModelConfig::DEFAULT_INDIVIDUAL_MINIMUM_MODE_FRACTION;
     params.s_MinimumModeCount = 24.0;
     params.s_MultivariateByFields = true;
+    params.s_MaximumSeasonalJitter = 0;
     this->makeModel(params, {model_t::E_IndividualCountByBucketAndPerson}, startTime, 4);
-    CEventRateModel* model = dynamic_cast<CEventRateModel*>(m_Model.get());
+    auto* model = dynamic_cast<CEventRateModel*>(m_Model.get());
     BOOST_TEST_REQUIRE(model);
 
     core_t::TTime time{startTime};

--- a/lib/model/unittest/CForecastModelPersistTest.cc
+++ b/lib/model/unittest/CForecastModelPersistTest.cc
@@ -50,7 +50,8 @@ BOOST_AUTO_TEST_CASE(testPersistAndRestore) {
                                                       params.s_DecayRate,
                                                       minimumSeasonalVarianceScale,
                                                       params.s_MinimumTimeToDetectChange,
-                                                      params.s_MaximumTimeToTestForChange};
+                                                      params.s_MaximumTimeToTestForChange,
+                                                      params.s_MaximumSeasonalJitter};
     maths::time_series::CUnivariateTimeSeriesModel timeSeriesModel{
         timeSeriesModelParams, 1, trend, prior};
 

--- a/lib/model/unittest/CModelDetailsViewTest.cc
+++ b/lib/model/unittest/CModelDetailsViewTest.cc
@@ -79,8 +79,13 @@ BOOST_FIXTURE_TEST_CASE(testModelPlot, CTestFixture) {
         maths::time_series::CTimeSeriesDecomposition trend;
         maths::common::CNormalMeanPrecConjugate prior{
             maths::common::CNormalMeanPrecConjugate::nonInformativePrior(maths_t::E_ContinuousData)};
-        maths::common::CModelParams timeSeriesModelParams{
-            bucketLength, 1.0, 0.001, 0.2, 6 * core::constants::HOUR, 24 * core::constants::HOUR};
+        maths::common::CModelParams timeSeriesModelParams{bucketLength,
+                                                          1.0,
+                                                          0.001,
+                                                          0.2,
+                                                          6 * core::constants::HOUR,
+                                                          24 * core::constants::HOUR,
+                                                          15 * core::constants::MINUTE};
         maths::time_series::CUnivariateTimeSeriesModel timeSeriesModel{
             timeSeriesModelParams, 0, trend, prior};
         model::CMockModel::TMathsModelUPtrVec models;

--- a/lib/model/unittest/CModelTestFixtureBase.cc
+++ b/lib/model/unittest/CModelTestFixtureBase.cc
@@ -186,7 +186,7 @@ void CModelTestFixtureBase::generateOrderedAnomalies(std::size_t numAnomalies,
 
     TAnomalyAccumulator anomalies(numAnomalies);
 
-    for (std::size_t i = 0u, bucket = 0; i < messages.size(); ++i) {
+    for (std::size_t i = 0, bucket = 0; i < messages.size(); ++i) {
         if (messages[i].s_Time >= startTime + bucketLength) {
             LOG_DEBUG(<< "Updating and testing bucket = [" << startTime << ","
                       << startTime + bucketLength << ")");
@@ -199,13 +199,12 @@ void CModelTestFixtureBase::generateOrderedAnomalies(std::size_t numAnomalies,
                 model.computeProbability(pid, startTime, startTime + bucketLength,
                                          partitioningFields, 2, annotatedProbability);
 
-                std::string person = model.personName(pid);
+                std::string person{model.personName(pid)};
                 TDoubleStrPrVec attributes;
                 for (const auto& probability : annotatedProbability.s_AttributeProbabilities) {
                     attributes.emplace_back(probability.s_Probability,
                                             *probability.s_Attribute);
                 }
-                LOG_DEBUG(<< "Adding anomaly " << pid);
                 anomalies.add({annotatedProbability.s_Probability,
                                {bucket, person, attributes}});
             }

--- a/lib/model/unittest/CModelToolsTest.cc
+++ b/lib/model/unittest/CModelToolsTest.cc
@@ -54,7 +54,8 @@ maths::common::CModelParams params(core_t::TTime bucketLength) {
                                        DECAY_RATE,
                                        minimumSeasonalVarianceScale,
                                        6 * core::constants::HOUR,
-                                       24 * core::constants::HOUR};
+                                       24 * core::constants::HOUR,
+                                       15 * core::constants::MINUTE};
 }
 
 maths::common::CNormalMeanPrecConjugate normal() {

--- a/lib/model/unittest/CProbabilityAndInfluenceCalculatorTest.cc
+++ b/lib/model/unittest/CProbabilityAndInfluenceCalculatorTest.cc
@@ -94,7 +94,8 @@ maths::common::CModelParams params(core_t::TTime bucketLength) {
                                        0.0,
                                        minimumSeasonalVarianceScale,
                                        6 * core::constants::HOUR,
-                                       24 * core::constants::HOUR};
+                                       24 * core::constants::HOUR,
+                                       15 * core::constants::MINUTE};
 }
 
 std::size_t dimension(double) {
@@ -280,7 +281,8 @@ void testProbabilityAndGetInfluences(model_t::EFeature feature,
     double probability;
     BOOST_TEST_REQUIRE(calculator.calculate(probability, influences));
 
-    double pj, pe;
+    double pj;
+    double pe;
     BOOST_TEST_REQUIRE(pJoint.calculate(pj));
     BOOST_TEST_REQUIRE(pExtreme.calculate(pe));
 
@@ -458,7 +460,7 @@ BOOST_AUTO_TEST_CASE(testLogProbabilityComplementInfluenceCalculator) {
                 {TStrCRef(i1), make_pair(70.0, 1.0)},
                 {TStrCRef(i2), make_pair(50.0, 1.0)}};
             std::string expectedInfluencerValues[]{"i1", "i2"};
-            TDoubleVecVec expectedInfluences{{1.0, 1.0}, {0.0, 0.0}, {1.0, 1.0}, {0.8, 0.6}};
+            TDoubleVecVec expectedInfluences{{1.0, 1.0}, {0.0, 0.0}, {1.0, 1.0}, {0.8, 0.65}};
 
             for (std::size_t i = 0; i < testTimes.size(); ++i) {
                 core_t::TTime time = testTimes[i];
@@ -513,7 +515,8 @@ BOOST_AUTO_TEST_CASE(testLogProbabilityComplementInfluenceCalculator) {
 
             core_t::TTime times[]{0, 0};
             double values[]{15.0, 15.0};
-            double lb, ub;
+            double lb;
+            double ub;
             TTail10Vec tail;
             prior.probabilityOfLessLikelySamples(
                 maths_t::E_TwoSided, {TDouble10Vec(&values[0], &values[2])},


### PR DESCRIPTION
Currently, we have can issues with our time series model when:
1. The data repeat is not a multiple of the bucket length (or at least not very close to a multiple),
2. The data are periodic but the pattern shifts from time to time.

In the first case we get slow precession of the periodic pattern and generally we don't adapt to this fast enough. The effect is we lose prediction accuracy and sensitivity over time. In the second case we get similar effects, but also often generate bursts of anomalies when the pattern shifts slightly.

This change introduces a latent time shift for each seasonal component which is modelled and solves for the shift which minimises the difference between its predictions and the observed values. Shifts are accumulated over each period which is observed, which allows us to handle slow precession.