### PR TITLE
[ML] Improve calendar component test

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -44,6 +44,8 @@
   and regression models. (See {ml-pull}2229[#2229].)
 * Improve handling of extremely large outliers in time series modelling.
   (See {ml-pull}2230[#2230].)
+* Improve detection and modeling of time series' calendar cyclic features.
+  (See {ml-pull}2236[#2236].)
 
 === Bug Fixes
 

--- a/include/maths/time_series/CCalendarComponent.h
+++ b/include/maths/time_series/CCalendarComponent.h
@@ -48,7 +48,7 @@ public:
     //! \param[in] maxSize The maximum number of component buckets.
     //! \param[in] decayRate Controls the rate at which information is lost from
     //! its adaptive bucketing.
-    //! \param[in] minimumBucketLength The minimum bucket length permitted in the
+    //! \param[in] minBucketLength The minimum bucket length permitted in the
     //! adaptive bucketing.
     //! \param[in] boundaryCondition The boundary condition to use for the splines.
     //! \param[in] valueInterpolationType The style of interpolation to use for
@@ -60,14 +60,14 @@ public:
         core_t::TTime timeZoneOffset,
         std::size_t maxSize,
         double decayRate = 0.0,
-        double minimumBucketLength = 0.0,
+        double minBucketLength = 0.0,
         common::CSplineTypes::EBoundaryCondition boundaryCondition = common::CSplineTypes::E_Periodic,
         common::CSplineTypes::EType valueInterpolationType = common::CSplineTypes::E_Cubic,
         common::CSplineTypes::EType varianceInterpolationType = common::CSplineTypes::E_Linear);
 
     //! Construct by traversing part of an state document.
     CCalendarComponent(double decayRate,
-                       double minimumBucketLength,
+                       double minBucketLength,
                        core::CStateRestoreTraverser& traverser,
                        common::CSplineTypes::EType valueInterpolationType = common::CSplineTypes::E_Cubic,
                        common::CSplineTypes::EType varianceInterpolationType = common::CSplineTypes::E_Linear);
@@ -120,7 +120,7 @@ public:
     void propagateForwardsByTime(double time);
 
     //! Get the calendar feature.
-    CCalendarFeature feature() const;
+    CCalendarFeatureAndTZ feature() const;
 
     //! Interpolate the component at \p time.
     //!

--- a/include/maths/time_series/CCalendarComponent.h
+++ b/include/maths/time_series/CCalendarComponent.h
@@ -57,6 +57,7 @@ public:
     //! computing variances.
     CCalendarComponent(
         const CCalendarFeature& feature,
+        core_t::TTime timeZoneOffset,
         std::size_t maxSize,
         double decayRate = 0.0,
         double minimumBucketLength = 0.0,

--- a/include/maths/time_series/CCalendarComponentAdaptiveBucketing.h
+++ b/include/maths/time_series/CCalendarComponentAdaptiveBucketing.h
@@ -86,7 +86,7 @@ public:
     void propagateForwardsByTime(double time);
 
     //! Get the calendar feature.
-    CCalendarFeature feature() const;
+    CCalendarFeatureAndTZ feature() const;
 
     //! The count in the bucket containing \p time.
     double count(core_t::TTime time) const;

--- a/include/maths/time_series/CCalendarComponentAdaptiveBucketing.h
+++ b/include/maths/time_series/CCalendarComponentAdaptiveBucketing.h
@@ -47,9 +47,10 @@ public:
 
 public:
     CCalendarComponentAdaptiveBucketing();
-    explicit CCalendarComponentAdaptiveBucketing(CCalendarFeature feature,
-                                                 double decayRate = 0.0,
-                                                 double minimumBucketLength = 0.0);
+    CCalendarComponentAdaptiveBucketing(CCalendarFeature feature,
+                                        core_t::TTime timeZoneOffset,
+                                        double decayRate = 0.0,
+                                        double minimumBucketLength = 0.0);
     //! Construct by traversing a state document.
     CCalendarComponentAdaptiveBucketing(double decayRate,
                                         double minimumBucketLength,
@@ -154,6 +155,9 @@ private:
 private:
     //! The time provider.
     CCalendarFeature m_Feature;
+
+    //! The timezone offset to apply to the feature (which is in GMT).
+    core_t::TTime m_TimeZoneOffset{0};
 
     //! The bucket values.
     TFloatMeanVarVec m_Values;

--- a/include/maths/time_series/CCalendarCyclicTest.h
+++ b/include/maths/time_series/CCalendarCyclicTest.h
@@ -49,7 +49,8 @@ namespace time_series {
 //! errors it returns the feature with the highest mean prediction error.
 class MATHS_TIME_SERIES_EXPORT CCalendarCyclicTest {
 public:
-    using TOptionalFeature = boost::optional<CCalendarFeature>;
+    using TFeatureTimePr = std::pair<CCalendarFeature, core_t::TTime>;
+    using TOptionalFeatureTimePr = boost::optional<TFeatureTimePr>;
 
 public:
     explicit CCalendarCyclicTest(double decayRate = 0.0);
@@ -67,7 +68,7 @@ public:
     void add(core_t::TTime time, double error, double weight = 1.0);
 
     //! Check if there are calendar components.
-    TOptionalFeature test() const;
+    TOptionalFeatureTimePr test() const;
 
     //! Get a checksum for this object.
     std::uint64_t checksum(std::uint64_t seed = 0) const;
@@ -92,9 +93,9 @@ private:
         //! Initialize from a delimited string.
         bool fromDelimited(const std::string& str);
 
-        std::uint32_t s_Count = 0;
-        std::uint32_t s_LargeErrorCount = 0;
-        common::CFloatStorage s_LargeErrorSum = 0.0;
+        std::uint32_t s_Count{0};
+        std::uint32_t s_LargeErrorCount{0};
+        common::CFloatStorage s_LargeErrorSum{0.0};
     };
     using TErrorStatsVec = std::vector<SErrorStats>;
 
@@ -102,8 +103,11 @@ private:
     //! Winsorise \p error.
     double winsorise(double error) const;
 
+    //! Get an estimate of the value of the survival function for \p error.
+    double survivalFunction(double error) const;
+
     //! Get the significance of \p x large errors given \p n samples.
-    double significance(double n, double x) const;
+    double significance(double n, double nl, double nv) const;
 
     //! Convert to a compressed representation.
     void deflate(const TErrorStatsVec& stats);

--- a/include/maths/time_series/CCalendarFeature.h
+++ b/include/maths/time_series/CCalendarFeature.h
@@ -106,7 +106,7 @@ MATHS_TIME_SERIES_EXPORT
 std::ostream& operator<<(std::ostream& strm, const CCalendarFeature& feature);
 
 //! \brief A wrapper around CCalendarFeature and time zone offset.
-class CCalendarFeatureAndTZ {
+class MATHS_TIME_SERIES_EXPORT CCalendarFeatureAndTZ {
 public:
     CCalendarFeatureAndTZ(CCalendarFeature feature, core_t::TTime timeZoneOffset);
 

--- a/include/maths/time_series/CCalendarFeature.h
+++ b/include/maths/time_series/CCalendarFeature.h
@@ -104,6 +104,35 @@ private:
 
 MATHS_TIME_SERIES_EXPORT
 std::ostream& operator<<(std::ostream& strm, const CCalendarFeature& feature);
+
+//! \brief A wrapper around CCalendarFeature and time zone offset.
+class CCalendarFeatureAndTZ {
+public:
+    CCalendarFeatureAndTZ(CCalendarFeature feature, core_t::TTime timeZoneOffset);
+
+    //! Check if the underlying feature matches.
+    bool operator==(CCalendarFeature feature) const;
+
+    //! \name Time Transforms
+    //@{
+    //! The offset of \p time w.r.t. the start of the current month's
+    //! feature window.
+    core_t::TTime offset(core_t::TTime time) const;
+
+    //! Check if \p time is in this feature's window.
+    bool inWindow(core_t::TTime time) const;
+    //@}
+
+    //! Get this feature's window.
+    core_t::TTime window() const;
+
+    //! Get a debug description of the feature.
+    std::string print() const;
+
+private:
+    CCalendarFeature m_Feature;
+    core_t::TTime m_TimeZoneOffset;
+};
 }
 }
 }

--- a/include/maths/time_series/CCalendarFeature.h
+++ b/include/maths/time_series/CCalendarFeature.h
@@ -69,6 +69,9 @@ public:
     //! Total ordering of two calendar features.
     bool operator<(CCalendarFeature rhs) const;
 
+    //! Check if we should test the feature for \p timeZoneOffset.
+    bool testForTimeZoneOffset(core_t::TTime timeZoneOffset) const;
+
     //! \name Time Transforms
     //@{
     //! The offset of \p time w.r.t. the start of the current month's

--- a/include/maths/time_series/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/time_series/CTimeSeriesDecompositionDetail.h
@@ -127,10 +127,15 @@ public:
     //! \brief The message passed to indicate calendar components have been
     //! detected.
     struct MATHS_TIME_SERIES_EXPORT SDetectedCalendar : public SMessage {
-        SDetectedCalendar(core_t::TTime time, core_t::TTime lastTime, CCalendarFeature feature);
+        SDetectedCalendar(core_t::TTime time,
+                          core_t::TTime lastTime,
+                          CCalendarFeature feature,
+                          core_t::TTime timeZoneOffset);
 
         //! The calendar feature found.
         CCalendarFeature s_Feature;
+        //! The time zone offset which applies to the feature.
+        core_t::TTime s_TimeZoneOffset;
     };
 
     //! \brief The message passed to indicate the trend is being used for prediction.
@@ -875,7 +880,11 @@ public:
             bool initialized() const;
 
             //! Add and initialize a new component.
-            void add(const CCalendarFeature& feature, std::size_t size, double decayRate, double bucketLength);
+            void add(const CCalendarFeature& feature,
+                     core_t::TTime timeZoneOffset,
+                     std::size_t size,
+                     double decayRate,
+                     double bucketLength);
 
             //! Apply \p change to the components.
             void apply(const CChangePoint& change);
@@ -916,7 +925,7 @@ public:
         void addSeasonalComponents(const CSeasonalDecomposition& components);
 
         //! Add a new calendar component.
-        void addCalendarComponent(const CCalendarFeature& feature);
+        void addCalendarComponent(const CCalendarFeature& feature, core_t::TTime timeZoneOffset);
 
         //! Fit the trend component \p component to \p values.
         void fitTrend(core_t::TTime startTime,

--- a/lib/maths/time_series/CCalendarComponent.cc
+++ b/lib/maths/time_series/CCalendarComponent.cc
@@ -43,18 +43,18 @@ CCalendarComponent::CCalendarComponent(const CCalendarFeature& feature,
                                        core_t::TTime timeZoneOffset,
                                        std::size_t maxSize,
                                        double decayRate,
-                                       double minimumBucketLength,
+                                       double minBucketLength,
                                        common::CSplineTypes::EBoundaryCondition boundaryCondition,
                                        common::CSplineTypes::EType valueInterpolationType,
                                        common::CSplineTypes::EType varianceInterpolationType)
     : CDecompositionComponent{maxSize, boundaryCondition,
                               valueInterpolationType, varianceInterpolationType},
-      m_Bucketing{feature, timeZoneOffset, decayRate, minimumBucketLength},
+      m_Bucketing{feature, timeZoneOffset, decayRate, minBucketLength},
       m_LastInterpolationTime{2 * (std::numeric_limits<core_t::TTime>::min() / 3)} {
 }
 
 CCalendarComponent::CCalendarComponent(double decayRate,
-                                       double minimumBucketLength,
+                                       double minBucketLength,
                                        core::CStateRestoreTraverser& traverser,
                                        common::CSplineTypes::EType valueInterpolationType,
                                        common::CSplineTypes::EType varianceInterpolationType)
@@ -62,7 +62,7 @@ CCalendarComponent::CCalendarComponent(double decayRate,
                               valueInterpolationType, varianceInterpolationType},
       m_LastInterpolationTime{2 * (std::numeric_limits<core_t::TTime>::min() / 3)} {
     if (traverser.traverseSubLevel([&](auto& traverser_) {
-            return this->acceptRestoreTraverser(decayRate, minimumBucketLength, traverser_);
+            return this->acceptRestoreTraverser(decayRate, minBucketLength, traverser_);
         }) == false) {
         traverser.setBadState();
     }
@@ -163,7 +163,7 @@ void CCalendarComponent::propagateForwardsByTime(double time) {
     m_Bucketing.propagateForwardsByTime(time);
 }
 
-CCalendarFeature CCalendarComponent::feature() const {
+CCalendarFeatureAndTZ CCalendarComponent::feature() const {
     return m_Bucketing.feature();
 }
 

--- a/lib/maths/time_series/CCalendarComponent.cc
+++ b/lib/maths/time_series/CCalendarComponent.cc
@@ -40,6 +40,7 @@ const std::string EMPTY_STRING;
 }
 
 CCalendarComponent::CCalendarComponent(const CCalendarFeature& feature,
+                                       core_t::TTime timeZoneOffset,
                                        std::size_t maxSize,
                                        double decayRate,
                                        double minimumBucketLength,
@@ -48,7 +49,7 @@ CCalendarComponent::CCalendarComponent(const CCalendarFeature& feature,
                                        common::CSplineTypes::EType varianceInterpolationType)
     : CDecompositionComponent{maxSize, boundaryCondition,
                               valueInterpolationType, varianceInterpolationType},
-      m_Bucketing{feature, decayRate, minimumBucketLength},
+      m_Bucketing{feature, timeZoneOffset, decayRate, minimumBucketLength},
       m_LastInterpolationTime{2 * (std::numeric_limits<core_t::TTime>::min() / 3)} {
 }
 
@@ -87,7 +88,6 @@ bool CCalendarComponent::acceptRestoreTraverser(double decayRate,
                                true, m_Bucketing.swap(bucketing))
         RESTORE_BUILT_IN(LAST_INTERPOLATION_TAG, m_LastInterpolationTime)
     } while (traverser.next());
-
     return true;
 }
 

--- a/lib/maths/time_series/CCalendarComponentAdaptiveBucketing.cc
+++ b/lib/maths/time_series/CCalendarComponentAdaptiveBucketing.cc
@@ -49,7 +49,6 @@ CCalendarComponentAdaptiveBucketing::CCalendarComponentAdaptiveBucketing(CCalend
                                                                          double decayRate,
                                                                          double minimumBucketLength)
     : CAdaptiveBucketing{decayRate, minimumBucketLength}, m_Feature{feature}, m_TimeZoneOffset{timeZoneOffset} {
-    LOG_INFO(<< "time zone = " << m_TimeZoneOffset);
 }
 
 CCalendarComponentAdaptiveBucketing::CCalendarComponentAdaptiveBucketing(
@@ -121,8 +120,8 @@ void CCalendarComponentAdaptiveBucketing::add(core_t::TTime time, double value, 
     }
 }
 
-CCalendarFeature CCalendarComponentAdaptiveBucketing::feature() const {
-    return m_Feature;
+CCalendarFeatureAndTZ CCalendarComponentAdaptiveBucketing::feature() const {
+    return {m_Feature, m_TimeZoneOffset};
 }
 
 void CCalendarComponentAdaptiveBucketing::propagateForwardsByTime(double time) {

--- a/lib/maths/time_series/CCalendarCyclicTest.cc
+++ b/lib/maths/time_series/CCalendarCyclicTest.cc
@@ -295,7 +295,7 @@ double CCalendarCyclicTest::winsorise(double error) const {
 double CCalendarCyclicTest::survivalFunction(double error) const {
     using TMomentsAccumulator = common::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
 
-    // We us an approximation for the right tail of a KDE from the error
+    // We use an approximation for the right tail of a KDE from the error
     // percentiles to estimate the survival function.
     TMomentsAccumulator tailMoments;
     for (double i = 0.0; i < 5.0; i += 1.0) {

--- a/lib/maths/time_series/CCalendarCyclicTest.cc
+++ b/lib/maths/time_series/CCalendarCyclicTest.cc
@@ -29,17 +29,21 @@
 #include <maths/common/Constants.h>
 
 #include <boost/math/distributions/binomial.hpp>
+#include <boost/math/distributions/normal.hpp>
 #include <boost/unordered_map.hpp>
 
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <string>
 
 namespace ml {
 namespace maths {
 namespace time_series {
 namespace {
+using TTimeVec = std::vector<core_t::TTime>;
+
 //! \brief Sets the time zone to a specified value in a constructor
 //! call so it can be called once by static initialisation.
 struct SSetTimeZone {
@@ -70,10 +74,15 @@ const std::string DELIMITER{","};
 const core_t::TTime SIZE{155};
 const core_t::TTime BUCKET{core::constants::DAY};
 const core_t::TTime WINDOW{SIZE * BUCKET};
-const core_t::TTime TIME_ZONE_OFFSETS[]{0};
+// We can't determine the exact time zone given the state we maintain but we can
+// determine if the whole pattern is shifted 1 day late or early.
+const TTimeVec TIME_ZONE_OFFSETS{0, -12 * core::constants::HOUR - 1,
+                                 12 * core::constants::HOUR + 1};
 
 //! The percentile of a large error.
 const double LARGE_ERROR_PERCENTILE{98.5};
+//! The percentile of a very large error.
+const double VERY_LARGE_ERROR_PERCENTILE{99.99};
 //! The minimum number of repeats to test a feature.
 const unsigned int MINIMUM_REPEATS{4};
 //! The maximum significance to accept a feature.
@@ -164,17 +173,22 @@ void CCalendarCyclicTest::add(core_t::TTime time, double error, double weight) {
 
         ++m_CurrentBucketErrorStats.s_Count;
 
-        double large;
-        m_ErrorQuantiles.quantile(LARGE_ERROR_PERCENTILE, large);
-
-        if (error >= large) {
-            ++m_CurrentBucketErrorStats.s_LargeErrorCount;
+        double largeError;
+        m_ErrorQuantiles.quantile(LARGE_ERROR_PERCENTILE, largeError);
+        if (error >= largeError) {
+            bool isVeryLarge{100.0 * (1.0 - this->survivalFunction(error)) >=
+                             VERY_LARGE_ERROR_PERCENTILE};
+            m_CurrentBucketErrorStats.s_LargeErrorCount +=
+                std::min(std::numeric_limits<std::size_t>::max() -
+                             m_CurrentBucketErrorStats.s_LargeErrorCount,
+                         static_cast<std::size_t>(isVeryLarge ? (1 << 17) + 1 : 1));
             m_CurrentBucketErrorStats.s_LargeErrorSum += this->winsorise(error);
         }
     }
 }
 
-CCalendarCyclicTest::TOptionalFeature CCalendarCyclicTest::test() const {
+CCalendarCyclicTest::TOptionalFeatureTimePr CCalendarCyclicTest::test() const {
+
     // The statistics we need in order to be able to test for calendar
     // features.
     struct SStats {
@@ -182,60 +196,71 @@ CCalendarCyclicTest::TOptionalFeature CCalendarCyclicTest::test() const {
         unsigned int s_Repeats{0};
         double s_Sum{0.0};
         double s_Count{0.0};
-        double s_Significance{0.0};
+        double s_PValue{0.0};
     };
     using TFeatureStatsUMap = boost::unordered_map<CCalendarFeature, SStats, SHashFeature>;
-    using TDoubleTimeCalendarFeatureTr = core::CTriple<double, core_t::TTime, CCalendarFeature>;
-    using TMaxAccumulator =
-        common::CBasicStatistics::SMax<TDoubleTimeCalendarFeatureTr>::TAccumulator;
 
     TErrorStatsVec errors{this->inflate()};
-    TFeatureStatsUMap stats{errors.size()};
 
-    // Note that the current index points to the next bucket to overwrite,
-    // i.e. the earliest bucket error statistics we have. The start of
-    // this bucket is WINDOW before the start time of the current partial
-    // bucket.
-    for (auto offset : TIME_ZONE_OFFSETS) {
-        for (core_t::TTime i = m_CurrentBucketIndex, time = m_CurrentBucketTime - WINDOW;
-             time < m_CurrentBucketTime; i = (i + 1) % SIZE, time += BUCKET) {
-            if (errors[i].s_Count > 0) {
-                double n{static_cast<double>(errors[i].s_Count)};
-                double x{static_cast<double>(errors[i].s_LargeErrorCount)};
-                double s{this->significance(n, x)};
-                core_t::TTime midpoint{time + BUCKET / 2 + offset};
-                for (auto feature : CCalendarFeature::features(midpoint)) {
-                    feature.offset(offset);
-                    SStats& stat = stats[feature];
-                    ++stat.s_Repeats;
-                    stat.s_Offset = offset;
-                    stat.s_Sum += errors[i].s_LargeErrorSum;
-                    stat.s_Count += x;
-                    stat.s_Significance = std::max(stat.s_Significance, s);
-                }
-            }
-        }
-    }
+    double mostSignificantError{0.0};
+    CCalendarFeature mostSignificantFeature;
+    core_t::TTime mostSignificantOffset{0};
 
     double errorThreshold;
     m_ErrorQuantiles.quantile(50.0, errorThreshold);
     errorThreshold *= 2.0;
 
-    TMaxAccumulator result;
+    for (auto offset : TIME_ZONE_OFFSETS) {
+        // Note that the current index points to the next bucket to overwrite,
+        // i.e. the earliest bucket error statistics we have. The start of
+        // this bucket is WINDOW before the start time of the current partial
+        // bucket.
+        TFeatureStatsUMap stats{errors.size()};
+        for (core_t::TTime i = m_CurrentBucketIndex, time = m_CurrentBucketTime - WINDOW;
+             time < m_CurrentBucketTime; i = (i + 1) % SIZE, time += BUCKET) {
+            if (errors[i].s_Count > 0) {
+                double n{static_cast<double>(errors[i].s_Count)};
+                double nl{static_cast<double>(errors[i].s_LargeErrorCount % (1 << 17))};
+                double nv{static_cast<double>(errors[i].s_LargeErrorCount / (1 << 17))};
+                double pValue{this->significance(n, nl, nv)};
+                core_t::TTime midpoint{time + BUCKET / 2 + offset};
+                for (auto feature : CCalendarFeature::features(midpoint)) {
+                    if (feature.testForTimeZoneOffset(offset)) {
+                        SStats& stat = stats[feature];
+                        ++stat.s_Repeats;
+                        stat.s_Sum += errors[i].s_LargeErrorSum;
+                        stat.s_Count += nl;
+                        stat.s_PValue = std::max(stat.s_PValue, pValue);
+                    }
+                }
+            }
+        }
 
-    for (const auto& stat : stats) {
-        CCalendarFeature feature = stat.first;
-        double r{static_cast<double>(stat.second.s_Repeats)};
-        double x{stat.second.s_Count};
-        double e{stat.second.s_Sum};
-        double s{stat.second.s_Significance};
-        if (stat.second.s_Repeats >= MINIMUM_REPEATS &&
-            e > errorThreshold * x && std::pow(s, r) < MAXIMUM_SIGNIFICANCE) {
-            result.add({e, stat.second.s_Offset, feature});
+        double mostSignificantErrorForOffset{0.0};
+        CCalendarFeature mostSignificantFeatureForOffset;
+        for (const auto& stat : stats) {
+            CCalendarFeature feature = stat.first;
+            double r{static_cast<double>(stat.second.s_Repeats)};
+            double nl{stat.second.s_Count};
+            double sl{stat.second.s_Sum};
+            double pValue{stat.second.s_PValue};
+            if (stat.second.s_Repeats >= MINIMUM_REPEATS &&
+                sl > errorThreshold * nl && sl > mostSignificantErrorForOffset &&
+                std::pow(pValue, r) < MAXIMUM_SIGNIFICANCE) {
+                mostSignificantErrorForOffset = sl;
+                mostSignificantFeatureForOffset = feature;
+            }
+        }
+        if (mostSignificantErrorForOffset > mostSignificantError) {
+            mostSignificantError = mostSignificantErrorForOffset;
+            mostSignificantFeature = mostSignificantFeatureForOffset;
+            mostSignificantOffset = offset;
         }
     }
 
-    return result.count() > 0 ? result[0].third : TOptionalFeature();
+    return mostSignificantError > 0
+               ? std::make_pair(mostSignificantFeature, mostSignificantOffset)
+               : TOptionalFeatureTimePr();
 }
 
 std::uint64_t CCalendarCyclicTest::checksum(std::uint64_t seed) const {
@@ -267,19 +292,45 @@ double CCalendarCyclicTest::winsorise(double error) const {
     return std::min(error, high);
 }
 
-double CCalendarCyclicTest::significance(double n, double x) const {
+double CCalendarCyclicTest::survivalFunction(double error) const {
+    using TMomentsAccumulator = common::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+
+    // We us an approximation for the right tail of a KDE from the error
+    // percentiles to estimate the survival function.
+    TMomentsAccumulator tailMoments;
+    for (double i = 0.0; i < 5.0; i += 1.0) {
+        double eq;
+        m_ErrorQuantiles.quantile(
+            LARGE_ERROR_PERCENTILE + i * (100.0 - LARGE_ERROR_PERCENTILE) / 5.0, eq);
+        tailMoments.add(eq);
+    }
+    try {
+        boost::math::normal normal{common::CBasicStatistics::mean(tailMoments),
+                                   std::sqrt(common::CBasicStatistics::variance(tailMoments))};
+        return (100.0 - LARGE_ERROR_PERCENTILE) / 100.0 *
+               common::CTools::safeCdfComplement(normal, error);
+
+    } catch (const std::exception& e) {
+        LOG_ERROR(<< "Failed to compute tail distribution '" << e.what() << "'");
+    }
+    return 1.0;
+}
+
+double CCalendarCyclicTest::significance(double n, double nl, double nv) const {
     if (n > 0.0) {
         try {
             // We have roughly 31 independent error samples, one for each
             // day of the month, so the chance of seeing as extreme an event
             // among all of them is:
             //   1 - P("don't see as extreme event") = 1 - (1 - P("event"))^31
-            boost::math::binomial binom{n, 1.0 - LARGE_ERROR_PERCENTILE / 100.0};
-            double p{std::min(2.0 * common::CTools::safeCdfComplement(binom, x - 1.0), 1.0)};
+            boost::math::binomial bl{n, 1.0 - LARGE_ERROR_PERCENTILE / 100.0};
+            boost::math::binomial bv{n, 1.0 - VERY_LARGE_ERROR_PERCENTILE / 100.0};
+            double p{std::min({2.0 * common::CTools::safeCdfComplement(bl, nl - 1.0),
+                               2.0 * common::CTools::safeCdfComplement(bv, nv - 1.0), 1.0})};
             return common::CTools::oneMinusPowOneMinusX(p, 31.0);
         } catch (const std::exception& e) {
             LOG_ERROR(<< "Failed to calculate significance: " << e.what()
-                      << " n = " << n << " x = " << x);
+                      << " n = " << n << " nl = " << nl << " nv = " << nv);
         }
     }
     return 1.0;

--- a/lib/maths/time_series/CCalendarFeature.cc
+++ b/lib/maths/time_series/CCalendarFeature.cc
@@ -148,6 +148,23 @@ bool CCalendarFeature::operator<(CCalendarFeature rhs) const {
                                                        rhs.m_Feature, rhs.m_Value);
 }
 
+bool CCalendarFeature::testForTimeZoneOffset(core_t::TTime timeZoneOffset) const {
+    switch (m_Feature) {
+    case DAYS_SINCE_START_OF_MONTH:
+    case DAYS_BEFORE_END_OF_MONTH:
+        // Translations in time of these features are irrelevant since
+        // they'll remain cyclic w.r.t. the calendar.
+        return timeZoneOffset == 0;
+    case DAY_OF_WEEK_AND_WEEKS_SINCE_START_OF_MONTH:
+    case DAY_OF_WEEK_AND_WEEKS_BEFORE_END_OF_MONTH:
+        return true;
+    default:
+        LOG_ERROR(<< "Invalid feature: '" << m_Feature << "'");
+        break;
+    }
+    return false;
+}
+
 core_t::TTime CCalendarFeature::offset(core_t::TTime time) const {
     int dayOfWeek{};
     int dayOfMonth{};

--- a/lib/maths/time_series/CCalendarFeature.cc
+++ b/lib/maths/time_series/CCalendarFeature.cc
@@ -247,6 +247,31 @@ const std::uint16_t CCalendarFeature::INVALID(std::numeric_limits<std::uint16_t>
 std::ostream& operator<<(std::ostream& strm, const CCalendarFeature& feature) {
     return strm << feature.print();
 }
+
+CCalendarFeatureAndTZ::CCalendarFeatureAndTZ(CCalendarFeature feature, core_t::TTime timeZoneOffset)
+    : m_Feature{feature}, m_TimeZoneOffset{timeZoneOffset} {
+}
+
+bool CCalendarFeatureAndTZ::operator==(CCalendarFeature feature) const {
+    return m_Feature == feature;
+}
+
+core_t::TTime CCalendarFeatureAndTZ::offset(core_t::TTime time) const {
+    return m_Feature.offset(time + m_TimeZoneOffset);
+}
+
+bool CCalendarFeatureAndTZ::inWindow(core_t::TTime time) const {
+    return m_Feature.inWindow(time + m_TimeZoneOffset);
+}
+
+core_t::TTime CCalendarFeatureAndTZ::window() const {
+    return m_Feature.window();
+}
+
+std::string CCalendarFeatureAndTZ::print() const {
+    return m_Feature.print() + (m_TimeZoneOffset < 0 ? " -" : " +") +
+           std::to_string(m_TimeZoneOffset / core::constants::HOUR);
+}
 }
 }
 }

--- a/lib/maths/time_series/unittest/CCalendarComponentAdaptiveBucketingTest.cc
+++ b/lib/maths/time_series/unittest/CCalendarComponentAdaptiveBucketingTest.cc
@@ -35,10 +35,10 @@ using namespace ml;
 namespace {
 using TDoubleVec = std::vector<double>;
 using TFloatVec = std::vector<maths::common::CFloatStorage>;
+using TTimeVec = std::vector<core_t::TTime>;
 using TMeanAccumulator = maths::common::CBasicStatistics::SSampleMean<double>::TAccumulator;
 using TMinAccumulator = maths::common::CBasicStatistics::SMin<double>::TAccumulator;
 using TMaxAccumulator = maths::common::CBasicStatistics::SMax<double>::TAccumulator;
-}
 
 class CTestFixture {
 public:
@@ -52,6 +52,7 @@ public:
 private:
     std::string m_OrigTimezone;
 };
+}
 
 BOOST_FIXTURE_TEST_CASE(testInitialize, CTestFixture) {
     maths::time_series::CCalendarFeature feature{
@@ -129,10 +130,10 @@ BOOST_FIXTURE_TEST_CASE(testSwap, CTestFixture) {
 BOOST_FIXTURE_TEST_CASE(testRefine, CTestFixture) {
     // Test that refine reduces the function approximation error.
 
-    core_t::TTime times[] = {-1,    3600,  10800, 18000, 25200, 32400, 39600,
-                             46800, 54000, 61200, 68400, 75600, 82800, 86400};
-    double function[] = {10, 10,  10, 10, 100, 90, 80,
-                         90, 100, 20, 10, 10,  10, 10};
+    TTimeVec times{-1,    3600,  10800, 18000, 25200, 32400, 39600,
+                   46800, 54000, 61200, 68400, 75600, 82800, 86400};
+    TDoubleVec function{10, 10,  10, 10, 100, 90, 80,
+                        90, 100, 20, 10, 10,  10, 10};
 
     maths::time_series::CCalendarFeature feature{
         maths::time_series::CCalendarFeature::DAYS_SINCE_START_OF_MONTH, 0};
@@ -244,9 +245,9 @@ BOOST_FIXTURE_TEST_CASE(testPropagateForwardsByTime, CTestFixture) {
 BOOST_FIXTURE_TEST_CASE(testMinimumBucketLength, CTestFixture) {
     using TSizeVec = std::vector<std::size_t>;
 
-    double function[]{0.0, 0.0, 10.0, 12.0, 11.0, 16.0, 15.0, 1.0,
-                      0.0, 0.0, 0.0,  0.0,  0.0,  0.0,  0.0,  0.0,
-                      0.0, 0.0, 0.0,  0.0,  0.0,  0.0,  0.0,  0.0};
+    TDoubleVec function{0.0, 0.0, 10.0, 12.0, 11.0, 16.0, 15.0, 1.0,
+                        0.0, 0.0, 0.0,  0.0,  0.0,  0.0,  0.0,  0.0,
+                        0.0, 0.0, 0.0,  0.0,  0.0,  0.0,  0.0,  0.0};
     std::size_t n{boost::size(function)};
 
     test::CRandomNumbers rng;

--- a/lib/maths/time_series/unittest/CCalendarComponentAdaptiveBucketingTest.cc
+++ b/lib/maths/time_series/unittest/CCalendarComponentAdaptiveBucketingTest.cc
@@ -56,7 +56,7 @@ private:
 BOOST_FIXTURE_TEST_CASE(testInitialize, CTestFixture) {
     maths::time_series::CCalendarFeature feature{
         maths::time_series::CCalendarFeature::DAYS_SINCE_START_OF_MONTH, 86400};
-    maths::time_series::CCalendarComponentAdaptiveBucketing bucketing{feature};
+    maths::time_series::CCalendarComponentAdaptiveBucketing bucketing{feature, 0};
 
     BOOST_TEST_REQUIRE(!bucketing.initialize(0));
 
@@ -87,7 +87,7 @@ BOOST_FIXTURE_TEST_CASE(testSwap, CTestFixture) {
 
     maths::time_series::CCalendarFeature feature1{
         maths::time_series::CCalendarFeature::DAYS_SINCE_START_OF_MONTH, now};
-    maths::time_series::CCalendarComponentAdaptiveBucketing bucketing1{feature1, 0.05};
+    maths::time_series::CCalendarComponentAdaptiveBucketing bucketing1{feature1, 0, 0.05};
 
     test::CRandomNumbers rng;
 
@@ -112,7 +112,7 @@ BOOST_FIXTURE_TEST_CASE(testSwap, CTestFixture) {
     maths::time_series::CCalendarFeature feature2{
         maths::time_series::CCalendarFeature::DAYS_BEFORE_END_OF_MONTH,
         now - core::constants::WEEK};
-    maths::time_series::CCalendarComponentAdaptiveBucketing bucketing2{feature2, 0.1};
+    maths::time_series::CCalendarComponentAdaptiveBucketing bucketing2{feature2, 0, 0.1};
 
     uint64_t checksum1{bucketing1.checksum()};
     uint64_t checksum2{bucketing2.checksum()};
@@ -136,8 +136,8 @@ BOOST_FIXTURE_TEST_CASE(testRefine, CTestFixture) {
 
     maths::time_series::CCalendarFeature feature{
         maths::time_series::CCalendarFeature::DAYS_SINCE_START_OF_MONTH, 0};
-    maths::time_series::CCalendarComponentAdaptiveBucketing bucketing1{feature};
-    maths::time_series::CCalendarComponentAdaptiveBucketing bucketing2{feature};
+    maths::time_series::CCalendarComponentAdaptiveBucketing bucketing1{feature, 0};
+    maths::time_series::CCalendarComponentAdaptiveBucketing bucketing2{feature, 0};
 
     bucketing1.initialize(12);
     bucketing2.initialize(12);
@@ -218,7 +218,7 @@ BOOST_FIXTURE_TEST_CASE(testPropagateForwardsByTime, CTestFixture) {
 
     maths::time_series::CCalendarFeature feature{
         maths::time_series::CCalendarFeature::DAYS_SINCE_START_OF_MONTH, 0};
-    maths::time_series::CCalendarComponentAdaptiveBucketing bucketing{feature, 0.2};
+    maths::time_series::CCalendarComponentAdaptiveBucketing bucketing{feature, 0, 0.2};
 
     bucketing.initialize(10);
     for (core_t::TTime t = 0; t < 86400; t += 1800) {
@@ -253,8 +253,8 @@ BOOST_FIXTURE_TEST_CASE(testMinimumBucketLength, CTestFixture) {
 
     maths::time_series::CCalendarFeature feature{
         maths::time_series::CCalendarFeature::DAYS_SINCE_START_OF_MONTH, 0};
-    maths::time_series::CCalendarComponentAdaptiveBucketing bucketing1{feature, 0.0, 0.0};
-    maths::time_series::CCalendarComponentAdaptiveBucketing bucketing2{feature, 0.0, 1500.0};
+    maths::time_series::CCalendarComponentAdaptiveBucketing bucketing1{feature, 0, 0.0, 0.0};
+    maths::time_series::CCalendarComponentAdaptiveBucketing bucketing2{feature, 0, 0.0, 1500.0};
     bucketing1.initialize(n);
     bucketing2.initialize(n);
 
@@ -333,7 +333,7 @@ BOOST_FIXTURE_TEST_CASE(testUnintialized, CTestFixture) {
 
     maths::time_series::CCalendarFeature feature{
         maths::time_series::CCalendarFeature::DAYS_SINCE_START_OF_MONTH, 0};
-    maths::time_series::CCalendarComponentAdaptiveBucketing bucketing{feature, 0.1};
+    maths::time_series::CCalendarComponentAdaptiveBucketing bucketing{feature, 0, 0.1};
 
     bucketing.add(0, 1.0, 1.0);
     bucketing.add(1, 2.0, 2.0);
@@ -381,7 +381,8 @@ BOOST_FIXTURE_TEST_CASE(testKnots, CTestFixture) {
 
     LOG_DEBUG(<< "*** Values ***");
     {
-        maths::time_series::CCalendarComponentAdaptiveBucketing bucketing{feature, 0.0, 600.0};
+        maths::time_series::CCalendarComponentAdaptiveBucketing bucketing{
+            feature, 0, 0.0, 600.0};
 
         bucketing.initialize(24);
 
@@ -420,7 +421,8 @@ BOOST_FIXTURE_TEST_CASE(testKnots, CTestFixture) {
 
     LOG_DEBUG(<< "*** Variances ***");
     {
-        maths::time_series::CCalendarComponentAdaptiveBucketing bucketing{feature, 0.0, 600.0};
+        maths::time_series::CCalendarComponentAdaptiveBucketing bucketing{
+            feature, 0, 0.0, 600.0};
 
         bucketing.initialize(24);
 
@@ -471,11 +473,12 @@ BOOST_FIXTURE_TEST_CASE(testPersist, CTestFixture) {
 
     double decayRate{0.1};
     double minimumBucketLength{1.0};
+    core_t::TTime timeZoneOffset{3600};
 
     maths::time_series::CCalendarFeature feature{
         maths::time_series::CCalendarFeature::DAYS_SINCE_START_OF_MONTH, 0};
     maths::time_series::CCalendarComponentAdaptiveBucketing bucketing{
-        feature, decayRate, minimumBucketLength};
+        feature, timeZoneOffset, decayRate, minimumBucketLength};
 
     bucketing.initialize(10);
     for (std::size_t p = 0; p < 10; ++p) {
@@ -527,11 +530,12 @@ BOOST_FIXTURE_TEST_CASE(testPersist, CTestFixture) {
 BOOST_FIXTURE_TEST_CASE(testName, CTestFixture) {
     double decayRate{0.1};
     double minimumBucketLength{1.0};
+    core_t::TTime timeZoneOffset{3600};
 
     maths::time_series::CCalendarFeature feature{
         maths::time_series::CCalendarFeature::DAYS_SINCE_START_OF_MONTH, 0};
     maths::time_series::CCalendarComponentAdaptiveBucketing bucketing{
-        feature, decayRate, minimumBucketLength};
+        feature, timeZoneOffset, decayRate, minimumBucketLength};
 
     BOOST_REQUIRE_EQUAL(std::string("Calendar[") + std::to_string(decayRate) +
                             "," + std::to_string(minimumBucketLength) + "]",

--- a/lib/maths/time_series/unittest/CCalendarComponentTest.cc
+++ b/lib/maths/time_series/unittest/CCalendarComponentTest.cc
@@ -1,0 +1,203 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the following additional limitation. Functionality enabled by the
+ * files subject to the Elastic License 2.0 may only be used in production when
+ * invoked by an Elasticsearch process with a license key installed that permits
+ * use of machine learning features. You may not use this file except in
+ * compliance with the Elastic License 2.0 and the foregoing additional
+ * limitation.
+ */
+
+#include <boost/test/tools/interface.hpp>
+#include <core/CLogger.h>
+#include <core/CRapidXmlParser.h>
+#include <core/CRapidXmlStatePersistInserter.h>
+#include <core/CRapidXmlStateRestoreTraverser.h>
+#include <core/CTimezone.h>
+#include <core/Constants.h>
+#include <core/CoreTypes.h>
+
+#include <maths/common/CBasicStatistics.h>
+#include <maths/common/CTools.h>
+
+#include <maths/common/MathsTypes.h>
+#include <maths/time_series/CCalendarComponent.h>
+#include <maths/time_series/CCalendarFeature.h>
+
+#include <test/CRandomNumbers.h>
+
+#include "TestUtils.h"
+#include "maths/common/CBasicStatistics.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(CCalendarComponentTest)
+
+using namespace ml;
+
+namespace {
+using TDoubleVec = std::vector<double>;
+using TTimeVec = std::vector<core_t::TTime>;
+using TMeanAccumulator = maths::common::CBasicStatistics::SSampleMean<double>::TAccumulator;
+
+class CTestFixture {
+public:
+    CTestFixture()
+        : m_OrigTimezone{core::CTimezone::instance().timezoneName()} {
+        core::CTimezone::instance().setTimezone("GMT");
+    }
+
+    ~CTestFixture() { core::CTimezone::instance().setTimezone(m_OrigTimezone); }
+
+private:
+    std::string m_OrigTimezone;
+};
+
+class CTestCalendarComponent : public maths::time_series::CCalendarComponent {
+public:
+    // Bring base class method hidden by the signature above into scope.
+    using maths::time_series::CCalendarComponent::initialize;
+
+public:
+    CTestCalendarComponent(const maths::time_series::CCalendarFeature& feature,
+                           core_t::TTime timeZoneOffset,
+                           std::size_t maxSize,
+                           double decayRate = 0.0,
+                           double minBucketLength = 0.0)
+        : CCalendarComponent{feature, timeZoneOffset, maxSize, decayRate, minBucketLength} {
+        this->initialize();
+    }
+
+    void addPoint(core_t::TTime time, double value, double weight = 1.0) {
+        if (this->shouldInterpolate(time)) {
+            this->interpolate(time);
+        }
+        if (this->feature().inWindow(time)) {
+            this->add(time, value, weight);
+        }
+    }
+};
+
+const core_t::TTime HOUR{core::constants::HOUR};
+const core_t::TTime DAY{core::constants::DAY};
+
+auto calendarCyclic(core_t::TTime timeZoneOffset) {
+
+    TTimeVec months{
+        86400,    // 2nd Jan
+        2764800,  // 2nd Feb
+        5184000,  // 2nd Mar
+        7862400,  // 2nd Apr
+        10454400, // 2nd May
+        13132800, // 2nd June
+        15724800  // 2nd July
+    };
+
+    TTimeVec knots{-1,        2 * HOUR,  4 * HOUR,  6 * HOUR,  8 * HOUR,
+                   10 * HOUR, 12 * HOUR, 14 * HOUR, 16 * HOUR, 18 * HOUR,
+                   20 * HOUR, 22 * HOUR, 24 * HOUR};
+    TDoubleVec values{10, 10, 10, 30, 80, 90, 80, 70, 50, 90, 30, 20, 10};
+
+    return [=](core_t::TTime time) {
+        auto month = std::upper_bound(months.begin(), months.end(),
+                                      time + timeZoneOffset - DAY);
+        if (time + timeZoneOffset >= *month && time + timeZoneOffset < *month + DAY) {
+            time -= *month - timeZoneOffset;
+            auto knot = std::upper_bound(knots.begin(), knots.end(), time);
+            double ta{static_cast<double>(*knot - 2 * HOUR)};
+            double tb{static_cast<double>(*knot)};
+            double va{values[(knot - knots.begin() - 1)]};
+            double vb{values[(knot - knots.begin())]};
+            return maths::common::CTools::linearlyInterpolate(
+                ta, tb, va, vb, static_cast<double>(time));
+        }
+        return 0.0;
+    };
+}
+}
+
+BOOST_FIXTURE_TEST_CASE(testFit, CTestFixture) {
+
+    // Test the quality of fit to a supplied calendar feature.
+
+    for (core_t::TTime timeZoneOffset :
+         {0 * core::constants::HOUR, -6 * core::constants::HOUR, 6 * core::constants::HOUR}) {
+        LOG_DEBUG(<< "time zone offset = " << timeZoneOffset);
+
+        auto trend = calendarCyclic(timeZoneOffset);
+
+        test::CRandomNumbers rng;
+
+        CTestCalendarComponent component{
+            maths::time_series::CCalendarFeature{maths::time_series::CCalendarFeature::DAYS_SINCE_START_OF_MONTH,
+                                                 DAY + 12 * HOUR},
+            timeZoneOffset, 24};
+
+        TDoubleVec noise;
+        for (core_t::TTime time = 0; time < 15724800; time += HOUR) {
+            rng.generateNormalSamples(0.0, 9.0, 1, noise);
+            component.addPoint(time, trend(time) + noise[0]);
+        }
+        TMeanAccumulator mae;
+        for (core_t::TTime time = 15724800 - timeZoneOffset;
+             time < 15724800 - timeZoneOffset + DAY; time += HOUR) {
+            mae.add(std::fabs(
+                (maths::common::CBasicStatistics::mean(component.value(time, 0.0)) - trend(time)) /
+                trend(time)));
+        }
+        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(mae) < 0.06);
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(testPersist, CTestFixture) {
+    // Check that persistence is idempotent.
+
+    for (core_t::TTime timeZoneOffset :
+         {0 * core::constants::HOUR, -6 * core::constants::HOUR, 6 * core::constants::HOUR}) {
+        LOG_DEBUG(<< "time zone offset = " << timeZoneOffset);
+
+        auto trend = calendarCyclic(timeZoneOffset);
+
+        test::CRandomNumbers rng;
+
+        CTestCalendarComponent origComponent{
+            maths::time_series::CCalendarFeature{maths::time_series::CCalendarFeature::DAYS_SINCE_START_OF_MONTH,
+                                                 DAY + 12 * HOUR},
+            timeZoneOffset, 24};
+
+        TDoubleVec noise;
+        for (core_t::TTime time = 0; time < 15724800; time += HOUR) {
+            rng.generateNormalSamples(0.0, 9.0, 1, noise);
+            origComponent.addPoint(time, trend(time) + noise[0]);
+        }
+
+        std::string origXml;
+        {
+            core::CRapidXmlStatePersistInserter inserter("root");
+            origComponent.acceptPersistInserter(inserter);
+            inserter.toXml(origXml);
+        }
+
+        LOG_DEBUG(<< "seasonal component XML representation:\n" << origXml);
+
+        // Restore the XML into a new component.
+        core::CRapidXmlParser parser;
+        BOOST_TEST_REQUIRE(parser.parseStringIgnoreCdata(origXml));
+        core::CRapidXmlStateRestoreTraverser traverser(parser);
+        maths::time_series::CCalendarComponent restoredComponent{0.0, 0.0, traverser};
+
+        std::string newXml;
+        {
+            core::CRapidXmlStatePersistInserter inserter("root");
+            restoredComponent.acceptPersistInserter(inserter);
+            inserter.toXml(newXml);
+        }
+        BOOST_REQUIRE_EQUAL(origXml, newXml);
+        BOOST_REQUIRE_EQUAL(origComponent.checksum(), restoredComponent.checksum());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/maths/time_series/unittest/CCalendarComponentTest.cc
+++ b/lib/maths/time_series/unittest/CCalendarComponentTest.cc
@@ -9,7 +9,6 @@
  * limitation.
  */
 
-#include <boost/test/tools/interface.hpp>
 #include <core/CLogger.h>
 #include <core/CRapidXmlParser.h>
 #include <core/CRapidXmlStatePersistInserter.h>
@@ -20,15 +19,14 @@
 
 #include <maths/common/CBasicStatistics.h>
 #include <maths/common/CTools.h>
-
 #include <maths/common/MathsTypes.h>
+
 #include <maths/time_series/CCalendarComponent.h>
 #include <maths/time_series/CCalendarFeature.h>
 
 #include <test/CRandomNumbers.h>
 
 #include "TestUtils.h"
-#include "maths/common/CBasicStatistics.h"
 
 #include <boost/test/unit_test.hpp>
 

--- a/lib/maths/time_series/unittest/Makefile
+++ b/lib/maths/time_series/unittest/Makefile
@@ -26,6 +26,7 @@ SRCS=\
 	Main.cc \
 	CAdaptiveBucketingTest.cc \
 	CCalendarComponentAdaptiveBucketingTest.cc \
+	CCalendarComponentTest.cc \
 	CCalendarCyclicTestTest.cc \
 	CCalendarFeatureTest.cc \
 	CCountMinSketchTest.cc \


### PR DESCRIPTION
Currently, we test to see whether there is significant evidence for calendar predictive calendar features for time series modelling. The approach we use has two deficiencies:
1. If there is a single bucket with a very large deviation predicted by a calendar feature, then our existing test will not necessarily pick this up,
2. For "day of week, week of month" features (for example 1st Monday of the month) one must account for time zone shifts to reliably detect. For example, if the Monday lands on the first day of the month then the time zone may mean that it is in a different month in GMT.

This change addresses both deficiencies. We now test shifting the pattern up to one day earlier or later to allow for the time zone. We also keep track of very large errors. Even if one such error happens every calendar period we will typically detect the feature.

Finally, when first initialising, we should ignore Winsorizating weights since they can stop us learning any correction to the model predictions.
