### PR TITLE
[ML] Upgrade to PyTorch 1.11 on Windows

### DIFF
--- a/build-setup/windows.md
+++ b/build-setup/windows.md
@@ -213,7 +213,7 @@ On the "Advanced Options" screen, check "Install for all users" and "Add Python 
 
 For the time being, do not take advantage of the option on the final installer screen to reconfigure the machine to allow paths longer than 260 characters.  We still support Windows versions that do not have this option.
 
-### PyTorch 1.9.0
+### PyTorch 1.11.0
 
 PyTorch requires that certain Python modules are installed.  Start a command prompt "cmd.exe" using "Run as administrator".  In it run:
 
@@ -227,7 +227,7 @@ Next, in a Git bash shell run:
 
 ```
 cd /c/tools
-git clone --depth=1 --branch=v1.9.0 git@github.com:pytorch/pytorch.git
+git clone --depth=1 --branch=v1.11.0 git@github.com:pytorch/pytorch.git
 cd pytorch
 git submodule sync
 git submodule update --init --recursive
@@ -278,7 +278,7 @@ set USE_QNNPACK=OFF
 set USE_PYTORCH_QNNPACK=OFF
 set USE_XNNPACK=OFF
 set MSVC_Z7_OVERRIDE=OFF
-set PYTORCH_BUILD_VERSION=1.9.0
+set PYTORCH_BUILD_VERSION=1.11.0
 set PYTORCH_BUILD_NUMBER=1
 python setup.py install
 ```

--- a/dev-tools/download_windows_deps.ps1
+++ b/dev-tools/download_windows_deps.ps1
@@ -9,9 +9,9 @@
 # limitation.
 #
 $ErrorActionPreference="Stop"
-$Archive="usr-x86_64-windows-2016-5.zip"
+$Archive="usr-x86_64-windows-2016-6.zip"
 $Destination="C:\"
-if (!(Test-Path "$Destination\usr\local\lib\boost_system-vc142-mt-x64-1_77.dll")) {
+if (!(Test-Path "$Destination\usr\local\include\pytorch\torch\csrc\profiler\api.h")) {
     Remove-Item "$Destination\usr" -Recurse -Force -ErrorAction Ignore
     $ZipSource="https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/$Archive"
     $ZipDestination="$Env:TEMP\$Archive"


### PR DESCRIPTION
There are no changes to the build process since 1.9.

We still don't ship with MKL on Windows. The size of MKL proved
controversial on Linux, so it's best not to increase distribution
size even further by adding in the Windows version. (We can still
revisit this in the future if there's sufficient demand for NLP
in production on Windows.)