### PR TITLE
[ML] Allow on-the-fly adjustment of the number of threads in use

### DIFF
--- a/include/core/CStaticThreadPool.h
+++ b/include/core/CStaticThreadPool.h
@@ -46,6 +46,11 @@ public:
     CStaticThreadPool& operator=(const CStaticThreadPool&) = delete;
     CStaticThreadPool& operator=(CStaticThreadPool&&) = delete;
 
+    //! Adjust the number of threads which are being used by the pool.
+    //!
+    //! \note \p threads should be in the range [1, pool size].
+    void numberThreadsInUse(std::size_t threads);
+
     //! Schedule a Callable type to be executed by a thread in the pool.
     //!
     //! \note This forwards the task to the queue.
@@ -88,9 +93,10 @@ private:
     // This doesn't have to be atomic because it is always only set to true,
     // always set straight before it is checked on each worker in the pool
     // and tearing can't happen for single byte writes.
-    bool m_Done = false;
+    bool m_Done{false};
     std::atomic_bool m_Busy;
     std::atomic<std::uint64_t> m_Cursor;
+    std::atomic<std::size_t> m_NumberThreadsInUse;
     TWrappedTaskQueueVec m_TaskQueues;
     TThreadVec m_Pool;
 };

--- a/lib/core/CStaticThreadPool.cc
+++ b/lib/core/CStaticThreadPool.cc
@@ -42,7 +42,7 @@ CStaticThreadPool::~CStaticThreadPool() {
 }
 
 void CStaticThreadPool::numberThreadsInUse(std::size_t threads) {
-    threads = std::max(std::min(threads, m_Pool.size()), 1UL);
+    threads = std::max(std::min(threads, m_Pool.size()), std::size_t{1});
     m_NumberThreadsInUse.store(threads);
 }
 

--- a/lib/core/unittest/CStaticThreadPoolTest.cc
+++ b/lib/core/unittest/CStaticThreadPoolTest.cc
@@ -236,7 +236,8 @@ BOOST_AUTO_TEST_CASE(testNumberThreadsInUse) {
             std::scoped_lock<std::mutex> lock{mutex};
             if (numberProcessedTasks == 200) {
                 LOG_DEBUG(<< "# threads used = " << executionThreads.size());
-                BOOST_REQUIRE_EQUAL(numberThreadsInUse, executionThreads.size());
+                // A subset of threads can steal all the work.
+                BOOST_REQUIRE(numberThreadsInUse <= executionThreads.size());
                 numberProcessedTasks = 0;
                 executionThreads.clear();
                 break;

--- a/lib/core/unittest/CStaticThreadPoolTest.cc
+++ b/lib/core/unittest/CStaticThreadPoolTest.cc
@@ -234,9 +234,9 @@ BOOST_AUTO_TEST_CASE(testNumberThreadsInUse) {
             std::scoped_lock<std::mutex> lock{mutex};
             if (numberProcessedTasks == 200) {
                 LOG_DEBUG(<< "# threads used = " << executionThreads.size());
+                BOOST_REQUIRE_EQUAL(numberThreadsInUse, executionThreads.size());
                 numberProcessedTasks = 0;
                 executionThreads.clear();
-                BOOST_REQUIRE_EQUAL(numberThreadsInUse, executionThreads.size());
                 break;
             }
         }

--- a/lib/core/unittest/CStaticThreadPoolTest.cc
+++ b/lib/core/unittest/CStaticThreadPoolTest.cc
@@ -237,7 +237,7 @@ BOOST_AUTO_TEST_CASE(testNumberThreadsInUse) {
             if (numberProcessedTasks == 200) {
                 LOG_DEBUG(<< "# threads used = " << executionThreads.size());
                 // A subset of threads can steal all the work.
-                BOOST_REQUIRE(numberThreadsInUse <= executionThreads.size());
+                BOOST_REQUIRE(executionThreads.size() <= numberThreadsInUse);
                 numberProcessedTasks = 0;
                 executionThreads.clear();
                 break;

--- a/lib/core/unittest/CStaticThreadPoolTest.cc
+++ b/lib/core/unittest/CStaticThreadPoolTest.cc
@@ -212,11 +212,13 @@ BOOST_AUTO_TEST_CASE(testNumberThreadsInUse) {
     // Start a threadpool then change the number of threads and check we aren't
     // getting execution on more than the specified number of distinct threads.
 
+    using TThreadIdUSet = boost::unordered_set<std::thread::id, std::hash<std::thread::id>>;
+
     core::CStaticThreadPool pool{8};
 
     std::mutex mutex;
     std::size_t numberProcessedTasks{0};
-    boost::unordered_set<std::thread::id> executionThreads;
+    TThreadIdUSet executionThreads;
 
     for (std::size_t numberThreadsInUse : {5, 6, 2}) {
 

--- a/lib/core/unittest/CStaticThreadPoolTest.cc
+++ b/lib/core/unittest/CStaticThreadPoolTest.cc
@@ -15,12 +15,12 @@
 #include <test/CRandomNumbers.h>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/unordered_set.hpp>
 
 #include <atomic>
 #include <chrono>
 #include <mutex>
 #include <thread>
-#include <unordered_set>
 
 BOOST_AUTO_TEST_SUITE(CStaticThreadPoolTest)
 
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(testNumberThreadsInUse) {
 
     std::mutex mutex;
     std::size_t numberProcessedTasks{0};
-    std::unordered_set<std::thread::id> executionThreads;
+    boost::unordered_set<std::thread::id> executionThreads;
 
     for (std::size_t numberThreadsInUse : {5, 6, 2}) {
 


### PR DESCRIPTION
For PyTorch model inference we want to be able to control the number of threads we assign to parallel calls to forward on-the-fly to adjust the number of cores each model consumes on a node as cluster wide tasks are added or removed. This lays the groundwork by adding a dynamic setting for the number of threads the pool will use. The idea is we always start the process thread pool with the hardware concurrency (divided by the number of threads we give libtorch), but then adjust the threads actually used by control message. Unused threads will simply be idle waiting to pop an empty queue so are effectively free.

cc @dimitris-athanasiou.