### PR TITLE
[ML] Fix cause of log error

### DIFF
--- a/lib/maths/time_series/CCalendarCyclicTest.cc
+++ b/lib/maths/time_series/CCalendarCyclicTest.cc
@@ -304,6 +304,10 @@ double CCalendarCyclicTest::survivalFunction(double error) const {
             LARGE_ERROR_PERCENTILE + i * (100.0 - LARGE_ERROR_PERCENTILE) / 5.0, eq);
         tailMoments.add(eq);
     }
+
+    if (common::CBasicStatistics::variance(tailMoments) == 0.0) {
+        return error > common::CBasicStatistics::mean(tailMoments) ? 0.0 : 1.0;
+    }
     try {
         boost::math::normal normal{common::CBasicStatistics::mean(tailMoments),
                                    std::sqrt(common::CBasicStatistics::variance(tailMoments))};


### PR DESCRIPTION
Following on from #2236, we weren't properly handling the case that all values for a time series are the same and triggering a log error. This simply traps the edge case and exits the calculation early.

This is unreleased code so marking as a non-issue.