### PR TITLE
[ML] Specify main instead of master when using infra Docker image

### DIFF
--- a/dev-tools/jenkins_combine_artifacts.sh
+++ b/dev-tools/jenkins_combine_artifacts.sh
@@ -54,8 +54,7 @@ if [ -n "$(git ls-remote --heads origin $MAJOR.$MINOR)" ] ; then
 elif [ -n "$(git ls-remote --heads origin $MAJOR.x)" ] ; then
     BRANCH=$MAJOR.x
 else
-    # TODO: keep an eye on this in case it changes to main
-    BRANCH=master
+    BRANCH=main
 fi
 
 # Jenkins sets BUILD_SNAPSHOT, but the Docker container requires a workflow that


### PR DESCRIPTION
The infra repo is still using a master branch instead of main.
However, the infra Docker image has been changed so that if the
branch to use is specified as main then it gets mapped to master.
Therefore it's more future-proof to specify main rather than
master. Specifying main means that when the infra repo is changed
from master to main nothing will need changing in the ml-cpp
repo. The change at that time will be in the infra repo, which is
easier to coordinate with a branch rename in that same repo.