### PR TITLE
[8.1][ML] Address causes of "[CStatisticalTests.cc@102] Test statistic is nan"  log errors

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -47,6 +47,8 @@
 * Avoid edge cases in the classification weights calculation to maximize
   minimum recall which could lead to only a single class being predicted.
   (See {ml-pull}2194[#2194].)
+* Address cause of "[CStatisticalTests.cc@102] Test statistic is nan"
+  log errors. (See {ml-pull}2196[#2196].)
 
 == {es} version 8.0.0-rc1
 

--- a/include/maths/common/CStatisticalTests.h
+++ b/include/maths/common/CStatisticalTests.h
@@ -36,15 +36,24 @@ public:
     using TDoubleVec = std::vector<double>;
 
 public:
-    //! Get the significance of a left tail F-test for \p x when
-    //! the test statistic has \p d1 and \p d2 degrees of freedom
-    //! under the null hypothesis.
-    static double leftTailFTest(double x, double d1, double d2);
+    //! Get the significance of a left tail F-test for \p x
+    //! under the null hypothesis, when the H0 and H1 have
+    // \p d1 and \p d2 degrees of freedom, respectively.
+    static double leftTailFTest(double x, double df0, double df1);
+
+    //! Get the significance of a right tail F-test for the
+    //! statistic \p v0 / \p v1 under the null hypothesis,
+    //! when H0 and H1 have \p d1 and \p d2 degrees of freedom,
+    //! respectively.
+    //!
+    //! \note This handles edge cases where any of \p v0, \p v1,
+    //! \p df0 or \p df1 are zero.
+    static double rightTailFTest(double v0, double v1, double df0, double df1);
 
     //! Get the significance of a right tail F-test for \p x when
     //! the test statistic has \p d1 and \p d2 degrees of freedom
     //! under the null hypothesis.
-    static double rightTailFTest(double x, double d1, double d2);
+    static double rightTailFTest(double x, double df0, double df1);
 
     //! A two sample Kolmogorov-Smirnov test.
     //!

--- a/lib/maths/common/CStatisticalTests.cc
+++ b/lib/maths/common/CStatisticalTests.cc
@@ -70,7 +70,7 @@ const std::string F_TAG("c");
 const std::string EMPTY_STRING;
 }
 
-double CStatisticalTests::leftTailFTest(double x, double d1, double d2) {
+double CStatisticalTests::leftTailFTest(double x, double df0, double df1) {
     if (x < 0.0) {
         return 0.0;
     }
@@ -82,16 +82,30 @@ double CStatisticalTests::leftTailFTest(double x, double d1, double d2) {
         return 1.0;
     }
     try {
-        boost::math::fisher_f F(d1, d2);
+        boost::math::fisher_f F(df0, df1);
         return boost::math::cdf(F, x);
     } catch (const std::exception& e) {
         LOG_ERROR(<< "Failed to compute significance " << e.what()
-                  << " d1 = " << d1 << ", d2 = " << d2 << ", x = " << x);
+                  << " df0 = " << df0 << ", df1 = " << df1 << ", x = " << x);
     }
     return 1.0;
 }
 
-double CStatisticalTests::rightTailFTest(double x, double d1, double d2) {
+double CStatisticalTests::rightTailFTest(double v0, double v1, double df0, double df1) {
+    // If there is insufficient data for either hypothesis treat we are conservative
+    // and say the alternative hypothesis is not provable.
+    if (df0 <= 0.0 || df1 <= 0.0) {
+        return 1.0;
+    }
+    // The test statistic is infinite which corresponds to a p-value of 0.
+    if (v0 > 0.0 && v1 == 0) {
+        return 0.0;
+    }
+    double F{v0 == v1 ? df1 / df0 : (df1 * v0) / (df0 * v1)};
+    return rightTailFTest(F, df0, df1);
+}
+
+double CStatisticalTests::rightTailFTest(double x, double df0, double df1) {
     if (x < 0.0) {
         return 1.0;
     }
@@ -103,11 +117,11 @@ double CStatisticalTests::rightTailFTest(double x, double d1, double d2) {
         return 1.0;
     }
     try {
-        boost::math::fisher_f F(d1, d2);
+        boost::math::fisher_f F(df0, df1);
         return boost::math::cdf(boost::math::complement(F, x));
     } catch (const std::exception& e) {
         LOG_ERROR(<< "Failed to compute significance " << e.what()
-                  << " d1 = " << d1 << ", d2 = " << d2 << ", x = " << x);
+                  << " df0 = " << df0 << ", df1 = " << df1 << ", x = " << x);
     }
     return 1.0;
 }

--- a/lib/maths/time_series/CSignal.cc
+++ b/lib/maths/time_series/CSignal.cc
@@ -825,10 +825,10 @@ double CSignal::nestedDecompositionPValue(const SVarianceStats& H0,
                 H1.s_DegreesFreedom};
 
     // This assumes that H1 is nested in H0.
-    double F[]{(df[1] * std::max(v0[0] - v1[0], 0.0)) / (df[0] * v1[0]),
-               (df[1] * std::max(v0[1] - v1[1], 0.0)) / (df[0] * v1[1])};
-    return std::min(common::CStatisticalTests::rightTailFTest(F[0], df[0], df[1]),
-                    common::CStatisticalTests::rightTailFTest(F[1], df[0], df[1]));
+    return std::min(common::CStatisticalTests::rightTailFTest(
+                        std::max(v0[0] - v1[0], 0.0), v1[0], df[0], df[1]),
+                    common::CStatisticalTests::rightTailFTest(
+                        std::max(v0[1] - v1[1], 0.0), v1[1], df[0], df[1]));
 }
 
 std::size_t CSignal::selectComponentSize(const TFloatMeanAccumulatorVec& values,
@@ -908,16 +908,14 @@ std::size_t CSignal::selectComponentSize(const TFloatMeanAccumulatorVec& values,
                       << core::CContainerPrinter::print(degreesFreedom));
             LOG_TRACE(<< "variances = " << core::CContainerPrinter::print(variances));
 
-            if ((variances[H0] > 0.0 && variances[1 - H0] == 0.0) ||
-                common::CStatisticalTests::rightTailFTest(
-                    variances[H0] == variances[1 - H0] ? 1.0 : variances[H0] / variances[1 - H0],
-                    degreesFreedom[H0], degreesFreedom[1 - H0]) < 0.1) {
+            if (common::CStatisticalTests::rightTailFTest(
+                    variances[H0], variances[1 - H0], degreesFreedom[H0],
+                    degreesFreedom[1 - H0]) < 0.1) {
                 break;
             }
-            if ((variances[1 - H0] > 0.0 && variances[H0] == 0.0) ||
-                common::CStatisticalTests::rightTailFTest(
-                    variances[1 - H0] == variances[H0] ? 1.0 : variances[1 - H0] / variances[H0],
-                    degreesFreedom[1 - H0], degreesFreedom[H0]) < 0.1) {
+            if (common::CStatisticalTests::rightTailFTest(
+                    variances[1 - H0], variances[H0], degreesFreedom[1 - H0],
+                    degreesFreedom[H0]) < 0.1) {
                 H0 = 1 - H0;
             }
             size = compressedComponent.size();

--- a/lib/maths/time_series/CTimeSeriesSegmentation.cc
+++ b/lib/maths/time_series/CTimeSeriesSegmentation.cc
@@ -458,9 +458,9 @@ void CTimeSeriesSegmentation::fitTopDownPiecewiseLinear(ITR begin,
                        common::MINIMUM_COEFFICIENT_OF_VARIATION *
                            common::CBasicStatistics::mean(meanAbs)};
         double df[]{4.0 - 2.0, static_cast<double>(range - 4)};
-        double F{(df[1] * std::max(v[0] - v[1], 0.0)) / (df[0] * v[1])};
         double pValue{common::CTools::oneMinusPowOneMinusX(
-            common::CStatisticalTests::rightTailFTest(F, df[0], df[1]),
+            common::CStatisticalTests::rightTailFTest(std::max(v[0] - v[1], 0.0),
+                                                      v[1], df[0], df[1]),
             static_cast<double>(reweighted.size() / initialStep))};
         LOG_TRACE(<< "  p-value = " << pValue);
 
@@ -632,9 +632,9 @@ void CTimeSeriesSegmentation::fitTopDownPiecewiseLinearScaledSeasonal(
                        common::MINIMUM_COEFFICIENT_OF_VARIATION *
                            common::CBasicStatistics::mean(meanAbs)};
         double df[]{2.0 - 1.0, static_cast<double>(range - 2)};
-        double F{df[1] * std::max(v[0] - v[1], 0.0) / (df[0] * v[1])};
         double pValue{common::CTools::oneMinusPowOneMinusX(
-            common::CStatisticalTests::rightTailFTest(F, df[0], df[1]),
+            common::CStatisticalTests::rightTailFTest(std::max(v[0] - v[1], 0.0),
+                                                      v[1], df[0], df[1]),
             static_cast<double>(range - 4))};
         LOG_TRACE(<< "  p-value = " << pValue);
 
@@ -901,9 +901,9 @@ void CTimeSeriesSegmentation::fitTopDownPiecewiseTimeShifted(ITR begin,
                    bestSplitVariance + common::MINIMUM_COEFFICIENT_OF_VARIATION *
                                            common::CBasicStatistics::mean(meanAbs)};
         double df[]{3.0 - 2.0, static_cast<double>(range - 3)};
-        double F{df[1] * std::max(v[0] - v[1], 0.0) / (df[0] * v[1])};
         double pValue{common::CTools::oneMinusPowOneMinusX(
-            common::CStatisticalTests::rightTailFTest(F, df[0], df[1]),
+            common::CStatisticalTests::rightTailFTest(std::max(v[0] - v[1], 0.0),
+                                                      v[1], df[0], df[1]),
             static_cast<double>(range - 10))};
         LOG_TRACE(<< "  p-value = " << pValue);
 

--- a/lib/maths/time_series/CTimeSeriesTestForSeasonality.cc
+++ b/lib/maths/time_series/CTimeSeriesTestForSeasonality.cc
@@ -46,16 +46,6 @@ namespace ml {
 namespace maths {
 namespace time_series {
 namespace {
-double rightTailFTest(double v0, double v1, double df0, double df1) {
-    // If there is insufficient data for either hypothesis treat we are conservative
-    // and say the alternative hypothesis is not provable.
-    if (df0 <= 0.0 || df1 <= 0.0) {
-        return 1.0;
-    }
-    double F{v0 == v1 ? 1.0 : v0 / v1};
-    return common::CStatisticalTests::rightTailFTest(F, df0, df1);
-}
-
 bool almostDivisor(std::size_t i, std::size_t j, double eps) {
     if (i > j) {
         return false;
@@ -2106,8 +2096,8 @@ double CTimeSeriesTestForSeasonality::SModel::pValue(const SModel& H0,
     v1[1] += minimumRelativeTruncatedVariance * v1[0];
 
     return std::max(
-        std::min(rightTailFTest(v0[0] / df0[0], v1[0] / df1[0], df0[0], df1[0]),
-                 rightTailFTest(v0[1] / df0[1], v1[1] / df1[1], df0[1], df1[1])),
+        std::min(common::CStatisticalTests::rightTailFTest(v0[0], v1[0], df0[0], df1[0]),
+                 common::CStatisticalTests::rightTailFTest(v0[1], v1[1], df0[1], df1[1])),
         common::CTools::smallestProbability());
 }
 

--- a/lib/maths/time_series/unittest/CForecastTest.cc
+++ b/lib/maths/time_series/unittest/CForecastTest.cc
@@ -353,8 +353,8 @@ BOOST_AUTO_TEST_CASE(testComplexNoLongTermTrend) {
     test.bucketLength(bucketLength)
         .daysToLearn(63)
         .noiseVariance(4.0)
-        .maximumPercentageOutOfBounds(9.0)
-        .maximumError(0.06)
+        .maximumPercentageOutOfBounds(8.0)
+        .maximumError(0.08)
         .run(trend);
 }
 

--- a/lib/maths/time_series/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/time_series/unittest/CTimeSeriesDecompositionTest.cc
@@ -317,7 +317,7 @@ BOOST_FIXTURE_TEST_CASE(testDistortedPeriodicProblemCase, CTestFixture) {
             LOG_DEBUG(<< "70% error = " << percentileError / sumValue);
 
             if (time >= 2 * WEEK) {
-                BOOST_TEST_REQUIRE(sumResidual < 0.26 * sumValue);
+                BOOST_TEST_REQUIRE(sumResidual < 0.27 * sumValue);
                 BOOST_TEST_REQUIRE(maxResidual < 0.54 * maxValue);
                 BOOST_TEST_REQUIRE(percentileError < 0.18 * sumValue);
 
@@ -336,7 +336,7 @@ BOOST_FIXTURE_TEST_CASE(testDistortedPeriodicProblemCase, CTestFixture) {
     LOG_DEBUG(<< "total 'max residual' / 'max value' = " << totalMaxResidual / totalMaxValue);
     LOG_DEBUG(<< "total 70% error = " << totalPercentileError / totalSumValue);
 
-    BOOST_TEST_REQUIRE(totalSumResidual < 0.16 * totalSumValue);
+    BOOST_TEST_REQUIRE(totalSumResidual < 0.17 * totalSumValue);
     BOOST_TEST_REQUIRE(totalMaxResidual < 0.23 * totalMaxValue);
     BOOST_TEST_REQUIRE(totalPercentileError < 0.10 * totalSumValue);
 }
@@ -915,7 +915,7 @@ BOOST_FIXTURE_TEST_CASE(testVarianceScale, CTestFixture) {
                   << maths::common::CBasicStatistics::mean(percentileError));
         LOG_DEBUG(<< "mean scale = " << maths::common::CBasicStatistics::mean(meanScale));
         BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(error) < 0.3);
-        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(percentileError) < 0.04);
+        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(percentileError) < 0.15);
         BOOST_REQUIRE_CLOSE_ABSOLUTE(
             1.0, maths::common::CBasicStatistics::mean(meanScale), 0.02);
     }

--- a/lib/maths/time_series/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/time_series/unittest/CTimeSeriesModelTest.cc
@@ -1603,7 +1603,7 @@ BOOST_AUTO_TEST_CASE(testWeights) {
             }
         }
         LOG_DEBUG(<< "error = " << maths::common::CBasicStatistics::mean(error));
-        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(error) < 0.29);
+        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(error) < 0.3);
 
         LOG_DEBUG(<< "Winsorisation");
         TDouble2Vec prediction(model.predict(time));

--- a/lib/maths/time_series/unittest/CTimeSeriesTestForSeasonalityTest.cc
+++ b/lib/maths/time_series/unittest/CTimeSeriesTestForSeasonalityTest.cc
@@ -1159,8 +1159,8 @@ BOOST_AUTO_TEST_CASE(testModelledSeasonalityWithChange) {
 
     LOG_DEBUG(<< "recall = " << TP / (TP + FN));
     LOG_DEBUG(<< "accuracy = " << TP / (TP + FP));
-    BOOST_TEST_REQUIRE(TP / (TP + FN) > 0.92);
-    BOOST_TEST_REQUIRE(TP / (TP + FP) > 0.85);
+    BOOST_TEST_REQUIRE(TP / (TP + FN) > 0.9);
+    BOOST_TEST_REQUIRE(TP / (TP + FP) > 0.8);
 }
 
 BOOST_AUTO_TEST_CASE(testNewComponentInitialValues) {


### PR DESCRIPTION
Backport #2196.