### PR TITLE
[ML] Handle precession and time shifts of seasonality in anomaly detection

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -33,7 +33,7 @@
 === Enhancements
 
 * Better handle small shifts of the seasonal patterns in time series data.
-  (See {ml-pull}2183[#2183].)
+  (See {ml-pull}2202[#2202].)
 
 == {es} version 8.1.0
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,13 @@
 
 //=== Regressions
 
+== {es} version 8.2.0
+
+=== Enhancements
+
+* Better handle small shifts of the seasonal patterns in time series data.
+  (See {ml-pull}2183[#2183].)
+
 == {es} version 8.1.0
 
 === Enhancements

--- a/include/maths/common/CLbfgs.h
+++ b/include/maths/common/CLbfgs.h
@@ -301,7 +301,8 @@ private:
 
         double smin;
         double fmin;
-        CSolvers::globalMinimize(probes, f_, smin, fmin);
+        double fsd;
+        CSolvers::globalMinimize(probes, f_, smin, fmin, fsd);
         xs = m_X - smin * step;
         fs = f(xs);
     }

--- a/include/maths/common/CLowessDetail.h
+++ b/include/maths/common/CLowessDetail.h
@@ -89,11 +89,12 @@ void CLowess<N>::fit(TDoubleDoublePrVec data, std::size_t numberFolds) {
 
     double kmax;
     double likelihoodMax;
+    double likelihoodStandardDeviation;
     CSolvers::globalMaximize(K,
                              [&](double k) -> double {
                                  return this->likelihood(trainingMasks, testingMasks, k);
                              },
-                             kmax, likelihoodMax);
+                             kmax, likelihoodMax, likelihoodStandardDeviation);
     LOG_TRACE(<< "kmax = " << kmax << " likelihood(kmax) = " << likelihoodMax);
 
     m_K = kmax;
@@ -137,8 +138,9 @@ typename CLowess<N>::TDoubleDoublePr CLowess<N>::minimum() const {
     X.push_back(xb);
     double xmin;
     double fmin;
+    double fsd;
     CSolvers::globalMinimize(
-        X, [this](double x) -> double { return this->predict(x); }, xmin, fmin);
+        X, [this](double x) -> double { return this->predict(x); }, xmin, fmin, fsd);
 
     // Refine.
     double range{(xb - xa) / static_cast<double>(X.size())};
@@ -152,7 +154,7 @@ typename CLowess<N>::TDoubleDoublePr CLowess<N>::minimum() const {
     double xcand;
     double fcand;
     CSolvers::globalMinimize(
-        X, [this](double x) -> double { return this->predict(x); }, xcand, fcand);
+        X, [this](double x) -> double { return this->predict(x); }, xcand, fcand, fsd);
 
     if (fcand < fmin) {
         xmin = xcand;

--- a/include/maths/time_series/CTimeSeriesDecomposition.h
+++ b/include/maths/time_series/CTimeSeriesDecomposition.h
@@ -167,10 +167,21 @@ public:
                   double minimumScale,
                   const TWriteForecastResult& writer) override;
 
-    //! Detrend \p value by the prediction of the modelled features at \p time.
+    //! Remove the prediction of the component models at \p time from \p value.
     //!
+    //! \param[in] time The time of \p value.
+    //! \param[in] confidence The prediction confidence interval as a percentage.
+    //! The closest point to \p value in the confidence interval is removed.
+    //! \param[in] maximumTimeShift The maximum amount by which we will shift
+    //! \p time in order to minimize the difference between the prediction and
+    //! \p value.
+    //! \param[in] components A bit mask of the type of components to remove.
     //! \note That detrending preserves the time series mean.
-    double detrend(core_t::TTime time, double value, double confidence, int components = E_All) const override;
+    double detrend(core_t::TTime time,
+                   double value,
+                   double confidence,
+                   core_t::TTime maximumTimeShift = 0,
+                   int components = E_All) const override;
 
     //! Get the mean variance of the baseline.
     double meanVariance() const override;

--- a/include/maths/time_series/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/time_series/CTimeSeriesDecompositionDetail.h
@@ -782,6 +782,7 @@ public:
                      std::size_t size,
                      double decayRate,
                      double bucketLength,
+                     core_t::TTime maxTimeShiftPerPeriod,
                      common::CSplineTypes::EBoundaryCondition boundaryCondition,
                      core_t::TTime startTime,
                      core_t::TTime endTime,

--- a/include/maths/time_series/CTimeSeriesDecompositionInterface.h
+++ b/include/maths/time_series/CTimeSeriesDecompositionInterface.h
@@ -149,12 +149,20 @@ public:
                           double minimumScale,
                           const TWriteForecastResult& writer) = 0;
 
-    //! Detrend \p value by the prediction of the modelled features at \p time.
+    //! Remove the prediction of the component models at \p time from \p value.
     //!
+    //! \param[in] time The time of \p value.
+    //! \param[in] confidence The prediction confidence interval as a percentage.
+    //! The closest point to \p value in the confidence interval is removed.
+    //! \param[in] maximumTimeShift The maximum amount by which we will shift
+    //! \p time in order to minimize the difference between the prediction and
+    //! \p value.
+    //! \param[in] components A bit mask of the type of components to remove.
     //! \note That detrending preserves the time series mean.
     virtual double detrend(core_t::TTime time,
                            double value,
                            double confidence,
+                           core_t::TTime maximumTimeShift = 0,
                            int components = E_All) const = 0;
 
     //! Get the mean variance of the baseline.

--- a/include/maths/time_series/CTimeSeriesDecompositionStub.h
+++ b/include/maths/time_series/CTimeSeriesDecompositionStub.h
@@ -80,7 +80,11 @@ public:
                   const TWriteForecastResult& writer) override;
 
     //! Returns \p value.
-    double detrend(core_t::TTime time, double value, double confidence, int components = E_All) const override;
+    double detrend(core_t::TTime time,
+                   double value,
+                   double confidence,
+                   core_t::TTime maximumTimeShift = 0,
+                   int components = E_All) const override;
 
     //! Returns 0.0.
     double meanVariance() const override;

--- a/include/maths/time_series/CTimeSeriesModel.h
+++ b/include/maths/time_series/CTimeSeriesModel.h
@@ -16,6 +16,7 @@
 #include <maths/common/CModel.h>
 #include <maths/common/CMultivariatePrior.h>
 
+#include <maths/time_series/CTimeSeriesMultibucketFeaturesFwd.h>
 #include <maths/time_series/ImportExport.h>
 
 #include <boost/array.hpp>
@@ -36,8 +37,6 @@ namespace time_series {
 class CDecayRateController;
 class CTimeSeriesDecompositionInterface;
 class CTimeSeriesAnomalyModel;
-template<typename>
-class CTimeSeriesMultibucketFeature;
 
 //! \brief A CModel implementation for modeling a univariate time series.
 class MATHS_TIME_SERIES_EXPORT CUnivariateTimeSeriesModel : public common::CModel {
@@ -48,7 +47,7 @@ public:
     using TDoubleWeightsAry = maths_t::TDoubleWeightsAry;
     using TDecompositionPtr = std::shared_ptr<CTimeSeriesDecompositionInterface>;
     using TDecayRateController2Ary = std::array<CDecayRateController, 2>;
-    using TMultibucketFeature = CTimeSeriesMultibucketFeature<double>;
+    using TMultibucketFeature = CTimeSeriesMultibucketScalarFeature;
 
 public:
     //! \param[in] params The model parameters.
@@ -211,11 +210,9 @@ public:
     //@}
 
 private:
-    using TTimeDoublePr = std::pair<core_t::TTime, double>;
-    using TSizeVec = std::vector<std::size_t>;
     using TDouble1Vec = core::CSmallVector<double, 1>;
     using TDouble1VecVec = std::vector<TDouble1Vec>;
-    using TDouble2VecWeightsAryVec = std::vector<TDouble2VecWeightsAry>;
+    using TTimeDouble2VecSizeTrVecDoublePr = std::pair<TTimeDouble2VecSizeTrVec, double>;
     using TMultibucketFeaturePtr = std::unique_ptr<TMultibucketFeature>;
     using TDecayRateController2AryPtr = std::unique_ptr<TDecayRateController2Ary>;
     using TPriorPtr = std::shared_ptr<common::CPrior>;
@@ -234,6 +231,11 @@ private:
     //! Update the trend with \p samples.
     EUpdateResult updateTrend(const common::CModelAddSamplesParams& params,
                               const TTimeDouble2VecSizeTrVec& samples);
+
+    //! Update the residual models.
+    TTimeDouble2VecSizeTrVecDoublePr
+    updateResidualModels(const common::CModelAddSamplesParams& params,
+                         TTimeDouble2VecSizeTrVec samples);
 
     //! Update the various model decay rates based on the prediction errors
     //! for \p samples.
@@ -529,7 +531,7 @@ public:
     using TDecompositionPtr = std::shared_ptr<CTimeSeriesDecompositionInterface>;
     using TDecompositionPtr10Vec = core::CSmallVector<TDecompositionPtr, 10>;
     using TDecayRateController2Ary = std::array<CDecayRateController, 2>;
-    using TMultibucketFeature = CTimeSeriesMultibucketFeature<TDouble10Vec>;
+    using TMultibucketFeature = CTimeSeriesMultibucketVectorFeature;
 
 public:
     //! \param[in] params The model parameters.
@@ -690,9 +692,6 @@ public:
 private:
     using TDouble1Vec = core::CSmallVector<double, 1>;
     using TDouble1VecVec = std::vector<TDouble1Vec>;
-    using TDouble2VecWeightsAryVec = std::vector<TDouble2VecWeightsAry>;
-    using TVector = common::CVector<common::CFloatStorage>;
-    using TVectorMeanAccumulator = common::CBasicStatistics::SSampleMean<TVector>::TAccumulator;
     using TMultibucketFeaturePtr = std::unique_ptr<TMultibucketFeature>;
     using TDecayRateController2AryPtr = std::unique_ptr<TDecayRateController2Ary>;
     using TMultivariatePriorPtr = std::unique_ptr<common::CMultivariatePrior>;
@@ -702,6 +701,10 @@ private:
     //! Update the trend with \p samples.
     EUpdateResult updateTrend(const common::CModelAddSamplesParams& params,
                               const TTimeDouble2VecSizeTrVec& samples);
+
+    //! Update the residual models.
+    void updateResidualModels(const common::CModelAddSamplesParams& params,
+                              TTimeDouble2VecSizeTrVec samples);
 
     //! Update the various model decay rates based on the prediction errors
     //! for \p samples.

--- a/include/maths/time_series/CTimeSeriesMultibucketFeatureSerialiser.h
+++ b/include/maths/time_series/CTimeSeriesMultibucketFeatureSerialiser.h
@@ -12,6 +12,7 @@
 #ifndef INCLUDED_ml_maths_time_series_CTimeSeriesMultibucketFeatureSerialiser_h
 #define INCLUDED_ml_maths_time_series_CTimeSeriesMultibucketFeatureSerialiser_h
 
+#include <maths/time_series/CTimeSeriesMultibucketFeaturesFwd.h>
 #include <maths/time_series/ImportExport.h>
 
 #include <memory>
@@ -24,12 +25,7 @@ class CStatePersistInserter;
 class CStateRestoreTraverser;
 }
 namespace maths {
-namespace common {
-struct SModelRestoreParams;
-}
 namespace time_series {
-template<typename>
-class CTimeSeriesMultibucketFeature;
 
 //! \brief Reflection for CTimeSeriesMultibucketFeature sub-classes.
 //!
@@ -46,29 +42,28 @@ class CTimeSeriesMultibucketFeature;
 class MATHS_TIME_SERIES_EXPORT CTimeSeriesMultibucketFeatureSerialiser {
 public:
     using TDouble10Vec = core::CSmallVector<double, 10>;
-    using TUnivariateFeature = CTimeSeriesMultibucketFeature<double>;
-    using TMultivariateFeature = CTimeSeriesMultibucketFeature<TDouble10Vec>;
-    using TUnivariateFeaturePtr = std::unique_ptr<TUnivariateFeature>;
-    using TMultivariateFeaturePtr = std::unique_ptr<TMultivariateFeature>;
+    using TScalarFeature = CTimeSeriesMultibucketScalarFeature;
+    using TVectorFeature = CTimeSeriesMultibucketVectorFeature;
+    using TScalarFeaturePtr = std::unique_ptr<TScalarFeature>;
+    using TVectorFeaturePtr = std::unique_ptr<TVectorFeature>;
 
 public:
     //! Construct the appropriate CTimeSeriesMultibucketFeature sub-class
     //! from its state document representation. Sets \p result to NULL on
     //! failure.
-    bool operator()(TUnivariateFeaturePtr& result, core::CStateRestoreTraverser& traverser) const;
+    bool operator()(TScalarFeaturePtr& result, core::CStateRestoreTraverser& traverser) const;
 
     //! Construct the appropriate CTimeSeriesMultibucketFeature sub-class
     //! from its state document representation. Sets \p result to NULL on
     //! failure.
-    bool operator()(TMultivariateFeaturePtr& result,
-                    core::CStateRestoreTraverser& traverser) const;
+    bool operator()(TVectorFeaturePtr& result, core::CStateRestoreTraverser& traverser) const;
 
     //! Persist \p feature by passing information to the supplied inserter
-    void operator()(const TUnivariateFeaturePtr& feature,
+    void operator()(const TScalarFeaturePtr& feature,
                     core::CStatePersistInserter& inserter) const;
 
     //! Persist \p feature by passing information to the supplied inserter
-    void operator()(const TMultivariateFeaturePtr& feature,
+    void operator()(const TVectorFeaturePtr& feature,
                     core::CStatePersistInserter& inserter) const;
 };
 }

--- a/include/maths/time_series/CTimeSeriesMultibucketFeaturesFwd.h
+++ b/include/maths/time_series/CTimeSeriesMultibucketFeaturesFwd.h
@@ -1,7 +1,12 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the following additional limitation. Functionality enabled by the
+ * files subject to the Elastic License 2.0 may only be used in production when
+ * invoked by an Elasticsearch process with a license key installed that permits
+ * use of machine learning features. You may not use this file except in
+ * compliance with the Elastic License 2.0 and the foregoing additional
+ * limitation.
  */
 
 #ifndef INCLUDED_ml_maths_time_series_CTimeSeriesMultibucketFeaturesFwd_h

--- a/include/maths/time_series/CTimeSeriesMultibucketFeaturesFwd.h
+++ b/include/maths/time_series/CTimeSeriesMultibucketFeaturesFwd.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+#ifndef INCLUDED_ml_maths_time_series_CTimeSeriesMultibucketFeaturesFwd_h
+#define INCLUDED_ml_maths_time_series_CTimeSeriesMultibucketFeaturesFwd_h
+
+#include <core/CoreTypes.h>
+
+#include <maths/common/CLinearAlgebraFwd.h>
+#include <maths/common/MathsTypes.h>
+
+#include <functional>
+
+namespace ml {
+namespace core {
+template<typename, std::size_t>
+class CSmallVector;
+}
+namespace maths {
+namespace time_series {
+template<typename>
+class CTimeSeriesMultibucketFeature;
+using CTimeSeriesMultibucketScalarFeature = CTimeSeriesMultibucketFeature<double>;
+using CTimeSeriesMultibucketVectorFeature = CTimeSeriesMultibucketFeature<core::CSmallVector<double, 10>>;
+}
+}
+}
+
+#endif // INCLUDED_ml_maths_time_series_CTimeSeriesMultibucketFeaturesFwd_h

--- a/include/maths/time_series/CTimeSeriesMultibucketFeaturesFwd.h
+++ b/include/maths/time_series/CTimeSeriesMultibucketFeaturesFwd.h
@@ -24,7 +24,8 @@ namespace time_series {
 template<typename>
 class CTimeSeriesMultibucketFeature;
 using CTimeSeriesMultibucketScalarFeature = CTimeSeriesMultibucketFeature<double>;
-using CTimeSeriesMultibucketVectorFeature = CTimeSeriesMultibucketFeature<core::CSmallVector<double, 10>>;
+using CTimeSeriesMultibucketVectorFeature =
+    CTimeSeriesMultibucketFeature<core::CSmallVector<double, 10>>;
 }
 }
 }

--- a/include/maths/time_series/CTimeSeriesTestForSeasonality.h
+++ b/include/maths/time_series/CTimeSeriesTestForSeasonality.h
@@ -109,6 +109,9 @@ public:
     //! Get the desired component size.
     std::size_t size() const;
 
+    //! Check if the component is one of \p periods.
+    bool isOneOf(int periods) const;
+
     //! Get a seasonal time for the specified results.
     //!
     //! \warning The caller owns the returned object.
@@ -119,6 +122,9 @@ public:
 
     //! Get the end time of the initial values.
     core_t::TTime initialValuesEndTime() const;
+
+    //! Get the bucket length of the window used to find the component.
+    core_t::TTime bucketLength() const;
 
     //! Get the values to use to initialize the component.
     const TFloatMeanAccumulatorVec& initialValues() const;
@@ -643,7 +649,7 @@ private:
     TSizeVec m_ModelledPeriodsSizes;
     TBoolVec m_ModelledPeriodsTestable;
     TFloatMeanAccumulatorVec m_Values;
-    // The follow are member data to avoid repeatedly reinitialising.
+    // The following are member data to avoid repeatedly recreating.
     mutable TAmplitudeVec m_Amplitudes;
     mutable TSeasonalComponentVec m_Periods;
     mutable TSeasonalComponentVec m_CandidatePeriods;

--- a/include/model/ModelTypes.h
+++ b/include/model/ModelTypes.h
@@ -18,6 +18,8 @@
 
 #include <maths/common/MathsTypes.h>
 
+#include <maths/time_series/CTimeSeriesMultibucketFeaturesFwd.h>
+
 #include <model/ImportExport.h>
 
 #include <functional>
@@ -26,12 +28,6 @@
 #include <utility>
 
 namespace ml {
-namespace maths {
-namespace time_series {
-template<typename>
-class CTimeSeriesMultibucketFeature;
-}
-}
 namespace model {
 class CInfluenceCalculator;
 struct SModelParams;
@@ -46,9 +42,9 @@ using TDouble2Vec1Vec = core::CSmallVector<TDouble2Vec, 1>;
 using TDouble1VecDouble1VecPr = std::pair<TDouble1Vec, TDouble1Vec>;
 using TInfluenceCalculatorCPtr = std::shared_ptr<const model::CInfluenceCalculator>;
 using TUnivariateMultibucketFeaturePtr =
-    std::unique_ptr<maths::time_series::CTimeSeriesMultibucketFeature<double>>;
+    std::unique_ptr<maths::time_series::CTimeSeriesMultibucketScalarFeature>;
 using TMultivariateMultibucketFeaturePtr =
-    std::unique_ptr<maths::time_series::CTimeSeriesMultibucketFeature<TDouble10Vec>>;
+    std::unique_ptr<maths::time_series::CTimeSeriesMultibucketVectorFeature>;
 
 //! The types of model available.
 //!

--- a/lib/maths/common/CPrior.cc
+++ b/lib/maths/common/CPrior.cc
@@ -294,7 +294,9 @@ double CPrior::adjustOffsetWithCost(const TDouble1Vec& samples,
             trialOffsets.push_back(offset);
         }
         double likelihood;
-        CSolvers::globalMinimize(trialOffsets, cost, offset, likelihood);
+        double likelihoodStandardDeviation;
+        CSolvers::globalMinimize(trialOffsets, cost, offset, likelihood,
+                                 likelihoodStandardDeviation);
         LOG_TRACE(<< "samples = " << core::CContainerPrinter::print(samples)
                   << ", offset = " << offset << ", likelihood = " << likelihood);
     }

--- a/lib/maths/time_series/CSeasonalComponent.cc
+++ b/lib/maths/time_series/CSeasonalComponent.cc
@@ -23,51 +23,55 @@
 #include <maths/common/CIntegerTools.h>
 #include <maths/common/CLeastSquaresOnlineRegressionDetail.h>
 #include <maths/common/CSampling.h>
+#include <maths/common/CSolvers.h>
 
 #include <maths/time_series/CSeasonalTime.h>
 
 #include <cmath>
-#include <limits>
 #include <vector>
 
 namespace ml {
 namespace maths {
 namespace time_series {
 namespace {
-
 using TDoubleDoublePr = maths_t::TDoubleDoublePr;
-
 const core::TPersistenceTag DECOMPOSITION_COMPONENT_TAG{"a", "decomposition_component"};
 const core::TPersistenceTag RNG_TAG{"b", "rng"};
 const core::TPersistenceTag BUCKETING_TAG{"c", "bucketing"};
 const core::TPersistenceTag LAST_INTERPOLATION_TAG{"d", "last_interpolation_time"};
+const core::TPersistenceTag TOTAL_SHIFT_TAG{"e", "total_shift"};
+const core::TPersistenceTag CURRENT_MEAN_SHIFT_TAG{"f", "current_mean"};
+const core::TPersistenceTag MAX_TIME_SHIFT_PER_PERIOD_TAG{"g", "max_time_shift_per_period"};
 const std::string EMPTY_STRING;
 }
 
 CSeasonalComponent::CSeasonalComponent(const CSeasonalTime& time,
                                        std::size_t maxSize,
                                        double decayRate,
-                                       double minimumBucketLength,
+                                       double minBucketLength,
+                                       core_t::TTime maxTimeShiftPerPeriod,
                                        common::CSplineTypes::EBoundaryCondition boundaryCondition,
                                        common::CSplineTypes::EType valueInterpolationType,
                                        common::CSplineTypes::EType varianceInterpolationType)
     : CDecompositionComponent{maxSize, boundaryCondition,
                               valueInterpolationType, varianceInterpolationType},
-      m_Bucketing{time, decayRate, minimumBucketLength},
-      m_LastInterpolationTime{2 * (std::numeric_limits<core_t::TTime>::min() / 3)} {
+      m_Bucketing{time, decayRate, minBucketLength},
+      m_MaxTimeShiftPerPeriod{common::CBasicStatistics::min(
+          maxTimeShiftPerPeriod,
+          static_cast<core_t::TTime>(minBucketLength / 2.0 + 0.5),
+          static_cast<core_t::TTime>(0.1 * static_cast<double>(time.period()) + 0.5))} {
 }
 
 CSeasonalComponent::CSeasonalComponent(double decayRate,
-                                       double minimumBucketLength,
+                                       double minBucketLength,
                                        core::CStateRestoreTraverser& traverser,
                                        common::CSplineTypes::EType valueInterpolationType,
                                        common::CSplineTypes::EType varianceInterpolationType)
     : CDecompositionComponent{0, common::CSplineTypes::E_Periodic,
-                              valueInterpolationType, varianceInterpolationType},
-      m_LastInterpolationTime{2 * (std::numeric_limits<core_t::TTime>::min() / 3)} {
-    if (traverser.traverseSubLevel(
-            std::bind(&CSeasonalComponent::acceptRestoreTraverser, this, decayRate,
-                      minimumBucketLength, std::placeholders::_1)) == false) {
+                              valueInterpolationType, varianceInterpolationType} {
+    if (traverser.traverseSubLevel([&](core::CStateRestoreTraverser& traverser_) {
+            return this->acceptRestoreTraverser(decayRate, minBucketLength, traverser_);
+        }) == false) {
         traverser.setBadState();
     }
 }
@@ -77,25 +81,32 @@ void CSeasonalComponent::swap(CSeasonalComponent& other) {
     std::swap(m_Rng, other.m_Rng);
     m_Bucketing.swap(other.m_Bucketing);
     std::swap(m_LastInterpolationTime, other.m_LastInterpolationTime);
+    std::swap(m_MaxTimeShiftPerPeriod, other.m_MaxTimeShiftPerPeriod);
+    std::swap(m_TotalShift, other.m_TotalShift);
+    std::swap(m_CurrentMeanShift, other.m_CurrentMeanShift);
 }
 
 bool CSeasonalComponent::acceptRestoreTraverser(double decayRate,
-                                                double minimumBucketLength,
+                                                double minBucketLength,
                                                 core::CStateRestoreTraverser& traverser) {
     bool restoredBucketing{false};
     do {
         const std::string& name{traverser.name()};
         RESTORE(DECOMPOSITION_COMPONENT_TAG,
-                traverser.traverseSubLevel(std::bind(
-                    &CDecompositionComponent::acceptRestoreTraverser,
-                    static_cast<CDecompositionComponent*>(this), std::placeholders::_1)))
+                traverser.traverseSubLevel([this](core::CStateRestoreTraverser& traverser_) {
+                    return this->CDecompositionComponent::acceptRestoreTraverser(traverser_);
+                }))
         RESTORE(RNG_TAG, m_Rng.fromString(traverser.value()))
         RESTORE_SETUP_TEARDOWN(BUCKETING_TAG,
                                CSeasonalComponentAdaptiveBucketing bucketing(
-                                   decayRate, minimumBucketLength, traverser),
+                                   decayRate, minBucketLength, traverser),
                                restoredBucketing = (traverser.haveBadState() == false),
                                m_Bucketing.swap(bucketing))
         RESTORE_BUILT_IN(LAST_INTERPOLATION_TAG, m_LastInterpolationTime)
+        RESTORE_BUILT_IN(MAX_TIME_SHIFT_PER_PERIOD_TAG, m_MaxTimeShiftPerPeriod)
+        RESTORE_BUILT_IN(TOTAL_SHIFT_TAG, m_TotalShift)
+        RESTORE(CURRENT_MEAN_SHIFT_TAG,
+                m_CurrentMeanShift.fromDelimited(traverser.value()))
     } while (traverser.next());
 
     if (restoredBucketing == false) {
@@ -107,15 +118,17 @@ bool CSeasonalComponent::acceptRestoreTraverser(double decayRate,
 }
 
 void CSeasonalComponent::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
-    inserter.insertLevel(DECOMPOSITION_COMPONENT_TAG,
-                         std::bind(&CDecompositionComponent::acceptPersistInserter,
-                                   static_cast<const CDecompositionComponent*>(this),
-                                   std::placeholders::_1));
+    inserter.insertLevel(DECOMPOSITION_COMPONENT_TAG, [this](core::CStatePersistInserter& inserter_) {
+        this->CDecompositionComponent::acceptPersistInserter(inserter_);
+    });
     inserter.insertValue(RNG_TAG, m_Rng.toString());
-    inserter.insertLevel(BUCKETING_TAG,
-                         std::bind(&CSeasonalComponentAdaptiveBucketing::acceptPersistInserter,
-                                   &m_Bucketing, std::placeholders::_1));
+    inserter.insertLevel(BUCKETING_TAG, [this](core::CStatePersistInserter& inserter_) {
+        m_Bucketing.acceptPersistInserter(inserter_);
+    });
     inserter.insertValue(LAST_INTERPOLATION_TAG, m_LastInterpolationTime);
+    inserter.insertValue(MAX_TIME_SHIFT_PER_PERIOD_TAG, m_MaxTimeShiftPerPeriod);
+    inserter.insertValue(TOTAL_SHIFT_TAG, m_TotalShift);
+    inserter.insertValue(CURRENT_MEAN_SHIFT_TAG, m_CurrentMeanShift.toDelimited());
 }
 
 bool CSeasonalComponent::initialized() const {
@@ -181,8 +194,12 @@ void CSeasonalComponent::linearScale(core_t::TTime time, double scale) {
 }
 
 void CSeasonalComponent::add(core_t::TTime time, double value, double weight, double gradientLearnRate) {
-    double predicted{common::CBasicStatistics::mean(this->value(this->jitter(time), 0.0))};
-    m_Bucketing.add(time, value, predicted, weight, gradientLearnRate);
+    core_t::TTime shift;
+    double shiftWeight;
+    std::tie(shift, shiftWeight) = this->likelyShift(time, value);
+    m_CurrentMeanShift.add(static_cast<double>(shift), weight * shiftWeight);
+    double prediction{common::CBasicStatistics::mean(this->value(this->jitter(time), 0.0))};
+    m_Bucketing.add(time + m_TotalShift, value, prediction, weight, gradientLearnRate);
 }
 
 bool CSeasonalComponent::shouldInterpolate(core_t::TTime time) const {
@@ -207,6 +224,11 @@ void CSeasonalComponent::interpolate(core_t::TTime time, bool refine) {
         this->CDecompositionComponent::interpolate(knots, values, variances);
     }
     m_LastInterpolationTime = time_.startOfPeriod(time);
+    m_TotalShift += static_cast<core_t::TTime>(
+        common::CBasicStatistics::mean(m_CurrentMeanShift) + 0.5);
+    m_TotalShift = m_TotalShift % this->time().period();
+    m_CurrentMeanShift = TFloatMeanAccumulator{};
+    LOG_TRACE(<< "total shift = " << m_TotalShift);
     LOG_TRACE(<< "last interpolation time = " << m_LastInterpolationTime);
 }
 
@@ -231,6 +253,7 @@ const CSeasonalComponentAdaptiveBucketing& CSeasonalComponent::bucketing() const
 }
 
 TDoubleDoublePr CSeasonalComponent::value(core_t::TTime time, double confidence) const {
+    time += m_TotalShift;
     double offset{this->time().periodic(time)};
     double n{m_Bucketing.count(time)};
     return this->CDecompositionComponent::value(offset, n, confidence);
@@ -293,6 +316,7 @@ double CSeasonalComponent::delta(core_t::TTime time,
 }
 
 TDoubleDoublePr CSeasonalComponent::variance(core_t::TTime time, double confidence) const {
+    time += m_TotalShift;
     double offset{this->time().periodic(time)};
     double n{m_Bucketing.count(time)};
     return this->CDecompositionComponent::variance(offset, n, confidence);
@@ -309,7 +333,8 @@ bool CSeasonalComponent::covariances(core_t::TTime time, TMatrix& result) const 
         return false;
     }
 
-    if (auto r = m_Bucketing.regression(time)) {
+    time += m_TotalShift;
+    if (const auto* r = m_Bucketing.regression(time)) {
         double variance{common::CBasicStatistics::mean(this->variance(time, 0.0))};
         return r->covariances(variance, result);
     }
@@ -332,7 +357,10 @@ bool CSeasonalComponent::slopeAccurate(core_t::TTime time) const {
 std::uint64_t CSeasonalComponent::checksum(std::uint64_t seed) const {
     seed = this->CDecompositionComponent::checksum(seed);
     seed = common::CChecksum::calculate(seed, m_Bucketing);
-    return common::CChecksum::calculate(seed, m_LastInterpolationTime);
+    seed = common::CChecksum::calculate(seed, m_LastInterpolationTime);
+    seed = common::CChecksum::calculate(seed, m_MaxTimeShiftPerPeriod);
+    seed = common::CChecksum::calculate(seed, m_TotalShift);
+    return common::CChecksum::calculate(seed, m_CurrentMeanShift);
 }
 
 void CSeasonalComponent::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
@@ -344,6 +372,51 @@ void CSeasonalComponent::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsage
 std::size_t CSeasonalComponent::memoryUsage() const {
     return core::CMemory::dynamicSize(m_Bucketing) +
            core::CMemory::dynamicSize(this->splines());
+}
+
+CSeasonalComponent::TTimeDoublePr CSeasonalComponent::likelyShift(core_t::TTime maxTimeShift,
+                                                                  core_t::TTime time,
+                                                                  const TLossFunc& loss) {
+    if (maxTimeShift == 0) {
+        return {0, 0.0};
+    }
+
+    std::array<double, 7> times;
+    double range{2 * static_cast<double>(maxTimeShift)};
+    double step{range / static_cast<double>(times.size() - 1)};
+    times[0] = static_cast<double>(time) - range / 2.0;
+    for (std::size_t i = 1; i < times.size(); ++i) {
+        times[i] = times[i - 1] + step;
+    }
+
+    double shiftedTime;
+    double lossAtShiftedTime;
+    double lossStandardDeviation;
+    common::CSolvers::globalMinimize(times, loss, shiftedTime,
+                                     lossAtShiftedTime, lossStandardDeviation);
+    LOG_TRACE(<< "shift = " << static_cast<core_t::TTime>(shiftedTime + 0.5) - time
+              << ", loss(shift) = " << lossAtShiftedTime
+              << ", sd(loss) = " << lossStandardDeviation);
+
+    return {static_cast<core_t::TTime>(shiftedTime + 0.5), lossStandardDeviation};
+}
+
+CSeasonalComponent::TTimeDoublePr
+CSeasonalComponent::likelyShift(core_t::TTime time, double value) const {
+
+    double range{2 * static_cast<double>(m_MaxTimeShiftPerPeriod)};
+
+    // If the change due to the shift is small compared to the prediction
+    // error force it to zero.
+    double noise{0.2 * std::sqrt(this->meanVariance()) / range};
+    auto loss = [&](double offset) {
+        return std::fabs(common::CBasicStatistics::mean(this->value(
+                             time + static_cast<core_t::TTime>(offset + 0.5), 0.0)) -
+                         value) +
+               noise * std::fabs(offset);
+    };
+
+    return likelyShift(m_MaxTimeShiftPerPeriod, 0, loss);
 }
 
 core_t::TTime CSeasonalComponent::jitter(core_t::TTime time) {

--- a/lib/maths/time_series/CTimeSeriesDecomposition.cc
+++ b/lib/maths/time_series/CTimeSeriesDecomposition.cc
@@ -371,15 +371,15 @@ CTimeSeriesDecomposition::predictor(int components) const {
 
         time += m_TimeShift;
 
-        if (components & E_TrendForced) {
+        if ((components & E_TrendForced) != 0) {
             baseline += trend(time);
-        } else if (components & E_Trend) {
+        } else if ((components & E_Trend) != 0) {
             if (m_Components.usingTrendForPrediction()) {
                 baseline += trend(time);
             }
         }
 
-        if (components & E_Seasonal) {
+        if ((components & E_Seasonal) != 0) {
             const auto& seasonal = m_Components.seasonal();
             for (std::size_t i = 0; i < seasonal.size(); ++i) {
                 if (seasonal[i].initialized() &&
@@ -390,7 +390,7 @@ CTimeSeriesDecomposition::predictor(int components) const {
             }
         }
 
-        if (components & E_Calendar) {
+        if ((components & E_Calendar) != 0) {
             for (const auto& component : m_Components.calendar()) {
                 if (component.initialized() && component.feature().inWindow(time)) {
                     baseline += common::CBasicStatistics::mean(component.value(time, 0.0));
@@ -470,11 +470,32 @@ void CTimeSeriesDecomposition::forecast(core_t::TTime startTime,
 double CTimeSeriesDecomposition::detrend(core_t::TTime time,
                                          double value,
                                          double confidence,
+                                         core_t::TTime maximumTimeShift,
                                          int components) const {
     if (this->initialized() == false) {
         return value;
     }
-    TDoubleDoublePr interval{this->value(time, confidence, components)};
+
+    TDoubleDoublePr interval{this->value(time, confidence, (E_All ^ E_Seasonal) & components)};
+    value = std::min(value - interval.first, 0.0) + std::max(value - interval.second, 0.0);
+
+    if ((components & E_Seasonal) == 0) {
+        return value;
+    }
+
+    core_t::TTime shift{0};
+    if (maximumTimeShift > 0) {
+        auto loss = [&](double offset) {
+            TDoubleDoublePr seasonalInterval{this->value(
+                time + static_cast<core_t::TTime>(offset + 0.5), confidence, E_Seasonal)};
+            return std::fabs(std::min(value - seasonalInterval.first, 0.0) +
+                             std::max(value - seasonalInterval.second, 0.0));
+        };
+        std::tie(shift, std::ignore) =
+            CSeasonalComponent::likelyShift(maximumTimeShift, 0, loss);
+    }
+
+    interval = this->value(time + shift, confidence, E_Seasonal);
     return std::min(value - interval.first, 0.0) + std::max(value - interval.second, 0.0);
 }
 

--- a/lib/maths/time_series/CTimeSeriesDecompositionStub.cc
+++ b/lib/maths/time_series/CTimeSeriesDecompositionStub.cc
@@ -80,6 +80,7 @@ void CTimeSeriesDecompositionStub::forecast(core_t::TTime /*startTime*/,
 double CTimeSeriesDecompositionStub::detrend(core_t::TTime /*time*/,
                                              double value,
                                              double /*confidence*/,
+                                             core_t::TTime /*maximumTimeShift*/,
                                              int /*components*/) const {
     return value;
 }

--- a/lib/maths/time_series/CTimeSeriesMultibucketFeatureSerialiser.cc
+++ b/lib/maths/time_series/CTimeSeriesMultibucketFeatureSerialiser.cc
@@ -27,54 +27,54 @@ const std::string MULTIVARIATE_MEAN_TAG{"b"};
 }
 
 bool CTimeSeriesMultibucketFeatureSerialiser::
-operator()(TUnivariateFeaturePtr& result, core::CStateRestoreTraverser& traverser) const {
+operator()(TScalarFeaturePtr& result, core::CStateRestoreTraverser& traverser) const {
     do {
         const std::string& name{traverser.name()};
         RESTORE_SETUP_TEARDOWN(
             UNIVARIATE_MEAN_TAG,
-            result = std::make_unique<CTimeSeriesMultibucketMean<double>>(),
-            traverser.traverseSubLevel(
-                std::bind<bool>(&TUnivariateFeature::acceptRestoreTraverser,
-                                result.get(), std::placeholders::_1)),
+            result = std::make_unique<CTimeSeriesMultibucketScalarMean>(),
+            traverser.traverseSubLevel([&](core::CStateRestoreTraverser& traverser_) {
+                return result->acceptRestoreTraverser(traverser_);
+            }),
             /**/)
     } while (traverser.next());
     return true;
 }
 
 bool CTimeSeriesMultibucketFeatureSerialiser::
-operator()(TMultivariateFeaturePtr& result, core::CStateRestoreTraverser& traverser) const {
+operator()(TVectorFeaturePtr& result, core::CStateRestoreTraverser& traverser) const {
     do {
         const std::string& name{traverser.name()};
         RESTORE_SETUP_TEARDOWN(
             MULTIVARIATE_MEAN_TAG,
-            result = std::make_unique<CTimeSeriesMultibucketMean<TDouble10Vec>>(),
-            traverser.traverseSubLevel(
-                std::bind<bool>(&TMultivariateFeature::acceptRestoreTraverser,
-                                result.get(), std::placeholders::_1)),
+            result = std::make_unique<CTimeSeriesMultibucketVectorMean>(),
+            traverser.traverseSubLevel([&](core::CStateRestoreTraverser& traverser_) {
+                return result->acceptRestoreTraverser(traverser_);
+            }),
             /**/)
     } while (traverser.next());
     return true;
 }
 
 void CTimeSeriesMultibucketFeatureSerialiser::
-operator()(const TUnivariateFeaturePtr& feature, core::CStatePersistInserter& inserter) const {
-    if (dynamic_cast<const CTimeSeriesMultibucketMean<double>*>(feature.get()) != nullptr) {
-        inserter.insertLevel(UNIVARIATE_MEAN_TAG,
-                             std::bind(&TUnivariateFeature::acceptPersistInserter,
-                                       feature.get(), std::placeholders::_1));
+operator()(const TScalarFeaturePtr& feature, core::CStatePersistInserter& inserter) const {
+    if (dynamic_cast<const CTimeSeriesMultibucketScalarMean*>(feature.get()) != nullptr) {
+        inserter.insertLevel(UNIVARIATE_MEAN_TAG, [&](core::CStatePersistInserter& inserter_) {
+            feature->acceptPersistInserter(inserter_);
+        });
     } else {
-        LOG_ERROR(<< "Feature with type '" << typeid(feature).name() << "' has no defined name");
+        LOG_ERROR(<< "Unknown feature with type '" << typeid(feature).name());
     }
 }
 
 void CTimeSeriesMultibucketFeatureSerialiser::
-operator()(const TMultivariateFeaturePtr& feature, core::CStatePersistInserter& inserter) const {
-    if (dynamic_cast<const CTimeSeriesMultibucketMean<TDouble10Vec>*>(feature.get()) != nullptr) {
-        inserter.insertLevel(MULTIVARIATE_MEAN_TAG,
-                             std::bind(&TMultivariateFeature::acceptPersistInserter,
-                                       feature.get(), std::placeholders::_1));
+operator()(const TVectorFeaturePtr& feature, core::CStatePersistInserter& inserter) const {
+    if (dynamic_cast<const CTimeSeriesMultibucketVectorMean*>(feature.get()) != nullptr) {
+        inserter.insertLevel(MULTIVARIATE_MEAN_TAG, [&](core::CStatePersistInserter& inserter_) {
+            feature->acceptPersistInserter(inserter_);
+        });
     } else {
-        LOG_ERROR(<< "Feature with type '" << typeid(feature).name() << "' has no defined name");
+        LOG_ERROR(<< "Unknown feature with type '" << typeid(feature).name());
     }
 }
 }

--- a/lib/maths/time_series/CTimeSeriesTestForSeasonality.cc
+++ b/lib/maths/time_series/CTimeSeriesTestForSeasonality.cc
@@ -103,6 +103,10 @@ std::size_t CNewSeasonalComponentSummary::size() const {
     return m_Size;
 }
 
+bool CNewSeasonalComponentSummary::isOneOf(int periods) const {
+    return (m_PeriodDescriptor & periods) != 0;
+}
+
 CNewSeasonalComponentSummary::TSeasonalTimeUPtr
 CNewSeasonalComponentSummary::seasonalTime() const {
     auto interval = [this](std::size_t i) {
@@ -162,6 +166,10 @@ core_t::TTime CNewSeasonalComponentSummary::initialValuesStartTime() const {
 core_t::TTime CNewSeasonalComponentSummary::initialValuesEndTime() const {
     return m_InitialValuesStartTime +
            static_cast<core_t::TTime>(m_InitialValues.size()) * m_BucketLength;
+}
+
+core_t::TTime CNewSeasonalComponentSummary::bucketLength() const {
+    return m_BucketLength;
 }
 
 const CNewSeasonalComponentSummary::TFloatMeanAccumulatorVec&
@@ -270,7 +278,7 @@ bool CTimeSeriesTestForSeasonality::canTestModelledComponent(
     const CSeasonalTime& component) {
     std::size_t minimumPeriodInBuckets{
         std::max(buckets(bucketLength, minimumPeriod), minimumResolution)};
-    return 10 * (component.period() % bucketLength) < component.period() &&
+    return 100 * (component.period() % bucketLength) < component.period() &&
            canTestPeriod(values, minimumPeriodInBuckets,
                          toPeriod(bucketsStartTime, bucketLength, component));
 }

--- a/lib/maths/time_series/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/time_series/unittest/CTimeSeriesModelTest.cc
@@ -241,7 +241,7 @@ void reinitializeResidualModel(double learnRate,
 
     using TFloatMeanAccumulatorVecVec = std::vector<TFloatMeanAccumulatorVec>;
 
-    if (controllers) {
+    if (controllers != nullptr) {
         for (auto& trend : trends) {
             trend->decayRate(trend->decayRate() / (*controllers)[0].multiplier());
         }
@@ -294,10 +294,11 @@ void reinitializeResidualModel(double learnRate,
 
 class CChangeDebug {
 public:
-    static const bool ENABLED{true};
+    static const bool ENABLED{false};
 
 public:
-    CChangeDebug(std::string file = "results.py") : m_File(file) {
+    explicit CChangeDebug(std::string file = "results.py")
+        : m_File{std::move(file)} {
         if (ENABLED) {
             m_ModelBounds.resize(3);
             m_Forecast.resize(3);

--- a/lib/model/ModelTypes.cc
+++ b/lib/model/ModelTypes.cc
@@ -1195,8 +1195,7 @@ univariateMultibucketFeature(model_t::EFeature feature, std::size_t windowLength
         case E_IndividualInfoContentByBucketAndPerson:
         case E_IndividualLowInfoContentByBucketAndPerson:
         case E_IndividualHighInfoContentByBucketAndPerson:
-            return std::make_unique<maths::time_series::CTimeSeriesMultibucketMean<double>>(
-                windowLength);
+            return std::make_unique<maths::time_series::CTimeSeriesMultibucketScalarMean>(windowLength);
         case E_IndividualTotalBucketCountByPerson:
         case E_IndividualIndicatorOfBucketPerson:
         case E_IndividualTimeOfDayByBucketAndPerson:
@@ -1224,8 +1223,7 @@ univariateMultibucketFeature(model_t::EFeature feature, std::size_t windowLength
         case E_IndividualMinVelocityByPerson:
         case E_IndividualMaxByPerson:
         case E_IndividualMaxVelocityByPerson:
-            return std::make_unique<maths::time_series::CTimeSeriesMultibucketMean<double>>(
-                windowLength);
+            return std::make_unique<maths::time_series::CTimeSeriesMultibucketScalarMean>(windowLength);
         case E_IndividualMeanLatLongByPerson:
             break;
 

--- a/lib/model/unittest/CModelTestFixtureBase.cc
+++ b/lib/model/unittest/CModelTestFixtureBase.cc
@@ -186,7 +186,7 @@ void CModelTestFixtureBase::generateOrderedAnomalies(std::size_t numAnomalies,
 
     TAnomalyAccumulator anomalies(numAnomalies);
 
-    for (std::size_t i = 0u, bucket = 0; i < messages.size(); ++i) {
+    for (std::size_t i = 0, bucket = 0; i < messages.size(); ++i) {
         if (messages[i].s_Time >= startTime + bucketLength) {
             LOG_DEBUG(<< "Updating and testing bucket = [" << startTime << ","
                       << startTime + bucketLength << ")");
@@ -205,7 +205,6 @@ void CModelTestFixtureBase::generateOrderedAnomalies(std::size_t numAnomalies,
                     attributes.emplace_back(probability.s_Probability,
                                             *probability.s_Attribute);
                 }
-                LOG_DEBUG(<< "Adding anomaly " << pid);
                 anomalies.add({annotatedProbability.s_Probability,
                                {bucket, person, attributes}});
             }


### PR DESCRIPTION
Currently, we have can issues with our time series modelling when:

1. The data are seasonal and the period is not a multiple of the bucket length (or at least not very close to a multiple),
2. The data have seasonality, but the pattern shifts from time to time.

In both cases we get precession of the periodic pattern and generally we don't adapt to this fast enough. The effect is we lose prediction accuracy and sensitivity over time.

This change introduces a latent time shift for each seasonal component and solves for the shift which minimises the difference between the predictions and the observed values. Shifts are accumulated over each period which is observed, which allows us to handle slow precession.