### PR TITLE
[ML] Improve handling of non-finite values

### DIFF
--- a/include/maths/common/CMathsFuncs.h
+++ b/include/maths/common/CMathsFuncs.h
@@ -56,6 +56,9 @@ public:
     static bool isNan(const CSymmetricMatrix<double>& val);
     //! Check if any of the entries are NaN.
     static bool isNan(const core::CSmallVectorBase<double>& val);
+    //! Check if any of the entries are NaN.
+    template<typename T, std::size_t N>
+    static bool isNan(const std::array<T, N>& val);
 
     //! Check if value is infinite.
     static bool isInf(double val);
@@ -71,6 +74,9 @@ public:
     static bool isInf(const CSymmetricMatrix<double>& val);
     //! Check if any of the entries is infinite.
     static bool isInf(const core::CSmallVectorBase<double>& val);
+    //! Check if any of the entries is infinite.
+    template<typename T, std::size_t N>
+    static bool isInf(const std::array<T, N>& val);
 
     //! Neither infinite nor NaN.
     static bool isFinite(double val);
@@ -86,6 +92,9 @@ public:
     static bool isFinite(const CSymmetricMatrix<double>& val);
     //! Check if all of the entries are finite.
     static bool isFinite(const core::CSmallVectorBase<double>& val);
+    //! Check if all of the entries are finite.
+    template<typename T, std::size_t N>
+    static bool isFinite(const std::array<T, N>& val);
 
     //! Check the floating point status of \p value.
     static maths_t::EFloatingPointErrorStatus fpStatus(double val);

--- a/include/maths/common/CMathsFuncsForMatrixAndVectorTypes.h
+++ b/include/maths/common/CMathsFuncsForMatrixAndVectorTypes.h
@@ -15,6 +15,8 @@
 #include <maths/common/CLinearAlgebra.h>
 #include <maths/common/CMathsFuncs.h>
 
+#include <algorithm>
+
 namespace ml {
 namespace maths {
 namespace common {
@@ -72,6 +74,12 @@ bool CMathsFuncs::isNan(const CSymmetricMatrixNxN<double, N>& val) {
     return anElement(static_cast<bool (*)(double)>(&isNan), val);
 }
 
+template<typename T, std::size_t N>
+bool CMathsFuncs::isNan(const std::array<T, N>& val) {
+    return std::any_of(val.begin(), val.end(),
+                       [](const auto& x) { return isNan(x); });
+}
+
 template<std::size_t N>
 bool CMathsFuncs::isInf(const CVectorNx1<double, N>& val) {
     return aComponent(static_cast<bool (*)(double)>(&isInf), val);
@@ -82,6 +90,12 @@ bool CMathsFuncs::isInf(const CSymmetricMatrixNxN<double, N>& val) {
     return anElement(static_cast<bool (*)(double)>(&isInf), val);
 }
 
+template<typename T, std::size_t N>
+bool CMathsFuncs::isInf(const std::array<T, N>& val) {
+    return std::any_of(val.begin(), val.end(),
+                       [](const auto& x) { return isInf(x); });
+}
+
 template<std::size_t N>
 bool CMathsFuncs::isFinite(const CVectorNx1<double, N>& val) {
     return everyComponent(static_cast<bool (*)(double)>(&isFinite), val);
@@ -90,6 +104,12 @@ bool CMathsFuncs::isFinite(const CVectorNx1<double, N>& val) {
 template<std::size_t N>
 bool CMathsFuncs::isFinite(const CSymmetricMatrixNxN<double, N>& val) {
     return everyElement(static_cast<bool (*)(double)>(&isFinite), val);
+}
+
+template<typename T, std::size_t N>
+bool CMathsFuncs::isFinite(const std::array<T, N>& val) {
+    return std::all_of(val.begin(), val.end(),
+                       [](const auto& x) { return isFinite(x); });
 }
 }
 }

--- a/lib/maths/common/CGammaRateConjugate.cc
+++ b/lib/maths/common/CGammaRateConjugate.cc
@@ -23,6 +23,7 @@
 #include <maths/common/CChecksum.h>
 #include <maths/common/CIntegration.h>
 #include <maths/common/CMathsFuncs.h>
+#include <maths/common/CMathsFuncsForMatrixAndVectorTypes.h>
 #include <maths/common/COrderings.h>
 #include <maths/common/CRestoreParams.h>
 #include <maths/common/CSolvers.h>
@@ -363,15 +364,20 @@ bool evaluateFunctionOnJointDistribution(const TDouble1Vec& samples,
     LOG_TRACE(<< "likelihoodShape = " << likelihoodShape
               << ", priorShape = " << priorShape << ", priorRate = " << priorRate);
 
+    bool success = false;
     try {
         if (isNonInformative) {
             // The non-informative prior is improper and effectively zero
             // everywhere. (It is acceptable to approximate all finite samples
             // as at the median of this distribution.)
             for (std::size_t i = 0; i < samples.size(); ++i) {
+                if (CMathsFuncs::isNan(samples[i]) || CMathsFuncs::isNan(weights[i])) {
+                    continue;
+                }
                 double n = maths_t::count(weights[i]);
                 double x = samples[i] + offset;
                 result = aggregate(result, func(CTools::SImproperDistribution(), x), n);
+                success = true;
             }
         } else if (priorShape > 2 && priorShape > likelihoodShape * MINIMUM_GAMMA_SHAPE) {
             // The marginal likelihood is well approximated by a moment matched
@@ -399,6 +405,10 @@ bool evaluateFunctionOnJointDistribution(const TDouble1Vec& samples,
             LOG_TRACE(<< "shape = " << shape << ", rate = " << rate);
 
             for (std::size_t i = 0; i < samples.size(); ++i) {
+                if (CMathsFuncs::isNan(samples[i]) || CMathsFuncs::isNan(weights[i])) {
+                    continue;
+                }
+
                 // We assume the data are described by X = Y - u where, Y is
                 // gamma distributed and u is a constant offset. This means
                 // that {x(i) + u} are gamma distributed.
@@ -415,6 +425,7 @@ bool evaluateFunctionOnJointDistribution(const TDouble1Vec& samples,
                 boost::math::gamma_distribution<> gamma(scaledShape, 1.0 / scaledRate);
 
                 result = aggregate(result, func(gamma, x), n);
+                success = true;
             }
         } else {
             // We use the fact that the random variable is Z = X / (b + X) is
@@ -426,6 +437,10 @@ bool evaluateFunctionOnJointDistribution(const TDouble1Vec& samples,
             // and then using the beta distribution.
 
             for (std::size_t i = 0; i < samples.size(); ++i) {
+                if (CMathsFuncs::isNan(samples[i]) || CMathsFuncs::isNan(weights[i])) {
+                    continue;
+                }
+
                 // We assume the data are described by X = Y - u where, Y is
                 // gamma distributed and u is a constant offset. This means
                 // that {x(i) + u} are gamma distributed.
@@ -441,6 +456,7 @@ bool evaluateFunctionOnJointDistribution(const TDouble1Vec& samples,
                 LOG_TRACE(<< "x = " << x << ", z = " << z);
 
                 result = aggregate(result, func(beta, z), n);
+                success = true;
             }
         }
     } catch (const std::exception& e) {
@@ -453,7 +469,7 @@ bool evaluateFunctionOnJointDistribution(const TDouble1Vec& samples,
 
     LOG_TRACE(<< "result = " << result);
 
-    return true;
+    return success;
 }
 
 //! Evaluates a specified function object, which must be default constructible,
@@ -524,7 +540,10 @@ public:
                 CJointProbabilityOfLessLikelySamples::SAddProbability(), m_IsNonInformative,
                 m_Offset + x, m_LikelihoodShape, m_PriorShape, m_PriorRate, probability) ||
             !probability.calculate(result)) {
-            LOG_ERROR(<< "Failed to compute probability of less likely samples");
+            LOG_ERROR(<< "Failed to compute probability of less likely samples (samples ="
+                      << core::CContainerPrinter::print(m_Samples)
+                      << ", weights = " << core::CContainerPrinter::print(m_Weights)
+                      << ", offset = " << m_Offset + x << ")");
             return false;
         }
 
@@ -582,7 +601,7 @@ public:
     //! Evaluate the log marginal likelihood at the offset \p x.
     bool operator()(double x, double& result) const {
 
-        if (m_ErrorStatus & maths_t::E_FpFailed) {
+        if ((m_ErrorStatus & maths_t::E_FpFailed) != 0) {
             return false;
         }
 
@@ -590,8 +609,12 @@ public:
         double sampleSum = 0.0;
         double logSeasonalScaleSum = 0.0;
 
+        bool success = false;
         try {
             for (std::size_t i = 0; i < m_Samples.size(); ++i) {
+                if (CMathsFuncs::isNan(m_Samples[i]) || CMathsFuncs::isNan(m_Samples[i])) {
+                    continue;
+                }
                 double n = maths_t::countForUpdate(m_Weights[i]);
                 double varianceScale = maths_t::seasonalVarianceScale(m_Weights[i]) *
                                        maths_t::countVarianceScale(m_Weights[i]);
@@ -615,9 +638,14 @@ public:
                 logSamplesSum += n * (m_LikelihoodShape / varianceScale - 1.0) *
                                  std::log(sample);
                 sampleSum += n / varianceScale * sample;
+                success = true;
             }
         } catch (const std::exception& e) {
             LOG_ERROR(<< "Failed to calculate likelihood: " << e.what());
+            this->addErrorStatus(maths_t::E_FpFailed);
+            return false;
+        }
+        if (!success) {
             this->addErrorStatus(maths_t::E_FpFailed);
             return false;
         }
@@ -667,11 +695,9 @@ private:
                      nResidual * std::lgamma(m_LikelihoodShape) +
                      std::lgamma(m_ImpliedShape);
 
-        if (std::isnan(m_ImpliedShape) || std::isnan(m_Constant)) {
-            LOG_ERROR(<< "Error calculating marginal likelihood: floating point nan");
+        if (CMathsFuncs::isNan(m_ImpliedShape) || CMathsFuncs::isNan(m_Constant)) {
             this->addErrorStatus(maths_t::E_FpFailed);
-        } else if (std::isinf(m_ImpliedShape) || std::isinf(m_Constant)) {
-            LOG_ERROR(<< "Error calculating marginal likelihood: floating point overflow");
+        } else if (CMathsFuncs::isInf(m_ImpliedShape) || CMathsFuncs::isInf(m_Constant)) {
             this->addErrorStatus(maths_t::E_FpOverflowed);
         }
     }
@@ -882,16 +908,15 @@ void CGammaRateConjugate::addSamples(const TDouble1Vec& samples,
         double shift = boost::math::digamma(m_LikelihoodShape);
         for (std::size_t i = 0; i < samples.size(); ++i) {
             double x = samples[i] + m_Offset;
+            if (x <= 0.0 || !CMathsFuncs::isFinite(x) ||
+                !CMathsFuncs::isFinite(weights[i])) {
+                LOG_ERROR(<< "Discarding sample = " << x << ", weights = "
+                          << core::CContainerPrinter::print(weights));
+                continue;
+            }
             double n = maths_t::countForUpdate(weights[i]);
             double varianceScale = maths_t::seasonalVarianceScale(weights[i]) *
                                    maths_t::countVarianceScale(weights[i]);
-
-            if (x <= 0.0 || !CMathsFuncs::isFinite(x) || !CMathsFuncs::isFinite(n) ||
-                !CMathsFuncs::isFinite(varianceScale)) {
-                LOG_ERROR(<< "Discarding sample = " << x << ", weight = " << n
-                          << ", variance scale = " << varianceScale);
-                continue;
-            }
 
             double shift_ = -shift + boost::math::digamma(m_LikelihoodShape / varianceScale) +
                             std::log(varianceScale);
@@ -1167,11 +1192,11 @@ CGammaRateConjugate::jointLogMarginalLikelihood(const TDouble1Vec& samples,
 
         status = static_cast<maths_t::EFloatingPointErrorStatus>(
             logMarginalLikelihood.errorStatus() | CMathsFuncs::fpStatus(result));
-        if (status & maths_t::E_FpFailed) {
+        if ((status & maths_t::E_FpFailed) != 0) {
             LOG_ERROR(<< "Failed to compute log likelihood (" << this->debug() << ")");
             LOG_ERROR(<< "samples = " << core::CContainerPrinter::print(samples));
             LOG_ERROR(<< "weights = " << core::CContainerPrinter::print(weights));
-        } else if (status & maths_t::E_FpOverflowed) {
+        } else if ((status & maths_t::E_FpOverflowed) != 0) {
             LOG_TRACE(<< "Log likelihood overflowed for (" << this->debug() << ")");
             LOG_TRACE(<< "samples = " << core::CContainerPrinter::print(samples));
             LOG_TRACE(<< "weights = " << core::CContainerPrinter::print(weights));
@@ -1201,10 +1226,10 @@ void CGammaRateConjugate::sampleMarginalLikelihood(std::size_t numberSamples,
         double root_two = boost::math::double_constants::root_two;
 
         switch (numberSamples) {
-        case 1u:
+        case 1:
             samples.push_back(mean);
             break;
-        case 2u:
+        case 2:
             samples.push_back(mean - deviation / root_two);
             samples.push_back(mean + deviation / root_two);
             break;
@@ -1330,8 +1355,9 @@ bool CGammaRateConjugate::minusLogJointCdf(const TDouble1Vec& samples,
         double value;
         if (!CIntegration::logGaussLegendre<CIntegration::OrderThree>(
                 minusLogCdf, 0.0, 1.0, value)) {
-            LOG_ERROR(<< "Failed computing c.d.f. for "
-                      << core::CContainerPrinter::print(samples));
+            LOG_ERROR(<< "Failed computing c.d.f. (samples = "
+                      << core::CContainerPrinter::print(samples) << ", weights = "
+                      << core::CContainerPrinter::print(weights) << ")");
             return false;
         }
 
@@ -1341,8 +1367,9 @@ bool CGammaRateConjugate::minusLogJointCdf(const TDouble1Vec& samples,
 
     double value;
     if (!minusLogCdf(0.0, value)) {
-        LOG_ERROR(<< "Failed computing c.d.f. for "
-                  << core::CContainerPrinter::print(samples));
+        LOG_ERROR(<< "Failed computing c.d.f. (samples = "
+                  << core::CContainerPrinter::print(samples)
+                  << ", weights = " << core::CContainerPrinter::print(weights) << ")");
         return false;
     }
 
@@ -1370,8 +1397,9 @@ bool CGammaRateConjugate::minusLogJointCdfComplement(const TDouble1Vec& samples,
         double value;
         if (!CIntegration::logGaussLegendre<CIntegration::OrderThree>(
                 minusLogCdfComplement, 0.0, 1.0, value)) {
-            LOG_ERROR(<< "Failed computing c.d.f. complement for "
-                      << core::CContainerPrinter::print(samples));
+            LOG_ERROR(<< "Failed computing c.d.f. complement (samples = "
+                      << core::CContainerPrinter::print(samples) << ", weights = "
+                      << core::CContainerPrinter::print(weights) << ")");
             return false;
         }
 
@@ -1381,8 +1409,9 @@ bool CGammaRateConjugate::minusLogJointCdfComplement(const TDouble1Vec& samples,
 
     double value;
     if (!minusLogCdfComplement(0.0, value)) {
-        LOG_ERROR(<< "Failed computing c.d.f. complement for "
-                  << core::CContainerPrinter::print(samples));
+        LOG_ERROR(<< "Failed computing c.d.f. complement (samples = "
+                  << core::CContainerPrinter::print(samples)
+                  << ", weights = " << core::CContainerPrinter::print(weights) << ")");
         return false;
     }
 
@@ -1410,8 +1439,6 @@ bool CGammaRateConjugate::probabilityOfLessLikelySamples(maths_t::EProbabilityCa
         double value;
         if (!CIntegration::gaussLegendre<CIntegration::OrderThree>(probability, 0.0,
                                                                    1.0, value)) {
-            LOG_ERROR(<< "Failed computing probability for "
-                      << core::CContainerPrinter::print(samples));
             return false;
         }
 
@@ -1423,8 +1450,6 @@ bool CGammaRateConjugate::probabilityOfLessLikelySamples(maths_t::EProbabilityCa
 
     double value;
     if (!probability(0.0, value)) {
-        LOG_ERROR(<< "Failed computing probability for "
-                  << core::CContainerPrinter::print(samples));
         return false;
     }
 

--- a/lib/maths/common/CLogTDistribution.cc
+++ b/lib/maths/common/CLogTDistribution.cc
@@ -135,7 +135,7 @@ double pdf(const CLogTDistribution& distribution, double x) {
     }
 
     double degreesFreedom = distribution.degreesFreedom();
-    boost::math::students_t_distribution<> students(degreesFreedom);
+    boost::math::students_t students(degreesFreedom);
 
     double scale = distribution.scale();
     double location = distribution.location();
@@ -162,7 +162,7 @@ double cdf(const CLogTDistribution& distribution, double x) {
     }
 
     double degreesFreedom = distribution.degreesFreedom();
-    boost::math::students_t_distribution<> students(degreesFreedom);
+    boost::math::students_t students(degreesFreedom);
 
     double scale = distribution.scale();
     double location = distribution.location();
@@ -183,7 +183,7 @@ double cdfComplement(const CLogTDistribution& distribution, double x) {
     }
 
     double degreesFreedom = distribution.degreesFreedom();
-    boost::math::students_t_distribution<> students(degreesFreedom);
+    boost::math::students_t students(degreesFreedom);
 
     double scale = distribution.scale();
     double location = distribution.location();
@@ -198,7 +198,7 @@ double quantile(const CLogTDistribution& distribution, double q) {
     // distribution by the transformation x_q = exp(s * y_q + m).
 
     double degreesFreedom = distribution.degreesFreedom();
-    boost::math::students_t_distribution<> students(degreesFreedom);
+    boost::math::students_t students(degreesFreedom);
     double y_q = boost::math::quantile(students, q);
 
     double scale = distribution.scale();

--- a/lib/maths/common/CNormalMeanPrecConjugate.cc
+++ b/lib/maths/common/CNormalMeanPrecConjugate.cc
@@ -23,6 +23,7 @@
 #include <maths/common/CChecksum.h>
 #include <maths/common/CIntegration.h>
 #include <maths/common/CMathsFuncs.h>
+#include <maths/common/CMathsFuncsForMatrixAndVectorTypes.h>
 #include <maths/common/CRestoreParams.h>
 #include <maths/common/CTools.h>
 #include <maths/common/Constants.h>
@@ -116,19 +117,20 @@ bool evaluateFunctionOnJointDistribution(const TDouble1Vec& samples,
     //
     // This becomes increasingly accurate as the prior distribution narrows.
 
+    bool success = false;
     try {
         if (isNonInformative) {
             // The non-informative prior is improper and effectively 0 everywhere.
             // (It is acceptable to approximate all finite samples as at the median
             // of this distribution.)
             for (std::size_t i = 0; i < samples.size(); ++i) {
+                if (CMathsFuncs::isNan(samples[i]) || CMathsFuncs::isNan(weights[i])) {
+                    continue;
+                }
                 double x = samples[i];
                 double n = maths_t::count(weights[i]);
-                if (!CMathsFuncs::isFinite(n)) {
-                    LOG_ERROR(<< "Bad count weight " << n);
-                    return false;
-                }
                 result = aggregate(result, func(CTools::SImproperDistribution(), x), n);
+                success = true;
             }
         } else if (shape > MINIMUM_GAUSSIAN_SHAPE) {
             // For large shape the marginal likelihood is very well approximated
@@ -138,6 +140,9 @@ bool evaluateFunctionOnJointDistribution(const TDouble1Vec& samples,
             // and the error function is significantly cheaper to compute.
 
             for (std::size_t i = 0; i < samples.size(); ++i) {
+                if (CMathsFuncs::isNan(samples[i]) || CMathsFuncs::isNan(weights[i])) {
+                    continue;
+                }
                 double n = maths_t::count(weights[i]);
                 double seasonalScale =
                     std::sqrt(maths_t::seasonalVarianceScale(weights[i]));
@@ -155,6 +160,7 @@ bool evaluateFunctionOnJointDistribution(const TDouble1Vec& samples,
                                              scaledPrecision * scaledRate / shape);
                 boost::math::normal normal(mean, deviation);
                 result = aggregate(result, func(normal, x + offset), n);
+                success = false;
             }
         } else {
             // The marginal likelihood is a t distribution with 2*a degrees of
@@ -167,6 +173,9 @@ bool evaluateFunctionOnJointDistribution(const TDouble1Vec& samples,
             boost::math::students_t students(2.0 * shape);
 
             for (std::size_t i = 0; i < samples.size(); ++i) {
+                if (CMathsFuncs::isNan(samples[i]) || CMathsFuncs::isNan(weights[i])) {
+                    continue;
+                }
                 double n = maths_t::count(weights[i]);
                 double seasonalScale =
                     std::sqrt(maths_t::seasonalVarianceScale(weights[i]));
@@ -184,6 +193,7 @@ bool evaluateFunctionOnJointDistribution(const TDouble1Vec& samples,
                                          scaledPrecision * scaledRate / shape);
                 double sample = (x + offset - mean) / scale;
                 result = aggregate(result, func(students, sample), n);
+                success = false;
             }
         }
     } catch (const std::exception& e) {
@@ -268,7 +278,9 @@ public:
                 CJointProbabilityOfLessLikelySamples::SAddProbability(), m_IsNonInformative,
                 x, m_Shape, m_Rate, m_Mean, m_Precision, m_PredictionMean, probability) ||
             !probability.calculate(result)) {
-            LOG_ERROR(<< "Failed to compute probability of less likely samples");
+            LOG_ERROR(<< "Failed to compute probability of less likely samples (samples ="
+                      << core::CContainerPrinter::print(m_Samples) << ", weights = "
+                      << core::CContainerPrinter::print(m_Weights) << ")");
             return false;
         }
 
@@ -329,7 +341,7 @@ public:
     //! Evaluate the log marginal likelihood at the offset \p x.
     bool operator()(double x, double& result) const {
 
-        if (m_ErrorStatus & maths_t::E_FpFailed) {
+        if ((m_ErrorStatus & maths_t::E_FpFailed) != 0) {
             return false;
         }
 
@@ -362,7 +374,11 @@ private:
         TMeanVarAccumulator sampleMoments;
         double logVarianceScaleSum = 0.0;
 
+        bool success = false;
         for (std::size_t i = 0; i < samples.size(); ++i) {
+            if (CMathsFuncs::isNan(samples[i]) || CMathsFuncs::isNan(weights[i])) {
+                continue;
+            }
             double n = maths_t::countForUpdate(weights[i]);
             double seasonalScale = std::sqrt(maths_t::seasonalVarianceScale(weights[i]));
             double countVarianceScale = maths_t::countVarianceScale(weights[i]);
@@ -378,7 +394,13 @@ private:
             if (countVarianceScale != 1.0) {
                 logVarianceScaleSum += std::log(countVarianceScale);
             }
+            success = true;
         }
+        if (!success) {
+            this->addErrorStatus(maths_t::E_FpFailed);
+            return;
+        }
+
         m_WeightedNumberSamples = CBasicStatistics::count(sampleMoments);
         m_SampleMean = CBasicStatistics::mean(sampleMoments);
         m_SampleSquareDeviation = (m_WeightedNumberSamples - 1.0) *
@@ -391,11 +413,9 @@ private:
                      0.5 * m_NumberSamples * LOG_2_PI -
                      0.5 * logVarianceScaleSum + std::lgamma(impliedShape) -
                      std::lgamma(m_Shape) + m_Shape * std::log(m_Rate);
-        if (std::isnan(m_Constant)) {
-            LOG_ERROR(<< "Error calculating marginal likelihood, floating point nan");
+        if (CMathsFuncs::isNan(m_Constant)) {
             this->addErrorStatus(maths_t::E_FpFailed);
-        } else if (std::isinf(m_Constant)) {
-            LOG_ERROR(<< "Error calculating marginal likelihood, floating point overflow");
+        } else if (CMathsFuncs::isInf(m_Constant)) {
             this->addErrorStatus(maths_t::E_FpOverflowed);
         }
     }
@@ -621,15 +641,14 @@ void CNormalMeanPrecConjugate::addSamples(const TDouble1Vec& samples,
     TMeanVarAccumulator sampleMoments;
     for (std::size_t i = 0; i < samples.size(); ++i) {
         double x = samples[i];
+        if (!CMathsFuncs::isFinite(x) || !CMathsFuncs::isFinite(weights[i])) {
+            LOG_ERROR(<< "Discarding sample = " << x << ", weights = " < < < <
+                      core::CContainerPrinter::print(weights[i]));
+            continue;
+        }
         double n = maths_t::countForUpdate(weights[i]);
         double varianceScale = maths_t::seasonalVarianceScale(weights[i]) *
                                maths_t::countVarianceScale(weights[i]);
-        if (!CMathsFuncs::isFinite(x) || !CMathsFuncs::isFinite(n) ||
-            !CMathsFuncs::isFinite(varianceScale)) {
-            LOG_ERROR(<< "Discarding sample = " << x << ", weight = " << n
-                      << ", variance scale = " << varianceScale);
-            continue;
-        }
         numberSamples += n;
         sampleMoments.add(samples[i], n / varianceScale);
     }
@@ -854,13 +873,13 @@ CNormalMeanPrecConjugate::jointLogMarginalLikelihood(const TDouble1Vec& samples,
         logMarginalLikelihood(0.0, result);
     }
 
-    maths_t::EFloatingPointErrorStatus status = static_cast<maths_t::EFloatingPointErrorStatus>(
+    auto status = static_cast<maths_t::EFloatingPointErrorStatus>(
         logMarginalLikelihood.errorStatus() | CMathsFuncs::fpStatus(result));
-    if (status & maths_t::E_FpFailed) {
+    if ((status & maths_t::E_FpFailed) != 0) {
         LOG_ERROR(<< "Failed to compute log likelihood (" << this->debug() << ")");
         LOG_ERROR(<< "samples = " << core::CContainerPrinter::print(samples));
         LOG_ERROR(<< "weights = " << core::CContainerPrinter::print(weights));
-    } else if (status & maths_t::E_FpOverflowed) {
+    } else if ((status & maths_t::E_FpOverflowed) != 0) {
         LOG_TRACE(<< "Log likelihood overflowed for (" << this->debug() << ")");
         LOG_TRACE(<< "samples = " << core::CContainerPrinter::print(samples));
         LOG_TRACE(<< "weights = " << core::CContainerPrinter::print(weights));
@@ -1053,8 +1072,9 @@ bool CNormalMeanPrecConjugate::minusLogJointCdf(const TDouble1Vec& samples,
         double value;
         if (!CIntegration::logGaussLegendre<CIntegration::OrderThree>(
                 minusLogCdf, 0.0, 1.0, value)) {
-            LOG_ERROR(<< "Failed computing c.d.f. for "
-                      << core::CContainerPrinter::print(samples));
+            LOG_ERROR(<< "Failed computing c.d.f. (samples = "
+                      << core::CContainerPrinter::print(samples) << ", weights = "
+                      << core::CContainerPrinter::print(weights) << ")");
             return false;
         }
 
@@ -1064,8 +1084,9 @@ bool CNormalMeanPrecConjugate::minusLogJointCdf(const TDouble1Vec& samples,
 
     double value;
     if (!minusLogCdf(0.0, value)) {
-        LOG_ERROR(<< "Failed computing c.d.f. for "
-                  << core::CContainerPrinter::print(samples));
+        LOG_ERROR(<< "Failed computing c.d.f. (samples = "
+                  << core::CContainerPrinter::print(samples)
+                  << ", weights = " << core::CContainerPrinter::print(weights) << ")");
         return false;
     }
 
@@ -1093,8 +1114,9 @@ bool CNormalMeanPrecConjugate::minusLogJointCdfComplement(const TDouble1Vec& sam
         double value;
         if (!CIntegration::logGaussLegendre<CIntegration::OrderThree>(
                 minusLogCdfComplement, 0.0, 1.0, value)) {
-            LOG_ERROR(<< "Failed computing c.d.f. complement for "
-                      << core::CContainerPrinter::print(samples));
+            LOG_ERROR(<< "Failed computing c.d.f. complement (samples = "
+                      << core::CContainerPrinter::print(samples) << ", weights = "
+                      << core::CContainerPrinter::print(weights) << ")");
             return false;
         }
 
@@ -1104,8 +1126,9 @@ bool CNormalMeanPrecConjugate::minusLogJointCdfComplement(const TDouble1Vec& sam
 
     double value;
     if (!minusLogCdfComplement(0.0, value)) {
-        LOG_ERROR(<< "Failed computing c.d.f. complement for "
-                  << core::CContainerPrinter::print(samples));
+        LOG_ERROR(<< "Failed computing c.d.f. complement (samples = "
+                  << core::CContainerPrinter::print(samples)
+                  << ", weights = " << core::CContainerPrinter::print(weights) << ")");
         return false;
     }
 
@@ -1135,8 +1158,6 @@ bool CNormalMeanPrecConjugate::probabilityOfLessLikelySamples(
         double value;
         if (!CIntegration::gaussLegendre<CIntegration::OrderThree>(probability, 0.0,
                                                                    1.0, value)) {
-            LOG_ERROR(<< "Failed computing probability for "
-                      << core::CContainerPrinter::print(samples));
             return false;
         }
 
@@ -1148,8 +1169,6 @@ bool CNormalMeanPrecConjugate::probabilityOfLessLikelySamples(
 
     double value;
     if (!probability(0.0, value)) {
-        LOG_ERROR(<< "Failed computing probability for "
-                  << core::CContainerPrinter::print(samples));
         return false;
     }
 

--- a/lib/maths/common/CTools.cc
+++ b/lib/maths/common/CTools.cc
@@ -774,7 +774,7 @@ operator()(const CLogTDistribution& logt, double x, maths_t::ETail& tail) const 
     double step = std::max(b2, std::exp(l) - b2);
     double growthFactor = 1.0;
     for (;;) {
-        if (maxIterations == 0 || f2 <= fx) {
+        if (maxIterations == 2 || f2 <= fx) {
             break;
         }
 

--- a/lib/maths/common/unittest/CToolsTest.cc
+++ b/lib/maths/common/unittest/CToolsTest.cc
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_CASE(testProbabilityOfLessLikelySample) {
 
     LOG_DEBUG(<< "******** student's t ********");
 
-    boost::math::students_t_distribution<> students(2.0);
+    boost::math::students_t students(2.0);
 
     tail = maths_t::E_UndeterminedTail;
     p1 = numericalProbabilityOfLessLikelySample(students, -4.0);


### PR DESCRIPTION
This makes a number of changes to improve numeric robustness around handling of NaN and infinite values:
1. Trap NaN and inf inputs to distribution probability of less likely samples calculations,
2. Avoid using x * y, which can underflow, when testing for root bracketing,
3. Avoid v * w / x * y which can lead to NaN when the products underflow,
4. Trap the case `maxIterations` is supplied as 0 to various numeric routines, which would lead looping over all positive integers,
5. Tidy up and improve the logging of non finite values in various places (avoid duplicate logging and add extra useful information).

These were found trying to reproduce "x = NaN, distribution = N5boost4math23students_t_distribution..." log errors by injecting NaNs at various places.