### PR TITLE
Use deps and nodeps archives for project artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -327,7 +327,6 @@ def dependenciesSpec(source) {
 
 task buildDependenciesZip(type: Zip) {
   description = 'Create a zip of dependencies only from combined platform-specific C++ distributions'
-  dependsOn buildUberZip
 
   classifier = 'deps'
   reproducibleFileOrder = true
@@ -335,7 +334,7 @@ task buildDependenciesZip(type: Zip) {
   // timestamp diffs between otherwise identical archives
   preserveFileTimestamps = false
 
-  with dependenciesSpec(zipTree(buildUberZip))
+  with dependenciesSpec(zipTree(buildUberZip.archiveFile))
 }
 
 task buildDependenciesZipFromDownloads(type: Zip) {
@@ -373,7 +372,6 @@ def noDependenciesSpec(source) {
 
 task buildNoDependenciesZip(type: Zip) {
   description = 'Create a zip excluding dependencies from combined platform-specific C++ distributions'
-  dependsOn buildUberZip
 
   classifier = 'nodeps'
   reproducibleFileOrder = true
@@ -381,7 +379,7 @@ task buildNoDependenciesZip(type: Zip) {
   // timestamp diffs between otherwise identical archives
   preserveFileTimestamps = false
 
-  with noDependenciesSpec(zipTree(buildUberZip))
+  with noDependenciesSpec(zipTree(buildUberZip.archiveFile))
 }
 
 task buildNoDependenciesZipFromDownloads(type: Zip) {

--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,7 @@ task format(type: Exec) {
 
 task buildZip(type: Zip) {
   dependsOn strip
+  archiveClassifier = artifactClassifier
   from("${buildDir}/distribution") {
     // Don't copy Windows import libraries
     exclude "**/*.lib"
@@ -155,7 +156,7 @@ task buildZip(type: Zip) {
 
 task buildZipSymbols(type: Zip) {
   dependsOn strip
-  classifier = "debug"
+  archiveClassifier = "${artifactClassifier}-debug"
   from("${buildDir}/distribution") {
     // only take debug files
     include "**/*-debug"
@@ -201,7 +202,7 @@ check {
 }
 
 assemble {
-  dependsOn = ['buildUberZip', 'buildZipSymbols']
+  dependsOn = ['buildUberZip', 'buildZip', 'buildZipSymbols']
   description = 'Assemble the C++ part of Machine Learning'
 }
 
@@ -326,6 +327,7 @@ def dependenciesSpec(source) {
 
 task buildDependenciesZip(type: Zip) {
   description = 'Create a zip of dependencies only from combined platform-specific C++ distributions'
+  dependsOn buildUberZip
 
   classifier = 'deps'
   reproducibleFileOrder = true
@@ -333,7 +335,7 @@ task buildDependenciesZip(type: Zip) {
   // timestamp diffs between otherwise identical archives
   preserveFileTimestamps = false
 
-  with dependenciesSpec(buildUberZip)
+  with dependenciesSpec(zipTree(buildUberZip))
 }
 
 task buildDependenciesZipFromDownloads(type: Zip) {
@@ -371,6 +373,7 @@ def noDependenciesSpec(source) {
 
 task buildNoDependenciesZip(type: Zip) {
   description = 'Create a zip excluding dependencies from combined platform-specific C++ distributions'
+  dependsOn buildUberZip
 
   classifier = 'nodeps'
   reproducibleFileOrder = true
@@ -378,7 +381,7 @@ task buildNoDependenciesZip(type: Zip) {
   // timestamp diffs between otherwise identical archives
   preserveFileTimestamps = false
 
-  with noDependenciesSpec(buildUberZip)
+  with noDependenciesSpec(zipTree(buildUberZip))
 }
 
 task buildNoDependenciesZipFromDownloads(type: Zip) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: 'base'
+
 description = 'Builds the Machine Learning native binaries'
 
 import org.elastic.gradle.UploadS3Task
@@ -90,11 +92,15 @@ configurations.all {
   resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
 }
 
-task clean(type: Exec) {
-  environment makeEnvironment
-  commandLine bash
-  args '-c', 'source ./set_env.sh && rm -rf build && ' + make + ' clean'
-  workingDir "${projectDir}"
+clean {
+  doLast {
+    exec {
+      environment makeEnvironment
+      commandLine bash
+      args '-c', 'source ./set_env.sh && ' + make + ' clean'
+      workingDir "${projectDir}"
+    }
+  }
 }
 
 task compile(type: Exec) {
@@ -129,7 +135,8 @@ task format(type: Exec) {
   workingDir "${projectDir}"
 }
 
-def zipSpec = copySpec {
+task buildZip(type: Zip) {
+  dependsOn strip
   from("${buildDir}/distribution") {
     // Don't copy Windows import libraries
     exclude "**/*.lib"
@@ -146,16 +153,9 @@ def zipSpec = copySpec {
   }
 }
 
-task buildZip(type: Zip) {
+task buildZipSymbols(type: Zip) {
   dependsOn strip
-  archiveBaseName = artifactName
-  with zipSpec
-  destinationDirectory = file("${buildDir}/distributions")
-  archiveVersion = project.version
-  archiveClassifier = artifactClassifier
-}
-
-def zipSpecSymbols = copySpec {
+  classifier = "debug"
   from("${buildDir}/distribution") {
     // only take debug files
     include "**/*-debug"
@@ -165,19 +165,10 @@ def zipSpecSymbols = copySpec {
   }
 }
 
-task buildZipSymbols(type: Zip) {
+task buildUberZip(type: Zip) {
   dependsOn strip
-  archiveBaseName = "$artifactName-debug"
-  with zipSpecSymbols
-  destinationDirectory = file("${buildDir}/distributions")
-  archiveVersion = project.version
-  archiveClassifier = artifactClassifier
-}
 
-// The uber zip contains C++ binaries for as many platforms as possible
-def uberZipSpec = copySpec {
-  // We know we'll have binaries from the current build
-  from(zipTree(buildZip.outputs.files.singleFile))
+  with buildZip
   // We might also have binaries for other platforms (e.g. if they've been built in Docker)
   def localZips = fileTree("${buildDir}/distributions").matching {
       include "${artifactName}-${project.version}-darwin-*.zip"
@@ -189,22 +180,9 @@ def uberZipSpec = copySpec {
       duplicatesStrategy 'exclude'
     }
   }
-}
-
-task buildUberZip(type: Zip) {
-  dependsOn buildZip
-  archiveBaseName = "$artifactName"
-  with uberZipSpec
-  destinationDirectory = file("${buildDir}/distributions")
-  archiveVersion = project.version
   reproducibleFileOrder = true
 }
 
-configurations.create('default')
-
-artifacts {
-  'default' buildUberZip
-}
 
 String artifactGroupPath = project.group.replaceAll("\\.", "/")
 
@@ -217,18 +195,17 @@ task test(type: Exec) {
   description = 'Run C++ tests'
 }
 
-task check {
-  dependsOn 'test'
+check {
+  dependsOn = ['test']
   description = 'Run all verification tasks'
 }
 
-task assemble {
-  dependsOn 'buildUberZip', 'buildZipSymbols'
+assemble {
+  dependsOn = ['buildUberZip', 'buildZipSymbols']
   description = 'Assemble the C++ part of Machine Learning'
 }
 
-task build(dependsOn: [check, assemble]) {
-  group = 'Build'
+build {
   description = 'Assemble and test the C++ part of Machine Learning'
 }
 
@@ -314,76 +291,106 @@ class DownloadPlatformSpecific extends DefaultTask {
 }
 
 task downloadPlatformSpecific(type: DownloadPlatformSpecific) {
+  description = 'Download and extract previously created platform-specific C++ zips'
   baseName = artifactName
   downloadDirectory = "${buildDir}/distributions"
   extractDirectory = file("${buildDir}/temp")
-  description = 'Download and extract previously created platform-specific C++ zips'
 }
 
-task buildUberZipFromDownloads(type: Zip, dependsOn: downloadPlatformSpecific) {
-  archiveBaseName = artifactName
-  archiveVersion = project.version
-  destinationDirectory = file("${buildDir}/distributions")
-  from(fileTree(downloadPlatformSpecific.outputs.files.singleFile))
+task buildUberZipFromDownloads(type: Zip) {
   description = 'Create an uber zip from combined platform-specific C++ distributions'
+  destinationDirectory = file("${buildDir}/distributions")
+  from(downloadPlatformSpecific)
   reproducibleFileOrder = true
 }
 
-def dependenciesSpec = copySpec {
-  from(fileTree(downloadPlatformSpecific.outputs.files.singleFile)) {
-    // Don't copy ML libraries
-    exclude "**/libMl*"
-    // Don't copy ML programs
-    exclude "platform/darwin*/controller.app/Contents/MacOS/*"
-    exclude "platform/linux*/bin/*"
-    exclude "platform/windows*/bin/*.exe"
-    // Don't copy resources
-    exclude "**/ml-en.dict"
-    exclude "**/Info.plist"
-    exclude "**/date_time_zonespec.csv"
-    // Don't copy licenses
-    exclude "**/licenses/**"
-    includeEmptyDirs = false
+def dependenciesSpec(source) {
+  return copySpec {
+    from(source) {
+      // Don't copy ML libraries
+      exclude "**/libMl*"
+      // Don't copy ML programs
+      exclude "platform/darwin*/controller.app/Contents/MacOS/*"
+      exclude "platform/linux*/bin/*"
+      exclude "platform/windows*/bin/*.exe"
+      // Don't copy resources
+      exclude "**/ml-en.dict"
+      exclude "**/Info.plist"
+      exclude "**/date_time_zonespec.csv"
+      // Don't copy licenses
+      exclude "**/licenses/**"
+      includeEmptyDirs = false
+    }
   }
 }
 
-task buildDependenciesZipFromDownloads(type: Zip, dependsOn: downloadPlatformSpecific) {
-  archiveBaseName = artifactName + '-deps'
-  archiveVersion = project.version
-  destinationDirectory = file("${buildDir}/distributions")
-  with dependenciesSpec
+task buildDependenciesZip(type: Zip) {
   description = 'Create a zip of dependencies only from combined platform-specific C++ distributions'
+
+  classifier = 'deps'
   reproducibleFileOrder = true
   // Drop the file timestamps for the dependencies to avoid
   // timestamp diffs between otherwise identical archives
   preserveFileTimestamps = false
+
+  with dependenciesSpec(buildUberZip)
 }
 
-def noDependenciesSpec = copySpec {
-  from(fileTree(downloadPlatformSpecific.outputs.files.singleFile)) {
-    // Copy ML libraries
-    include "**/libMl*"
-    // Copy ML programs
-    include "platform/darwin*/controller.app/Contents/MacOS/*"
-    include "platform/linux*/bin/*"
-    include "platform/windows*/bin/*.exe"
-    // Copy resources
-    include "**/ml-en.dict"
-    include "**/Info.plist"
-    include "**/date_time_zonespec.csv"
-    // Copy licenses
-    include "**/licenses/**"
-    includeEmptyDirs = false
+task buildDependenciesZipFromDownloads(type: Zip) {
+  description = 'Create a zip of dependencies only from combined platform-specific C++ distributions from published snapshot'
+
+  classifier = 'deps'
+  reproducibleFileOrder = true
+  // Drop the file timestamps for the dependencies to avoid
+  // timestamp diffs between otherwise identical archives
+  preserveFileTimestamps = false
+
+  with dependenciesSpec(downloadPlatformSpecific)
+}
+
+
+def noDependenciesSpec(source) {
+   return copySpec {
+    from(source) {
+      // Copy ML libraries
+      include "**/libMl*"
+      // Copy ML programs
+      include "platform/darwin*/controller.app/Contents/MacOS/*"
+      include "platform/linux*/bin/*"
+      include "platform/windows*/bin/*.exe"
+      // Copy resources
+      include "**/ml-en.dict"
+      include "**/Info.plist"
+      include "**/date_time_zonespec.csv"
+      // Copy licenses
+      include "**/licenses/**"
+      includeEmptyDirs = false
+    }
   }
 }
 
-task buildNoDependenciesZipFromDownloads(type: Zip, dependsOn: downloadPlatformSpecific) {
-  archiveBaseName = artifactName + '-nodeps'
-  archiveVersion = project.version
-  destinationDirectory = file("${buildDir}/distributions")
-  with noDependenciesSpec
+task buildNoDependenciesZip(type: Zip) {
   description = 'Create a zip excluding dependencies from combined platform-specific C++ distributions'
+
+  classifier = 'nodeps'
   reproducibleFileOrder = true
+  // Drop the file timestamps for the dependencies to avoid
+  // timestamp diffs between otherwise identical archives
+  preserveFileTimestamps = false
+
+  with noDependenciesSpec(buildUberZip)
+}
+
+task buildNoDependenciesZipFromDownloads(type: Zip) {
+  description = 'Create a zip excluding dependencies from combined platform-specific C++ distributions from published snapshot'
+
+  classifier = 'nodeps'
+  reproducibleFileOrder = true
+  // Drop the file timestamps for the dependencies to avoid
+  // timestamp diffs between otherwise identical archives
+  preserveFileTimestamps = false
+
+  with noDependenciesSpec(downloadPlatformSpecific)
 }
 
 task buildDependencyReport(type: Exec) {
@@ -431,4 +438,10 @@ wrapper {
     wrapper.getPropertiesFile() << "distributionSha256Sum=${sha256Sum}\n"
     println "Added checksum to wrapper properties"
   }
+}
+
+
+artifacts {
+  'default' buildDependenciesZip
+  'default' buildNoDependenciesZip
 }

--- a/build.gradle
+++ b/build.gradle
@@ -409,7 +409,9 @@ task buildDependencyReport(type: Exec) {
 task upload(type: UploadS3Task) {
   bucket 'prelert-artifacts'
   // Only upload the platform-specific artifacts in this task
-  def zipFileDir = fileTree("${buildDir}/distributions").matching { include "*-aarch64.zip", "*-x86_64.zip" }
+  def zipFileDir = fileTree("${buildDir}/distributions").matching {
+    include "*-aarch64.zip", "*-aarch64-debug.zip", "*-x86_64.zip", "*-x86_64-debug.zip"
+  }
   for (zipFile in zipFileDir) {
     upload zipFile, "maven/${artifactGroupPath}/${artifactName}/${project.version}/${zipFile.name}"
   }
@@ -440,7 +442,6 @@ wrapper {
     println "Added checksum to wrapper properties"
   }
 }
-
 
 artifacts {
   'default' buildDependenciesZip

--- a/build.gradle
+++ b/build.gradle
@@ -156,7 +156,7 @@ task buildZip(type: Zip) {
 
 task buildZipSymbols(type: Zip) {
   dependsOn strip
-  archiveClassifier = "${artifactClassifier}-debug"
+  archiveClassifier = "debug-${artifactClassifier}"
   from("${buildDir}/distribution") {
     // only take debug files
     include "**/*-debug"
@@ -281,7 +281,7 @@ class DownloadPlatformSpecific extends DefaultTask {
       }
       zip.close()
       // Also download the corresponding zip of debug symbols, but there's no need to extract this
-      File debugZipFile = new File(downloadDirectory, "${baseName}-debug-${version}-${it}.zip")
+      File debugZipFile = new File(downloadDirectory, "${baseName}-${version}-debug-${it}.zip")
       new URL("https://prelert-artifacts.s3.amazonaws.com/maven/${artifactGroupPath}/${baseName}/${version}/${debugZipFile.name}").withInputStream { i ->
         debugZipFile.withOutputStream { o ->
           o << i
@@ -410,7 +410,7 @@ task upload(type: UploadS3Task) {
   bucket 'prelert-artifacts'
   // Only upload the platform-specific artifacts in this task
   def zipFileDir = fileTree("${buildDir}/distributions").matching {
-    include "*-aarch64.zip", "*-aarch64-debug.zip", "*-x86_64.zip", "*-x86_64-debug.zip"
+    include "*-aarch64.zip", "*-x86_64.zip"
   }
   for (zipFile in zipFileDir) {
     upload zipFile, "maven/${artifactGroupPath}/${artifactName}/${project.version}/${zipFile.name}"

--- a/dev-tools/docker/docker_entrypoint.sh
+++ b/dev-tools/docker/docker_entrypoint.sh
@@ -50,7 +50,7 @@ mkdir ../distributions
 # Exclude import libraries, test support libraries, debug files and core dumps
 zip -9 ../distributions/$ARTIFACT_NAME-$PRODUCT_VERSION-$BUNDLE_PLATFORM.zip `find * | egrep -v '\.lib$|unit_test_framework|libMlTest|\.dSYM|-debug$|\.pdb$|/core'`
 # Include only debug files
-zip -9 ../distributions/$ARTIFACT_NAME-debug-$PRODUCT_VERSION-$BUNDLE_PLATFORM.zip `find * | egrep '\.dSYM|-debug$|\.pdb$'`
+zip -9 ../distributions/$ARTIFACT_NAME-$PRODUCT_VERSION-$BUNDLE_PLATFORM-debug.zip `find * | egrep '\.dSYM|-debug$|\.pdb$'`
 cd ../..
 
 if [ "x$1" = "x--test" ] ; then

--- a/dev-tools/docker/docker_entrypoint.sh
+++ b/dev-tools/docker/docker_entrypoint.sh
@@ -50,7 +50,7 @@ mkdir ../distributions
 # Exclude import libraries, test support libraries, debug files and core dumps
 zip -9 ../distributions/$ARTIFACT_NAME-$PRODUCT_VERSION-$BUNDLE_PLATFORM.zip `find * | egrep -v '\.lib$|unit_test_framework|libMlTest|\.dSYM|-debug$|\.pdb$|/core'`
 # Include only debug files
-zip -9 ../distributions/$ARTIFACT_NAME-$PRODUCT_VERSION-$BUNDLE_PLATFORM-debug.zip `find * | egrep '\.dSYM|-debug$|\.pdb$'`
+zip -9 ../distributions/$ARTIFACT_NAME-$PRODUCT_VERSION-debug-$BUNDLE_PLATFORM.zip `find * | egrep '\.dSYM|-debug$|\.pdb$'`
 cd ../..
 
 if [ "x$1" = "x--test" ] ; then

--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -147,9 +147,9 @@ case `uname` in
             mkdir -p "${IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/$VERSION"
             cp "../build/distributions/ml-cpp-$VERSION-linux-$HARDWARE_ARCH.zip" "${IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/$VERSION/ml-cpp-$VERSION.zip"
             # Since this is all local, for simplicity, cheat with the dependencies/no-dependencies split
-            cp "../build/distributions/ml-cpp-$VERSION-linux-$HARDWARE_ARCH.zip" "${IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/$VERSION/ml-cpp-nodeps-$VERSION.zip"
+            cp "../build/distributions/ml-cpp-$VERSION-linux-$HARDWARE_ARCH.zip" "${IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/$VERSION/ml-cpp-$VERSION-nodeps.zip"
             # We're cheating here - the dependencies are really in the "no dependencies" zip for this flow
-            cp minimal.zip "${IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/$VERSION/ml-cpp-deps-$VERSION.zip"
+            cp minimal.zip "${IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/$VERSION/ml-cpp-$VERSION-deps.zip"
             ./run_es_tests.sh "${GIT_TOPLEVEL}/.." "$(cd "${IVY_REPO}" && pwd)"
         fi
         ;;


### PR DESCRIPTION
This relates to https://github.com/elastic/elasticsearch/pull/84536. For composite build integration to work using the separate "deps" and "nodeps" artifacts, we need to tweak the build to expose _both_ as project artifacts so they can be properly resolved by the Elasticsearch build. This PR includes a few things to make that happen:

1. Apply the Gradle "base" plugin to inherit the necessary configuration so that the `default` configuration is properly consumed by the ES build.
2. Introduce additional tasks to create the "deps" and "nodeps" artifacts from the locally built zip (isntead of from a downloaded snapshot)
3. Remove superfluous configuration which is provided by base plugin conventions.
4. Modify lifecycle tasks (ie. clean, assemble, check, etc) to work with base plugin.