### PR TITLE
[ML] Refactor state traverser checks for bad state

### DIFF
--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -950,8 +950,7 @@ bool CAnomalyJob::restoreState(core::CStateRestoreTraverser& traverser,
             m_ModelConfig.interimBucketCorrector(interimBucketCorrector);
         } else if (name == TOP_LEVEL_DETECTOR_TAG) {
             if (traverser.traverseSubLevel(std::bind(&CAnomalyJob::restoreSingleDetector,
-                                                     this, std::placeholders::_1)) == false ||
-                traverser.haveBadState()) {
+                                                     this, std::placeholders::_1)) == false) {
                 LOG_ERROR(<< "Cannot restore anomaly detector");
                 return false;
             }
@@ -959,8 +958,7 @@ bool CAnomalyJob::restoreState(core::CStateRestoreTraverser& traverser,
         } else if (name == RESULTS_AGGREGATOR_TAG) {
             if (traverser.traverseSubLevel(std::bind(
                     &model::CHierarchicalResultsAggregator::acceptRestoreTraverser,
-                    &m_Aggregator, std::placeholders::_1)) == false ||
-                traverser.haveBadState()) {
+                    &m_Aggregator, std::placeholders::_1)) == false) {
                 LOG_ERROR(<< "Cannot restore results aggregator");
                 return false;
             }
@@ -1038,8 +1036,7 @@ bool CAnomalyJob::restoreSingleDetector(core::CStateRestoreTraverser& traverser)
         return false;
     }
 
-    if (this->restoreDetectorState(key, partitionFieldValue, traverser) == false ||
-        traverser.haveBadState()) {
+    if (this->restoreDetectorState(key, partitionFieldValue, traverser) == false) {
         LOG_ERROR(<< "Delegated portion of anomaly detector restore failed");
         m_RestoredStateDetail.s_RestoredStateStatus = E_Failure;
         return false;
@@ -1070,8 +1067,7 @@ bool CAnomalyJob::restoreDetectorState(const model::CSearchKey& key,
 
     if (traverser.traverseSubLevel(std::bind(
             &model::CAnomalyDetector::acceptRestoreTraverser, detector.get(),
-            std::cref(partitionFieldValue), std::placeholders::_1)) == false ||
-        traverser.haveBadState()) {
+            std::cref(partitionFieldValue), std::placeholders::_1)) == false) {
         LOG_ERROR(<< "Error restoring anomaly detector for key '" << key.debug()
                   << '/' << partitionFieldValue << '\'');
         return false;

--- a/lib/api/CSingleFieldDataCategorizer.cc
+++ b/lib/api/CSingleFieldDataCategorizer.cc
@@ -184,8 +184,7 @@ bool CSingleFieldDataCategorizer::acceptRestoreTraverser(core::CStateRestoreTrav
         if (traverser.name() == CATEGORY_ID_MAPPER_TAG) {
             if (traverser.traverseSubLevel([this](core::CStateRestoreTraverser& traverser_) {
                     return m_CategoryIdMapper->acceptRestoreTraverser(traverser_);
-                }) == false ||
-                traverser.haveBadState()) {
+                }) == false) {
                 LOG_ERROR(<< "Cannot restore category ID mapper, unexpected element: "
                           << traverser.value());
                 return false;

--- a/lib/core/CJsonStateRestoreTraverser.cc
+++ b/lib/core/CJsonStateRestoreTraverser.cc
@@ -73,6 +73,10 @@ bool CJsonStateRestoreTraverser::nextObject() {
         return false;
     }
 
+    if (haveBadState()) {
+        return false;
+    }
+
     // Advance to the next start object token
     bool ok = this->advance() && this->advance();
     ok = ok && this->next();
@@ -85,6 +89,10 @@ bool CJsonStateRestoreTraverser::hasSubLevel() const {
         if (const_cast<CJsonStateRestoreTraverser*>(this)->start() == false) {
             return false;
         }
+    }
+
+    if (haveBadState()) {
+        return false;
     }
 
     return this->currentLevel() == 1 + m_DesiredLevel;
@@ -125,6 +133,10 @@ bool CJsonStateRestoreTraverser::descend() {
         }
     }
 
+    if (haveBadState()) {
+        return false;
+    }
+
     if (this->currentLevel() != 1 + m_DesiredLevel) {
         return false;
     }
@@ -148,6 +160,10 @@ bool CJsonStateRestoreTraverser::ascend() {
     // wrong
     if (m_DesiredLevel == 0) {
         LOG_ERROR(<< "Inconsistency - trying to ascend above JSON root");
+        return false;
+    }
+
+    if (haveBadState()) {
         return false;
     }
 

--- a/lib/model/CBucketGatherer.cc
+++ b/lib/model/CBucketGatherer.cc
@@ -155,8 +155,7 @@ struct SBucketCountsPersister {
             }
             if (traverser.traverseSubLevel(
                     std::bind(&restorePersonAttributeCounts, std::placeholders::_1,
-                              std::ref(key), std::ref(count))) == false ||
-                traverser.haveBadState()) {
+                              std::ref(key), std::ref(count))) == false) {
                 LOG_ERROR(<< "Invalid person attribute count");
                 continue;
             }

--- a/lib/model/CDataCategorizer.cc
+++ b/lib/model/CDataCategorizer.cc
@@ -75,10 +75,9 @@ bool CDataCategorizer::areNewCategoriesAllowed() {
 }
 
 bool CDataCategorizer::restoreExamplesCollector(core::CStateRestoreTraverser& traverser) {
-    if (traverser.traverseSubLevel(
-            std::bind(&model::CCategoryExamplesCollector::acceptRestoreTraverser,
-                      std::ref(m_ExamplesCollector), std::placeholders::_1)) == false ||
-        traverser.haveBadState()) {
+    if (traverser.traverseSubLevel(std::bind(
+            &model::CCategoryExamplesCollector::acceptRestoreTraverser,
+            std::ref(m_ExamplesCollector), std::placeholders::_1)) == false) {
         LOG_ERROR(<< "Cannot restore category examples, unexpected element: "
                   << traverser.value());
         return false;

--- a/lib/model/CDataGatherer.cc
+++ b/lib/model/CDataGatherer.cc
@@ -203,8 +203,7 @@ CDataGatherer::CDataGatherer(model_t::EAnalysisCategory gathererType,
     if (traverser.traverseSubLevel(std::bind(
             &CDataGatherer::acceptRestoreTraverser, this, std::cref(summaryCountFieldName),
             std::cref(personFieldName), std::cref(attributeFieldName), std::cref(valueFieldName),
-            std::cref(influenceFieldNames), std::placeholders::_1)) == false ||
-        traverser.haveBadState()) {
+            std::cref(influenceFieldNames), std::placeholders::_1)) == false) {
         LOG_ERROR(<< "Failed to correctly restore data gatherer");
     }
 }

--- a/lib/model/CEventRateBucketGatherer.cc
+++ b/lib/model/CEventRateBucketGatherer.cc
@@ -263,9 +263,8 @@ bool restoreFeatureData(core::CStateRestoreTraverser& traverser,
         auto* data{boost::unsafe_any_cast<TSizeUSetVec>(
             &featureData.emplace(model_t::E_AttributePeople, TSizeUSetVec())
                  .first->second)};
-        if (traverser.traverseSubLevel(std::bind(
-                &restoreAttributePeopleData, std::placeholders::_1, std::ref(*data))) == false ||
-            traverser.haveBadState()) {
+        if (traverser.traverseSubLevel(std::bind(&restoreAttributePeopleData, std::placeholders::_1,
+                                                 std::ref(*data))) == false) {
             LOG_ERROR(<< "Invalid attribute/people mapping in " << traverser.value());
             return false;
         }
@@ -280,8 +279,7 @@ bool restoreFeatureData(core::CStateRestoreTraverser& traverser,
         if (traverser.traverseSubLevel(std::bind<bool>(
                 TSizeSizePrStrDataUMapQueue::CSerializer<SStrDataBucketSerializer>(
                     TSizeSizePrStrDataUMap(1)),
-                std::ref(*data), std::placeholders::_1)) == false ||
-            traverser.haveBadState()) {
+                std::ref(*data), std::placeholders::_1)) == false) {
             LOG_ERROR(<< "Invalid unique value mapping in " << traverser.value());
             return false;
         }
@@ -294,8 +292,7 @@ bool restoreFeatureData(core::CStateRestoreTraverser& traverser,
                  .first->second)};
         if (traverser.traverseSubLevel(std::bind<bool>(
                 TSizeSizePrMeanAccumulatorUMapQueue::CSerializer<STimesBucketSerializer>(),
-                std::ref(*data), std::placeholders::_1)) == false ||
-            traverser.haveBadState()) {
+                std::ref(*data), std::placeholders::_1)) == false) {
             LOG_ERROR(<< "Invalid times mapping in " << traverser.value());
             return false;
         }

--- a/lib/model/CMetricBucketGatherer.cc
+++ b/lib/model/CMetricBucketGatherer.cc
@@ -421,8 +421,7 @@ private:
                 if (name == ATTRIBUTE_TAG) {
                     if (traverser.traverseSubLevel(std::bind<bool>(
                             &CDoNewRestore::restoreAttributes<T>, this, std::placeholders::_1,
-                            std::cref(gatherer), std::ref(result))) == false ||
-                        traverser.haveBadState()) {
+                            std::cref(gatherer), std::ref(result))) == false) {
                         LOG_ERROR(<< "Invalid data in " << traverser.value());
                         return false;
                     }
@@ -456,8 +455,7 @@ private:
                     }
                     if (traverser.traverseSubLevel(std::bind<bool>(
                             &CDoNewRestore::restorePeople<T>, this, std::placeholders::_1,
-                            std::cref(gatherer), std::ref(result[lastCid]))) == false ||
-                        traverser.haveBadState()) {
+                            std::cref(gatherer), std::ref(result[lastCid]))) == false) {
                         LOG_ERROR(<< "Invalid data in " << traverser.value());
                         return false;
                     }
@@ -494,8 +492,7 @@ private:
                               gatherer.endInfluencers());
                     if (traverser.traverseSubLevel(
                             std::bind<bool>(&T::acceptRestoreTraverser, &initial,
-                                            std::placeholders::_1)) == false ||
-                        traverser.haveBadState()) {
+                                            std::placeholders::_1)) == false) {
                         LOG_ERROR(<< "Invalid data in " << traverser.value());
                         return false;
                     }
@@ -542,8 +539,7 @@ private:
                               gatherer.endInfluencers());
                     if (traverser.traverseSubLevel(
                             std::bind(&T::acceptRestoreTraverser, &initial,
-                                      std::placeholders::_1)) == false ||
-                        traverser.haveBadState()) {
+                                      std::placeholders::_1)) == false) {
                         LOG_ERROR(<< "Invalid data in " << traverser.value());
                         return false;
                     }
@@ -585,8 +581,7 @@ private:
                               gatherer.endInfluencers());
                     if (traverser.traverseSubLevel(
                             std::bind(&T::acceptRestoreTraverser, &initial,
-                                      std::placeholders::_1)) == false ||
-                        traverser.haveBadState()) {
+                                      std::placeholders::_1)) == false) {
                         LOG_ERROR(<< "Invalid data in " << traverser.value());
                         return false;
                     }
@@ -990,8 +985,7 @@ bool CMetricBucketGatherer::acceptRestoreTraverser(core::CStateRestoreTraverser&
         const std::string& name = traverser.name();
         if (name == BASE_TAG) {
             if (traverser.traverseSubLevel(std::bind(&CBucketGatherer::baseAcceptRestoreTraverser,
-                                                     this, std::placeholders::_1)) == false ||
-                traverser.haveBadState()) {
+                                                     this, std::placeholders::_1)) == false) {
                 LOG_ERROR(<< "Invalid data gatherer in " << traverser.value());
                 return false;
             }


### PR DESCRIPTION
Centralise checks for bad state in the public methods of the state
traverser itself.

Relates #2219