### PR TITLE
[ML] Implement a configurable hard upper memory limit for classification and regression models

### DIFF
--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -53,6 +53,7 @@ public:
     static const std::string SOFT_TREE_DEPTH_LIMIT;
     static const std::string SOFT_TREE_DEPTH_TOLERANCE;
     static const std::string MAX_TREES;
+    static const std::string MAX_DEPLOYED_SIZE;
     static const std::string FEATURE_BAG_FRACTION;
     static const std::string NUM_FOLDS;
     static const std::string TRAIN_FRACTION_PER_FOLD;

--- a/include/maths/analytics/CBoostedTree.h
+++ b/include/maths/analytics/CBoostedTree.h
@@ -184,6 +184,9 @@ public:
     //! parameters.
     static std::size_t estimateMemoryUsage(std::size_t numberLossParameters);
 
+    //! Get the memory the node will will use in bytes when deployed.
+    std::size_t deployedSize() const;
+
     //! Persist by passing information to \p inserter.
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 

--- a/include/maths/analytics/CBoostedTreeFactory.h
+++ b/include/maths/analytics/CBoostedTreeFactory.h
@@ -117,6 +117,8 @@ public:
     CBoostedTreeFactory& etaGrowthRatePerTree(double etaGrowthRatePerTree);
     //! Set the maximum number of trees in the ensemble.
     CBoostedTreeFactory& maximumNumberTrees(std::size_t maximumNumberTrees);
+    //! Set the maximum supported size for deploying a model.
+    CBoostedTreeFactory& maximumDeployedSize(std::size_t maximumDeployedSize);
     //! Set the fraction of features we'll use in the bag to build a tree.
     CBoostedTreeFactory& featureBagFraction(double featureBagFraction);
     //! Set the maximum number of optimisation rounds we'll use for hyperparameter

--- a/include/maths/analytics/CBoostedTreeImpl.h
+++ b/include/maths/analytics/CBoostedTreeImpl.h
@@ -347,6 +347,12 @@ private:
     //! a good idea.
     std::size_t maximumTreeSize(std::size_t numberRows) const;
 
+    //! Get the maximum memory of any trained model we will produce.
+    //!
+    //! This is the largest model we will train if there is a limit on the
+    //! deployed model.
+    std::size_t maximumTrainedModelSize() const;
+
     //! Start monitoring fine tuning hyperparameters.
     void startProgressMonitoringFineTuneHyperparameters();
 
@@ -397,6 +403,7 @@ private:
     double m_TrainFractionPerFold = 0.75;
     std::size_t m_MaximumNumberTrees = 20;
     std::size_t m_MaximumAttemptsToAddTree = 3;
+    std::size_t m_MaximumDeployedSize = std::numeric_limits<std::size_t>::max();
     std::size_t m_NumberSplitsPerFeature = 75;
     std::size_t m_MaximumOptimisationRoundsPerHyperparameter = 2;
     std::size_t m_RowsPerFeature = 50;

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -63,6 +63,8 @@ const CDataFrameAnalysisConfigReader& CDataFrameTrainBoostedTreeRunner::paramete
         theReader.addParameter(SOFT_TREE_DEPTH_TOLERANCE,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(MAX_TREES, CDataFrameAnalysisConfigReader::E_OptionalParameter);
+        theReader.addParameter(MAX_DEPLOYED_SIZE,
+                               CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(FEATURE_BAG_FRACTION,
                                CDataFrameAnalysisConfigReader::E_OptionalParameter);
         theReader.addParameter(NUM_FOLDS, CDataFrameAnalysisConfigReader::E_OptionalParameter);
@@ -107,6 +109,8 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     double downsampleFactor{parameters[DOWNSAMPLE_FACTOR].fallback(-1.0)};
 
     std::size_t maxTrees{parameters[MAX_TREES].fallback(std::size_t{0})};
+    std::size_t maximumDeployedSize{
+        parameters[MAX_DEPLOYED_SIZE].fallback(std::size_t{1024 * 1024 * 1024})};
     std::size_t numberFolds{parameters[NUM_FOLDS].fallback(std::size_t{0})};
     double trainFractionPerFold{parameters[TRAIN_FRACTION_PER_FOLD].fallback(-1.0)};
     std::size_t numberRoundsPerHyperparameter{
@@ -168,7 +172,8 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
         .stopCrossValidationEarly(stopCrossValidationEarly)
         .analysisInstrumentation(m_Instrumentation)
         .trainingStateCallback(this->statePersister())
-        .earlyStoppingEnabled(earlyStoppingEnabled);
+        .earlyStoppingEnabled(earlyStoppingEnabled)
+        .maximumDeployedSize(maximumDeployedSize);
 
     if (downsampleRowsPerFeature > 0) {
         m_BoostedTreeFactory->initialDownsampleRowsPerFeature(
@@ -406,6 +411,7 @@ const std::string CDataFrameTrainBoostedTreeRunner::ETA_GROWTH_RATE_PER_TREE{"et
 const std::string CDataFrameTrainBoostedTreeRunner::SOFT_TREE_DEPTH_LIMIT{"soft_tree_depth_limit"};
 const std::string CDataFrameTrainBoostedTreeRunner::SOFT_TREE_DEPTH_TOLERANCE{"soft_tree_depth_tolerance"};
 const std::string CDataFrameTrainBoostedTreeRunner::MAX_TREES{"max_trees"};
+const std::string CDataFrameTrainBoostedTreeRunner::MAX_DEPLOYED_SIZE{"max_size"};
 const std::string CDataFrameTrainBoostedTreeRunner::FEATURE_BAG_FRACTION{"feature_bag_fraction"};
 const std::string CDataFrameTrainBoostedTreeRunner::NUM_FOLDS{"num_folds"};
 const std::string CDataFrameTrainBoostedTreeRunner::TRAIN_FRACTION_PER_FOLD{"train_fraction_per_fold"};

--- a/lib/maths/analytics/CBoostedTree.cc
+++ b/lib/maths/analytics/CBoostedTree.cc
@@ -130,6 +130,10 @@ std::size_t CBoostedTreeNode::estimateMemoryUsage(std::size_t numberLossParamete
            common::las::estimateMemoryUsage<TVector>(numberLossParameters);
 }
 
+std::size_t CBoostedTreeNode::deployedSize() const {
+    return this->isLeaf() ? (m_NodeValue.size() + 2) * 8 : 7 * 8;
+}
+
 void CBoostedTreeNode::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
     core::CPersistUtils::persist(ASSIGN_MISSING_TO_LEFT_TAG, m_AssignMissingToLeft, inserter);
     core::CPersistUtils::persist(CURVATURE_TAG, m_Curvature, inserter);

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -1329,6 +1329,16 @@ CBoostedTreeFactory& CBoostedTreeFactory::maximumNumberTrees(std::size_t maximum
     return *this;
 }
 
+CBoostedTreeFactory& CBoostedTreeFactory::maximumDeployedSize(std::size_t maximumDeployedSize) {
+    // We don't have any validation of this because we don't have a plausible
+    // smallest value. Clearly if it is too small we won't be able to produce
+    // a sensible model, but it is not expected that this will be set by the
+    // user and is instead a function of the inference code and is set
+    // programatically.
+    m_TreeImpl->m_MaximumDeployedSize = maximumDeployedSize;
+    return *this;
+}
+
 CBoostedTreeFactory& CBoostedTreeFactory::featureBagFraction(double featureBagFraction) {
     if (featureBagFraction < 0.0 || featureBagFraction > 1.0) {
         LOG_WARN(<< "Truncating supplied feature bag fraction " << featureBagFraction


### PR DESCRIPTION
Currently, we impose no limit to memory based on the maximum size of model which it is possible to deploy for inference in Elasticsearch. This is currently 1GB. As a result we can arrive at an unfortunate situation (albeit unlikely) that we train a model which is not deployable for inference.

This introduces a hard limit which we meet by simply stopping early. In the event this is important for a data set, hyperparameter optimisation will ensure we choose sensible parameters to trade model size and accuracy subject to this constraint based on cross-validation error.