### PR TITLE
[ML] Support testing on a holdout set rather than cross-validation when training

### DIFF
--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -62,7 +62,7 @@ public:
     static const std::string TREE_TOPOLOGY_CHANGE_PENALTY;
     static const std::string NUM_FOLDS;
     static const std::string TRAIN_FRACTION_PER_FOLD;
-    static const std::string END_OF_HOLDOUT_ROWS;
+    static const std::string NUM_HOLDOUT_ROWS;
     static const std::string STOP_CROSS_VALIDATION_EARLY;
     static const std::string MAX_OPTIMIZATION_ROUNDS_PER_HYPERPARAMETER;
     static const std::string BAYESIAN_OPTIMISATION_RESTARTS;

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -62,6 +62,7 @@ public:
     static const std::string TREE_TOPOLOGY_CHANGE_PENALTY;
     static const std::string NUM_FOLDS;
     static const std::string TRAIN_FRACTION_PER_FOLD;
+    static const std::string END_OF_HOLDOUT_ROWS;
     static const std::string STOP_CROSS_VALIDATION_EARLY;
     static const std::string MAX_OPTIMIZATION_ROUNDS_PER_HYPERPARAMETER;
     static const std::string BAYESIAN_OPTIMISATION_RESTARTS;

--- a/include/maths/analytics/CBoostedTree.h
+++ b/include/maths/analytics/CBoostedTree.h
@@ -315,14 +315,17 @@ public:
     const core::CPackedBitVector& newTrainingRowMask() const override;
 
     //! Read the model prediction from \p row.
-    TDouble2Vec readPrediction(const TRowRef& row) const override;
+    TDouble2Vec prediction(const TRowRef& row) const override;
+
+    //! Read the previous model prediction from \p row if it has been updated.
+    TDouble2Vec previousPrediction(const TRowRef& row) const override;
 
     //! Read the raw model prediction from \p row and make posthoc adjustments.
     //!
     //! For example, classification multiplicative weights are used for each
     //! class to target different objectives (accuracy or minimum recall) when
     //! assigning classes.
-    TDouble2Vec readAndAdjustPrediction(const TRowRef& row) const override;
+    TDouble2Vec adjustedPrediction(const TRowRef& row) const override;
 
     //! Get the selected rows that summarize.
     core::CPackedBitVector dataSummarization() const override;

--- a/include/maths/analytics/CBoostedTreeFactory.h
+++ b/include/maths/analytics/CBoostedTreeFactory.h
@@ -115,14 +115,14 @@ public:
     CBoostedTreeFactory& classificationWeights(TStrDoublePrVec weights);
     //! Set the minimum fraction with a category value to one-hot encode.
     CBoostedTreeFactory& minimumFrequencyToOneHotEncode(double frequency);
+    //! Set the number of initial rows to use as a holdout set for evaluation.
+    CBoostedTreeFactory& endOfHoldoutRows(std::size_t endOfHoldoutRows);
     //! Set the number of folds to use for estimating the generalisation error.
     CBoostedTreeFactory& numberFolds(std::size_t numberFolds);
     //! Set the fraction fold data to use for training.
     CBoostedTreeFactory& trainFractionPerFold(double fraction);
     //! Set the maximum number of rows to use for training when tuning hyperparameters.
     CBoostedTreeFactory& maximumNumberTrainRows(std::size_t rows);
-    //! Evaluate using only the specified hold-out set. This disables cross-valiation.
-    CBoostedTreeFactory& holdoutRowMask(core::CPackedBitVector holdoutRowMask);
     //! Stratify the cross-validation we do for regression.
     CBoostedTreeFactory& stratifyRegressionCrossValidation(bool stratify);
     //! Stop cross-validation early if the test loss is not promising.
@@ -362,7 +362,7 @@ private:
 
 private:
     TOptionalDouble m_MinimumFrequencyToOneHotEncode;
-    core::CPackedBitVector m_HoldoutRowMask;
+    std::size_t m_EndOfHoldoutRows{0};
     bool m_StratifyRegressionCrossValidation{true};
     double m_InitialDownsampleRowsPerFeature{200.0};
     std::size_t m_MaximumNumberOfTrainRows{500000};

--- a/include/maths/analytics/CBoostedTreeFactory.h
+++ b/include/maths/analytics/CBoostedTreeFactory.h
@@ -116,7 +116,7 @@ public:
     //! Set the minimum fraction with a category value to one-hot encode.
     CBoostedTreeFactory& minimumFrequencyToOneHotEncode(double frequency);
     //! Set the number of initial rows to use as a holdout set for evaluation.
-    CBoostedTreeFactory& endOfHoldoutRows(std::size_t endOfHoldoutRows);
+    CBoostedTreeFactory& numberHoldoutRows(std::size_t numberHoldoutRows);
     //! Set the number of folds to use for estimating the generalisation error.
     CBoostedTreeFactory& numberFolds(std::size_t numberFolds);
     //! Set the fraction fold data to use for training.
@@ -362,7 +362,7 @@ private:
 
 private:
     TOptionalDouble m_MinimumFrequencyToOneHotEncode;
-    std::size_t m_EndOfHoldoutRows{0};
+    std::size_t m_NumberHoldoutRows{0};
     bool m_StratifyRegressionCrossValidation{true};
     double m_InitialDownsampleRowsPerFeature{200.0};
     std::size_t m_MaximumNumberOfTrainRows{500000};

--- a/include/maths/analytics/CBoostedTreeFactory.h
+++ b/include/maths/analytics/CBoostedTreeFactory.h
@@ -121,6 +121,8 @@ public:
     CBoostedTreeFactory& trainFractionPerFold(double fraction);
     //! Set the maximum number of rows to use for training when tuning hyperparameters.
     CBoostedTreeFactory& maximumNumberTrainRows(std::size_t rows);
+    //! Evaluate using only the specified hold-out set. This disables cross-valiation.
+    CBoostedTreeFactory& holdoutRowMask(core::CPackedBitVector holdoutRowMask);
     //! Stratify the cross-validation we do for regression.
     CBoostedTreeFactory& stratifyRegressionCrossValidation(bool stratify);
     //! Stop cross-validation early if the test loss is not promising.
@@ -360,6 +362,7 @@ private:
 
 private:
     TOptionalDouble m_MinimumFrequencyToOneHotEncode;
+    core::CPackedBitVector m_HoldoutRowMask;
     bool m_StratifyRegressionCrossValidation{true};
     double m_InitialDownsampleRowsPerFeature{200.0};
     std::size_t m_MaximumNumberOfTrainRows{500000};

--- a/include/maths/analytics/CBoostedTreeHyperparameters.h
+++ b/include/maths/analytics/CBoostedTreeHyperparameters.h
@@ -639,7 +639,9 @@ public:
     bool selectNext(const TMeanVarAccumulator& testLossMoments,
                     double explainedVariance = 0.0);
 
-    //! Capture the current hyperparameters if they're the best we've seen so far.
+    //! Capture the current hyperparameters if they're the best we've seen.
+    //!
+    //! \return True if we they are the best hyperparameters.
     bool captureBest(const TMeanVarAccumulator& testLossMoments,
                      double meanLossGap,
                      double numberKeptNodes,

--- a/include/maths/analytics/CBoostedTreeHyperparameters.h
+++ b/include/maths/analytics/CBoostedTreeHyperparameters.h
@@ -640,7 +640,7 @@ public:
                     double explainedVariance = 0.0);
 
     //! Capture the current hyperparameters if they're the best we've seen so far.
-    void captureBest(const TMeanVarAccumulator& testLossMoments,
+    bool captureBest(const TMeanVarAccumulator& testLossMoments,
                      double meanLossGap,
                      double numberKeptNodes,
                      double numberNewNodes,

--- a/include/maths/analytics/CBoostedTreeImpl.h
+++ b/include/maths/analytics/CBoostedTreeImpl.h
@@ -201,6 +201,8 @@ private:
     using TWorkspace = CBoostedTreeLeafNodeStatistics::CWorkspace;
     using TArgMinLossVec = std::vector<boosted_tree::CArgMinLoss>;
     using TArgMinLossVecVec = std::vector<TArgMinLossVec>;
+    using TRowRef = boosted_tree_detail::TRowRef;
+    using TMemoryMappedFloatVector = boosted_tree_detail::TMemoryMappedFloatVector;
     // clang-format off
     using TMakeRootLeafNodeStatistics =
         std::function<TLeafNodeStatisticsPtr (const TFloatVecVec&,
@@ -209,8 +211,7 @@ private:
                                               const core::CPackedBitVector&,
                                               TWorkspace&)>;
     using TUpdateRowPrediction =
-        std::function<void (const boosted_tree_detail::TRowRef&,
-                            boosted_tree_detail::TMemoryMappedFloatVector&)>;
+        std::function<void (const TRowRef&, TMemoryMappedFloatVector&)>;
     // clang-format on
 
     //! \brief The result of cross-validation.
@@ -367,27 +368,33 @@ private:
                                TArgMinLossVecVec& result) const;
 
     //! Update the predictions and the \p loss gradient and curvature for the
-    //! \p rowMask rows of \p frame for all training data.
+    //! \p rowMask rows of \p frame for all data.
     void refreshPredictionsAndLossDerivatives(core::CDataFrame& frame,
                                               const core::CPackedBitVector& rowMask,
                                               const TLossFunction& loss,
                                               const TUpdateRowPrediction& updateRowPrediction) const;
 
     //! Update the predictions and the \p loss gradient and curvature for the
-    //! \p rowMask rows of \p frame for old or new training data.
+    //! \p rowMask rows of \p frame for old or new data.
     void refreshPredictionsAndLossDerivatives(bool newExample,
                                               core::CDataFrame& frame,
                                               const core::CPackedBitVector& rowMask,
                                               const TLossFunction& loss,
                                               const TUpdateRowPrediction& updateRowPrediction) const;
 
+    //! Update the predictions \p rowMask rows of \p frame.
+    void refreshPredictions(core::CDataFrame& frame,
+                            const core::CPackedBitVector& rowMask,
+                            const TLossFunction& loss,
+                            const TUpdateRowPrediction& updateRowPrediction) const;
+
     //! Compute the mean of the loss function on the masked rows of \p frame.
     double meanLoss(const core::CDataFrame& frame, const core::CPackedBitVector& rowMask) const;
 
     //! Compute the mean of the loss function on the masked rows of \p frame
     //! adjusted for incremental training.
-    double meanAdjustedLoss(const core::CDataFrame& frame,
-                            const core::CPackedBitVector& rowMask) const;
+    double meanChangePenalisedLoss(const core::CDataFrame& frame,
+                                   const core::CPackedBitVector& rowMask) const;
 
     //! Compute the overall variance of the error we see between folds.
     double betweenFoldTestLossVariance() const;

--- a/include/maths/analytics/CBoostedTreeImpl.h
+++ b/include/maths/analytics/CBoostedTreeImpl.h
@@ -58,15 +58,14 @@ class MATHS_ANALYTICS_EXPORT CBoostedTreeImpl final {
 public:
     using TDoubleVec = std::vector<double>;
     using TSizeVec = std::vector<std::size_t>;
-    using TStrVec = std::vector<std::string>;
     using TOptionalDouble = boost::optional<double>;
+    using TOptionalDoubleVec = std::vector<TOptionalDouble>;
+    using TOptionalDoubleVecVec = std::vector<TOptionalDoubleVec>;
     using TStrDoublePrVec = std::vector<std::pair<std::string, double>>;
     using TOptionalStrDoublePrVec = boost::optional<TStrDoublePrVec>;
     using TVector = common::CDenseVector<double>;
-    using TMeanAccumulator = common::CBasicStatistics::SSampleMean<double>::TAccumulator;
     using TMeanVarAccumulator = common::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
     using TMeanVarAccumulatorVec = std::vector<TMeanVarAccumulator>;
-    using TBayesinOptimizationUPtr = std::unique_ptr<common::CBayesianOptimisation>;
     using TNodeVec = CBoostedTree::TNodeVec;
     using TNodeVecVec = CBoostedTree::TNodeVecVec;
     using TLossFunction = boosted_tree::CLoss;
@@ -183,14 +182,13 @@ public:
     //!
     //! Get the feature sample probabilities.
     const TDoubleVec& featureSampleProbabilities() const;
+
+    //! Get the fold test losses for each round.
+    const TOptionalDoubleVecVec& foldRoundTestLosses() const;
     //@}
 
 private:
     using TDoubleDoublePr = std::pair<double, double>;
-    using TOptionalDoubleVec = std::vector<TOptionalDouble>;
-    using TOptionalDoubleVecVec = std::vector<TOptionalDoubleVec>;
-    using TOptionalSize = boost::optional<std::size_t>;
-    using TDoubleVecVec = std::vector<TDoubleVec>;
     using TFloatVec = std::vector<common::CFloatStorage>;
     using TFloatVecVec = std::vector<TFloatVec>;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
@@ -217,6 +215,7 @@ private:
 
     //! \brief The result of cross-validation.
     struct SCrossValidationResult {
+        TNodeVecVec s_Forest;
         TMeanVarAccumulator s_TestLossMoments;
         double s_MeanLossGap{0.0};
         std::size_t s_NumberTrees{0};

--- a/include/maths/analytics/CDataFramePredictiveModel.h
+++ b/include/maths/analytics/CDataFramePredictiveModel.h
@@ -88,10 +88,13 @@ public:
     virtual const core::CPackedBitVector& newTrainingRowMask() const = 0;
 
     //! Read the prediction out of \p row.
-    virtual TDouble2Vec readPrediction(const TRowRef& row) const = 0;
+    virtual TDouble2Vec prediction(const TRowRef& row) const = 0;
+
+    //! Read the previous model prediction from \p row if it has been updated.
+    virtual TDouble2Vec previousPrediction(const TRowRef& row) const = 0;
 
     //! Read the raw model prediction from \p row and make posthoc adjustments.
-    virtual TDouble2Vec readAndAdjustPrediction(const TRowRef& row) const = 0;
+    virtual TDouble2Vec adjustedPrediction(const TRowRef& row) const = 0;
 
     //! Get the selected rows that summarize.
     virtual core::CPackedBitVector dataSummarization() const = 0;

--- a/include/test/CDataFrameAnalyzerTrainingFactory.h
+++ b/include/test/CDataFrameAnalyzerTrainingFactory.h
@@ -195,7 +195,7 @@ public:
 
         frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
-                auto prediction = tree->readAndAdjustPrediction(*row);
+                auto prediction = tree->adjustedPrediction(*row);
                 appendPrediction(*frame, weights.size(), prediction, expectedPredictions);
             }
         });

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -139,9 +139,9 @@ void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(
     const auto& tree = this->boostedTree();
     this->writeOneRow(
         frame, tree.columnHoldingDependentVariable(),
-        [&](const TRowRef& row_) { return tree.readPrediction(row_); },
-        [&](const TRowRef& row_) { return tree.readAndAdjustPrediction(row_); },
-        row, writer, tree.shap());
+        [&](const TRowRef& row_) { return tree.prediction(row_); },
+        [&](const TRowRef& row_) { return tree.adjustedPrediction(row_); }, row,
+        writer, tree.shap());
 }
 
 void CDataFrameTrainBoostedTreeClassifierRunner::writeOneRow(

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -110,7 +110,7 @@ void CDataFrameTrainBoostedTreeRegressionRunner::writeOneRow(
 
     writer.StartObject();
     writer.Key(this->predictionFieldName());
-    writer.Double(tree.readPrediction(row)[0]);
+    writer.Double(tree.prediction(row)[0]);
     writer.Key(IS_TRAINING_FIELD_NAME);
     writer.Bool(maths::analytics::CDataFrameUtils::isMissing(
                     row[columnHoldingDependentVariable]) == false);

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -76,8 +76,7 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::paramete
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(TREE_TOPOLOGY_CHANGE_PENALTY,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
-        theReader.addParameter(NUM_HOLDOUT_ROWS,
-                               CDataFrameAnalysisConfigReader::E_OptionalParameter);
+        theReader.addParameter(NUM_HOLDOUT_ROWS, CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(NUM_FOLDS, CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(TRAIN_FRACTION_PER_FOLD,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -76,7 +76,7 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::paramete
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(TREE_TOPOLOGY_CHANGE_PENALTY,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
-        theReader.addParameter(END_OF_HOLDOUT_ROWS,
+        theReader.addParameter(NUM_HOLDOUT_ROWS,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(NUM_FOLDS, CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(TRAIN_FRACTION_PER_FOLD,
@@ -143,7 +143,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     std::size_t seed{parameters[RANDOM_NUMBER_GENERATOR_SEED].fallback(std::size_t{0})};
 
     std::size_t maxTrees{parameters[MAX_TREES].fallback(std::size_t{0})};
-    std::size_t endOfHoldoutRows{parameters[END_OF_HOLDOUT_ROWS].fallback(std::size_t{0})};
+    std::size_t numberHoldoutRows{parameters[NUM_HOLDOUT_ROWS].fallback(std::size_t{0})};
     std::size_t numberFolds{parameters[NUM_FOLDS].fallback(std::size_t{0})};
     std::size_t downsampleRowsPerFeature{
         parameters[DOWNSAMPLE_ROWS_PER_FEATURE].fallback(std::size_t{0})};
@@ -243,7 +243,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     m_BoostedTreeFactory = this->boostedTreeFactory(std::move(loss), frameAndDirectory);
     (*m_BoostedTreeFactory)
         .seed(seed)
-        .endOfHoldoutRows(endOfHoldoutRows)
+        .numberHoldoutRows(numberHoldoutRows)
         .stopCrossValidationEarly(stopCrossValidationEarly)
         .analysisInstrumentation(m_Instrumentation)
         .trainingStateCallback(this->statePersister())
@@ -574,7 +574,7 @@ const std::string CDataFrameTrainBoostedTreeRunner::MAX_TREES{"max_trees"};
 const std::string CDataFrameTrainBoostedTreeRunner::FEATURE_BAG_FRACTION{"feature_bag_fraction"};
 const std::string CDataFrameTrainBoostedTreeRunner::PREDICTION_CHANGE_COST{"prediction_change_cost"};
 const std::string CDataFrameTrainBoostedTreeRunner::TREE_TOPOLOGY_CHANGE_PENALTY{"tree_topology_change_penalty"};
-const std::string CDataFrameTrainBoostedTreeRunner::END_OF_HOLDOUT_ROWS{"end_of_holdout_rows"};
+const std::string CDataFrameTrainBoostedTreeRunner::NUM_HOLDOUT_ROWS{"num_holdout_rows"};
 const std::string CDataFrameTrainBoostedTreeRunner::NUM_FOLDS{"num_folds"};
 const std::string CDataFrameTrainBoostedTreeRunner::TRAIN_FRACTION_PER_FOLD{"train_fraction_per_fold"};
 const std::string CDataFrameTrainBoostedTreeRunner::STOP_CROSS_VALIDATION_EARLY{"stop_cross_validation_early"};

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -76,6 +76,8 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::paramete
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(TREE_TOPOLOGY_CHANGE_PENALTY,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
+        theReader.addParameter(END_OF_HOLDOUT_ROWS,
+                               CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(NUM_FOLDS, CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(TRAIN_FRACTION_PER_FOLD,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
@@ -141,6 +143,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     std::size_t seed{parameters[RANDOM_NUMBER_GENERATOR_SEED].fallback(std::size_t{0})};
 
     std::size_t maxTrees{parameters[MAX_TREES].fallback(std::size_t{0})};
+    std::size_t endOfHoldoutRows{parameters[END_OF_HOLDOUT_ROWS].fallback(std::size_t{0})};
     std::size_t numberFolds{parameters[NUM_FOLDS].fallback(std::size_t{0})};
     std::size_t downsampleRowsPerFeature{
         parameters[DOWNSAMPLE_ROWS_PER_FEATURE].fallback(std::size_t{0})};
@@ -240,6 +243,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     m_BoostedTreeFactory = this->boostedTreeFactory(std::move(loss), frameAndDirectory);
     (*m_BoostedTreeFactory)
         .seed(seed)
+        .endOfHoldoutRows(endOfHoldoutRows)
         .stopCrossValidationEarly(stopCrossValidationEarly)
         .analysisInstrumentation(m_Instrumentation)
         .trainingStateCallback(this->statePersister())
@@ -570,6 +574,7 @@ const std::string CDataFrameTrainBoostedTreeRunner::MAX_TREES{"max_trees"};
 const std::string CDataFrameTrainBoostedTreeRunner::FEATURE_BAG_FRACTION{"feature_bag_fraction"};
 const std::string CDataFrameTrainBoostedTreeRunner::PREDICTION_CHANGE_COST{"prediction_change_cost"};
 const std::string CDataFrameTrainBoostedTreeRunner::TREE_TOPOLOGY_CHANGE_PENALTY{"tree_topology_change_penalty"};
+const std::string CDataFrameTrainBoostedTreeRunner::END_OF_HOLDOUT_ROWS{"end_of_holdout_rows"};
 const std::string CDataFrameTrainBoostedTreeRunner::NUM_FOLDS{"num_folds"};
 const std::string CDataFrameTrainBoostedTreeRunner::TRAIN_FRACTION_PER_FOLD{"train_fraction_per_fold"};
 const std::string CDataFrameTrainBoostedTreeRunner::STOP_CROSS_VALIDATION_EARLY{"stop_cross_validation_early"};

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -1142,7 +1142,7 @@ BOOST_AUTO_TEST_CASE(testRegressionIncrementalTraining) {
                     [&](const TRowItr& beginRows, const TRowItr& endRows) {
                         for (auto row = beginRows; row != endRows; ++row) {
                             BOOST_REQUIRE_CLOSE_ABSOLUTE(
-                                (*prediction++), regression->readPrediction(*row)[0], 1e-6);
+                                (*prediction++), regression->prediction(*row)[0], 1e-6);
                         }
                     },
                     &newTrainingRowMask);
@@ -1342,7 +1342,7 @@ BOOST_AUTO_TEST_CASE(testClassificationWithUserClassWeights) {
     TStrVec expectedPredictions(frame->numberRows());
     frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
-            auto scores = classifier->readAndAdjustPrediction(*row);
+            auto scores = classifier->adjustedPrediction(*row);
             std::size_t prediction(scores[1] < scores[0] ? 0 : 1);
             expectedPredictions[row->index()] = frame->categoricalColumnValues()[3][prediction];
         }
@@ -1549,7 +1549,7 @@ BOOST_AUTO_TEST_CASE(testClassificationIncrementalTraining) {
         1, 0, frame->numberRows(),
         [&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
-                double expectedPrediction{classification->readPrediction(*row)[0]};
+                double expectedPrediction{classification->prediction(*row)[0]};
                 // The prediction_probability result contains the highest scoring
                 // class probability which is usually, but not always, the highest
                 // class probability. The probability of the prediction result is
@@ -1836,7 +1836,7 @@ BOOST_AUTO_TEST_CASE(testIncrementalTrainingFieldMismatch) {
         1, 0, frame->numberRows(),
         [&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
-                double expectedPrediction{classification->readPrediction(*row)[0]};
+                double expectedPrediction{classification->prediction(*row)[0]};
                 // See testClassificationIncrementalTraining for an explanation.
                 BOOST_REQUIRE((std::fabs(*prediction - expectedPrediction) < 1e-6) ||
                               (std::fabs(*prediction + expectedPrediction - 1.0) < 1e-6));

--- a/lib/maths/analytics/CBoostedTree.cc
+++ b/lib/maths/analytics/CBoostedTree.cc
@@ -263,20 +263,26 @@ const core::CPackedBitVector& CBoostedTree::newTrainingRowMask() const {
     return m_Impl->newTrainingRowMask();
 }
 
-CBoostedTree::TDouble2Vec CBoostedTree::readPrediction(const TRowRef& row) const {
+CBoostedTree::TDouble2Vec CBoostedTree::prediction(const TRowRef& row) const {
     const auto& loss = m_Impl->loss();
     return loss
-        .transform(boosted_tree_detail::readPrediction(row, m_Impl->extraColumns(),
-                                                       loss.numberParameters()))
+        .transform(readPrediction(row, m_Impl->extraColumns(), loss.numberParameters()))
         .to<TDouble2Vec>();
 }
 
-CBoostedTree::TDouble2Vec CBoostedTree::readAndAdjustPrediction(const TRowRef& row) const {
+CBoostedTree::TDouble2Vec CBoostedTree::previousPrediction(const TRowRef& row) const {
+    const auto& loss = m_Impl->loss();
+    return loss
+        .transform(readPreviousPrediction(row, m_Impl->extraColumns(), loss.numberParameters()))
+        .to<TDouble2Vec>();
+}
+
+CBoostedTree::TDouble2Vec CBoostedTree::adjustedPrediction(const TRowRef& row) const {
 
     const auto& loss = m_Impl->loss();
 
-    auto prediction = loss.transform(boosted_tree_detail::readPrediction(
-        row, m_Impl->extraColumns(), loss.numberParameters()));
+    auto prediction = loss.transform(
+        readPrediction(row, m_Impl->extraColumns(), loss.numberParameters()));
 
     switch (loss.type()) {
     case E_BinaryClassification:

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -335,10 +335,10 @@ void CBoostedTreeFactory::initializeMissingFeatureMasks(const core::CDataFrame& 
 
 void CBoostedTreeFactory::initializeNumberFolds(core::CDataFrame& frame) const {
 
-    if (m_EndOfHoldoutRows > 0) {
+    if (m_NumberHoldoutRows > 0) {
         m_TreeImpl->m_NumberFolds.fixTo(1);
         m_TreeImpl->m_TrainFractionPerFold.fixTo(
-            1.0 - static_cast<double>(m_EndOfHoldoutRows) /
+            1.0 - static_cast<double>(m_NumberHoldoutRows) /
                       m_TreeImpl->allTrainingRowsMask().manhattan());
     } else {
         auto result = frame.readRows(
@@ -466,14 +466,14 @@ void CBoostedTreeFactory::initializeCrossValidation(core::CDataFrame& frame) con
 
     core::CPackedBitVector allTrainingRowsMask{m_TreeImpl->allTrainingRowsMask()};
 
-    if (m_EndOfHoldoutRows > 0) {
-        if (m_EndOfHoldoutRows > frame.numberRows()) {
+    if (m_NumberHoldoutRows > 0) {
+        if (m_NumberHoldoutRows > frame.numberRows()) {
             HANDLE_FATAL(<< "Supplied fewer than holdout rows (" << frame.numberRows()
-                         << " < " << m_EndOfHoldoutRows << ").");
+                         << " < " << m_NumberHoldoutRows << ").");
         }
 
-        core::CPackedBitVector holdoutRowMask{m_EndOfHoldoutRows, true};
-        holdoutRowMask.extend(false, frame.numberRows() - m_EndOfHoldoutRows);
+        core::CPackedBitVector holdoutRowMask{m_NumberHoldoutRows, true};
+        holdoutRowMask.extend(false, frame.numberRows() - m_NumberHoldoutRows);
 
         m_TreeImpl->m_TrainingRowMasks.clear();
         m_TreeImpl->m_TestingRowMasks.clear();
@@ -1233,8 +1233,8 @@ CBoostedTreeFactory& CBoostedTreeFactory::minimumFrequencyToOneHotEncode(double 
     return *this;
 }
 
-CBoostedTreeFactory& CBoostedTreeFactory::endOfHoldoutRows(std::size_t endOfHoldoutRows) {
-    m_EndOfHoldoutRows = endOfHoldoutRows;
+CBoostedTreeFactory& CBoostedTreeFactory::numberHoldoutRows(std::size_t numberHoldoutRows) {
+    m_NumberHoldoutRows = numberHoldoutRows;
     return *this;
 }
 

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -127,9 +127,9 @@ CBoostedTreeFactory::buildForTrain(core::CDataFrame& frame, std::size_t dependen
     m_TreeImpl->m_DependentVariable = dependentVariable;
 
     skipIfAfter(CBoostedTreeImpl::E_NotInitialized,
-                [&] { this->initializeNumberFolds(frame); });
-    skipIfAfter(CBoostedTreeImpl::E_NotInitialized,
                 [&] { this->initializeMissingFeatureMasks(frame); });
+    skipIfAfter(CBoostedTreeImpl::E_NotInitialized,
+                [&] { this->initializeNumberFolds(frame); });
     skipIfAfter(CBoostedTreeImpl::E_NotInitialized, [&] {
         if (frame.numberRows() > m_TreeImpl->m_NewTrainingRowMask.size()) {
             m_TreeImpl->m_NewTrainingRowMask.extend(
@@ -180,9 +180,9 @@ CBoostedTreeFactory::buildForTrainIncremental(core::CDataFrame& frame,
     m_TreeImpl->m_Hyperparameters.incrementalTraining(true);
 
     skipIfAfter(CBoostedTreeImpl::E_NotInitialized,
-                [&] { this->initializeNumberFolds(frame); });
-    skipIfAfter(CBoostedTreeImpl::E_NotInitialized,
                 [&] { this->initializeMissingFeatureMasks(frame); });
+    skipIfAfter(CBoostedTreeImpl::E_NotInitialized,
+                [&] { this->initializeNumberFolds(frame); });
     skipIfAfter(CBoostedTreeImpl::E_NotInitialized, [&] {
         if (frame.numberRows() > m_TreeImpl->m_NewTrainingRowMask.size()) {
             // We assume any additional rows are new examples.
@@ -335,58 +335,66 @@ void CBoostedTreeFactory::initializeMissingFeatureMasks(const core::CDataFrame& 
 
 void CBoostedTreeFactory::initializeNumberFolds(core::CDataFrame& frame) const {
 
-    auto result = frame.readRows(
-        m_NumberThreads,
-        core::bindRetrievableState(
-            [this](std::size_t& numberTrainingRows, const TRowItr& beginRows, const TRowItr& endRows) {
-                for (auto row = beginRows; row != endRows; ++row) {
-                    double target{(*row)[m_TreeImpl->m_DependentVariable]};
-                    if (CDataFrameUtils::isMissing(target) == false) {
-                        ++numberTrainingRows;
+    if (m_HoldoutRowMask.size() > 0) {
+        m_TreeImpl->m_NumberFolds.fixTo(1);
+        m_TreeImpl->m_TrainFractionPerFold.fixTo(
+            1.0 - m_HoldoutRowMask.manhattan() /
+                      m_TreeImpl->allTrainingRowsMask().manhattan());
+    } else {
+        auto result = frame.readRows(
+            m_NumberThreads,
+            core::bindRetrievableState(
+                [this](std::size_t& numberTrainingRows,
+                       const TRowItr& beginRows, const TRowItr& endRows) {
+                    for (auto row = beginRows; row != endRows; ++row) {
+                        double target{(*row)[m_TreeImpl->m_DependentVariable]};
+                        if (CDataFrameUtils::isMissing(target) == false) {
+                            ++numberTrainingRows;
+                        }
                     }
-                }
-            },
-            std::size_t{0}));
-    std::size_t totalNumberTrainingRows{0};
-    for (const auto& numberTrainingRows : result.first) {
-        totalNumberTrainingRows += numberTrainingRows.s_FunctionState;
+                },
+                std::size_t{0}));
+        std::size_t totalNumberTrainingRows{0};
+        for (const auto& numberTrainingRows : result.first) {
+            totalNumberTrainingRows += numberTrainingRows.s_FunctionState;
+        }
+        LOG_TRACE(<< "total number training rows = " << totalNumberTrainingRows);
+
+        // We want to choose the number of folds so we'll have enough training data
+        // after leaving out one fold. We choose the initial downsample size based
+        // on the same sort of criterion. So we require that leaving out one fold
+        // shouldn't mean than we have fewer rows than constant * desired downsample
+        // # rows if possible. We choose the constant to be two for no particularly
+        // good reason except that:
+        //   1. it isn't too large
+        //   2. it still means we'll have plenty of variation between random bags.
+        //
+        // In order to estimate this we use the number of input features as a proxy
+        // for the number of features we'll actually use after feature selection.
+        //
+        // So how does the following work: we'd like "c * f * # rows" training rows.
+        // For k folds we'll have "(1 - 1 / k) * # rows" training rows. So we want
+        // to find the smallest integer k s.t. c * f * # rows <= (1 - 1 / k) * # rows.
+        // This gives k = ceil(1 / (1 - c * f)). However, we also upper bound this
+        // by MAX_NUMBER_FOLDS.
+        //
+        // In addition, we want to constrain the maximum amount of training data we'll
+        // use during hyperparameter search to avoid very long run times. To do this
+        // we use less than the implied 1 - 1/k : 1/k for the train : test split when
+        // it results in more train rows than the defined maximum.
+
+        double initialDownsampleFraction{(m_InitialDownsampleRowsPerFeature *
+                                          static_cast<double>(frame.numberColumns() - 1)) /
+                                         static_cast<double>(totalNumberTrainingRows)};
+        LOG_TRACE(<< "initial downsample fraction = " << initialDownsampleFraction);
+        m_TreeImpl->m_NumberFolds.set(static_cast<std::size_t>(
+            std::ceil(1.0 / std::max(1.0 - initialDownsampleFraction / MAX_DESIRED_INITIAL_DOWNSAMPLE_FRACTION,
+                                     1.0 / MAX_NUMBER_FOLDS))));
+        m_TreeImpl->m_TrainFractionPerFold.set(std::min(
+            1.0 - 1.0 / static_cast<double>(m_TreeImpl->m_NumberFolds.value()),
+            static_cast<double>(m_MaximumNumberOfTrainRows) /
+                static_cast<double>(totalNumberTrainingRows)));
     }
-    LOG_TRACE(<< "total number training rows = " << totalNumberTrainingRows);
-
-    // We want to choose the number of folds so we'll have enough training data
-    // after leaving out one fold. We choose the initial downsample size based
-    // on the same sort of criterion. So we require that leaving out one fold
-    // shouldn't mean than we have fewer rows than constant * desired downsample
-    // # rows if possible. We choose the constant to be two for no particularly
-    // good reason except that:
-    //   1. it isn't too large
-    //   2. it still means we'll have plenty of variation between random bags.
-    //
-    // In order to estimate this we use the number of input features as a proxy
-    // for the number of features we'll actually use after feature selection.
-    //
-    // So how does the following work: we'd like "c * f * # rows" training rows.
-    // For k folds we'll have "(1 - 1 / k) * # rows" training rows. So we want
-    // to find the smallest integer k s.t. c * f * # rows <= (1 - 1 / k) * # rows.
-    // This gives k = ceil(1 / (1 - c * f)). However, we also upper bound this
-    // by MAX_NUMBER_FOLDS.
-    //
-    // In addition, we want to constrain the maximum amount of training data we'll
-    // use during hyperparameter search to avoid very long run times. To do this
-    // we use less than the implied 1 - 1/k : 1/k for the train : test split when
-    // it results in more train rows than the defined maximum.
-
-    double initialDownsampleFraction{(m_InitialDownsampleRowsPerFeature *
-                                      static_cast<double>(frame.numberColumns() - 1)) /
-                                     static_cast<double>(totalNumberTrainingRows)};
-    LOG_TRACE(<< "initial downsample fraction = " << initialDownsampleFraction);
-    m_TreeImpl->m_NumberFolds.set(static_cast<std::size_t>(
-        std::ceil(1.0 / std::max(1.0 - initialDownsampleFraction / MAX_DESIRED_INITIAL_DOWNSAMPLE_FRACTION,
-                                 1.0 / MAX_NUMBER_FOLDS))));
-    m_TreeImpl->m_TrainFractionPerFold.set(
-        std::min(1.0 - 1.0 / static_cast<double>(m_TreeImpl->m_NumberFolds.value()),
-                 static_cast<double>(m_MaximumNumberOfTrainRows) /
-                     static_cast<double>(totalNumberTrainingRows)));
     LOG_TRACE(<< "# folds = " << m_TreeImpl->m_NumberFolds.value() << ", train fraction per fold = "
               << m_TreeImpl->m_TrainFractionPerFold.value());
 }
@@ -457,41 +465,53 @@ void CBoostedTreeFactory::prepareDataFrameForIncrementalTrain(core::CDataFrame& 
 void CBoostedTreeFactory::initializeCrossValidation(core::CDataFrame& frame) const {
 
     core::CPackedBitVector allTrainingRowsMask{m_TreeImpl->allTrainingRowsMask()};
-    std::size_t dependentVariable{m_TreeImpl->m_DependentVariable};
 
-    std::size_t numberThreads{m_TreeImpl->m_NumberThreads};
-    std::size_t numberFolds{m_TreeImpl->m_NumberFolds.value()};
-    std::size_t numberBuckets(m_StratifyRegressionCrossValidation ? 10 : 1);
-    double trainFractionPerFold{m_TreeImpl->m_TrainFractionPerFold.value()};
-    auto& rng = m_TreeImpl->m_Rng;
+    if (m_HoldoutRowMask.size() > 0) {
+        m_TreeImpl->m_TrainingRowMasks.reserve(1);
+        m_TreeImpl->m_TestingRowMasks.reserve(1);
+        m_TreeImpl->m_TrainingRowMasks.push_back(allTrainingRowsMask & (~m_HoldoutRowMask));
+        m_TreeImpl->m_TestingRowMasks.push_back(allTrainingRowsMask & m_HoldoutRowMask);
+        m_TreeImpl->m_StopCrossValidationEarly = false;
 
-    if (m_TreeImpl->m_Hyperparameters.incrementalTraining() == false) {
-        std::tie(m_TreeImpl->m_TrainingRowMasks, m_TreeImpl->m_TestingRowMasks, std::ignore) =
-            CDataFrameUtils::stratifiedCrossValidationRowMasks(
-                numberThreads, frame, dependentVariable, rng, numberFolds,
-                trainFractionPerFold, numberBuckets, allTrainingRowsMask);
     } else {
+        std::size_t dependentVariable{m_TreeImpl->m_DependentVariable};
+        std::size_t numberThreads{m_TreeImpl->m_NumberThreads};
+        std::size_t numberFolds{m_TreeImpl->m_NumberFolds.value()};
+        std::size_t numberBuckets(m_StratifyRegressionCrossValidation ? 10 : 1);
+        double trainFractionPerFold{m_TreeImpl->m_TrainFractionPerFold.value()};
+        auto& rng = m_TreeImpl->m_Rng;
 
-        // Use separate stratified samples on old and new training data to ensure
-        // we have even splits of old and new data across all folds.
+        if (m_TreeImpl->m_Hyperparameters.incrementalTraining() == false) {
+            std::tie(m_TreeImpl->m_TrainingRowMasks,
+                     m_TreeImpl->m_TestingRowMasks, std::ignore) =
+                CDataFrameUtils::stratifiedCrossValidationRowMasks(
+                    numberThreads, frame, dependentVariable, rng, numberFolds,
+                    trainFractionPerFold, numberBuckets, allTrainingRowsMask);
+        } else {
 
-        const auto& newTrainingRowMask = m_TreeImpl->m_NewTrainingRowMask;
+            // Use separate stratified samples on old and new training data to ensure
+            // we have even splits of old and new data across all folds.
 
-        std::tie(m_TreeImpl->m_TrainingRowMasks, m_TreeImpl->m_TestingRowMasks, std::ignore) =
-            CDataFrameUtils::stratifiedCrossValidationRowMasks(
-                numberThreads, frame, dependentVariable, rng, numberFolds, trainFractionPerFold,
-                numberBuckets, allTrainingRowsMask & ~newTrainingRowMask);
+            const auto& newTrainingRowMask = m_TreeImpl->m_NewTrainingRowMask;
 
-        if (m_TreeImpl->m_NewTrainingRowMask.manhattan() > 0.0) {
-            TPackedBitVectorVec newTrainingRowMasks;
-            TPackedBitVectorVec newTestingRowMasks;
-            std::tie(newTrainingRowMasks, newTestingRowMasks, std::ignore) =
+            std::tie(m_TreeImpl->m_TrainingRowMasks,
+                     m_TreeImpl->m_TestingRowMasks, std::ignore) =
                 CDataFrameUtils::stratifiedCrossValidationRowMasks(
                     numberThreads, frame, dependentVariable, rng, numberFolds, trainFractionPerFold,
-                    numberBuckets, allTrainingRowsMask & newTrainingRowMask);
-            for (std::size_t i = 0; i < numberFolds; ++i) {
-                m_TreeImpl->m_TrainingRowMasks[i] |= newTrainingRowMasks[i];
-                m_TreeImpl->m_TestingRowMasks[i] |= newTestingRowMasks[i];
+                    numberBuckets, allTrainingRowsMask & ~newTrainingRowMask);
+
+            if (m_TreeImpl->m_NewTrainingRowMask.manhattan() > 0.0) {
+                TPackedBitVectorVec newTrainingRowMasks;
+                TPackedBitVectorVec newTestingRowMasks;
+                std::tie(newTrainingRowMasks, newTestingRowMasks, std::ignore) =
+                    CDataFrameUtils::stratifiedCrossValidationRowMasks(
+                        numberThreads, frame, dependentVariable, rng,
+                        numberFolds, trainFractionPerFold, numberBuckets,
+                        allTrainingRowsMask & newTrainingRowMask);
+                for (std::size_t i = 0; i < numberFolds; ++i) {
+                    m_TreeImpl->m_TrainingRowMasks[i] |= newTrainingRowMasks[i];
+                    m_TreeImpl->m_TestingRowMasks[i] |= newTestingRowMasks[i];
+                }
             }
         }
     }
@@ -1225,6 +1245,11 @@ CBoostedTreeFactory& CBoostedTreeFactory::trainFractionPerFold(double fraction) 
 
 CBoostedTreeFactory& CBoostedTreeFactory::maximumNumberTrainRows(std::size_t rows) {
     m_MaximumNumberOfTrainRows = rows;
+    return *this;
+}
+
+CBoostedTreeFactory& CBoostedTreeFactory::holdoutRowMask(core::CPackedBitVector holdoutRowMask) {
+    m_HoldoutRowMask = std::move(holdoutRowMask);
     return *this;
 }
 

--- a/lib/maths/analytics/CBoostedTreeHyperparameters.cc
+++ b/lib/maths/analytics/CBoostedTreeHyperparameters.cc
@@ -506,7 +506,7 @@ bool CBoostedTreeHyperparameters::selectNext(const TMeanVarAccumulator& testLoss
     return true;
 }
 
-void CBoostedTreeHyperparameters::captureBest(const TMeanVarAccumulator& testLossMoments,
+bool CBoostedTreeHyperparameters::captureBest(const TMeanVarAccumulator& testLossMoments,
                                               double meanLossGap,
                                               double numberKeptNodes,
                                               double numberNewNodes,
@@ -531,7 +531,9 @@ void CBoostedTreeHyperparameters::captureBest(const TMeanVarAccumulator& testLos
         m_MaximumNumberTrees.set(numberTrees);
         this->saveCurrent();
         m_MaximumNumberTrees.set(numberTreesToRestore);
+        return true;
     }
+    return false;
 }
 
 double CBoostedTreeHyperparameters::modelSizePenalty(double numberKeptNodes,

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -330,7 +330,7 @@ auto predictAndComputeEvaluationMetrics(const F& generateFunction,
             std::tie(bias, rSquared) = computeEvaluationMetrics(
                 *frame, trainRows, rows,
                 [&](const TRowRef& row) {
-                    return regression->readPrediction(row)[0];
+                    return regression->prediction(row)[0];
                 },
                 target, noiseVariance / static_cast<double>(rows));
             modelBias[test].push_back(bias);
@@ -390,9 +390,7 @@ auto predictAndComputeEvaluationMetrics(const F& generateFunction,
         double rSquared;
         std::tie(bias, rSquared) = computeEvaluationMetrics(
             *frame, trainRows, rows,
-            [&](const TRowRef& row) {
-                return regression->readPrediction(row)[0];
-            },
+            [&](const TRowRef& row) { return regression->prediction(row)[0]; },
             target, noiseVariance / static_cast<double>(rows), outliers);
         modelBias.push_back(bias);
         modelRSquared.push_back(rSquared);
@@ -782,7 +780,7 @@ BOOST_AUTO_TEST_CASE(testLowTrainFractionPerFold) {
     double rSquared;
     std::tie(bias, rSquared) = computeEvaluationMetrics(
         *frame, trainRows, rows,
-        [&](const TRowRef& row_) { return regression->readPrediction(row_)[0]; },
+        [&](const TRowRef& row_) { return regression->prediction(row_)[0]; },
         target, noiseVariance / static_cast<double>(rows));
 
     // Unbiased...
@@ -790,6 +788,182 @@ BOOST_AUTO_TEST_CASE(testLowTrainFractionPerFold) {
         0.0, bias, 7.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
     // Good R^2...
     BOOST_TEST_REQUIRE(rSquared > 0.98);
+}
+
+BOOST_AUTO_TEST_CASE(testHoldoutRowMask) {
+
+    // Check that we can effectively train using loss on a specified holdout set.
+
+    test::CRandomNumbers rng;
+    double noiseVariance{10.0};
+    std::size_t rows{1000};
+    std::size_t cols{6};
+
+    std::size_t endOfHoldoutRows{200};
+
+    auto target = [&] {
+        TDoubleVec m;
+        TDoubleVec s;
+        rng.generateUniformSamples(0.0, 10.0, cols - 1, m);
+        rng.generateUniformSamples(-10.0, 10.0, cols - 1, s);
+        return [=](const TRowRef& row) {
+            double result{0.0};
+            for (std::size_t i = 0; i < cols - 1; ++i) {
+                result += m[i] + s[i] * row[i];
+            }
+            return result;
+        };
+    }();
+
+    TDoubleVecVec x(cols - 1);
+    for (std::size_t i = 0; i < cols - 1; ++i) {
+        rng.generateUniformSamples(0.0, 10.0, rows, x[i]);
+    }
+
+    TDoubleVec noise;
+    rng.generateNormalSamples(0.0, noiseVariance, rows, noise);
+
+    auto frame = core::makeMainStorageDataFrame(cols, rows).first;
+    fillDataFrame(rows, 0, cols, x, noise, target, *frame);
+
+    auto regression = maths::analytics::CBoostedTreeFactory::constructFromParameters(
+                          1, std::make_unique<maths::analytics::boosted_tree::CMse>())
+                          .endOfHoldoutRows(endOfHoldoutRows)
+                          .buildForTrain(*frame, cols - 1);
+
+    regression->train();
+    regression->predict();
+
+    // Test the minimum cross-validation error matches the error we compute for
+    // holdout set.
+
+    core::CPackedBitVector holdoutRowMask(endOfHoldoutRows, true);
+    holdoutRowMask.extend(false, rows - endOfHoldoutRows);
+
+    TMeanVarAccumulator expectedMse;
+    frame->readRows(1, 0, frame->numberRows(),
+                    [&](const TRowItr& beginRows, const TRowItr& endRows) {
+                        for (auto row = beginRows; row != endRows; ++row) {
+                            double actual{(*row)[cols - 1]};
+                            double prediction{regression->prediction(*row)[0]};
+                            expectedMse.add(maths::common::CTools::pow2(actual - prediction));
+                        }
+                    },
+                    &holdoutRowMask);
+
+    auto roundLosses = regression->impl().foldRoundTestLosses()[0];
+
+    auto actualMse = *std::min_element(
+        roundLosses.begin(), roundLosses.end(),
+        [](const auto& lhs, const auto& rhs) { return *lhs < *rhs; });
+
+    BOOST_REQUIRE_CLOSE(maths::common::CBasicStatistics::mean(expectedMse), *actualMse, 1e-3);
+}
+
+BOOST_AUTO_TEST_CASE(testIncrementalHoldoutRowMask) {
+
+    // Check that we can effectively incrementally train using loss on a specified
+    // holdout set.
+
+    test::CRandomNumbers rng;
+    double noiseVariance{10.0};
+    std::size_t rows{1000};
+    std::size_t cols{6};
+
+    std::size_t extraTrainingRows{200};
+    std::size_t endOfHoldoutRows{200};
+
+    auto target = [&] {
+        TDoubleVec m;
+        TDoubleVec s;
+        rng.generateUniformSamples(0.0, 10.0, cols - 1, m);
+        rng.generateUniformSamples(-10.0, 10.0, cols - 1, s);
+        return [=](const TRowRef& row) {
+            double result{0.0};
+            for (std::size_t i = 0; i < cols - 1; ++i) {
+                result += m[i] + s[i] * row[i];
+            }
+            return result;
+        };
+    }();
+
+    TDoubleVecVec x(cols - 1);
+    for (std::size_t i = 0; i < cols - 1; ++i) {
+        rng.generateUniformSamples(0.0, 10.0, rows, x[i]);
+    }
+
+    TDoubleVec noise;
+    rng.generateNormalSamples(0.0, noiseVariance, rows, noise);
+
+    auto frame = core::makeMainStorageDataFrame(cols).first;
+    fillDataFrame(rows, 0, cols, x, noise, target, *frame);
+
+    auto regression = maths::analytics::CBoostedTreeFactory::constructFromParameters(
+                          1, std::make_unique<maths::analytics::boosted_tree::CMse>())
+                          .endOfHoldoutRows(endOfHoldoutRows)
+                          .eta({0.02})
+                          .buildForTrain(*frame, cols - 1);
+
+    regression->train();
+    regression->predict();
+
+    auto newFrame = core::makeMainStorageDataFrame(cols).first;
+
+    fillDataFrame(rows, 0, cols, x, noise, target, *newFrame);
+
+    for (std::size_t i = 0; i < cols - 1; ++i) {
+        rng.generateUniformSamples(0.0, 10.0, extraTrainingRows, x[i]);
+    }
+    rng.generateNormalSamples(0.0, noiseVariance, extraTrainingRows, noise);
+
+    fillDataFrame(extraTrainingRows, 0, cols, x, noise, target, *newFrame);
+
+    core::CPackedBitVector oldTrainingRowMask{rows, true};
+    oldTrainingRowMask.extend(false, extraTrainingRows);
+    core::CPackedBitVector newTrainingRowMask{~oldTrainingRowMask};
+
+    double alpha{regression->hyperparameters().depthPenaltyMultiplier().value()};
+    double gamma{regression->hyperparameters().treeSizePenaltyMultiplier().value()};
+    double lambda{regression->hyperparameters().leafWeightPenaltyMultiplier().value()};
+    regression = maths::analytics::CBoostedTreeFactory::constructFromModel(std::move(regression))
+                     .endOfHoldoutRows(endOfHoldoutRows)
+                     .newTrainingRowMask(newTrainingRowMask)
+                     .depthPenaltyMultiplier({0.5 * alpha, 2.0 * alpha})
+                     .treeSizePenaltyMultiplier({0.5 * gamma, 2.0 * gamma})
+                     .leafWeightPenaltyMultiplier({0.5 * lambda, 2.0 * lambda})
+                     .buildForTrainIncremental(*newFrame, cols - 1);
+
+    regression->trainIncremental();
+    regression->predict();
+
+    // Test the minimum cross-validation error matches the error we compute for
+    // holdout set.
+
+    core::CPackedBitVector holdoutRowMask(endOfHoldoutRows, true);
+    holdoutRowMask.extend(false, rows - endOfHoldoutRows);
+    TMeanAccumulator expectedMse;
+    TMeanAccumulator expectedMsd;
+    newFrame->readRows(
+        1, 0, frame->numberRows(),
+        [&](const TRowItr& beginRows, const TRowItr& endRows) {
+            for (auto row = beginRows; row != endRows; ++row) {
+                double actual{(*row)[cols - 1]};
+                double prediction{regression->prediction(*row)[0]};
+                double previousPrediction{regression->previousPrediction(*row)[0]};
+                expectedMse.add(maths::common::CTools::pow2(actual - prediction));
+                expectedMsd.add(maths::common::CTools::pow2(prediction - previousPrediction));
+            }
+        },
+        &holdoutRowMask);
+    LOG_DEBUG(<< expectedMse << " " << expectedMsd);
+    LOG_DEBUG(<< maths::common::CBasicStatistics::mean(expectedMse) +
+                     0.01 * maths::common::CBasicStatistics::mean(expectedMsd));
+
+    auto roundLosses = regression->impl().foldRoundTestLosses()[0];
+    LOG_DEBUG(<< core::CContainerPrinter::print(roundLosses));
+    auto actualMse = *std::min_element(
+        roundLosses.begin(), roundLosses.end(),
+        [](const auto& lhs, const auto& rhs) { return *lhs < *rhs; });
 }
 
 BOOST_AUTO_TEST_CASE(testMseIncrementalForTargetDrift) {
@@ -879,24 +1053,24 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalForTargetDrift) {
     regression->predict();
 
     // Get the average error on the old and new training data from the old model.
-    frame->readRows(
-        1, 0, frame->numberRows(),
-        [&](const TRowItr& beginRows, const TRowItr& endRows) {
-            for (auto row = beginRows; row != endRows; ++row) {
-                mseBeforeIncrementalTraining[OLD_TRAINING_DATA].add(maths::common::CTools::pow2(
-                    (*row)[cols - 1] - regression->readPrediction(*row)[0]));
-            }
-        },
-        &oldTrainingRowMask);
-    frame->readRows(
-        1, 0, frame->numberRows(),
-        [&](const TRowItr& beginRows, const TRowItr& endRows) {
-            for (auto row = beginRows; row != endRows; ++row) {
-                mseBeforeIncrementalTraining[NEW_TRAINING_DATA].add(maths::common::CTools::pow2(
-                    (*row)[cols - 1] - regression->readPrediction(*row)[0]));
-            }
-        },
-        &newTrainingRowMask);
+    frame->readRows(1, 0, frame->numberRows(),
+                    [&](const TRowItr& beginRows, const TRowItr& endRows) {
+                        for (auto row = beginRows; row != endRows; ++row) {
+                            mseBeforeIncrementalTraining[OLD_TRAINING_DATA].add(
+                                maths::common::CTools::pow2(
+                                    (*row)[cols - 1] - regression->prediction(*row)[0]));
+                        }
+                    },
+                    &oldTrainingRowMask);
+    frame->readRows(1, 0, frame->numberRows(),
+                    [&](const TRowItr& beginRows, const TRowItr& endRows) {
+                        for (auto row = beginRows; row != endRows; ++row) {
+                            mseBeforeIncrementalTraining[NEW_TRAINING_DATA].add(
+                                maths::common::CTools::pow2(
+                                    (*row)[cols - 1] - regression->prediction(*row)[0]));
+                        }
+                    },
+                    &newTrainingRowMask);
 
     double alpha{regression->hyperparameters().depthPenaltyMultiplier().value()};
     double gamma{regression->hyperparameters().treeSizePenaltyMultiplier().value()};
@@ -917,7 +1091,7 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalForTargetDrift) {
         [&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 mseAfterIncrementalTraining[OLD_TRAINING_DATA].add(maths::common::CTools::pow2(
-                    (*row)[cols - 1] - regression->readPrediction(*row)[0]));
+                    (*row)[cols - 1] - regression->prediction(*row)[0]));
             }
         },
         &oldTrainingRowMask);
@@ -926,7 +1100,7 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalForTargetDrift) {
         [&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 mseAfterIncrementalTraining[NEW_TRAINING_DATA].add(maths::common::CTools::pow2(
-                    (*row)[cols - 1] - regression->readPrediction(*row)[0]));
+                    (*row)[cols - 1] - regression->prediction(*row)[0]));
             }
         },
         &newTrainingRowMask);
@@ -1019,24 +1193,24 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalForOutOfDomain) {
     regression->predict();
 
     // Get the average error on the old and new training data from the old model.
-    frame->readRows(
-        1, 0, frame->numberRows(),
-        [&](const TRowItr& beginRows, const TRowItr& endRows) {
-            for (auto row = beginRows; row != endRows; ++row) {
-                mseBeforeIncrementalTraining[OLD_TRAINING_DATA].add(maths::common::CTools::pow2(
-                    (*row)[cols - 1] - regression->readPrediction(*row)[0]));
-            }
-        },
-        &oldTrainingRowMask);
-    frame->readRows(
-        1, 0, frame->numberRows(),
-        [&](const TRowItr& beginRows, const TRowItr& endRows) {
-            for (auto row = beginRows; row != endRows; ++row) {
-                mseBeforeIncrementalTraining[NEW_TRAINING_DATA].add(maths::common::CTools::pow2(
-                    (*row)[cols - 1] - regression->readPrediction(*row)[0]));
-            }
-        },
-        &newTrainingRowMask);
+    frame->readRows(1, 0, frame->numberRows(),
+                    [&](const TRowItr& beginRows, const TRowItr& endRows) {
+                        for (auto row = beginRows; row != endRows; ++row) {
+                            mseBeforeIncrementalTraining[OLD_TRAINING_DATA].add(
+                                maths::common::CTools::pow2(
+                                    (*row)[cols - 1] - regression->prediction(*row)[0]));
+                        }
+                    },
+                    &oldTrainingRowMask);
+    frame->readRows(1, 0, frame->numberRows(),
+                    [&](const TRowItr& beginRows, const TRowItr& endRows) {
+                        for (auto row = beginRows; row != endRows; ++row) {
+                            mseBeforeIncrementalTraining[NEW_TRAINING_DATA].add(
+                                maths::common::CTools::pow2(
+                                    (*row)[cols - 1] - regression->prediction(*row)[0]));
+                        }
+                    },
+                    &newTrainingRowMask);
 
     double alpha{regression->hyperparameters().depthPenaltyMultiplier().value()};
     double gamma{regression->hyperparameters().treeSizePenaltyMultiplier().value()};
@@ -1057,7 +1231,7 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalForOutOfDomain) {
         [&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 mseAfterIncrementalTraining[OLD_TRAINING_DATA].add(maths::common::CTools::pow2(
-                    (*row)[cols - 1] - regression->readPrediction(*row)[0]));
+                    (*row)[cols - 1] - regression->prediction(*row)[0]));
             }
         },
         &oldTrainingRowMask);
@@ -1066,7 +1240,7 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalForOutOfDomain) {
         [&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 mseAfterIncrementalTraining[NEW_TRAINING_DATA].add(maths::common::CTools::pow2(
-                    (*row)[cols - 1] - regression->readPrediction(*row)[0]));
+                    (*row)[cols - 1] - regression->prediction(*row)[0]));
             }
         },
         &newTrainingRowMask);
@@ -1089,7 +1263,7 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalForOutOfDomain) {
     BOOST_TEST_REQUIRE(errorDecreaseOnNew > 100.0 * errorIncreaseOnOld);
 }
 
-BOOST_AUTO_TEST_CASE(testIncrementalAddNewTrees) {
+BOOST_AUTO_TEST_CASE(testMseIncrementalAddNewTrees) {
     // Update the base model by allowing 0, 2, and 10 new trees. Verify that the test error is
     // note getting worse when allowing for more model capacity.
     // TODO #2188 Add a unit test with hold-out data.
@@ -1181,15 +1355,14 @@ BOOST_AUTO_TEST_CASE(testIncrementalAddNewTrees) {
             maths::analytics::CBoostedTreeFactory::constructFromModel(std::move(model))
                 .buildForPredict(*testData, cols - 1);
         predictor->predict();
-        testData->readRows(
-            1, 0, testData->numberRows(),
-            [&](const TRowItr& beginRows, const TRowItr& endRows) {
-                for (auto row = beginRows; row != endRows; ++row) {
-                    squaredError.add(maths::common::CTools::pow2(
-                        (*row)[cols - 1] - predictor->readPrediction(*row)[0]));
-                }
-            },
-            &testDataRowMask);
+        testData->readRows(1, 0, testData->numberRows(),
+                           [&](const TRowItr& beginRows, const TRowItr& endRows) {
+                               for (auto row = beginRows; row != endRows; ++row) {
+                                   squaredError.add(maths::common::CTools::pow2(
+                                       (*row)[cols - 1] - predictor->prediction(*row)[0]));
+                               }
+                           },
+                           &testDataRowMask);
         return maths::common::CBasicStatistics::mean(squaredError);
     };
 
@@ -1273,8 +1446,8 @@ BOOST_AUTO_TEST_CASE(testThreading) {
 
         frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
-                modelPredictionErrorMoments.add(
-                    target(*row) - regression->readPrediction(*row)[0]);
+                modelPredictionErrorMoments.add(target(*row) -
+                                                regression->prediction(*row)[0]);
             }
         });
 
@@ -1369,7 +1542,7 @@ BOOST_AUTO_TEST_CASE(testConstantTarget) {
 
     frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
-            modelPredictionError.add(1.0 - regression->readPrediction(*row)[0]);
+            modelPredictionError.add(1.0 - regression->prediction(*row)[0]);
         }
     });
 
@@ -1443,8 +1616,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalRegressors) {
     double modelRSquared;
     std::tie(modelBias, modelRSquared) = computeEvaluationMetrics(
         *frame, trainRows, rows,
-        [&](const TRowRef& row) { return regression->readPrediction(row)[0]; },
-        target, 0.0);
+        [&](const TRowRef& row) { return regression->prediction(row)[0]; }, target, 0.0);
 
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
@@ -1609,7 +1781,7 @@ BOOST_AUTO_TEST_CASE(testIntegerRegressor) {
     double modelRSquared;
     std::tie(modelBias, modelRSquared) = computeEvaluationMetrics(
         *frame, trainRows, rows,
-        [&](const TRowRef& row) { return regression->readPrediction(row)[0]; },
+        [&](const TRowRef& row) { return regression->prediction(row)[0]; },
         [&](const TRowRef& x) { return 10.0 * x[0]; }, 0.0);
 
     LOG_DEBUG(<< "bias = " << modelBias);
@@ -1655,7 +1827,7 @@ BOOST_AUTO_TEST_CASE(testSingleSplit) {
     double modelRSquared;
     std::tie(modelBias, modelRSquared) = computeEvaluationMetrics(
         *frame, 0, rows,
-        [&](const TRowRef& row) { return regression->readPrediction(row)[0]; },
+        [&](const TRowRef& row) { return regression->prediction(row)[0]; },
         [](const TRowRef& row) { return 10.0 * row[0]; }, 0.0);
 
     LOG_DEBUG(<< "bias = " << modelBias);
@@ -1714,12 +1886,10 @@ BOOST_AUTO_TEST_CASE(testTranslationInvariance) {
 
         double modelBias;
         double modelRSquared;
-        std::tie(modelBias, modelRSquared) =
-            computeEvaluationMetrics(*frame, trainRows, rows,
-                                     [&](const TRowRef& row) {
-                                         return regression->readPrediction(row)[0];
-                                     },
-                                     target_, 0.0);
+        std::tie(modelBias, modelRSquared) = computeEvaluationMetrics(
+            *frame, trainRows, rows,
+            [&](const TRowRef& row) { return regression->prediction(row)[0]; },
+            target_, 0.0);
 
         LOG_DEBUG(<< "bias = " << modelBias);
         LOG_DEBUG(<< " R^2 = " << modelRSquared);
@@ -1859,7 +2029,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
             for (auto row = beginRows; row != endRows; ++row) {
                 if (row->index() >= trainRows) {
                     double expectedProbability{probability(*row)};
-                    double actualProbability{classifier->readPrediction(*row)[1]};
+                    double actualProbability{classifier->prediction(*row)[1]};
                     logRelativeError.add(
                         std::log(std::max(actualProbability, expectedProbability) /
                                  std::min(actualProbability, expectedProbability)));
@@ -1972,13 +2142,13 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForTargetDrift) {
 
     auto addToRelativeError = [&](const TRowRef& row, TMeanAccumulator& logRelativeError) {
         double expectedProbability{probability(row)};
-        double actualProbability{classifier->readPrediction(row)[1]};
+        double actualProbability{classifier->prediction(row)[1]};
         logRelativeError.add(std::log(std::max(actualProbability, expectedProbability) /
                                       std::min(actualProbability, expectedProbability)));
     };
     auto addToPerturbedRelativeError = [&](const TRowRef& row, TMeanAccumulator& logRelativeError) {
         double expectedProbability{perturbedProbability(row)};
-        double actualProbability{classifier->readPrediction(row)[1]};
+        double actualProbability{classifier->prediction(row)[1]};
         logRelativeError.add(std::log(std::max(actualProbability, expectedProbability) /
                                       std::min(actualProbability, expectedProbability)));
     };
@@ -2129,7 +2299,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForOutOfDomain) {
 
     auto addToRelativeError = [&](const TRowRef& row, TMeanAccumulator& logRelativeError) {
         double expectedProbability{probability(row)};
-        double actualProbability{classifier->readPrediction(row)[1]};
+        double actualProbability{classifier->prediction(row)[1]};
         logRelativeError.add(std::log(std::max(actualProbability, expectedProbability) /
                                       std::min(actualProbability, expectedProbability)));
     };
@@ -2263,7 +2433,7 @@ BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
         TDoubleVec falseNegatives(2, 0.0);
         frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
-                auto scores = classifier->readAndAdjustPrediction(*row);
+                auto scores = classifier->adjustedPrediction(*row);
                 std::size_t prediction(scores[1] < scores[0] ? 0 : 1);
                 if (row->index() >= trainRows &&
                     row->index() < trainRows + classesRowCounts[2]) {
@@ -2421,7 +2591,7 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {
                 if (row->index() >= trainRows) {
                     TVector expectedProbability{probability(*row)};
                     TVector actualProbability{
-                        TVector::fromSmallVector(classifier->readPrediction(*row))};
+                        TVector::fromSmallVector(classifier->prediction(*row))};
                     logRelativeError.add(
                         (expectedProbability.cwiseMax(actualProbability).array() /
                          expectedProbability.cwiseMin(actualProbability).array())
@@ -2732,7 +2902,7 @@ BOOST_AUTO_TEST_CASE(testMissingFeatures) {
     frame->readRows(1, [&](const TRowItr& beginRows, const TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
             if (maths::analytics::CDataFrameUtils::isMissing((*row)[cols - 1])) {
-                actualPredictions.push_back(regression->readPrediction(*row)[0]);
+                actualPredictions.push_back(regression->prediction(*row)[0]);
             }
         }
     });
@@ -2848,75 +3018,6 @@ BOOST_AUTO_TEST_CASE(testHyperparameterOverrides) {
         BOOST_REQUIRE_EQUAL(
             1.1, regression->hyperparameters().etaGrowthRatePerTree().value());
     }
-}
-
-BOOST_AUTO_TEST_CASE(testHoldoutRowMask) {
-
-    // Check that we can effectively train using loss on a specified holdout set.
-
-    test::CRandomNumbers rng;
-    double noiseVariance{10.0};
-    std::size_t rows{1000};
-    std::size_t cols{6};
-
-    auto target = [&] {
-        TDoubleVec m;
-        TDoubleVec s;
-        rng.generateUniformSamples(0.0, 10.0, cols - 1, m);
-        rng.generateUniformSamples(-10.0, 10.0, cols - 1, s);
-        return [=](const TRowRef& row) {
-            double result{0.0};
-            for (std::size_t i = 0; i < cols - 1; ++i) {
-                result += m[i] + s[i] * row[i];
-            }
-            return result;
-        };
-    }();
-
-    auto frame = core::makeMainStorageDataFrame(cols, rows).first;
-
-    TDoubleVecVec x(cols - 1);
-    for (std::size_t i = 0; i < cols - 1; ++i) {
-        rng.generateUniformSamples(0.0, 10.0, rows, x[i]);
-    }
-
-    TDoubleVec noise;
-    rng.generateNormalSamples(0.0, noiseVariance, rows, noise);
-
-    fillDataFrame(rows, 0, cols, x, noise, target, *frame);
-
-    core::CPackedBitVector holdoutRowMask(rows - 200, false);
-    holdoutRowMask.extend(true, 200);
-
-    auto regression = maths::analytics::CBoostedTreeFactory::constructFromParameters(
-                          1, std::make_unique<maths::analytics::boosted_tree::CMse>())
-                          .holdoutRowMask(holdoutRowMask)
-                          .buildForTrain(*frame, cols - 1);
-
-    regression->train();
-    regression->predict();
-
-    // Test the minimum cross-validation error matches the error we compute for
-    // holdout set.
-
-    auto roundLosses = regression->impl().foldRoundTestLosses()[0];
-
-    TMeanVarAccumulator expectedMse;
-    frame->readRows(1, 0, frame->numberRows(),
-                    [&](const TRowItr& beginRows, const TRowItr& endRows) {
-                        for (auto row = beginRows; row != endRows; ++row) {
-                            double actual{(*row)[cols - 1]};
-                            double prediction{regression->readPrediction(*row)[0]};
-                            expectedMse.add(maths::common::CTools::pow2(actual - prediction));
-                        }
-                    },
-                    &holdoutRowMask);
-
-    auto actualMse = *std::min_element(
-        roundLosses.begin(), roundLosses.end(),
-        [](const auto& lhs, const auto& rhs) { return *lhs < *rhs; });
-
-    BOOST_REQUIRE_CLOSE(maths::common::CBasicStatistics::mean(expectedMse), *actualMse, 1e-3);
 }
 
 BOOST_AUTO_TEST_CASE(testPersistRestore) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -799,7 +799,7 @@ BOOST_AUTO_TEST_CASE(testHoldoutRowMask) {
     std::size_t rows{1000};
     std::size_t cols{6};
 
-    std::size_t endOfHoldoutRows{200};
+    std::size_t numberHoldoutRows{200};
 
     auto target = [&] {
         TDoubleVec m;
@@ -828,7 +828,7 @@ BOOST_AUTO_TEST_CASE(testHoldoutRowMask) {
 
     auto regression = maths::analytics::CBoostedTreeFactory::constructFromParameters(
                           1, std::make_unique<maths::analytics::boosted_tree::CMse>())
-                          .endOfHoldoutRows(endOfHoldoutRows)
+                          .numberHoldoutRows(numberHoldoutRows)
                           .buildForTrain(*frame, cols - 1);
 
     regression->train();
@@ -837,8 +837,8 @@ BOOST_AUTO_TEST_CASE(testHoldoutRowMask) {
     // Test the minimum cross-validation error matches the error we compute for
     // holdout set.
 
-    core::CPackedBitVector holdoutRowMask(endOfHoldoutRows, true);
-    holdoutRowMask.extend(false, rows - endOfHoldoutRows);
+    core::CPackedBitVector holdoutRowMask(numberHoldoutRows, true);
+    holdoutRowMask.extend(false, rows - numberHoldoutRows);
 
     TMeanVarAccumulator expectedMse;
     frame->readRows(1, 0, frame->numberRows(),
@@ -871,7 +871,7 @@ BOOST_AUTO_TEST_CASE(testIncrementalHoldoutRowMask) {
     std::size_t cols{6};
 
     std::size_t extraTrainingRows{200};
-    std::size_t endOfHoldoutRows{200};
+    std::size_t numberHoldoutRows{200};
 
     auto target = [&] {
         TDoubleVec m;
@@ -900,7 +900,7 @@ BOOST_AUTO_TEST_CASE(testIncrementalHoldoutRowMask) {
 
     auto regression = maths::analytics::CBoostedTreeFactory::constructFromParameters(
                           1, std::make_unique<maths::analytics::boosted_tree::CMse>())
-                          .endOfHoldoutRows(endOfHoldoutRows)
+                          .numberHoldoutRows(numberHoldoutRows)
                           .eta({0.02})
                           .buildForTrain(*frame, cols - 1);
 
@@ -926,7 +926,7 @@ BOOST_AUTO_TEST_CASE(testIncrementalHoldoutRowMask) {
     double gamma{regression->hyperparameters().treeSizePenaltyMultiplier().value()};
     double lambda{regression->hyperparameters().leafWeightPenaltyMultiplier().value()};
     regression = maths::analytics::CBoostedTreeFactory::constructFromModel(std::move(regression))
-                     .endOfHoldoutRows(endOfHoldoutRows)
+                     .numberHoldoutRows(numberHoldoutRows)
                      .newTrainingRowMask(newTrainingRowMask)
                      .depthPenaltyMultiplier({0.5 * alpha, 2.0 * alpha})
                      .treeSizePenaltyMultiplier({0.5 * gamma, 2.0 * gamma})
@@ -939,8 +939,8 @@ BOOST_AUTO_TEST_CASE(testIncrementalHoldoutRowMask) {
     // Test the minimum cross-validation error matches the error we compute for
     // holdout set.
 
-    core::CPackedBitVector holdoutRowMask(endOfHoldoutRows, true);
-    holdoutRowMask.extend(false, rows - endOfHoldoutRows);
+    core::CPackedBitVector holdoutRowMask(numberHoldoutRows, true);
+    holdoutRowMask.extend(false, rows - numberHoldoutRows);
     TMeanAccumulator expectedMse;
     TMeanAccumulator expectedMsd;
     newFrame->readRows(

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -955,15 +955,15 @@ BOOST_AUTO_TEST_CASE(testIncrementalHoldoutRowMask) {
             }
         },
         &holdoutRowMask);
-    LOG_DEBUG(<< expectedMse << " " << expectedMsd);
-    LOG_DEBUG(<< maths::common::CBasicStatistics::mean(expectedMse) +
-                     0.01 * maths::common::CBasicStatistics::mean(expectedMsd));
 
     auto roundLosses = regression->impl().foldRoundTestLosses()[0];
-    LOG_DEBUG(<< core::CContainerPrinter::print(roundLosses));
     auto actualMse = *std::min_element(
         roundLosses.begin(), roundLosses.end(),
         [](const auto& lhs, const auto& rhs) { return *lhs < *rhs; });
+
+    BOOST_REQUIRE_CLOSE(maths::common::CBasicStatistics::mean(expectedMse) +
+                            0.01 * maths::common::CBasicStatistics::mean(expectedMsd),
+                        *actualMse, 1e-3);
 }
 
 BOOST_AUTO_TEST_CASE(testMseIncrementalForTargetDrift) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -2048,7 +2048,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
     BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 0.52);
 }
 
-BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForTargetDrift) {
+BOOST_AUTO_TEST_CASE(testBinomialLogisticIncrementalForTargetDrift) {
 
     // Test incremental training for the binomial logistic objective for drift in the
     // target value.
@@ -2226,7 +2226,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForTargetDrift) {
     BOOST_TEST_REQUIRE(errorDecreaseOnNew > 100.0 * errorIncreaseOnOld);
 }
 
-BOOST_AUTO_TEST_CASE(testBinomialLogisticRegressionIncrementalForOutOfDomain) {
+BOOST_AUTO_TEST_CASE(testBinomialLogisticIncrementalForOutOfDomain) {
 
     // Test incremental training for binomial logistic objective for values out of the
     // training data domain.


### PR DESCRIPTION
When training from scratch on very large data sets using multiple rounds of incremental training, we have both plenty of data and we don't want the examples selected to include in the training set in later rounds to be used for validation. They will depend on the selection criterion and so will not be a uniform sampling of the full data set. Also this process is likely to leak information about the model.

In this case, it is better to use a fixed evaluation set which is held out from training and can be sampled at random upfront. This change introduces that holdout set. Since we maintain row masks for the test and train sets for cross-validation it is easy to hijack the cross-validation mechanism for this purpose by simply having one fold.