### PR TITLE
[ML] Correct loss gap calculation when evaluating using a holdout set

### DIFF
--- a/include/maths/analytics/CBoostedTreeImpl.h
+++ b/include/maths/analytics/CBoostedTreeImpl.h
@@ -250,6 +250,10 @@ private:
 private:
     CBoostedTreeImpl();
 
+    //! Get the loss gap we expect after incremental training.
+    double expectedLossGapAfterTrainIncremental(double numberOldTrainingRows,
+                                                double numberNewTrainingRows) const;
+
     //! Check if we can train a model.
     bool canTrain() const;
 

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -2402,14 +2402,14 @@ core::CPackedBitVector CBoostedTreeImpl::dataSummarization(const core::CDataFram
     // Note that if we are training on using a holdout set we include the holdout
     // set in the data we consider for summarisation. Typical usage in this case
     // is we're planning to train by query and so the summarisation fraction would
-    // be one.
+    // be one ensuring we retain the full holdout set.
     //
     // (I considered ensuring that the holdout set is always included in the data
     // summary in entirety, which is consistent with this usage, but in practice
     // it may be useful to be able to incrementally train a model with a cutdown
-    // summary after having trained by query. When we come to implement this it
-    // will be behind a new API which can ensure the data summarization fraction
-    // is set appropriately.)
+    // summary after having trained by query. When we come to implement train by
+    // query it will be behind a new API which can ensure the data summarization
+    // fraction is set appropriately.)
 
     core::CPackedBitVector allTrainingRowsMask{this->allTrainingRowsMask()};
 

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -902,6 +902,7 @@ BOOST_AUTO_TEST_CASE(testIncrementalHoldoutRowMask) {
                           1, std::make_unique<maths::analytics::boosted_tree::CMse>())
                           .numberHoldoutRows(numberHoldoutRows)
                           .eta({0.02})
+                          .dataSummarizationFraction(1.0)
                           .buildForTrain(*frame, cols - 1);
 
     regression->train();

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1336,6 +1336,7 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalAddNewTrees) {
                 .leafWeightPenaltyMultiplier({0.5 * lambda, 2.0 * lambda})
                 .maximumNumberNewTrees(maxNumNewTrees)
                 .numberHoldoutRows(numberHoldoutRows)
+                .forceAcceptIncrementalTraining(true)
                 .buildForTrainIncremental(*batch2, cols - 1);
         updatedModel->trainIncremental();
         updatedModel->predict();

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -932,6 +932,7 @@ BOOST_AUTO_TEST_CASE(testIncrementalHoldoutRowMask) {
                      .depthPenaltyMultiplier({0.5 * alpha, 2.0 * alpha})
                      .treeSizePenaltyMultiplier({0.5 * gamma, 2.0 * gamma})
                      .leafWeightPenaltyMultiplier({0.5 * lambda, 2.0 * lambda})
+                     .forceAcceptIncrementalTraining(true)
                      .buildForTrainIncremental(*newFrame, cols - 1);
 
     regression->trainIncremental();


### PR DESCRIPTION
When we are assessing generalisation error using a holdout set there is no need to account for the train/test loss gap comparing the output of  incremental training with the original model.