### PR TITLE
[7.17] [ML] Pass ml-cpp version to release manager integration code

### DIFF
--- a/dev-tools/jenkins_combine_artifacts.sh
+++ b/dev-tools/jenkins_combine_artifacts.sh
@@ -109,6 +109,7 @@ docker run --rm \
     cli collect \
       --project ml-cpp \
       --branch "$BRANCH" \
+      --version "$VERSION" \
       --commit `git rev-parse HEAD` \
       --workflow "$WORKFLOW" \
       --qualifier "$VERSION_QUALIFIER" \


### PR DESCRIPTION
Previously the release manager integration code used its own
version number. Generally this didn't matter, but it meant
there was a period when builds would fail as the version was
bumped in all the repos. Passing in the version from the ml-cpp
repo will mean that builds don't fail if the version bumps in
ml-cpp and infra are out of sync.

Backport of #2208