### PR TITLE
[8.1] [ML] Fix the PyTorch version reported in the dependency info

### DIFF
--- a/3rd_party/licenses/pytorch-INFO.csv
+++ b/3rd_party/licenses/pytorch-INFO.csv
@@ -1,2 +1,2 @@
 name,version,revision,url,license,copyright,sourceURL
-PyTorch,1.8.0,37c1f4a7fef115d719104e871d0cf39434aa9d56,https://pytorch.org,BSD-3-Clause,,
+PyTorch,1.9.0,d69c22dd61a2f006dcfe1e3ea8468a3ecaf931aa,https://pytorch.org,BSD-3-Clause,,


### PR DESCRIPTION
We upgraded to PyTorch 1.9 before 8.0.0 was released, but the
dependency info was still saying 1.8.

Backport of #2237