### PR TITLE
[ML] Remove some unused (and buggy) functionality in anomaly detection data gathering

### DIFF
--- a/include/model/CBucketGatherer.h
+++ b/include/model/CBucketGatherer.h
@@ -281,9 +281,6 @@ public:
     //! Get the start of the current bucketing time interval.
     core_t::TTime currentBucketStartTime() const;
 
-    //! Set the start of the current bucketing time interval.
-    void currentBucketStartTime(core_t::TTime time);
-
     //! The earliest time for which data can still arrive.
     core_t::TTime earliestBucketStartTime() const;
 

--- a/include/model/CBucketQueue.h
+++ b/include/model/CBucketQueue.h
@@ -132,13 +132,6 @@ public:
     //! Note, the queue should never be empty.
     void clear(const T& initial = T()) { this->fill(initial); }
 
-    //! Resets the queue to \p startTime.
-    //! This will clear the queue and will fill it with default items.
-    void reset(core_t::TTime startTime, const T& initial = T()) {
-        m_LatestBucketEnd = startTime + m_BucketLength - 1;
-        this->fill(initial);
-    }
-
     //! Returns an iterator pointing to the latest bucket and directed
     //! towards the earlier buckets.
     iterator begin() { return m_Queue.begin(); }
@@ -217,11 +210,9 @@ public:
                     if (!(core::CPersistUtils::restore(BUCKET_TAG, dummy, traverser))) {
                         LOG_ERROR(<< "Invalid bucket");
                     }
-                } else {
-                    if (!(core::CPersistUtils::restore(BUCKET_TAG, m_Queue[i], traverser))) {
-                        LOG_ERROR(<< "Invalid bucket");
-                        return false;
-                    }
+                } else if (!(core::CPersistUtils::restore(BUCKET_TAG, m_Queue[i], traverser))) {
+                    LOG_ERROR(<< "Invalid bucket");
+                    return false;
                 }
             }
         } while (traverser.next());

--- a/include/model/CDataGatherer.h
+++ b/include/model/CDataGatherer.h
@@ -539,9 +539,6 @@ public:
     //! Get the start of the current bucketing time interval.
     core_t::TTime currentBucketStartTime() const;
 
-    //! Reset the current bucketing interval start time.
-    void currentBucketStartTime(core_t::TTime bucketStart);
-
     //! Get the length of the bucketing time interval.
     core_t::TTime bucketLength() const;
 

--- a/lib/model/CBucketGatherer.cc
+++ b/lib/model/CBucketGatherer.cc
@@ -319,10 +319,6 @@ void CBucketGatherer::timeNow(core_t::TTime time) {
 void CBucketGatherer::hiddenTimeNow(core_t::TTime time, bool skipUpdates) {
     m_EarliestTime = std::min(m_EarliestTime, time);
     core_t::TTime n = (time - m_BucketStart) / this->bucketLength();
-    if (n <= 0) {
-        return;
-    }
-
     core_t::TTime newBucketStart = m_BucketStart;
     for (core_t::TTime i = 0; i < n; ++i) {
         newBucketStart += this->bucketLength();
@@ -424,10 +420,6 @@ void CBucketGatherer::removeAttributes(std::size_t lowestAttributeToRemove) {
 
 core_t::TTime CBucketGatherer::currentBucketStartTime() const {
     return m_BucketStart;
-}
-
-void CBucketGatherer::currentBucketStartTime(core_t::TTime time) {
-    m_BucketStart = time;
 }
 
 core_t::TTime CBucketGatherer::earliestBucketStartTime() const {

--- a/lib/model/CDataGatherer.cc
+++ b/lib/model/CDataGatherer.cc
@@ -549,10 +549,6 @@ core_t::TTime CDataGatherer::currentBucketStartTime() const {
     return m_BucketGatherer->currentBucketStartTime();
 }
 
-void CDataGatherer::currentBucketStartTime(core_t::TTime bucketStart) {
-    m_BucketGatherer->currentBucketStartTime(bucketStart);
-}
-
 core_t::TTime CDataGatherer::bucketLength() const {
     return m_BucketGatherer->bucketLength();
 }

--- a/lib/model/unittest/CEventRateDataGathererTest.cc
+++ b/lib/model/unittest/CEventRateDataGathererTest.cc
@@ -231,10 +231,6 @@ void testInfluencerPerFeature(model_t::EFeature feature,
     BOOST_REQUIRE_EQUAL(std::size_t(0), gatherer.numberOverFieldValues());
 
     BOOST_REQUIRE_EQUAL(startTime, gatherer.currentBucketStartTime());
-    gatherer.currentBucketStartTime(200);
-    BOOST_REQUIRE_EQUAL(static_cast<core_t::TTime>(200), gatherer.currentBucketStartTime());
-    gatherer.currentBucketStartTime(startTime);
-
     BOOST_REQUIRE_EQUAL(bucketLength, gatherer.bucketLength());
 
     core_t::TTime time = startTime;
@@ -443,12 +439,7 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeries, CTestFixture) {
 
         BOOST_REQUIRE_EQUAL(std::size_t(0), gatherer.numberActiveAttributes());
         BOOST_REQUIRE_EQUAL(std::size_t(0), gatherer.numberOverFieldValues());
-
         BOOST_REQUIRE_EQUAL(startTime, gatherer.currentBucketStartTime());
-        gatherer.currentBucketStartTime(200);
-        BOOST_REQUIRE_EQUAL(static_cast<core_t::TTime>(200),
-                            gatherer.currentBucketStartTime());
-        gatherer.currentBucketStartTime(startTime);
 
         BOOST_REQUIRE_EQUAL(bucketLength, gatherer.bucketLength());
 


### PR DESCRIPTION
This PR removes some functionality for updating time which was not being used and in fact wasn't properly maintaining class invariants. It also adds some extra useful information in various log messages, in case we still have problems in this area, after fixing #2213.

Finally, it addresses assorted warnings in this code generated by clang-tidy. Principally, we were using bind, because the code predated lambdas, however calling via lambdas often produces better inlining. 