### PR TITLE
[ML] Better handling of extreme outliers in time series modelling

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -42,6 +42,8 @@
 * Reduce worst case bucket processing time for anomaly detection. (See {ml-pull}2225[#2225].)
 * Improve handling of low cardinality features for training classification
   and regression models. (See {ml-pull}2229[#2229].)
+* Improve handling of extremely large outliers in time series modelling.
+  (See {ml-pull}2230[#2230].)
 
 === Bug Fixes
 

--- a/include/maths/time_series/CSignal.h
+++ b/include/maths/time_series/CSignal.h
@@ -352,6 +352,16 @@ public:
                                             TFloatMeanAccumulatorVec& values,
                                             TMeanAccumulatorVecVec& components);
 
+    //! Remove extreme outliers from \p values.
+    //!
+    //! If \p fraction contiguous values are extremely outlying w.r.t the remainder
+    //! of \p values then remove them altogether. This handles cases where reweighting
+    //! is not sufficient.
+    //!
+    //! \param[in] fraction The fraction of values treated as outliers.
+    //! \param[in,out] values The values to update.
+    static void removeExtremeOutliers(double fraction, TFloatMeanAccumulatorVec& values);
+
     //! Reweight outliers in \p values w.r.t. \p components.
     //!
     //! \param[in] periods The seasonal components in \p values.

--- a/include/maths/time_series/CTimeSeriesTestForSeasonality.h
+++ b/include/maths/time_series/CTimeSeriesTestForSeasonality.h
@@ -246,7 +246,7 @@ public:
     void modelledSeasonalityPredictor(const TPredictor& predictor);
 
     //! Fit and remove any seasonality we're modelling and can't test.
-    void fitAndRemoveUntestableModelledComponents();
+    void prepareWindowForDecompose();
 
     //! Check invariants which are relied on to hold.
     bool checkInvariants() const;
@@ -479,7 +479,7 @@ private:
                                                        removeComponentsMask)} {}
 
         //! Does this include seasonality?
-        bool seasonal() const { return s_Hypotheses.size() > 0; }
+        bool seasonal() const { return s_Hypotheses.empty() == false; }
         //! True if every seasonal component could be tested.
         bool isTestable() const;
         //! Should this behave as a null hypothesis?
@@ -564,7 +564,7 @@ private:
     std::size_t similarModelled(const TSeasonalComponent& period) const;
     void removeModelledPredictions(const TBoolVec& componentsToRemoveMask,
                                    TFloatMeanAccumulatorVec& values) const;
-    void removeDiscontinuities(const TSizeVec& modelTrendSegments,
+    void removeDiscontinuities(const TSizeVec& trendSegments,
                                TFloatMeanAccumulatorVec& values) const;
     bool constantScale(const TConstantScale& scale,
                        const TSeasonalComponentVec& periods,

--- a/lib/maths/time_series/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/time_series/CTimeSeriesDecompositionDetail.cc
@@ -1173,7 +1173,7 @@ void CTimeSeriesDecompositionDetail::CSeasonalityTest::test(const SAddValue& mes
                 auto seasonalityTest = makeTest(*window, minimumPeriod,
                                                 minimumResolutionToTestModelledComponent,
                                                 makePreconditioner());
-                seasonalityTest.fitAndRemoveUntestableModelledComponents();
+                seasonalityTest.prepareWindowForDecompose();
 
                 auto decomposition = seasonalityTest.decompose();
                 if (decomposition.componentsChanged()) {
@@ -1555,7 +1555,7 @@ CTimeSeriesDecompositionDetail::CComponents::CComponents(double decayRate,
 }
 
 CTimeSeriesDecompositionDetail::CComponents::CComponents(const CComponents& other)
-    : CHandler{}, m_Machine{other.m_Machine}, m_DecayRate{other.m_DecayRate},
+    : m_Machine{other.m_Machine}, m_DecayRate{other.m_DecayRate},
       m_BucketLength{other.m_BucketLength}, m_GainController{other.m_GainController},
       m_SeasonalComponentSize{other.m_SeasonalComponentSize},
       m_CalendarComponentSize{other.m_CalendarComponentSize}, m_Trend{other.m_Trend},
@@ -2378,7 +2378,7 @@ void CTimeSeriesDecompositionDetail::CComponents::CGainController::seed(const TD
 
 void CTimeSeriesDecompositionDetail::CComponents::CGainController::add(core_t::TTime time,
                                                                        const TDoubleVec& predictions) {
-    if (predictions.size() > 0) {
+    if (predictions.empty() == false) {
         m_MeanSumAmplitudes.add(std::accumulate(
             predictions.begin(), predictions.end(), 0.0, [](double sum, double prediction) {
                 return sum + std::fabs(prediction);

--- a/lib/maths/time_series/CTimeSeriesTestForChange.cc
+++ b/lib/maths/time_series/CTimeSeriesTestForChange.cc
@@ -389,7 +389,7 @@ CTimeSeriesTestForChange::TChangePointUPtr CTimeSeriesTestForChange::test() cons
                   changes.end());
     LOG_TRACE(<< "# changes = " << changes.size());
 
-    if (changes.size() > 0) {
+    if (changes.empty() == false) {
         std::stable_sort(changes.begin(), changes.end(), [](const auto& lhs, const auto& rhs) {
             return lhs.s_NumberParameters < rhs.s_NumberParameters;
         });
@@ -440,7 +440,7 @@ CTimeSeriesTestForChange::TDoubleDoubleDoubleTr CTimeSeriesTestForChange::quadra
     TRegression::TArray parameters;
     parameters.fill(0.0);
     auto predictor = [&](std::size_t i) {
-        return trend.predict(parameters, static_cast<double>(i));
+        return TRegression::predict(parameters, static_cast<double>(i));
     };
     for (std::size_t i = 0; i < 2; ++i) {
         CSignal::reweightOutliers(predictor, m_OutlierFraction, m_ValuesMinusPredictions);

--- a/lib/maths/time_series/CTimeSeriesTestForSeasonality.cc
+++ b/lib/maths/time_series/CTimeSeriesTestForSeasonality.cc
@@ -1427,8 +1427,8 @@ void CTimeSeriesTestForSeasonality::removeDiscontinuities(const TSizeVec& trendS
                                                           TFloatMeanAccumulatorVec& values) const {
     if (trendSegments.size() > 2) {
         // Ignore short segments since they often fit outliers.
-        std::size_t minimumSegmentLength{static_cast<std::size_t>(
-            m_OutlierFraction * static_cast<double>(CSignal::countNotMissing(values)) + 0.5)};
+        std::size_t minimumSegmentLength{static_cast<std::size_t>(std::ceil(
+            m_OutlierFraction * static_cast<double>(CSignal::countNotMissing(values)) / 2.0))};
         for (std::size_t i = 1; i < trendSegments.size(); ++i) {
             if (trendSegments[i] - trendSegments[i - 1] < minimumSegmentLength) {
                 for (std::size_t j = trendSegments[i - 1]; j < trendSegments[i]; ++j) {
@@ -1449,8 +1449,8 @@ bool CTimeSeriesTestForSeasonality::constantScale(const TConstantScale& scale,
                                                   TDoubleVec& scales) const {
     if (scaleSegments.size() > 2) {
         // Ignore short segments since they often fit outliers.
-        std::size_t minimumSegmentLength{static_cast<std::size_t>(
-            m_OutlierFraction * static_cast<double>(CSignal::countNotMissing(values)) + 0.5)};
+        std::size_t minimumSegmentLength{static_cast<std::size_t>(std::ceil(
+            m_OutlierFraction * static_cast<double>(CSignal::countNotMissing(values)) / 2.0))};
         for (std::size_t i = 1; i < scaleSegments.size(); ++i) {
             if (scaleSegments[i] - scaleSegments[i - 1] < minimumSegmentLength) {
                 for (std::size_t j = scaleSegments[i - 1]; j < scaleSegments[i]; ++j) {

--- a/lib/maths/time_series/CTimeSeriesTestForSeasonality.cc
+++ b/lib/maths/time_series/CTimeSeriesTestForSeasonality.cc
@@ -214,8 +214,9 @@ void CSeasonalDecomposition::withinBucketVariance(double variance) {
 }
 
 bool CSeasonalDecomposition::componentsChanged() const {
-    return m_Seasonal.size() > 0 || std::count(m_SeasonalToRemoveMask.begin(),
-                                               m_SeasonalToRemoveMask.end(), true) > 0;
+    return m_Seasonal.empty() == false ||
+           std::count(m_SeasonalToRemoveMask.begin(),
+                      m_SeasonalToRemoveMask.end(), true) > 0;
 }
 
 const CNewTrendSummary* CSeasonalDecomposition::trend() const {
@@ -304,7 +305,7 @@ void CTimeSeriesTestForSeasonality::modelledSeasonalityPredictor(const TPredicto
     m_ModelledPredictor = predictor;
 }
 
-void CTimeSeriesTestForSeasonality::fitAndRemoveUntestableModelledComponents() {
+void CTimeSeriesTestForSeasonality::prepareWindowForDecompose() {
 
     // Although we precondition by removing untestable modelled component predictions
     // there can be errors. This is problematic when the period is too short to test
@@ -319,13 +320,21 @@ void CTimeSeriesTestForSeasonality::fitAndRemoveUntestableModelledComponents() {
             untestable.push_back(period);
         }
     }
-    if (untestable.size() > 0) {
+    if (untestable.empty() == false) {
         TMeanAccumulatorVecVec components;
         CSignal::fitSeasonalComponentsRobust(untestable, m_OutlierFraction,
                                              m_Values, components);
-        this->removePredictions({untestable, 0, untestable.size()},
-                                {components, 0, components.size()}, m_Values);
+        removePredictions({untestable, 0, untestable.size()},
+                          {components, 0, components.size()}, m_Values);
     }
+
+    // Remove extremely outlying values for which reweighting is insufficient. This
+    // is defined as a contiguous range of much smaller or larger than typical values.
+    // We need to be careful with the definition we use because, for example, periodic
+    // spikes can appear to be extremely outlying for many measures. The definition we
+    // use requires that values in the interval are very different to _all_ remaining
+    // values which is sufficient to avoid false positives.
+    CSignal::removeExtremeOutliers(m_OutlierFraction / 2.0, m_Values);
 }
 
 bool CTimeSeriesTestForSeasonality::checkInvariants() const {
@@ -408,8 +417,8 @@ CSeasonalDecomposition CTimeSeriesTestForSeasonality::decompose() const {
     LOG_TRACE(<< "trend segments = " << core::CContainerPrinter::print(trendSegments));
 
     TRemoveTrend removeTrendModels[]{
-        [&](const TSeasonalComponentVec&, TFloatMeanAccumulatorVec& values,
-            TSizeVec& modelTrendSegments) {
+        [this](const TSeasonalComponentVec& /*periods*/,
+               TFloatMeanAccumulatorVec& values, TSizeVec& modelTrendSegments) {
             LOG_TRACE(<< "no trend");
             values = m_Values;
             modelTrendSegments.clear();
@@ -448,17 +457,17 @@ CSeasonalDecomposition CTimeSeriesTestForSeasonality::decompose() const {
                 // are used for each prediction. We optimise removePredictions by
                 // reading them once upfront.
                 trend.parameters(parameters);
-                this->removePredictions(predictor, values);
+                removePredictions(predictor, values);
                 return true;
             }
 
             for (std::size_t i = 0; i < 3; ++i) {
                 values = m_Values;
-                this->removePredictions(predictor, values);
+                removePredictions(predictor, values);
                 CSignal::fitSeasonalComponents(periods, values, m_Components);
                 values = m_Values;
-                this->removePredictions({periods, 0, periods.size()},
-                                        {m_Components, 0, m_Components.size()}, values);
+                removePredictions({periods, 0, periods.size()},
+                                  {m_Components, 0, m_Components.size()}, values);
                 trend = TRegression{};
                 for (std::size_t j = 0; j < values.size(); ++j) {
                     trend.add(static_cast<double>(j),
@@ -469,7 +478,7 @@ CSeasonalDecomposition CTimeSeriesTestForSeasonality::decompose() const {
                 trend.parameters(parameters);
             }
             values = m_Values;
-            this->removePredictions(predictor, values);
+            removePredictions(predictor, values);
             return true;
         },
         [&](const TSeasonalComponentVec& periods,
@@ -496,14 +505,13 @@ CSeasonalDecomposition CTimeSeriesTestForSeasonality::decompose() const {
             values = TSegmentation::removePiecewiseLinear(
                 std::move(values), modelTrendSegments, m_OutlierFraction);
 
-            if (periods.size() > 0) {
+            if (periods.empty() == false) {
                 CSignal::fitSeasonalComponents(periods, values, m_Components);
                 values = m_Values;
-                this->removePredictions(predictor, values);
+                removePredictions(predictor, values);
                 values = TSegmentation::removePiecewiseLinear(
                     std::move(values), modelTrendSegments, m_OutlierFraction);
-                this->removePredictions(
-                    [&](std::size_t j) { return -predictor(j); }, values);
+                removePredictions([&](std::size_t j) { return -predictor(j); }, values);
             }
 
             return true;
@@ -668,8 +676,8 @@ CSeasonalDecomposition CTimeSeriesTestForSeasonality::select(TModelVec& decompos
                            0.3 * std::log(1.0 + common::CTools::pow2(segments)) -
                            0.3 * std::log(std::max(leastCommonRepeat, 0.5))};
             double qualityToAccept{
-                1.0 * qualitySelected -
-                1.0 * std::log(1.0 + std::max(std::log(0.01 / pValueVsSelected), 0.0))};
+                qualitySelected -
+                std::log(1.0 + std::max(std::log(0.01 / pValueVsSelected), 0.0))};
             LOG_TRACE(<< "target size = " << decompositions[H1].targetModelSize()
                       << ", modelled = " << decompositions[H1].s_AlreadyModelled);
             LOG_TRACE(<< "quality = " << quality << " to accept = " << qualityToAccept);
@@ -750,7 +758,7 @@ void CTimeSeriesTestForSeasonality::addModelled(const TRemoveTrend& removeTrend,
                                                 TModelVec& decompositions) const {
     m_CandidatePeriods = m_ModelledPeriods;
     this->removeIfNotTestable(m_CandidatePeriods);
-    if (m_CandidatePeriods.size() > 0 &&
+    if (m_CandidatePeriods.empty() == false &&
         removeTrend(m_CandidatePeriods, m_ValuesMinusTrend, m_ModelTrendSegments)) {
 
         // Already modelled seasonal components.
@@ -767,8 +775,8 @@ void CTimeSeriesTestForSeasonality::addModelled(const TRemoveTrend& removeTrend,
         m_Periods = m_CandidatePeriods;
         CSignal::fitSeasonalComponents(m_Periods, m_ValuesMinusTrend, m_Components);
         m_TemporaryValues = m_ValuesMinusTrend;
-        this->removePredictions({m_Periods, 0, m_Periods.size()},
-                                {m_Components, 0, m_Components.size()}, m_TemporaryValues);
+        removePredictions({m_Periods, 0, m_Periods.size()},
+                          {m_Components, 0, m_Components.size()}, m_TemporaryValues);
         auto diurnal = std::make_tuple(this->day(), this->week(), this->year());
         for (const auto& period : CSignal::seasonalDecomposition(
                  m_TemporaryValues, m_OutlierFraction, diurnal,
@@ -813,7 +821,7 @@ void CTimeSeriesTestForSeasonality::addDiurnal(const TRemoveTrend& removeTrend,
             m_ValuesMinusTrend, m_OutlierFraction, this->week(), m_StartOfWeekOverride);
 
         // weekday/weekend modulation + year.
-        if (m_CandidatePeriods.size() > 0) {
+        if (m_CandidatePeriods.empty() == false) {
             CSignal::appendSeasonalComponentSummary(this->year(), m_CandidatePeriods);
             this->removeIfNotTestable(m_CandidatePeriods);
             if (this->includesNewComponents(m_CandidatePeriods)) {
@@ -982,12 +990,11 @@ CTimeSeriesTestForSeasonality::testDecomposition(const TSeasonalComponentVec& pe
                 m_Periods.push_back(periods[j]);
             }
         }
-        if (m_Periods.size() > 0) {
+        if (m_Periods.empty() == false) {
             LOG_TRACE(<< "removing " << core::CContainerPrinter::print(m_Periods));
             CSignal::fitSeasonalComponents(m_Periods, m_TemporaryValues, m_Components);
-            this->removePredictions({m_Periods, 0, m_Periods.size()},
-                                    {m_Components, 0, m_Components.size()},
-                                    m_TemporaryValues);
+            removePredictions({m_Periods, 0, m_Periods.size()},
+                              {m_Components, 0, m_Components.size()}, m_TemporaryValues);
         }
 
         // Restrict to the component to test time windows.
@@ -1172,9 +1179,8 @@ CTimeSeriesTestForSeasonality::finalizeHypotheses(const TFloatMeanAccumulatorVec
             m_TemporaryValues = residuals;
             m_WindowIndices.resize(residuals.size());
             std::iota(m_WindowIndices.begin(), m_WindowIndices.end(), 0);
-            this->removePredictions({m_Periods, i + 1, m_Periods.size()},
-                                    {m_Components, i + 1, m_Components.size()},
-                                    m_TemporaryValues);
+            removePredictions({m_Periods, i + 1, m_Periods.size()},
+                              {m_Components, i + 1, m_Components.size()}, m_TemporaryValues);
             CSignal::restrictTo(m_Periods[i], m_TemporaryValues);
             CSignal::restrictTo(m_Periods[i], m_WindowIndices);
             period.assign(1, CSignal::seasonalComponentSummary(m_Periods[i].period()));
@@ -1417,11 +1423,21 @@ void CTimeSeriesTestForSeasonality::removeModelledPredictions(const TBoolVec& co
     }
 }
 
-void CTimeSeriesTestForSeasonality::removeDiscontinuities(const TSizeVec& modelTrendSegments,
+void CTimeSeriesTestForSeasonality::removeDiscontinuities(const TSizeVec& trendSegments,
                                                           TFloatMeanAccumulatorVec& values) const {
-    if (modelTrendSegments.size() > 2) {
+    if (trendSegments.size() > 2) {
+        // Ignore short segments since they often fit outliers.
+        std::size_t minimumSegmentLength{static_cast<std::size_t>(
+            m_OutlierFraction * static_cast<double>(CSignal::countNotMissing(values)) + 0.5)};
+        for (std::size_t i = 1; i < trendSegments.size(); ++i) {
+            if (trendSegments[i] - trendSegments[i - 1] < minimumSegmentLength) {
+                for (std::size_t j = trendSegments[i - 1]; j < trendSegments[i]; ++j) {
+                    values[j] = TFloatMeanAccumulator{};
+                }
+            }
+        }
         values = TSegmentation::removePiecewiseLinearDiscontinuities(
-            std::move(values), modelTrendSegments, m_OutlierFraction);
+            std::move(values), trendSegments, m_OutlierFraction);
     }
 }
 
@@ -1432,6 +1448,16 @@ bool CTimeSeriesTestForSeasonality::constantScale(const TConstantScale& scale,
                                                   TMeanAccumulatorVecVec& components,
                                                   TDoubleVec& scales) const {
     if (scaleSegments.size() > 2) {
+        // Ignore short segments since they often fit outliers.
+        std::size_t minimumSegmentLength{static_cast<std::size_t>(
+            m_OutlierFraction * static_cast<double>(CSignal::countNotMissing(values)) + 0.5)};
+        for (std::size_t i = 1; i < scaleSegments.size(); ++i) {
+            if (scaleSegments[i] - scaleSegments[i - 1] < minimumSegmentLength) {
+                for (std::size_t j = scaleSegments[i - 1]; j < scaleSegments[i]; ++j) {
+                    values[j] = TFloatMeanAccumulator{};
+                }
+            }
+        }
         values = TSegmentation::constantScalePiecewiseLinearScaledSeasonal(
             values, periods, scaleSegments, scale, m_OutlierFraction, components, scales);
         return true;
@@ -1489,7 +1515,7 @@ std::size_t CTimeSeriesTestForSeasonality::numberTrendParameters(std::size_t num
 }
 
 bool CTimeSeriesTestForSeasonality::includesNewComponents(const TSeasonalComponentVec& periods) const {
-    return periods.size() > 0 && this->includesPermittedPeriod(periods) &&
+    return periods.empty() == false && this->includesPermittedPeriod(periods) &&
            this->alreadyModelled(periods) == false;
 }
 


### PR DESCRIPTION
We currently handle outliers when decomposing time series on a window by reducing their weight. This is usually sufficient, however extreme outliers can still create problems given the current approach. Ignoring values altogether is risky; for example, periodic spikes are large outliers for many measures. In the sorts of data we deal with extreme values are often localised in time, for example a very large spike. This PR makes a couple of changes to try and deal better with extreme values:
1. Exclude a single short interval within the window being decomposed which is very different from all other values in that window.
2. Discard any component scaling or trend piece we fit to a short interval when computing values with which to initialise the model (since such pieces are often used to "fit" outliers).

Here is a prototypical example of the sort of data which creates problems and the change in behaviour.
**before**
<img width="1130" alt="Screenshot 2022-03-15 at 19 37 47" src="https://user-images.githubusercontent.com/7591487/158457972-7d7c4bc1-dddc-44b9-8d58-9ebe77efb4a3.png">
**after**
<img width="1126" alt="Screenshot 2022-03-15 at 19 37 29" src="https://user-images.githubusercontent.com/7591487/158458026-45e06ee4-3095-4f6d-8511-7cafd2922c81.png">

In this case the spike creating problems is around 1500X larger than typical.
<img width="1138" alt="Screenshot 2022-03-15 at 19 38 19" src="https://user-images.githubusercontent.com/7591487/158458108-5a12d702-e5f8-47e0-911b-629acb6e737c.png">
