### PR TITLE
[ML] Speedup detection of calendar components

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -45,7 +45,7 @@
 * Improve handling of extremely large outliers in time series modelling.
   (See {ml-pull}2230[#2230].)
 * Improve detection and modeling of time series' calendar cyclic features.
-  (See {ml-pull}2236[#2236].)
+  (See {ml-pull}2236[#2236] and {ml-pull}2243[#2243].)
 
 === Bug Fixes
 

--- a/include/maths/time_series/CCalendarCyclicTest.h
+++ b/include/maths/time_series/CCalendarCyclicTest.h
@@ -61,6 +61,9 @@ public:
     //! Persist state by passing information to \p inserter.
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
+    //! Clear the error distribution summary.
+    void forgetErrorDistribution();
+
     //! Age the bucket values to account for \p time elapsed time.
     void propagateForwardsByTime(double time);
 

--- a/lib/maths/time_series/CCalendarCyclicTest.cc
+++ b/lib/maths/time_series/CCalendarCyclicTest.cc
@@ -145,6 +145,10 @@ void CCalendarCyclicTest::acceptPersistInserter(core::CStatePersistInserter& ins
     core::CPersistUtils::persist(ERRORS_6_4_TAG, errors, inserter);
 }
 
+void CCalendarCyclicTest::forgetErrorDistribution() {
+    m_ErrorQuantiles = common::CQuantileSketch{common::CQuantileSketch::E_Linear, 20};
+}
+
 void CCalendarCyclicTest::propagateForwardsByTime(double time) {
     if (common::CMathsFuncs::isFinite(time) == false || time < 0.0) {
         LOG_ERROR(<< "Bad propagation time " << time);

--- a/lib/maths/time_series/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/time_series/CTimeSeriesDecompositionDetail.cc
@@ -1429,8 +1429,17 @@ void CTimeSeriesDecompositionDetail::CCalendarTest::handle(const SAddValue& mess
 }
 
 void CTimeSeriesDecompositionDetail::CCalendarTest::handle(const SDetectedSeasonal& message) {
-    if (m_Machine.state() != CC_NOT_TESTING) {
+    switch (m_Machine.state()) {
+    case CC_TEST:
+        m_Test->forgetErrorDistribution();
+        break;
+    case CC_NOT_TESTING:
+    case CC_INITIAL:
+        break;
+    default:
+        LOG_ERROR(<< "Test in a bad state: " << m_Machine.state());
         this->apply(CC_RESET, message);
+        break;
     }
 }
 


### PR DESCRIPTION
Currently, if we detect a change in seasonal components we reset the calendar component test state. This is because unmodelled seasonal components can result in large errors and so our estimation of the prediction error distribution is unreliable. However, we can also choose a different seasonal decomposition if the data characteristics change somewhat from time-to-time. Resetting the large error count statistics mean we have to start again trying to detect predictive calendar features, which is a multi-month process. Since the primary driver for resetting the test state is the poor error distribution characterisation, this change switches to instead keeping large error count statistics but resetting the error distribution estimate.