### PR TITLE
[ML] Fix potential source of log errors training classification and regression models

### DIFF
--- a/include/maths/common/CLowessDetail.h
+++ b/include/maths/common/CLowessDetail.h
@@ -42,6 +42,8 @@ void CLowess<N>::fit(TDoubleDoublePrVec data, std::size_t numberFolds) {
     m_K = 0.0;
     m_Data = std::move(data);
     std::sort(m_Data.begin(), m_Data.end(), COrderings::SFirstLess{});
+    m_Mask.resize(m_Data.size());
+    std::iota(m_Mask.begin(), m_Mask.end(), 0);
 
     if (m_Data.size() < 4) {
         return;
@@ -67,9 +69,6 @@ void CLowess<N>::fit(TDoubleDoublePrVec data, std::size_t numberFolds) {
     // with sigma estimated from the training data prediction residuals to compute
     // the likelihood function L(Yi | f(x | p^*(k))).
 
-    m_Mask.resize(m_Data.size());
-    std::iota(m_Mask.begin(), m_Mask.end(), 0);
-
     TSizeVecVec trainingMasks;
     TSizeVecVec testingMasks;
     this->setupMasks(numberFolds, trainingMasks, testingMasks);
@@ -80,24 +79,26 @@ void CLowess<N>::fit(TDoubleDoublePrVec data, std::size_t numberFolds) {
     // parameters. We finish up by polishing up the minimum on the best candidate
     // interval using Brent's method. See CSolvers::globalMaximize for details.
 
-    TDoubleVec K(17);
     double range{m_Data.back().first - m_Data.front().first};
-    for (std::size_t i = 0; i < K.size(); ++i) {
-        K[i] = 2.0 * static_cast<double>(i) / range;
+    if (range > 0.0) {
+        TDoubleVec K(17);
+        for (std::size_t i = 0; i < K.size(); ++i) {
+            K[i] = 2.0 * static_cast<double>(i) / range;
+        }
+        LOG_TRACE(<< "range = " << range << ", K = " << core::CContainerPrinter::print(K));
+
+        double kmax;
+        double likelihoodMax;
+        double likelihoodStandardDeviation;
+        CSolvers::globalMaximize(K,
+                                 [&](double k) -> double {
+                                     return this->likelihood(trainingMasks, testingMasks, k);
+                                 },
+                                 kmax, likelihoodMax, likelihoodStandardDeviation);
+        LOG_TRACE(<< "kmax = " << kmax << " likelihood(kmax) = " << likelihoodMax);
+
+        m_K = kmax;
     }
-    LOG_TRACE(<< "range = " << range << ", K = " << core::CContainerPrinter::print(K));
-
-    double kmax;
-    double likelihoodMax;
-    double likelihoodStandardDeviation;
-    CSolvers::globalMaximize(K,
-                             [&](double k) -> double {
-                                 return this->likelihood(trainingMasks, testingMasks, k);
-                             },
-                             kmax, likelihoodMax, likelihoodStandardDeviation);
-    LOG_TRACE(<< "kmax = " << kmax << " likelihood(kmax) = " << likelihoodMax);
-
-    m_K = kmax;
 }
 
 template<std::size_t N>
@@ -136,6 +137,11 @@ typename CLowess<N>::TDoubleDoublePr CLowess<N>::minimum() const {
         X.push_back(xi.first);
     }
     X.push_back(xb);
+    X.erase(std::unique(X.begin(), X.end()), X.end());
+    if (X.size() == 1) {
+        return {X[0], this->predict(X[0])};
+    }
+
     double xmin;
     double fmin;
     double fsd;

--- a/lib/maths/common/unittest/CLowessTest.cc
+++ b/lib/maths/common/unittest/CLowessTest.cc
@@ -9,6 +9,7 @@
  * limitation.
  */
 
+#include <core/CContainerPrinter.h>
 #include <core/CLogger.h>
 
 #include <maths/common/CBasicStatistics.h>
@@ -98,6 +99,31 @@ BOOST_AUTO_TEST_CASE(testInvariants) {
             BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::variance(residualMoments) <
                                lowess.residualVariance());
         }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testEdgeCases) {
+    // Check we correctly initialise when there are too few points to cross-validate k.
+    {
+        maths::common::CLowess<2> lowess;
+        TDoubleDoublePrVec data{{0.0, 0.0}, {1.0, 0.5}, {2.0, 1.0}};
+        lowess.fit(data, 3);
+        LOG_DEBUG(<< "f(1.5) = " << lowess.predict(1.5));
+        // Should be 0.5 * x.
+        BOOST_REQUIRE_CLOSE(0.5 * 1.5, lowess.predict(1.5), 1e-3);
+    }
+    // Check we handle the case that all values are colocated.
+    {
+        maths::common::CLowess<2> lowess;
+        TDoubleDoublePrVec data{{0.0, 1.0}, {0.0, 0.9}, {0.0, 1.1}, {0.0, 1.2}};
+        lowess.fit(data, 4);
+        LOG_DEBUG(<< "f(0) = " << lowess.predict(0.0)
+                  << ", f(1) = " << lowess.predict(1.0));
+        // Should be the average of y values, i.e. 1.05.
+        BOOST_REQUIRE_CLOSE(1.05, lowess.predict(0.0), 1e-3);
+        BOOST_REQUIRE_CLOSE(1.05, lowess.predict(1.0), 1e-3);
+
+        LOG_DEBUG(<< "minimum = " << core::CContainerPrinter::print(lowess.minimum()));
     }
 }
 


### PR DESCRIPTION
This fixes a potential cause of `Discarding sample = -nan(ind), weight = 1, variance scale = 1` log errors we've seen very occasionally training regression and classification models. The lowess regression code wasn't properly handling the case that all the supplied values for the independent variable were colocated. In this case we should just predict a constant equal to the average of the dependent variable.