### PR TITLE
[ML] Speedup finding change points in the time series trend

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@
 * Limit the maximum size of classification and regression models training
   produces so they can always be deployed for inference inside the Elastic
   Stack. (See {ml-pull}2205[#2205].)
+* Reduce worst case bucket processing time for anomaly detection. (See {ml-pull}2225[#2225].)
 
 == {es} version 8.1.0
 

--- a/include/maths/common/CBasicStatistics.h
+++ b/include/maths/common/CBasicStatistics.h
@@ -257,7 +257,7 @@ public:
             T mean{s_Moments[0]};
             s_Moments[0] = beta * mean + alpha * x;
 
-            if (ORDER > 1) {
+            if constexpr (ORDER > 1) {
                 T r{x - s_Moments[0]};
                 T r2{las::componentwise(r) * las::componentwise(r)};
                 T dMean{mean - s_Moments[0]};
@@ -266,7 +266,7 @@ public:
 
                 s_Moments[1] = beta * (variance + dMean2) + alpha * r2;
 
-                if (ORDER > 2) {
+                if constexpr (ORDER > 2) {
                     T skew{s_Moments[2]};
                     T dSkew{TCoordinate(3) * variance + dMean2};
                     dSkew = las::componentwise(dSkew) * las::componentwise(dMean);
@@ -297,7 +297,7 @@ public:
 
             s_Moments[0] = beta * meanLhs + alpha * meanRhs;
 
-            if (ORDER > 1) {
+            if constexpr (ORDER > 1) {
                 T dMeanLhs{meanLhs - s_Moments[0]};
                 T dMean2Lhs{las::componentwise(dMeanLhs) * las::componentwise(dMeanLhs)};
                 T varianceLhs{s_Moments[1]};
@@ -308,7 +308,7 @@ public:
                 s_Moments[1] = beta * (varianceLhs + dMean2Lhs) +
                                alpha * (varianceRhs + dMean2Rhs);
 
-                if (ORDER > 2) {
+                if constexpr (ORDER > 2) {
                     T skewLhs{s_Moments[2]};
                     T dSkewLhs{TCoordinate{3} * varianceLhs + dMean2Lhs};
                     dSkewLhs = las::componentwise(dSkewLhs) * las::componentwise(dMeanLhs);
@@ -364,7 +364,7 @@ public:
 
             s_Moments[0] = beta * meanLhs - alpha * meanRhs;
 
-            if (ORDER > 1) {
+            if constexpr (ORDER > 1) {
                 T dMeanLhs{s_Moments[0] - meanLhs};
                 T dMean2Lhs{las::componentwise(dMeanLhs) * las::componentwise(dMeanLhs)};
                 T dMeanRhs{meanRhs - meanLhs};
@@ -375,7 +375,7 @@ public:
                                        alpha * (varianceRhs + dMean2Rhs - dMean2Lhs),
                                    T{0});
 
-                if (ORDER > 2) {
+                if constexpr (ORDER > 2) {
                     T skewLhs{s_Moments[2]};
                     T dSkewLhs{TCoordinate{3} * s_Moments[1] + dMean2Lhs};
                     dSkewLhs = las::componentwise(dSkewLhs) * las::componentwise(dMeanLhs);

--- a/include/maths/common/CBasicStatistics.h
+++ b/include/maths/common/CBasicStatistics.h
@@ -422,19 +422,19 @@ public:
     //! Accumulator object to compute the sample mean.
     template<typename T>
     struct SSampleMean {
-        using TAccumulator = SSampleCentralMoments<T, 1u>;
+        using TAccumulator = SSampleCentralMoments<T, 1>;
     };
 
     //! Accumulator object to compute the sample mean and variance.
     template<typename T>
     struct SSampleMeanVar {
-        using TAccumulator = SSampleCentralMoments<T, 2u>;
+        using TAccumulator = SSampleCentralMoments<T, 2>;
     };
 
     //! Accumulator object to compute the sample mean, variance and skewness.
     template<typename T>
     struct SSampleMeanVarSkew {
-        using TAccumulator = SSampleCentralMoments<T, 3u>;
+        using TAccumulator = SSampleCentralMoments<T, 3>;
     };
     //@}
 
@@ -442,8 +442,8 @@ public:
     //@{
     //! Make a mean accumulator.
     template<typename T, typename U>
-    static SSampleCentralMoments<T, 1u> momentsAccumulator(const U& count, const T& m1) {
-        SSampleCentralMoments<T, 1u> result;
+    static SSampleCentralMoments<T, 1> momentsAccumulator(const U& count, const T& m1) {
+        SSampleCentralMoments<T, 1> result;
         result.s_Count = count;
         result.s_Moments[0] = m1;
         return result;
@@ -451,9 +451,9 @@ public:
 
     //! Make a mean and variance accumulator.
     template<typename T, typename U>
-    static SSampleCentralMoments<T, 2u>
+    static SSampleCentralMoments<T, 2>
     momentsAccumulator(const U& count, const T& m1, const T& m2) {
-        SSampleCentralMoments<T, 2u> result;
+        SSampleCentralMoments<T, 2> result;
         result.s_Count = count;
         result.s_Moments[0] = m1;
         result.s_Moments[1] = m2;
@@ -462,9 +462,9 @@ public:
 
     //! Make a mean, variance and skew accumulator.
     template<typename T, typename U>
-    static SSampleCentralMoments<T, 3u>
+    static SSampleCentralMoments<T, 3>
     momentsAccumulator(const U& count, const T& m1, const T& m2, const T& m3) {
-        SSampleCentralMoments<T, 3u> result;
+        SSampleCentralMoments<T, 3> result;
         result.s_Count = count;
         result.s_Moments[0] = m1;
         result.s_Moments[1] = m2;
@@ -677,14 +677,14 @@ public:
     //@{
     //! Print a mean accumulator.
     template<typename T>
-    static inline std::string print(const SSampleCentralMoments<T, 1u>& accumulator) {
+    static inline std::string print(const SSampleCentralMoments<T, 1>& accumulator) {
         std::ostringstream result;
         result << '(' << count(accumulator) << ", " << mean(accumulator) << ')';
         return result.str();
     }
     //! Print a mean and variance accumulator.
     template<typename T>
-    static inline std::string print(const SSampleCentralMoments<T, 2u>& accumulator) {
+    static inline std::string print(const SSampleCentralMoments<T, 2>& accumulator) {
         std::ostringstream result;
         result << '(' << count(accumulator) << ", " << mean(accumulator) << ", "
                << variance(accumulator) << ')';
@@ -692,7 +692,7 @@ public:
     }
     //! Print a mean, variance and skew accumulator.
     template<typename T>
-    static inline std::string print(const SSampleCentralMoments<T, 3u>& accumulator) {
+    static inline std::string print(const SSampleCentralMoments<T, 3>& accumulator) {
         std::ostringstream result;
         result << '(' << count(accumulator) << ", " << mean(accumulator) << ", "
                << variance(accumulator) << ", " << skewness(accumulator) << ')';
@@ -1441,19 +1441,19 @@ public:
 
 template<typename T>
 std::ostream& operator<<(std::ostream& o,
-                         const CBasicStatistics::SSampleCentralMoments<T, 1u>& accumulator) {
+                         const CBasicStatistics::SSampleCentralMoments<T, 1>& accumulator) {
     return o << CBasicStatistics::print(accumulator);
 }
 
 template<typename T>
 std::ostream& operator<<(std::ostream& o,
-                         const CBasicStatistics::SSampleCentralMoments<T, 2u>& accumulator) {
+                         const CBasicStatistics::SSampleCentralMoments<T, 2>& accumulator) {
     return o << CBasicStatistics::print(accumulator);
 }
 
 template<typename T>
 std::ostream& operator<<(std::ostream& o,
-                         const CBasicStatistics::SSampleCentralMoments<T, 3u>& accumulator) {
+                         const CBasicStatistics::SSampleCentralMoments<T, 3>& accumulator) {
     return o << CBasicStatistics::print(accumulator);
 }
 

--- a/include/maths/common/CLeastSquaresOnlineRegression.h
+++ b/include/maths/common/CLeastSquaresOnlineRegression.h
@@ -101,7 +101,7 @@ constexpr std::size_t numberStatistics(std::size_t n, bool r2) {
 //! \tparam N_ The degree of the polynomial.
 //! \tparam T The storage type used for the statistics. Note that since
 //! we can't avoid losing precision in our formulation be careful using
-//! single precision if the polynomial degree is high. 
+//! single precision if the polynomial degree is high.
 //! \tparam R_2 If this is true you can additionally compute R^2 and
 //! the residual statistics, but it adds sizeof(T) to the memory usage.
 // clang-format off

--- a/include/maths/common/CLeastSquaresOnlineRegression.h
+++ b/include/maths/common/CLeastSquaresOnlineRegression.h
@@ -99,6 +99,11 @@ constexpr std::size_t numberStatistics(std::size_t n, bool r2) {
 //! is at a premium.
 //!
 //! \tparam N_ The degree of the polynomial.
+//! \tparam T The storage type used for the statistics. Note that since
+//! we can't avoid losing precision in our formulation be careful using
+//! single precision if the polynomial degree is high. 
+//! \tparam R_2 If this is true you can additionally compute R^2 and
+//! the residual statistics, but it adds sizeof(T) to the memory usage.
 // clang-format off
 template<std::size_t N_, typename T = CFloatStorage, bool R_2 = false>
 class CLeastSquaresOnlineRegression : boost::addable<CLeastSquaresOnlineRegression<N_, T>,
@@ -295,7 +300,7 @@ public:
 
         result = 0.0;
 
-        if (R_2 == false) {
+        if constexpr (R_2 == false) {
             return false;
         }
         if (CBasicStatistics::count(m_S) == T{0}) {
@@ -482,8 +487,8 @@ private:
     }
 
 private:
-    //! Sufficient statistics for computing the least squares
-    //! regression. There are 3N - 1 in total, for the distinct
+    //! Sufficient statistics for computing the least squares regression.
+    //! There are 3N - 1 (or 3N if computing R^2) in total, for the distinct
     //! values in the design matrix and vector.
     TVectorMeanAccumulator m_S;
 

--- a/include/maths/common/CLeastSquaresOnlineRegression.h
+++ b/include/maths/common/CLeastSquaresOnlineRegression.h
@@ -309,7 +309,7 @@ public:
 
         const auto& s = CBasicStatistics::mean(m_S);
         double variance{s(3 * N - 1) - CTools::pow2(s(2 * N - 1))};
-        double residualVariance{CBasicStatistics::variance(residualMoments)};
+        double residualVariance{CBasicStatistics::maximumLikelihoodVariance(residualMoments)};
         result = CTools::truncate(1.0 - residualVariance / variance, 0.0, 1.0);
         return true;
     }

--- a/include/maths/common/CLeastSquaresOnlineRegressionDetail.h
+++ b/include/maths/common/CLeastSquaresOnlineRegressionDetail.h
@@ -274,7 +274,23 @@ bool CLeastSquaresOnlineRegression<N, T, R_2>::residualMoments(std::size_t n,
         return false;
     }
 
-    // Don't bother checking the solution since we check the matrix condition above.
+    // The mean predictions are given by 1^t X p and the square residuals are given
+    // by 
+    //   ||y - X p - 1^t X p||^2                                                (1)
+    //
+    // and for least sqaures solution the parameters p = (X^t X)^-1 X^t y. We can
+    // calculate 1^t X from the statistics we maintain. To compute (1) we first use
+    // the fact that
+    //
+    //   ||y - X p - 1^t X p||^2 = ||y - X p||^2 + ||1^t X p||^2
+    //
+    // Substituting for p in the first term we have
+    //
+    //   ||y - X (X^t X)^-1 X^t y||^2
+    //       = y^t y - 2 y^t X (X^t X)^-1 X^t y + y^t X (X^t X)^-1 X^t X (X^t X)^-1 X^t y
+    //       = y^t y - 2 y^t X (X^t X)^-1 X^t y + y^t X (X^t X)^-1 X^t y
+    //       = y^t y - y^t X (X^t X)^-1 X^t y
+
     VECTOR r{svd.solve(y)};
     double count{CBasicStatistics::count(m_S)};
     double mean{s(2 * N - 1) - z.transpose() * r};

--- a/include/maths/common/CLeastSquaresOnlineRegressionDetail.h
+++ b/include/maths/common/CLeastSquaresOnlineRegressionDetail.h
@@ -275,7 +275,7 @@ bool CLeastSquaresOnlineRegression<N, T, R_2>::residualMoments(std::size_t n,
     }
 
     // The mean predictions are given by 1^t X p and the square residuals are given
-    // by 
+    // by
     //   ||y - X p - 1^t X p||^2                                                (1)
     //
     // and for least sqaures solution the parameters p = (X^t X)^-1 X^t y. We can

--- a/include/maths/time_series/CTimeSeriesSegmentation.h
+++ b/include/maths/time_series/CTimeSeriesSegmentation.h
@@ -251,6 +251,11 @@ private:
     using TRegressionArray = TRegression::TArray;
     using TPredictor = std::function<double(double)>;
     using TScale = std::function<double(std::size_t)>;
+    template<typename ITR>
+    using TDoubleItrPr = std::pair<double, ITR>;
+    template<typename ITR>
+    using TMinAccumulator =
+        typename common::CBasicStatistics::SMin<TDoubleItrPr<ITR>>::TAccumulator;
 
 private:
     //! Choose the final segmentation we'll use.
@@ -271,6 +276,16 @@ private:
                                           TSizeVec& segmentation,
                                           TDoubleDoublePrVec& depthAndPValue,
                                           TFloatMeanAccumulatorVec& values);
+
+    //! Finds the split of [\p begin, \p end) to minimise square residuals for a
+    //! linear model.
+    template<typename ITR>
+    static CTimeSeriesSegmentation::TMinAccumulator<ITR>
+    minimumResidualVarianceSplit(ITR begin,
+                                 ITR end,
+                                 std::ptrdiff_t step,
+                                 double startTime,
+                                 const TFloatMeanAccumulatorVec& reweighted);
 
     //! Fit a piecewise linear model to \p values for the segmentation \p segmentation.
     static TPredictor fitPiecewiseLinear(const TSizeVec& segmentation,

--- a/lib/maths/common/unittest/CLeastSquaresOnlineRegressionTest.cc
+++ b/lib/maths/common/unittest/CLeastSquaresOnlineRegressionTest.cc
@@ -488,6 +488,46 @@ BOOST_AUTO_TEST_CASE(testAge) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testR2) {
+
+    using TMeanVarAccumulator = maths::common::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+
+    double pi = 3.14159265358979;
+
+    TMeanAccumulator m;
+    maths::common::CLeastSquaresOnlineRegression<1, double, true> ls1;
+    maths::common::CLeastSquaresOnlineRegression<2, double, true> ls2;
+
+    TMeanVarAccumulator yMoments;
+    for (std::size_t i = 0; i <= 400; ++i) {
+        double x = 0.002 * pi * static_cast<double>(i);
+        double y = std::sin(x);
+        ls1.add(x, y);
+        ls2.add(x, y);
+        yMoments.add(y);
+    }
+
+    double r1;
+    double r2;
+    ls1.r2(r1);
+    ls2.r2(r2);
+
+    TMeanVarAccumulator yMinusP1Moments;
+    TMeanVarAccumulator yMinusP2Moments;
+    for (std::size_t i = 0; i <= 400; ++i) {
+        double x = 0.002 * pi * static_cast<double>(i);
+        double y = std::sin(x);
+        yMinusP1Moments.add(y - ls1.predict(x));
+        yMinusP2Moments.add(y - ls2.predict(x));
+    }
+
+    double r1Expected{1.0 - maths::common::CBasicStatistics::variance(yMinusP1Moments) / maths::common::CBasicStatistics::variance(yMoments)};
+    double r2Expected{1.0 - maths::common::CBasicStatistics::variance(yMinusP2Moments) / maths::common::CBasicStatistics::variance(yMoments)};
+
+    LOG_DEBUG(<< "         r1 = " << r1 << ", r2 = " << r2);
+    LOG_DEBUG(<< "expected r1 = " << r1Expected << ", r2 = " << r2Expected);
+}
+
 BOOST_AUTO_TEST_CASE(testPrediction) {
     // Check we get successive better predictions of a power
     // series function, i.e. x -> sin(x), using higher order


### PR DESCRIPTION
We check for change points in the trend both when performing change point detection and detecting trend and seasonality in our time series modelling. We do this by testing the significance of the change in residual variance with and without the change point. The current approach has O(n^2) complexity with respect to the time window length n. However, least squares regression allows one to compute residual moments in an online fashion, using largely the same set of statistics we currently maintain for estimating parameters. This allows one to drop the complexity to O(n). The slight downside is that we compute variance using the numerically lossy E[X^2] - E[X]^2 formulation. However, we can centre the data before computing variance which means in practice this isn't a problem.

For the sort of window lengths we currently test I got around a 6X performance improvement using this new approach. The impact on worst case bucket processing latency is stronger than average case because the tests are only performed intermittently. This change also adds a couple of constexpr if statements, since we're now on C++17, to ensure unneeded code really is removed altogether.