### PR TITLE
[ML] Boosted tree hyperparameter refactor

### DIFF
--- a/include/api/CDataFrameAnalysisConfigReader.h
+++ b/include/api/CDataFrameAnalysisConfigReader.h
@@ -140,8 +140,8 @@ public:
                 return fallback;
             }
             if (m_Value->IsArray() == false) {
-                this->handleFatal();
-                return fallback;
+                // Try parsing as a single value.
+                return {this->as<T>()};
             }
             std::vector<T> result;
             result.reserve(m_Value->Size());

--- a/include/api/CInferenceModelMetadata.h
+++ b/include/api/CInferenceModelMetadata.h
@@ -113,7 +113,6 @@ private:
         }};
     THyperparametersVec m_HyperparameterImportance;
     std::size_t m_NumberTrainingRows{0};
-    double m_TrainFractionPerFold{0.0};
 };
 }
 }

--- a/include/maths/analytics/CBoostedTree.h
+++ b/include/maths/analytics/CBoostedTree.h
@@ -287,9 +287,6 @@ public:
     //! Get the number of rows used to train the model.
     std::size_t numberTrainingRows() const override;
 
-    //! Get the fraction of data per fold used for training when tuning hyperparameters.
-    double trainFractionPerFold() const override;
-
     //! Get the column containing the dependent variable.
     std::size_t columnHoldingDependentVariable() const override;
 
@@ -323,18 +320,8 @@ public:
     //! Get the weight that has been chosen for each feature for training.
     const TDoubleVec& featureWeightsForTraining() const;
 
-    //! The name of the object holding the best hyperaparameters in the state document.
-    static const std::string& bestHyperparametersName();
-
-    //! The name of the object holding the best regularisation hyperparameters in the
-    //! state document.
-    static const std::string& bestRegularizationHyperparametersName();
-
-    //! A list of the names of the best individual hyperparameters in the state document.
-    static TStrVec bestHyperparameterNames();
-
     //! \return The best hyperparameters.
-    const CBoostedTreeHyperparameters& bestHyperparameters() const;
+    const CBoostedTreeHyperparameters& hyperparameters() const;
 
     //! \return The classification weights vector.
     TDoubleVec classificationWeights() const;

--- a/include/maths/analytics/CBoostedTreeFactory.h
+++ b/include/maths/analytics/CBoostedTreeFactory.h
@@ -43,12 +43,11 @@ class CBoostedTreeImpl;
 //! Factory for CBoostedTree objects.
 class MATHS_ANALYTICS_EXPORT CBoostedTreeFactory final {
 public:
+    using TDoubleVec = std::vector<double>;
     using TStrDoublePrVec = std::vector<std::pair<std::string, double>>;
-    using TVector = common::CVectorNx1<double, 3>;
     using TBoostedTreeUPtr = std::unique_ptr<CBoostedTree>;
     using TTrainingStateCallback = CBoostedTree::TTrainingStateCallback;
     using TLossFunctionUPtr = CBoostedTree::TLossFunctionUPtr;
-    using TAnalysisInstrumentationPtr = CDataFrameAnalysisInstrumentationInterface*;
 
 public:
     //! \name Instrumentation Phases
@@ -78,15 +77,19 @@ public:
     CBoostedTreeFactory(CBoostedTreeFactory&&) noexcept;
     CBoostedTreeFactory& operator=(CBoostedTreeFactory&&) noexcept;
 
+    //! Set the random number generator seed.
+    CBoostedTreeFactory& seed(std::uint64_t seed);
     //! Set the objective to use when choosing the class assignments.
     CBoostedTreeFactory&
     classAssignmentObjective(CBoostedTree::EClassAssignmentObjective objective);
-    //! Set the class weights used for assigning labels to classes from the predicted probabilities.
+    //! Set the class weights used for assigning classes from predicted probabilities.
     CBoostedTreeFactory& classificationWeights(TStrDoublePrVec weights);
     //! Set the column containing the row weights to use for training.
     CBoostedTreeFactory& rowWeightColumnName(std::string columnName);
     //! Set the minimum fraction with a category value to one-hot encode.
     CBoostedTreeFactory& minimumFrequencyToOneHotEncode(double frequency);
+    //! Set the number of initial rows to use as a holdout set for evaluation.
+    CBoostedTreeFactory& numberHoldoutRows(std::size_t numberHoldoutRows);
     //! Set the number of folds to use for estimating the generalisation error.
     CBoostedTreeFactory& numberFolds(std::size_t numberFolds);
     //! Set the fraction fold data to use for training.
@@ -100,32 +103,32 @@ public:
     //! The number of rows per feature to sample in the initial downsample.
     CBoostedTreeFactory& initialDownsampleRowsPerFeature(double rowsPerFeature);
     //! The amount by which to downsample the data for stochastic gradient estimates.
-    CBoostedTreeFactory& downsampleFactor(double factor);
+    CBoostedTreeFactory& downsampleFactor(TDoubleVec factor);
     //! Set the sum of leaf depth penalties multiplier.
-    CBoostedTreeFactory& depthPenaltyMultiplier(double depthPenaltyMultiplier);
+    CBoostedTreeFactory& depthPenaltyMultiplier(TDoubleVec multiplier);
     //! Set the tree size penalty multiplier.
-    CBoostedTreeFactory& treeSizePenaltyMultiplier(double treeSizePenaltyMultiplier);
+    CBoostedTreeFactory& treeSizePenaltyMultiplier(TDoubleVec multiplier);
     //! Set the sum of weights squared multiplier.
-    CBoostedTreeFactory& leafWeightPenaltyMultiplier(double leafWeightPenaltyMultiplier);
+    CBoostedTreeFactory& leafWeightPenaltyMultiplier(TDoubleVec multiplier);
     //! Set the soft tree depth limit.
-    CBoostedTreeFactory& softTreeDepthLimit(double softTreeDepthLimit);
+    CBoostedTreeFactory& softTreeDepthLimit(TDoubleVec limit);
     //! Set the soft tree depth tolerance. This controls how hard we'll try to
     //! respect the soft tree depth limit.
-    CBoostedTreeFactory& softTreeDepthTolerance(double softTreeDepthTolerance);
+    CBoostedTreeFactory& softTreeDepthTolerance(TDoubleVec tolerance);
     //! Set the fractional relative tolerance in the target maximum tree depth.
-    CBoostedTreeFactory& maxTreeDepthTolerance(double maxTreeDepthTolerance);
-    //! Set the amount we'll shrink the weights on each each iteration.
-    CBoostedTreeFactory& eta(double eta);
+    CBoostedTreeFactory& maxTreeDepthTolerance(TDoubleVec tolerance);
+    //! Set the amount we'll shrink the tree leaf weights we compute.
+    CBoostedTreeFactory& eta(TDoubleVec eta);
     //! Set the amount we'll grow eta on each each iteration.
-    CBoostedTreeFactory& etaGrowthRatePerTree(double etaGrowthRatePerTree);
+    CBoostedTreeFactory& etaGrowthRatePerTree(TDoubleVec growthRate);
     //! Set the maximum number of trees in the ensemble.
     CBoostedTreeFactory& maximumNumberTrees(std::size_t maximumNumberTrees);
     //! Set the maximum supported size for deploying a model.
     CBoostedTreeFactory& maximumDeployedSize(std::size_t maximumDeployedSize);
     //! Set the fraction of features we'll use in the bag to build a tree.
-    CBoostedTreeFactory& featureBagFraction(double featureBagFraction);
+    CBoostedTreeFactory& featureBagFraction(TDoubleVec fraction);
     //! Set the maximum number of optimisation rounds we'll use for hyperparameter
-    //! optimisation per parameter.
+    //! optimisation per parameter for fine tuning.
     CBoostedTreeFactory& maximumOptimisationRoundsPerHyperparameter(std::size_t rounds);
     //! Set the number of restarts to use in global probing for Bayesian Optimisation.
     CBoostedTreeFactory& bayesianOptimisationRestarts(std::size_t restarts);
@@ -142,30 +145,27 @@ public:
     //! Set the callback function for training state recording.
     CBoostedTreeFactory& trainingStateCallback(TTrainingStateCallback callback);
 
-    //! Estimate the maximum booking memory that training the boosted tree on a
-    //! data frame with \p numberRows row and \p numberColumns columns will use.
+    //! Estimate the maximum booking memory that training a boosted tree on a data
+    //! frame with \p numberRows row and \p numberColumns columns will use.
     std::size_t estimateMemoryUsage(std::size_t numberRows, std::size_t numberColumns) const;
     //! Estimate the number of columns training the model will add to the data frame.
-    static std::size_t estimatedExtraColumns(std::size_t numberColumns,
-                                             std::size_t numberLossParameters);
+    static std::size_t estimateExtraColumns(std::size_t numberColumns,
+                                            std::size_t numberLossParameters);
 
-    //! Build a boosted tree object for a given data frame.
+    //! Build a boosted tree object for training on \p frame.
     TBoostedTreeUPtr buildFor(core::CDataFrame& frame, std::size_t dependentVariable);
-    //! Restore a boosted tree object for a given data frame.
+
+    //! Restore a boosted tree object for training on \p frame.
+    //!
     //! \warning A tree object can only be restored once.
     TBoostedTreeUPtr restoreFor(core::CDataFrame& frame, std::size_t dependentVariable);
 
 private:
-    using TDoubleVec = std::vector<double>;
     using TDoubleDoublePr = std::pair<double, double>;
     using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
     using TOptionalDouble = boost::optional<double>;
-    using TOptionalSize = boost::optional<std::size_t>;
-    using TOptionalVector = boost::optional<TVector>;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
     using TBoostedTreeImplUPtr = std::unique_ptr<CBoostedTreeImpl>;
-    using TApplyParameter = std::function<bool(CBoostedTreeImpl&, double)>;
-    using TAdjustTestLoss = std::function<double(double, double, double)>;
 
 private:
     CBoostedTreeFactory(std::size_t numberThreads, TLossFunctionUPtr loss);
@@ -183,7 +183,7 @@ private:
     void initializeNumberFolds(core::CDataFrame& frame) const;
 
     //! Resize the data frame with the extra columns used by train.
-    void resizeDataFrame(core::CDataFrame& frame) const;
+    void prepareDataFrameForTrain(core::CDataFrame& frame) const;
 
     //! Set up cross validation.
     void initializeCrossValidation(core::CDataFrame& frame) const;
@@ -197,48 +197,34 @@ private:
     //! Determine the encoded feature types.
     void determineFeatureDataTypes(const core::CDataFrame& frame) const;
 
-    //! Initialize the regressors sample distribution.
+    //! Initialize the feature sample distribution.
     bool initializeFeatureSampleDistribution() const;
 
-    //! Set the initial values for the various hyperparameters.
+    //! Set the initial values for hyperparameters.
     void initializeHyperparameters(core::CDataFrame& frame);
 
-    //! Setup before initializing unset hyperparameters.
+    //! Setup before setting initial values for hyperparameters.
     void initializeHyperparametersSetup(core::CDataFrame& frame);
 
-    //! Estimate a good central value for the regularisation hyperparameters
-    //! search bounding box.
+    //! Estimate a good initial value and bounding box to search for regularisation
+    //! hyperparameters.
     void initializeUnsetRegularizationHyperparameters(core::CDataFrame& frame);
 
-    //! Estimate a good central value for the feature bag fraction search interval.
+    //! Estimate a good initial value and range to search for the feature bag
+    //! fraction.
     void initializeUnsetFeatureBagFraction(core::CDataFrame& frame);
 
-    //! Estimates a good central value for the downsample factor search interval.
+    //! Estimate a good initial value and range to search for the downsample
+    //! factor.
     void initializeUnsetDownsampleFactor(core::CDataFrame& frame);
 
-    //! Estimate a good central value for learn rate.
+    //! Estimate a good initial value and range to search for the learn rate.
     void initializeUnsetEta(core::CDataFrame& frame);
 
     //! Estimate the reduction in gain from a split and the total curvature of
     //! the loss function at a split.
     TDoubleDoublePrVec estimateTreeGainAndCurvature(core::CDataFrame& frame,
                                                     const TDoubleVec& percentiles) const;
-
-    //! Perform a line search for the test loss w.r.t. a single hyperparameter.
-    //! At the end we use a smooth curve fit through all test loss values (using
-    //! LOWESS regression) and use this to get a best estimate of where the true
-    //! minimum occurs.
-    //!
-    //! \return The interval to search during the main hyperparameter optimisation
-    //! loop or null if this couldn't be found.
-    TOptionalVector testLossLineSearch(core::CDataFrame& frame,
-                                       const TApplyParameter& applyParameterStep,
-                                       double intervalLeftEnd,
-                                       double intervalRightEnd,
-                                       const TAdjustTestLoss& adjustTestLoss = noopAdjustTestLoss) const;
-
-    //! Initialize the state for hyperparameter optimisation.
-    void initializeHyperparameterOptimisation() const;
 
     //! Get the number of hyperparameter tuning rounds to use.
     std::size_t numberHyperparameterTuningRounds() const;
@@ -292,7 +278,7 @@ private:
 
 private:
     TOptionalDouble m_MinimumFrequencyToOneHotEncode;
-    TOptionalSize m_BayesianOptimisationRestarts;
+    std::size_t m_NumberHoldoutRows{0};
     bool m_StratifyRegressionCrossValidation{true};
     double m_InitialDownsampleRowsPerFeature{200.0};
     std::size_t m_MaximumNumberOfTrainRows{500000};
@@ -301,16 +287,10 @@ private:
     double m_GainPerNode90thPercentile{0.0};
     double m_TotalCurvaturePerNode1stPercentile{0.0};
     double m_TotalCurvaturePerNode90thPercentile{0.0};
-    std::size_t m_NumberThreads;
+    std::size_t m_NumberThreads{1};
     std::string m_RowWeightColumnName;
     TBoostedTreeImplUPtr m_TreeImpl;
-    TVector m_LogDownsampleFactorSearchInterval;
-    TVector m_LogFeatureBagFractionInterval;
-    TVector m_LogDepthPenaltyMultiplierSearchInterval;
-    TVector m_LogTreeSizePenaltyMultiplierSearchInterval;
-    TVector m_LogLeafWeightPenaltyMultiplierSearchInterval;
-    TVector m_SoftDepthLimitSearchInterval;
-    TVector m_LogEtaSearchInterval;
+    mutable std::size_t m_PaddedExtraColumns{0};
     TTrainingStateCallback m_RecordTrainingState{noopRecordTrainingState};
 };
 }

--- a/include/maths/analytics/CBoostedTreeHyperparameters.h
+++ b/include/maths/analytics/CBoostedTreeHyperparameters.h
@@ -12,212 +12,636 @@
 #ifndef INCLUDED_ml_maths_analytics_CBoostedTreeHyperparameters_h
 #define INCLUDED_ml_maths_analytics_CBoostedTreeHyperparameters_h
 
-#include <maths/analytics/ImportExport.h>
-
 #include <core/CPersistUtils.h>
 #include <core/CStatePersistInserter.h>
 #include <core/CStateRestoreTraverser.h>
 #include <core/RestoreMacros.h>
 
+#include <maths/analytics/CBoostedTreeUtils.h>
+#include <maths/analytics/ImportExport.h>
+
+#include <maths/common/CBasicStatistics.h>
+#include <maths/common/CBayesianOptimisation.h>
+#include <maths/common/CChecksum.h>
+#include <maths/common/CLinearAlgebraFwd.h>
+#include <maths/common/CTools.h>
+
 #include <boost/optional.hpp>
 
-#include <cmath>
+#include <cstddef>
+#include <functional>
+#include <locale>
+#include <memory>
+#include <string>
+#include <utility>
 
 namespace ml {
+namespace core {
+class CDataFrame;
+}
 namespace maths {
 namespace analytics {
-//! \brief Holds the parameters associated with the different types of regularizer
-//! terms available.
+class CBoostedTreeImpl;
+class CDataFrameTrainBoostedTreeInstrumentationInterface;
 template<typename T>
-class CBoostedTreeRegularization final {
+class CScopeBoostedTreeParameterOverrides;
+
+//! \brief Encapsulates a boosted tree parameter.
+//!
+//! DESCRIPTION:\n
+//! This provides the ability to save and load, persist and restore and fix a
+//! parameter. Fixed parameters are not optimised. This is typically as a result
+//! of a user override but we can also choose to fix a parameter if we can't
+//! determine a good search range.
+template<typename T>
+class CBoostedTreeParameter final {
 public:
-    //! Set the multiplier of the tree depth penalty.
-    CBoostedTreeRegularization& depthPenaltyMultiplier(double depthPenaltyMultiplier) {
-        m_DepthPenaltyMultiplier = depthPenaltyMultiplier;
+    using TVector = common::CVectorNx1<T, 3>;
+
+    enum ESearchType { E_LinearSearch, E_LogSearch };
+
+public:
+    explicit CBoostedTreeParameter(T value, ESearchType logSearch = E_LinearSearch)
+        : m_Value{value}, m_MinValue{value}, m_MaxValue{value}, m_LogSearch{logSearch == E_LogSearch} {
+    }
+
+    //! Get the value.
+    T value() const { return m_Scale * m_Value; }
+
+    //! Set to \p value.
+    //!
+    //! \note Has no effect if the parameter is fixed.
+    CBoostedTreeParameter& set(T value) {
+        if (m_FixedToRange) {
+            value = common::CTools::truncate(value, m_MinValue, m_MaxValue);
+        }
+        m_Value = value;
         return *this;
     }
 
-    //! Set the multiplier of the tree size penalty.
-    CBoostedTreeRegularization& treeSizePenaltyMultiplier(double treeSizePenaltyMultiplier) {
-        m_TreeSizePenaltyMultiplier = treeSizePenaltyMultiplier;
+    //! Get the multiplier which is applied when the parameter is read.
+    T scale() const { return m_Scale; }
+
+    //! Set the multiplier which is applied when the parameter is read to \p scale.
+    CBoostedTreeParameter& scale(T scale) {
+        m_Scale = scale;
         return *this;
     }
 
-    //! Set the multiplier of the square leaf weight penalty.
-    CBoostedTreeRegularization& leafWeightPenaltyMultiplier(double leafWeightPenaltyMultiplier) {
-        m_LeafWeightPenaltyMultiplier = leafWeightPenaltyMultiplier;
+    //! Convert the scale to a multiplier of the parameter.
+    //!
+    //! \warning Handle with care since this also applies the scaling to the range
+    //! limits. This is consistent with the behaviour of scaling which can move
+    //! values outside this interval.
+    CBoostedTreeParameter& captureScale() {
+        m_Value *= m_Scale;
+        m_MinValue *= m_Scale;
+        m_MaxValue *= m_Scale;
+        m_Scale = T{1};
         return *this;
     }
 
-    //! Set the soft depth tree depth limit.
-    CBoostedTreeRegularization& softTreeDepthLimit(double softTreeDepthLimit) {
-        m_SoftTreeDepthLimit = softTreeDepthLimit;
+    //! Set to the midpoint of the range or \p value if the parameters isn't
+    //! fixed to a range.
+    //!
+    //! \note Has no effect if the parameter is fixed.
+    void setToRangeMidpointOr(T value) {
+        if (this->fixed() == false) {
+            m_Value = m_FixedToRange
+                          ? this->fromSearchValue((this->toSearchValue(m_MinValue) +
+                                                   this->toSearchValue(m_MaxValue)) /
+                                                  T{2})
+                          : value;
+        }
+    }
+
+    //! Fix to \p value.
+    void fixTo(T value) {
+        m_Value = value;
+        m_MinValue = value;
+        m_MaxValue = value;
+        m_Scale = T{1};
+        m_FixedToRange = true;
+    }
+
+    //! Fix to the range [ \p minValue, \p maxValue ].
+    //!
+    //! \note Has no effect if the parameter is fixed.
+    void fixToRange(T minValue, T maxValue) {
+        m_Value = common::CTools::truncate(m_Value, minValue, maxValue);
+        m_MinValue = minValue;
+        m_MaxValue = maxValue;
+        m_Scale = T{1};
+        m_FixedToRange = true;
+    }
+
+    //! Fix to either a single value or range depending on the length of \p value.
+    void fixTo(const std::vector<T>& value) {
+        if (value.empty()) {
+            return;
+        }
+        if (value.size() == 1) {
+            this->fixTo(value[0]);
+            return;
+        }
+        if (value[0] > value[1]) {
+            this->fixToRange(value[1], value[0]);
+        }
+        this->fixToRange(value[0], value[1]);
+    }
+
+    //! Fix the current value.
+    void fix() { this->fixTo(m_Value); }
+
+    //! Check if the value is fixed.
+    bool fixed() const { return m_FixedToRange && m_MinValue == m_MaxValue; }
+
+    //! Check if the range is fixed.
+    bool rangeFixed() const { return m_FixedToRange; }
+
+    //! Check if \p value is valid for this parameter.
+    bool valid(double value) const {
+        return m_LogSearch == false || value > 0.0;
+    }
+
+    //! Get the unscaled value converted to a search value.
+    double toSearchValue() const { return this->toSearchValue(m_Value); }
+
+    //! Convert \p value to the value used by BO for fine tuning.
+    double toSearchValue(T value) const {
+        return m_LogSearch ? common::CTools::stableLog(static_cast<double>(value))
+                           : static_cast<double>(value);
+    }
+
+    //! Convert \p value from its value used by BO for fine tuning.
+    T fromSearchValue(double value) const {
+        return static_cast<T>(m_LogSearch ? common::CTools::stableExp(value) : value);
+    }
+
+    //! Get the value range.
+    std::pair<T, T> searchRange() const {
+        return {this->toSearchValue(m_MinValue), this->toSearchValue(m_MaxValue)};
+    }
+
+    //! Save the current value.
+    void save() {
+        m_SavedValue = m_Value;
+        m_SavedMinValue = m_MinValue;
+        m_SavedMaxValue = m_MaxValue;
+        m_SavedScale = m_Scale;
+    }
+
+    //! Load the saved value.
+    CBoostedTreeParameter& load() {
+        m_Value = m_SavedValue;
+        m_MinValue = m_SavedMinValue;
+        m_MaxValue = m_SavedMaxValue;
+        m_Scale = m_SavedScale;
         return *this;
     }
 
-    //! Set the tolerance in the depth tree depth limit.
-    CBoostedTreeRegularization& softTreeDepthTolerance(double softTreeDepthTolerance) {
-        m_SoftTreeDepthTolerance = softTreeDepthTolerance;
-        return *this;
-    }
-
-    //! Count the number of parameters which have their default values.
-    std::size_t countNotSet() const {
-        return (m_DepthPenaltyMultiplier == T{} ? 1 : 0) +
-               (m_TreeSizePenaltyMultiplier == T{} ? 1 : 0) +
-               (m_LeafWeightPenaltyMultiplier == T{} ? 1 : 0) +
-               (m_SoftTreeDepthLimit == T{} ? 1 : 0) +
-               (m_SoftTreeDepthTolerance == T{} ? 1 : 0);
-    }
-
-    //! Multiplier of the tree depth penalty.
-    T depthPenaltyMultiplier() const { return m_DepthPenaltyMultiplier; }
-
-    //! Multiplier of the tree size penalty.
-    T treeSizePenaltyMultiplier() const { return m_TreeSizePenaltyMultiplier; }
-
-    //! Multiplier of the square leaf weight penalty.
-    T leafWeightPenaltyMultiplier() const {
-        return m_LeafWeightPenaltyMultiplier;
-    }
-
-    //! Soft depth tree depth limit.
-    T softTreeDepthLimit() const { return m_SoftTreeDepthLimit; }
-
-    //! Soft depth tree depth limit tolerance.
-    T softTreeDepthTolerance() const { return m_SoftTreeDepthTolerance; }
-
-    //! Get the penalty which applies to a leaf at depth \p depth.
-    T penaltyForDepth(std::size_t depth) const {
-        return std::exp((static_cast<double>(depth) / m_SoftTreeDepthLimit - 1.0) /
-                        m_SoftTreeDepthTolerance);
-    }
-
-    //! Get description of the regularization parameters.
-    std::string print() const {
-        return "(depth penalty multiplier = " + toString(m_DepthPenaltyMultiplier) +
-               ", soft depth limit = " + toString(m_SoftTreeDepthLimit) +
-               ", soft depth tolerance = " + toString(m_SoftTreeDepthTolerance) +
-               ", tree size penalty multiplier = " + toString(m_TreeSizePenaltyMultiplier) +
-               ", leaf weight penalty multiplier = " +
-               toString(m_LeafWeightPenaltyMultiplier) + ")";
-    }
-
-    //! Persist by passing information to \p inserter.
+    //! Persist writing to \p inserter.
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const {
-        core::CPersistUtils::persist(REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG,
-                                     m_DepthPenaltyMultiplier, inserter);
-        core::CPersistUtils::persist(REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG,
-                                     m_TreeSizePenaltyMultiplier, inserter);
-        core::CPersistUtils::persist(REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
-                                     m_LeafWeightPenaltyMultiplier, inserter);
-        core::CPersistUtils::persist(REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG,
-                                     m_SoftTreeDepthLimit, inserter);
-        core::CPersistUtils::persist(REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG,
-                                     m_SoftTreeDepthTolerance, inserter);
+        core::CPersistUtils::persist(FIXED_TO_RANGE_TAG, m_FixedToRange, inserter);
+        core::CPersistUtils::persist(LOG_SEARCH_TAG, m_LogSearch, inserter);
+        core::CPersistUtils::persist(MAX_VALUE_TAG, m_MaxValue, inserter);
+        core::CPersistUtils::persist(MIN_VALUE_TAG, m_MinValue, inserter);
+        core::CPersistUtils::persist(SAVED_MAX_VALUE_TAG, m_SavedMaxValue, inserter);
+        core::CPersistUtils::persist(SAVED_MIN_VALUE_TAG, m_SavedMinValue, inserter);
+        core::CPersistUtils::persist(SAVED_SCALE_TAG, m_SavedScale, inserter);
+        core::CPersistUtils::persist(SAVED_VALUE_TAG, m_SavedValue, inserter);
+        core::CPersistUtils::persist(SCALE_TAG, m_Scale, inserter);
+        core::CPersistUtils::persist(VALUE_TAG, m_Value, inserter);
     }
 
-    //! Populate the object from serialized data.
+    //! Restore reading from \p traverser.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
         do {
-            const std::string& name = traverser.name();
-            RESTORE(REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG,
-                    core::CPersistUtils::restore(REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG,
-                                                 m_DepthPenaltyMultiplier, traverser))
-            RESTORE(REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG,
-                    core::CPersistUtils::restore(REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG,
-                                                 m_TreeSizePenaltyMultiplier, traverser))
-            RESTORE(REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
-                    core::CPersistUtils::restore(REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
-                                                 m_LeafWeightPenaltyMultiplier, traverser))
-            RESTORE(REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG,
-                    core::CPersistUtils::restore(REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG,
-                                                 m_SoftTreeDepthLimit, traverser))
-            RESTORE(REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG,
-                    core::CPersistUtils::restore(REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG,
-                                                 m_SoftTreeDepthTolerance, traverser))
+            const std::string& name{traverser.name()};
+            RESTORE(FIXED_TO_RANGE_TAG,
+                    core::CPersistUtils::restore(FIXED_TO_RANGE_TAG, m_FixedToRange, traverser))
+            RESTORE(LOG_SEARCH_TAG,
+                    core::CPersistUtils::restore(LOG_SEARCH_TAG, m_LogSearch, traverser))
+            RESTORE(MAX_VALUE_TAG,
+                    core::CPersistUtils::restore(MAX_VALUE_TAG, m_MaxValue, traverser))
+            RESTORE(MIN_VALUE_TAG,
+                    core::CPersistUtils::restore(MIN_VALUE_TAG, m_MinValue, traverser))
+            RESTORE(SAVED_MAX_VALUE_TAG,
+                    core::CPersistUtils::restore(SAVED_MAX_VALUE_TAG, m_SavedMaxValue, traverser))
+            RESTORE(SAVED_MIN_VALUE_TAG,
+                    core::CPersistUtils::restore(SAVED_MIN_VALUE_TAG, m_SavedMinValue, traverser))
+            RESTORE(SAVED_SCALE_TAG,
+                    core::CPersistUtils::restore(SAVED_SCALE_TAG, m_SavedScale, traverser))
+            RESTORE(SAVED_VALUE_TAG,
+                    core::CPersistUtils::restore(SAVED_VALUE_TAG, m_SavedValue, traverser))
+            RESTORE(SCALE_TAG, core::CPersistUtils::restore(SCALE_TAG, m_Scale, traverser))
+            RESTORE(VALUE_TAG, core::CPersistUtils::restore(VALUE_TAG, m_Value, traverser))
         } while (traverser.next());
         return true;
     }
 
-public:
-    static const std::string REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG;
-    static const std::string REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG;
-    static const std::string REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG;
-    static const std::string REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG;
-    static const std::string REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG;
+    //! Get a checksum of this object.
+    std::uint64_t checksum(std::uint64_t seed = 0) const {
+        seed = common::CChecksum::calculate(seed, m_FixedToRange);
+        seed = common::CChecksum::calculate(seed, m_LogSearch);
+        seed = common::CChecksum::calculate(seed, m_MaxValue);
+        seed = common::CChecksum::calculate(seed, m_MinValue);
+        seed = common::CChecksum::calculate(seed, m_SavedMaxValue);
+        seed = common::CChecksum::calculate(seed, m_SavedMinValue);
+        seed = common::CChecksum::calculate(seed, m_SavedScale);
+        seed = common::CChecksum::calculate(seed, m_SavedValue);
+        seed = common::CChecksum::calculate(seed, m_Scale);
+        return common::CChecksum::calculate(seed, m_Value);
+    }
 
-private:
-    using TOptionalDouble = boost::optional<double>;
-
-private:
-    static std::string toString(double x) { return std::to_string(x); }
-    static std::string toString(TOptionalDouble x) {
-        return x != boost::none ? toString(*x) : "null";
+    //! Print for debug.
+    std::string print() const {
+        return std::to_string(m_Value) +
+               (m_Scale != T{1} ? " scaled by " + std::to_string(m_Scale) : "") +
+               (m_FixedToRange ? " fixed to [" + std::to_string(m_MinValue) +
+                                     "," + std::to_string(m_MaxValue) + "]"
+                               : "");
     }
 
 private:
-    T m_DepthPenaltyMultiplier = T{};
-    T m_TreeSizePenaltyMultiplier = T{};
-    T m_LeafWeightPenaltyMultiplier = T{};
-    T m_SoftTreeDepthLimit = T{};
-    T m_SoftTreeDepthTolerance = T{};
+    static const std::string FIXED_TO_RANGE_TAG;
+    static const std::string LOG_SEARCH_TAG;
+    static const std::string MIN_VALUE_TAG;
+    static const std::string MAX_VALUE_TAG;
+    static const std::string SAVED_MAX_VALUE_TAG;
+    static const std::string SAVED_MIN_VALUE_TAG;
+    static const std::string SAVED_SCALE_TAG;
+    static const std::string SAVED_VALUE_TAG;
+    static const std::string SCALE_TAG;
+    static const std::string VALUE_TAG;
+
+private:
+    T m_Value{};
+    T m_MinValue{};
+    T m_MaxValue{};
+    T m_Scale{1};
+    T m_SavedValue{};
+    T m_SavedMinValue{};
+    T m_SavedMaxValue{};
+    T m_SavedScale{1};
+    bool m_FixedToRange{false};
+    bool m_LogSearch{false};
+
+    template<typename>
+    friend class CScopeBoostedTreeParameterOverrides;
 };
 
 template<typename T>
-const std::string CBoostedTreeRegularization<T>::REGULARIZATION_DEPTH_PENALTY_MULTIPLIER_TAG{
-    "regularization_depth_penalty_multiplier"};
+const std::string CBoostedTreeParameter<T>::FIXED_TO_RANGE_TAG{"fixed_to_range"};
 template<typename T>
-const std::string CBoostedTreeRegularization<T>::REGULARIZATION_TREE_SIZE_PENALTY_MULTIPLIER_TAG{
-    "regularization_tree_size_penalty_multiplier"};
+const std::string CBoostedTreeParameter<T>::LOG_SEARCH_TAG{"log_search"};
 template<typename T>
-const std::string CBoostedTreeRegularization<T>::REGULARIZATION_LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG{
-    "regularization_leaf_weight_penalty_multiplier"};
+const std::string CBoostedTreeParameter<T>::MIN_VALUE_TAG{"max_value"};
 template<typename T>
-const std::string CBoostedTreeRegularization<T>::REGULARIZATION_SOFT_TREE_DEPTH_LIMIT_TAG{
-    "regularization_soft_tree_depth_limit"};
+const std::string CBoostedTreeParameter<T>::MAX_VALUE_TAG{"min_value"};
 template<typename T>
-const std::string CBoostedTreeRegularization<T>::REGULARIZATION_SOFT_TREE_DEPTH_TOLERANCE_TAG{
-    "regularization_soft_tree_depth_tolerance"};
+const std::string CBoostedTreeParameter<T>::SAVED_MAX_VALUE_TAG{"saved_max_value"};
+template<typename T>
+const std::string CBoostedTreeParameter<T>::SAVED_MIN_VALUE_TAG{"saved_min_value"};
+template<typename T>
+const std::string CBoostedTreeParameter<T>::SAVED_SCALE_TAG{"saved_scale_tag"};
+template<typename T>
+const std::string CBoostedTreeParameter<T>::SAVED_VALUE_TAG{"saved_value"};
+template<typename T>
+const std::string CBoostedTreeParameter<T>::SCALE_TAG{"scale_tag"};
+template<typename T>
+const std::string CBoostedTreeParameter<T>::VALUE_TAG{"value"};
 
-//! \brief The algorithm parameters we'll directly optimise to improve test error.
+//! \brief Simple RAII type to force override a collection of parameter values
+//! for the object lifetime.
+template<typename T>
+class CScopeBoostedTreeParameterOverrides {
+public:
+    CScopeBoostedTreeParameterOverrides() = default;
+    ~CScopeBoostedTreeParameterOverrides() {
+        // Undo changes in reverse order to which they were applied.
+        for (std::size_t i = m_Parameters.size(); i > 0; --i) {
+            m_Parameters[i - 1]->m_Value = m_ValuesToRestore[i - 1];
+        }
+    }
+
+    CScopeBoostedTreeParameterOverrides(const CScopeBoostedTreeParameterOverrides&) = delete;
+    CScopeBoostedTreeParameterOverrides&
+    operator=(const CScopeBoostedTreeParameterOverrides&) = delete;
+
+    void apply(CBoostedTreeParameter<T>& parameter, T value) {
+        m_ValuesToRestore.push_back(parameter.value());
+        m_Parameters.push_back(&parameter);
+        parameter.m_Value = value;
+    }
+
+private:
+    using TVec = std::vector<T>;
+    using TParameterPtrVec = std::vector<CBoostedTreeParameter<T>*>;
+
+private:
+    TParameterPtrVec m_Parameters;
+    TVec m_ValuesToRestore;
+};
+
+//! \name The hyperparameters for boosted tree training.
+//!
+//! DESCRIPTION:\n
+//! This stores and manages persistence of all the boosted tree training and
+//! incremental training hyperparameters. It also provides functionality for
+//! optimizing these using a combination of random (Sobolov sequence) search
+//! and Bayesian Optimisation.
 class MATHS_ANALYTICS_EXPORT CBoostedTreeHyperparameters {
 public:
-    using TRegularization = CBoostedTreeRegularization<double>;
+    using TDoubleDoublePrVec = std::vector<std::pair<double, double>>;
+    using TStrVec = std::vector<std::string>;
+    using TDoubleParameter = CBoostedTreeParameter<double>;
+    using TSizeParameter = CBoostedTreeParameter<std::size_t>;
+    using TVector3x1 = common::CVectorNx1<double, 3>;
+    using TOptionalVector3x1 = boost::optional<TVector3x1>;
+    using TMeanAccumulator = common::CBasicStatistics::SSampleMean<double>::TAccumulator;
+    using TMeanVarAccumulator = common::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
+    using THyperparameterImportanceVec =
+        std::vector<boosted_tree_detail::SHyperparameterImportance>;
+
+    //! \brief The arguments to the initial search we perform for each parameter.
+    class MATHS_ANALYTICS_EXPORT CInitializeFineTuneArguments {
+    public:
+        using TUpdateParameter = std::function<bool(CBoostedTreeImpl&, double)>;
+        using TTruncateParameter = std::function<void(TVector3x1&)>;
+        using TAdjustTestLoss = std::function<double(double, double, double)>;
+
+    public:
+        CInitializeFineTuneArguments(core::CDataFrame& frame,
+                                     CBoostedTreeImpl& tree,
+                                     double maxValue,
+                                     double searchInterval,
+                                     TUpdateParameter updateParameter)
+            : m_UpdateParameter{std::move(updateParameter)}, m_Frame{frame}, m_Tree{tree},
+              m_MaxValue{maxValue}, m_SearchInterval{searchInterval} {}
+
+        CInitializeFineTuneArguments(const CInitializeFineTuneArguments&) = delete;
+        CInitializeFineTuneArguments& operator=(const CInitializeFineTuneArguments&) = delete;
+
+        CInitializeFineTuneArguments& adjustLoss(TAdjustTestLoss adjustLoss) {
+            m_AdjustLoss = std::move(adjustLoss);
+            return *this;
+        }
+
+        CInitializeFineTuneArguments& truncateParameter(TTruncateParameter truncateParameter) {
+            m_TruncateParameter = std::move(truncateParameter);
+            return *this;
+        }
+
+        core::CDataFrame& frame() const { return m_Frame; }
+        CBoostedTreeImpl& tree() const { return m_Tree; }
+        double maxValue() const { return m_MaxValue; }
+        double searchInterval() const { return m_SearchInterval; }
+        const TUpdateParameter& updateParameter() const {
+            return m_UpdateParameter;
+        }
+        const TAdjustTestLoss& adjustLoss() const { return m_AdjustLoss; }
+        const TTruncateParameter& truncateParameter() const {
+            return m_TruncateParameter;
+        }
+
+    private:
+        static void noopTruncateParameter(TVector3x1&) {}
+        static double noopAdjustTestLoss(double, double, double testLoss) {
+            return testLoss;
+        }
+
+    private:
+        TUpdateParameter m_UpdateParameter;
+        TTruncateParameter m_TruncateParameter{noopTruncateParameter};
+        TAdjustTestLoss m_AdjustLoss{noopAdjustTestLoss};
+        core::CDataFrame& m_Frame;
+        CBoostedTreeImpl& m_Tree;
+        double m_MaxValue;
+        double m_SearchInterval;
+    };
 
 public:
-    CBoostedTreeHyperparameters() = default;
-    CBoostedTreeHyperparameters(const TRegularization& regularization,
-                                double downsampleFactor,
-                                double eta,
-                                double etaGrowthRatePerTree,
-                                std::size_t maximumNumberTrees,
-                                double featureBagFraction);
+    static const std::string BAYESIAN_OPTIMIZATION_TAG;
+    static const std::string BEST_FOREST_TEST_LOSS_TAG;
+    static const std::string CURRENT_ROUND_TAG;
+    static const std::string DEPTH_PENALTY_MULTIPLIER_TAG;
+    static const std::string DOWNSAMPLE_FACTOR_TAG;
+    static const std::string ETA_GROWTH_RATE_PER_TREE_TAG;
+    static const std::string ETA_TAG;
+    static const std::string FEATURE_BAG_FRACTION_TAG;
+    static const std::string LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG;
+    static const std::string MAXIMUM_NUMBER_TREES_TAG;
+    static const std::string MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG;
+    static const std::string MEAN_FOREST_SIZE_ACCUMULATOR_TAG;
+    static const std::string MEAN_TEST_LOSS_ACCUMULATOR_TAG;
+    static const std::string NUMBER_FOLDS_TAG;
+    static const std::string NUMBER_ROUNDS_TAG;
+    static const std::string SOFT_TREE_DEPTH_LIMIT_TAG;
+    static const std::string SOFT_TREE_DEPTH_TOLERANCE_TAG;
+    static const std::string STOP_HYPERPARAMETER_OPTIMIZATION_EARLY_TAG;
+    static const std::string TRAIN_FRACTION_PER_FOLD_TAG;
+    static const std::string TREE_SIZE_PENALTY_MULTIPLIER_TAG;
 
-    //! Set the regularisation parameters.
-    void regularization(const TRegularization& regularization);
-    //! The regularisation parameters.
-    const TRegularization& regularization() const;
+    //! We prefer smaller models if it costs little in test accuracy.
+    static constexpr double RELATIVE_SIZE_PENALTY{0.01};
+
+public:
+    CBoostedTreeHyperparameters();
+
+    //! Set whether we should scale regularisation hyperaparameters as we adjust
+    //! the downsample factor.
+    void disableScaling(bool disabled) { m_ScalingDisabled = disabled; }
+    //! \return True if we are not to scaling regularisation hyperaparameters as
+    //! we adjust the downsample factor.
+    bool scalingDisabled() const { return m_ScalingDisabled; }
+
+    //! Get the writeable multiplier of the tree depth penalty.
+    TDoubleParameter& depthPenaltyMultiplier() {
+        return m_DepthPenaltyMultiplier;
+    }
+    //! Get the multiplier of the tree depth penalty.
+    const TDoubleParameter& depthPenaltyMultiplier() const {
+        return m_DepthPenaltyMultiplier;
+    }
+
+    //! Get the writeable multiplier of the tree size penalty.
+    TDoubleParameter& treeSizePenaltyMultiplier() {
+        return m_TreeSizePenaltyMultiplier;
+    }
+    //! Get the multiplier of the tree size penalty.
+    const TDoubleParameter& treeSizePenaltyMultiplier() const {
+        return m_TreeSizePenaltyMultiplier;
+    }
+
+    //! Get the writeable multiplier of the square leaf weight penalty.
+    TDoubleParameter& leafWeightPenaltyMultiplier() {
+        return m_LeafWeightPenaltyMultiplier;
+    }
+    //! Get the multiplier of the square leaf weight penalty.
+    const TDoubleParameter& leafWeightPenaltyMultiplier() const {
+        return m_LeafWeightPenaltyMultiplier;
+    }
+
+    //! Get the writable soft depth tree depth limit.
+    TDoubleParameter& softTreeDepthLimit() { return m_SoftTreeDepthLimit; }
+    //! Get the soft depth tree depth limit.
+    const TDoubleParameter& softTreeDepthLimit() const {
+        return m_SoftTreeDepthLimit;
+    }
+
+    //! Get the writable tolerance in the depth tree depth limit.
+    TDoubleParameter& softTreeDepthTolerance() {
+        return m_SoftTreeDepthTolerance;
+    }
+    //! Get the soft depth tree depth limit tolerance.
+    const TDoubleParameter& softTreeDepthTolerance() const {
+        return m_SoftTreeDepthTolerance;
+    }
+    //! Get the penalty which applies to a leaf at depth \p depth.
+    double penaltyForDepth(std::size_t depth) const;
+
+    //! Get the writeable data downsample factor when computing loss derivatives.
+    TDoubleParameter& downsampleFactor() { return m_DownsampleFactor; }
+    //! Get the data downsample factor when computing loss derivatives.
+    const TDoubleParameter& downsampleFactor() const {
+        return m_DownsampleFactor;
+    }
+
+    //! Get the writeable fraction of features which are selected for training a tree.
+    TDoubleParameter& featureBagFraction() { return m_FeatureBagFraction; }
+    //! Get the fraction of features which are selected for training a tree.
+    const TDoubleParameter& featureBagFraction() const {
+        return m_FeatureBagFraction;
+    }
+
+    //! Get the writeable weight shinkage.
+    TDoubleParameter& eta() { return m_Eta; }
+    //! Get the weight shinkage.
+    const TDoubleParameter& eta() const { return m_Eta; }
+
+    //! Get the writeable growth in weight shrinkage per tree which is added.
+    TDoubleParameter& etaGrowthRatePerTree() { return m_EtaGrowthRatePerTree; }
+    //! Get the growth in weight shrinkage per tree which is added.
+    const TDoubleParameter& etaGrowthRatePerTree() const {
+        return m_EtaGrowthRatePerTree;
+    }
+
     //! Set the maximum number of trees to use.
-    void maximumNumberTrees(std::size_t maximumNumberTrees);
-    //! The maximum number of trees to use.
-    std::size_t maximumNumberTrees() const;
-    //! Set the downsample factor.
-    void downsampleFactor(double downsampleFactor);
-    //! The downsample factor.
-    double downsampleFactor() const;
-    //! Set the shrinkage.
-    void eta(double eta);
-    //! Shrinkage.
-    double eta() const;
-    //! Set the rate of growth of shrinkage in the training loop.
-    void etaGrowthRatePerTree(double etaGrowthRatePerTree);
-    //! Rate of growth of shrinkage in the training loop.
-    double etaGrowthRatePerTree() const;
-    //! Set the fraction of features we use per bag.
-    void featureBagFraction(double featureBagFraction);
-    //! The fraction of features we use per bag.
-    double featureBagFraction() const;
+    TSizeParameter& maximumNumberTrees() { return m_MaximumNumberTrees; }
+    //! Get the maximum number of trees to use.
+    const TSizeParameter& maximumNumberTrees() const {
+        return m_MaximumNumberTrees;
+    }
+
+    //! \name Optimisation
+    //@{
+    //! Set the number of search rounds to use per hyperparameter which is being tuned.
+    void maximumOptimisationRoundsPerHyperparameter(std::size_t rounds);
+
+    //! Set whether to stop hyperparameter optimization early.
+    void stopHyperparameterOptimizationEarly(bool enable);
+
+    //! Set the maximum number of restarts to use internally in Bayesian Optimisation.
+    void bayesianOptimisationRestarts(std::size_t restarts);
+
+    //! Get the maximum number of iterations used in testLossLineSearch.
+    std::size_t maxLineSearchIterations() const { return 10; }
+
+    //! Get the number of hyperparameters to tune.
+    std::size_t numberToTune() const;
+
+    //! Reset search state.
+    void resetSearch();
+
+    //! Compute the fine tune search interval for \p parameter.
+    void initializeFineTuneSearchInterval(const CInitializeFineTuneArguments& args,
+                                          TDoubleParameter& parameter) const;
+
+    //! Perform a line search for the test loss w.r.t. a single hyperparameter.
+    //! At the end we use a smooth curve fit through all test loss values (using
+    //! LOWESS regression) and use this to get a best estimate of where the true
+    //! minimum occurs.
+    //!
+    //! \return A vector comprising
+    //! <pre>
+    //!   | minimum value for fine tune |
+    //!   |       initial value         |
+    //!   | maximum value for fine tune |
+    //! </pre>
+    TOptionalVector3x1 testLossLineSearch(const CInitializeFineTuneArguments& args,
+                                          double intervalLeftEnd,
+                                          double intervalRightEnd) const;
+
+    //! Initialize the search for best values of tunable hyperparameters.
+    void initializeSearch();
+
+    //! Initialize a search for the best hyperparameters.
+    void startSearch();
+
+    //! Check if the search for the best hyperparameter values has finished.
+    bool searchNotFinished() const { return m_CurrentRound < m_NumberRounds; }
+
+    //! Start a new round of hyperparameter search.
+    void startNextSearchRound() { ++m_CurrentRound; }
+
+    //! Get the current round of the search for the best hyperparameters.
+    std::size_t currentRound() const { return m_CurrentRound; }
+
+    //! Get the maximum number of rounds used to search for the best hyperparameters.
+    std::size_t numberRounds() const { return m_NumberRounds; }
+
+    //! Get the best forest test loss.
+    double bestForestTestLoss() const { return m_BestForestTestLoss; }
+
+    //! Update with the statistics for the current round.
+    void addRoundStats(const TMeanAccumulator& meanForestSizeAccumulator, double meanTestLoss);
+
+    //! Choose the next set of hyperparameters to test.
+    bool selectNext(const TMeanVarAccumulator& testLossMoments,
+                    double explainedVariance = 0.0);
+
+    //! Capture the current hyperparameters if they're the best we've seen.
+    //!
+    //! \return True if we they are the best hyperparameters.
+    bool captureBest(const TMeanVarAccumulator& testLossMoments,
+                     std::size_t numberTrees,
+                     double numberNodes);
+
+    //! Restore the hyperparameters saved by captureBest.
+    void restoreBest();
+
+    //! Capture any scaling which has been applied to the hyperparameters.
+    void captureScale();
+
+    //! The penalty to apply based on the model size.
+    double modelSizePenalty(double numberNodes) const;
+
+    //! Compute the loss at \p n standard deviations of \p lossMoments above
+    //! the mean.
+    static double lossAtNSigma(double n, const TMeanVarAccumulator& lossMoments) {
+        return common::CBasicStatistics::mean(lossMoments) +
+               n * std::sqrt(common::CBasicStatistics::variance(lossMoments));
+    }
+
+    //! Get the vector of hyperparameter importances.
+    THyperparameterImportanceVec importances() const;
+    //@}
+
+    //! Write the current hyperparameters to \p instrumentation.
+    void recordHyperparameters(CDataFrameTrainBoostedTreeInstrumentationInterface& instrumentation) const;
+
+    //! Check invariants which are assumed to hold in order to optimize hyperparameters.
+    void checkSearchInvariants() const;
+
+    //! Check the invariants which should hold after restoring.
+    void checkRestoredInvariants(bool expectOptimizerInitialized) const;
+
+    //! Estimate the memory that this object will use.
+    std::size_t estimateMemoryUsage() const;
+
+    //! Get the memory used by this object.
+    std::size_t memoryUsage() const;
 
     //! Persist by passing information to \p inserter.
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
@@ -225,32 +649,70 @@ public:
     //! Populate the object from serialized data.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
-public:
-    static const std::string HYPERPARAM_DOWNSAMPLE_FACTOR_TAG;
-    static const std::string HYPERPARAM_ETA_TAG;
-    static const std::string HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG;
-    static const std::string HYPERPARAM_FEATURE_BAG_FRACTION_TAG;
-    static const std::string HYPERPARAM_MAXIMUM_NUMBER_TREES_TAG;
-    static const std::string HYPERPARAM_REGULARIZATION_TAG;
+    //! Compute a checksum for this object.
+    std::uint64_t checksum(std::uint64_t seed = 0) const;
+
+    //! Get description of the parameters.
+    std::string print() const;
+
+    //! \name Test Only
+    //@{
+    //! A list of the names of the best individual hyperparameters in the state document.
+    static TStrVec names();
+    //@}
 
 private:
-    //! The regularisation parameters.
-    TRegularization m_Regularization;
+    using TBayesinOptimizationUPtr = std::unique_ptr<common::CBayesianOptimisation>;
+    using TDoubleVec = std::vector<double>;
+    using TDoubleVecVec = std::vector<TDoubleVec>;
+    using THyperparametersVec = std::vector<boosted_tree_detail::EHyperparameter>;
+    using TOptionalSize = boost::optional<std::size_t>;
 
-    //! The downsample factor.
-    double m_DownsampleFactor = 0.0;
+private:
+    void initializeTunableHyperparameters();
+    void initialTestLossLineSearch(const CInitializeFineTuneArguments& args,
+                                   double intervalLeftEnd,
+                                   double intervalRightEnd,
+                                   TDoubleDoublePrVec& testLosses) const;
+    void fineTineTestLoss(const CInitializeFineTuneArguments& args,
+                          double intervalLeftEnd,
+                          double intervalRightEnd,
+                          TDoubleDoublePrVec& testLosses) const;
+    TVector3x1 minimizeTestLoss(double intervalLeftEnd,
+                                double intervalRightEnd,
+                                TDoubleDoublePrVec testLosses) const;
+    void saveCurrent();
 
-    //! Shrinkage.
-    double m_Eta = 0.0;
+private:
+    //! \name Hyperparameters
+    //@{
+    TDoubleParameter m_DepthPenaltyMultiplier{0.0, TDoubleParameter::E_LogSearch};
+    TDoubleParameter m_TreeSizePenaltyMultiplier{0.0, TDoubleParameter::E_LogSearch};
+    TDoubleParameter m_LeafWeightPenaltyMultiplier{0.0, TDoubleParameter::E_LogSearch};
+    TDoubleParameter m_SoftTreeDepthLimit{0.0, TDoubleParameter::E_LinearSearch};
+    TDoubleParameter m_SoftTreeDepthTolerance{1.0, TDoubleParameter::E_LinearSearch};
+    TDoubleParameter m_DownsampleFactor{0.5, TDoubleParameter::E_LogSearch};
+    TDoubleParameter m_FeatureBagFraction{0.5, TDoubleParameter::E_LogSearch};
+    TDoubleParameter m_Eta{0.1, TDoubleParameter::E_LogSearch};
+    TDoubleParameter m_EtaGrowthRatePerTree{1.05, TDoubleParameter::E_LinearSearch};
+    TSizeParameter m_MaximumNumberTrees{20, TSizeParameter::E_LinearSearch};
+    //@}
 
-    //! Rate of growth of shrinkage in the training loop.
-    double m_EtaGrowthRatePerTree = 0.0;
-
-    //! The maximum number of trees we'll use.
-    std::size_t m_MaximumNumberTrees = 0;
-
-    //! The fraction of features we use per bag.
-    double m_FeatureBagFraction = 0.0;
+    //@ \name Hyperparameter Optimisation
+    //@{
+    bool m_StopHyperparameterOptimizationEarly{true};
+    bool m_ScalingDisabled{false};
+    std::size_t m_MaximumOptimisationRoundsPerHyperparameter{2};
+    TOptionalSize m_BayesianOptimisationRestarts;
+    THyperparametersVec m_TunableHyperparameters;
+    TDoubleVecVec m_HyperparameterSamples;
+    TBayesinOptimizationUPtr m_BayesianOptimization;
+    std::size_t m_NumberRounds{1};
+    std::size_t m_CurrentRound{0};
+    double m_BestForestTestLoss{boosted_tree_detail::INF};
+    TMeanAccumulator m_MeanForestSizeAccumulator;
+    TMeanAccumulator m_MeanTestLossAccumulator;
+    //@}
 };
 }
 }

--- a/include/maths/analytics/CBoostedTreeImpl.h
+++ b/include/maths/analytics/CBoostedTreeImpl.h
@@ -43,9 +43,6 @@
 
 namespace ml {
 namespace maths {
-namespace common {
-class CBayesianOptimisation;
-}
 namespace analytics {
 class CBoostedTreeImplForTest;
 class CTreeShapFeatureImportance;
@@ -55,26 +52,20 @@ class MATHS_ANALYTICS_EXPORT CBoostedTreeImpl final {
 public:
     using TDoubleVec = std::vector<double>;
     using TSizeVec = std::vector<std::size_t>;
-    using TStrVec = std::vector<std::string>;
     using TOptionalDouble = boost::optional<double>;
+    using TOptionalDoubleVec = std::vector<TOptionalDouble>;
+    using TOptionalDoubleVecVec = std::vector<TOptionalDoubleVec>;
     using TStrDoublePrVec = std::vector<std::pair<std::string, double>>;
     using TOptionalStrDoublePrVec = boost::optional<TStrDoublePrVec>;
     using TVector = common::CDenseVector<double>;
-    using TMeanAccumulator = common::CBasicStatistics::SSampleMean<double>::TAccumulator;
     using TMeanVarAccumulator = common::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
-    using TMeanVarAccumulatorSizeDoubleTuple =
-        std::tuple<TMeanVarAccumulator, std::size_t, double>;
     using TMeanVarAccumulatorVec = std::vector<TMeanVarAccumulator>;
-    using TBayesinOptimizationUPtr = std::unique_ptr<common::CBayesianOptimisation>;
     using TNodeVec = CBoostedTree::TNodeVec;
     using TNodeVecVec = CBoostedTree::TNodeVecVec;
     using TLossFunction = boosted_tree::CLoss;
     using TLossFunctionUPtr = CBoostedTree::TLossFunctionUPtr;
     using TTrainingStateCallback = CBoostedTree::TTrainingStateCallback;
-    using TRegularization = CBoostedTreeRegularization<double>;
     using TAnalysisInstrumentationPtr = CDataFrameTrainBoostedTreeInstrumentationInterface*;
-    using THyperparameterImportanceVec =
-        std::vector<boosted_tree_detail::SHyperparameterImportance>;
 
 public:
     static const double MINIMUM_RELATIVE_GAIN_PER_SPLIT;
@@ -98,13 +89,24 @@ public:
     //! \warning Must be called only if a trained model is available.
     void predict(core::CDataFrame& frame) const;
 
+    //! Write the predictions of the best trained model to the masked rows of \p frame.
+    //!
+    //! \warning Must be called only if a trained model is available.
+    void predict(const core::CPackedBitVector& rowMask, core::CDataFrame& frame) const;
+
+    //! Get the hyperparameters.
+    const CBoostedTreeHyperparameters& hyperparameters() const;
+
+    //! Get the writeable hyperparameters.
+    CBoostedTreeHyperparameters& hyperparameters();
+
     //! Get the SHAP value calculator.
     //!
     //! \warning Will return a nullptr if a trained model isn't available.
     CTreeShapFeatureImportance* shap();
 
-    //! Get the vector of hyperparameter importances.
-    THyperparameterImportanceVec hyperparameterImportance() const;
+    //! Get the data frame row encoder.
+    const CDataFrameCategoryEncoder& encoder() const;
 
     //! Get the model produced by training if it has been run.
     const TNodeVecVec& trainedModel() const;
@@ -125,7 +127,7 @@ public:
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;
 
-    //! Estimate the maximum booking memory that training the boosted tree on a data
+    //! Estimate the maximum booking memory that training a boosted tree on a data
     //! frame with \p numberRows row and \p numberColumns columns will use.
     std::size_t estimateMemoryUsage(std::size_t numberRows, std::size_t numberColumns) const;
 
@@ -141,51 +143,66 @@ public:
     //! Visit this tree trainer implementation.
     void accept(CBoostedTree::CVisitor& visitor);
 
-    //! \return The best hyperparameters for validation error found so far.
-    const CBoostedTreeHyperparameters& bestHyperparameters() const;
-
-    //! \return The fraction of data we use for train per fold when tuning hyperparameters.
-    double trainFractionPerFold() const;
-
     //! \return The full training set data mask, i.e. all rows which aren't missing
     //! the dependent variable.
     core::CPackedBitVector allTrainingRowsMask() const;
 
     //!\ name Test Only
     //@{
-    //! The name of the object holding the best hyperaparameters in the state document.
-    static const std::string& bestHyperparametersName();
-
-    //! The name of the object holding the best regularisation hyperparameters in the
-    //! state document.
-    static const std::string& bestRegularizationHyperparametersName();
-
-    //! A list of the names of the best individual hyperparameters in the state document.
-    static TStrVec bestHyperparameterNames();
-
     //! Get the threshold on the predicted probability of class one at which to
     //!
     //! Get the feature sample probabilities.
     const TDoubleVec& featureSampleProbabilities() const;
+
+    //! Get the fold test losses for each round.
+    const TOptionalDoubleVecVec& foldRoundTestLosses() const;
     //@}
 
 private:
     using TBoolVec = std::vector<bool>;
     using TDoubleDoublePr = std::pair<double, double>;
-    using TOptionalDoubleVec = std::vector<TOptionalDouble>;
-    using TOptionalDoubleVecVec = std::vector<TOptionalDoubleVec>;
-    using TOptionalSize = boost::optional<std::size_t>;
     using TFloatVec = std::vector<common::CFloatStorage>;
     using TFloatVecVec = std::vector<TFloatVec>;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
-    using TNodeVecVecDoubleDoubleVecTuple = std::tuple<TNodeVecVec, double, TDoubleVec>;
+    using TDoubleParameter = CBoostedTreeParameter<double>;
+    using TSizeParameter = CBoostedTreeParameter<std::size_t>;
     using TDataFrameCategoryEncoderUPtr = std::unique_ptr<CDataFrameCategoryEncoder>;
     using TDataTypeVec = CDataFrameUtils::TDataTypeVec;
-    using TRegularizationOverride = CBoostedTreeRegularization<TOptionalDouble>;
     using TTreeShapFeatureImportanceUPtr = std::unique_ptr<CTreeShapFeatureImportance>;
+    using TLeafNodeStatisticsPtr = CBoostedTreeLeafNodeStatistics::TPtr;
     using TWorkspace = CBoostedTreeLeafNodeStatistics::CWorkspace;
-    using THyperparametersVec = std::vector<boosted_tree_detail::EHyperparameters>;
-    using TDoubleVecVec = std::vector<TDoubleVec>;
+    using TArgMinLossVec = std::vector<boosted_tree::CArgMinLoss>;
+    using TArgMinLossVecVec = std::vector<TArgMinLossVec>;
+    using TRowRef = boosted_tree_detail::TRowRef;
+    using TMemoryMappedFloatVector = boosted_tree_detail::TMemoryMappedFloatVector;
+    // clang-format off
+    using TMakeRootLeafNodeStatistics =
+        std::function<TLeafNodeStatisticsPtr (const TFloatVecVec&,
+                                              const TSizeVec&,
+                                              const TSizeVec&,
+                                              const core::CPackedBitVector&,
+                                              TWorkspace&)>;
+    using TUpdateRowPrediction =
+        std::function<void (const TRowRef&, TMemoryMappedFloatVector&)>;
+    // clang-format on
+
+    //! \brief The result of cross-validation.
+    struct SCrossValidationResult {
+        TNodeVecVec s_Forest;
+        TMeanVarAccumulator s_TestLossMoments;
+        std::size_t s_NumberTrees{0};
+        double s_NumberNodes{0.0};
+    };
+
+    //! \brief The result of training a single forest.
+    struct STrainForestResult {
+        std::tuple<TNodeVecVec, double, TDoubleVec> asTuple() {
+            return {std::move(s_Forest), s_TestLoss, std::move(s_TestLosses)};
+        }
+        TNodeVecVec s_Forest;
+        double s_TestLoss{0.0};
+        TDoubleVec s_TestLosses;
+    };
 
     //! Tag progress through initialization.
     enum EInitializationStage {
@@ -211,8 +228,8 @@ private:
 
     //! Compute the \p percentile percentile gain per split and the sum of row
     //! curvatures per internal node of \p forest.
-    TDoubleDoublePr gainAndCurvatureAtPercentile(double percentile,
-                                                 const TNodeVecVec& forest) const;
+    static TDoubleDoublePr gainAndCurvatureAtPercentile(double percentile,
+                                                        const TNodeVecVec& forest);
 
     //! Presize the collection to hold the per fold test errors.
     void initializePerFoldTestLosses();
@@ -224,7 +241,10 @@ private:
     void initializeTreeShap(const core::CDataFrame& frame);
 
     //! Train the forest and compute loss moments on each fold.
-    TMeanVarAccumulatorSizeDoubleTuple crossValidateForest(core::CDataFrame& frame);
+    template<typename F>
+    SCrossValidationResult crossValidateForest(core::CDataFrame& frame,
+                                               std::size_t maximumNumberTrees,
+                                               const F& trainForest);
 
     //! Initialize the predictions and loss function derivatives for the masked
     //! rows in \p frame.
@@ -233,11 +253,10 @@ private:
                                                      const core::CPackedBitVector& testingRowMask) const;
 
     //! Train one forest on the rows of \p frame in the mask \p trainingRowMask.
-    TNodeVecVecDoubleDoubleVecTuple
-    trainForest(core::CDataFrame& frame,
-                const core::CPackedBitVector& trainingRowMask,
-                const core::CPackedBitVector& testingRowMask,
-                core::CLoopProgress& trainingProgress) const;
+    STrainForestResult trainForest(core::CDataFrame& frame,
+                                   const core::CPackedBitVector& trainingRowMask,
+                                   const core::CPackedBitVector& testingRowMask,
+                                   core::CLoopProgress& trainingProgress) const;
 
     //! Randomly downsamples the training row mask by the downsample factor.
     core::CPackedBitVector downsample(const core::CPackedBitVector& trainingRowMask) const;
@@ -260,15 +279,20 @@ private:
     TNodeVec trainTree(core::CDataFrame& frame,
                        const core::CPackedBitVector& trainingRowMask,
                        const TFloatVecVec& candidateSplits,
-                       const std::size_t maximumTreeSize,
+                       std::size_t maximumNumberInternalNodes,
+                       const TMakeRootLeafNodeStatistics& makeRootLeafNodeStatistics,
                        TWorkspace& workspace) const;
+
+    //! Scale the multipliers of the regularisation terms in the loss function to
+    //! account for differences in training data set sizes.
+    void scaleRegularizationMultipliers(double scale);
 
     //! Compute the minimum mean test loss per fold for any round.
     double minimumTestLoss() const;
 
     //! Estimate the loss we'll get including the missing folds.
     TMeanVarAccumulator correctTestLossMoments(const TSizeVec& missing,
-                                               TMeanVarAccumulator lossMoments) const;
+                                               TMeanVarAccumulator testLossMoments) const;
 
     //! Estimate test losses for the \p missing folds.
     TMeanVarAccumulatorVec estimateMissingTestLosses(const TSizeVec& missing) const;
@@ -291,16 +315,31 @@ private:
                         TSizeVec& nodeFeatureBag) const;
 
     //! Get a column mask of the suitable regressor features.
-    void candidateRegressorFeatures(const TDoubleVec& probabilities, TSizeVec& features) const;
+    static void candidateRegressorFeatures(const TDoubleVec& probabilities, TSizeVec& features);
 
-    //! Refresh the predictions and loss function derivatives for the masked
-    //! rows in \p frame with predictions of \p tree.
+    //! Compute the leaf values to use for \p tree.
+    void computeLeafValues(core::CDataFrame& frame,
+                           const core::CPackedBitVector& trainingRowMask,
+                           const TLossFunction& loss,
+                           double eta,
+                           double lambda,
+                           TNodeVec& tree) const;
+
+    //! Extract the leaf values for \p tree which minimize \p loss on \p rowMask
+    //! rows of \p frame.
+    void minimumLossLeafValues(const core::CDataFrame& frame,
+                               const core::CPackedBitVector& rowMask,
+                               const TLossFunction& loss,
+                               const TSizeVec& leafMap,
+                               const TNodeVec& tree,
+                               TArgMinLossVecVec& result) const;
+
+    //! Update the predictions and the \p loss gradient and curvature for the
+    //! \p rowMask rows of \p frame for all data.
     void refreshPredictionsAndLossDerivatives(core::CDataFrame& frame,
-                                              const core::CPackedBitVector& trainingRowMask,
-                                              const core::CPackedBitVector& testingRowMask,
-                                              double eta,
-                                              double lambda,
-                                              TNodeVec& tree) const;
+                                              const core::CPackedBitVector& rowMask,
+                                              const TLossFunction& loss,
+                                              const TUpdateRowPrediction& updateRowPrediction) const;
 
     //! Compute the mean of the loss function on the masked rows of \p frame.
     double meanLoss(const core::CDataFrame& frame, const core::CPackedBitVector& rowMask) const;
@@ -308,29 +347,8 @@ private:
     //! Compute the overall variance of the error we see between folds.
     double betweenFoldTestLossVariance() const;
 
-    //! Get the root node of \p tree.
-    static const CBoostedTreeNode& root(const TNodeVec& tree);
-
-    //! Get the root node of \p tree.
-    static CBoostedTreeNode& root(TNodeVec& tree);
-
-    //! Get the forest's prediction for \p row.
-    TVector predictRow(const CEncodedDataFrameRowRef& row, const TNodeVecVec& forest) const;
-
-    //! Select the next hyperparameters for which to train a model.
-    bool selectNextHyperparameters(const TMeanVarAccumulator& lossMoments,
-                                   common::CBayesianOptimisation& bopt);
-
-    //! Capture the current hyperparameter values.
-    void captureBestHyperparameters(const TMeanVarAccumulator& lossMoments,
-                                    std::size_t maximumNumberTrees,
-                                    double numberNodes);
-
-    //! Set the hyperparamaters from the best recorded.
-    void restoreBestHyperparameters();
-
-    //! Scale the regulariser multipliers by \p scale.
-    void scaleRegularizers(double scale);
+    //! Get the best forest's prediction for \p row.
+    TVector predictRow(const CEncodedDataFrameRowRef& row) const;
 
     //! Check invariants which are assumed to hold after restoring.
     void checkRestoredInvariants() const;
@@ -338,20 +356,17 @@ private:
     //! Check invariants which are assumed to hold in order to train on \p frame.
     void checkTrainInvariants(const core::CDataFrame& frame) const;
 
-    //! Get the number of hyperparameters to tune.
-    std::size_t numberHyperparametersToTune() const;
+    //! Get the maximum number of nodes to use in a tree.
+    //!
+    //! \note This number will only be used if the regularised loss says its
+    //! a good idea.
+    static std::size_t maximumTreeSize(const core::CPackedBitVector& trainingRowMask);
 
     //! Get the maximum number of nodes to use in a tree.
     //!
     //! \note This number will only be used if the regularised loss says its
     //! a good idea.
-    std::size_t maximumTreeSize(const core::CPackedBitVector& trainingRowMask) const;
-
-    //! Get the maximum number of nodes to use in a tree.
-    //!
-    //! \note This number will only be used if the regularised loss says its
-    //! a good idea.
-    std::size_t maximumTreeSize(std::size_t numberRows) const;
+    static std::size_t maximumTreeSize(std::size_t numberRows);
 
     //! Get the maximum memory of any trained model we will produce.
     //!
@@ -374,72 +389,69 @@ private:
     //! Record hyperparameters for instrumentation.
     void recordHyperparameters();
 
-    //! Populate the list of tunable hyperparameters.
-    void initializeTunableHyperparameters();
-
-    //! Use Sobol sampler for for random hyperparamers.
-    void initializeHyperparameterSamples();
-
 private:
+    //! \name Parameters
+    //@{
+    std::uint64_t m_Seed{0};
     mutable common::CPRNG::CXorOShiro128Plus m_Rng;
-    EInitializationStage m_InitializationStage = E_NotInitialized;
-    std::size_t m_NumberThreads;
-    std::size_t m_DependentVariable = std::numeric_limits<std::size_t>::max();
-    std::size_t m_PaddedExtraColumns = 0;
+    std::size_t m_NumberThreads{1};
+    std::size_t m_DependentVariable{std::numeric_limits<std::size_t>::max()};
+    std::size_t m_MaximumDeployedSize{std::numeric_limits<std::size_t>::max()};
     TSizeVec m_ExtraColumns;
     TLossFunctionUPtr m_Loss;
-    CBoostedTree::EClassAssignmentObjective m_ClassAssignmentObjective =
-        CBoostedTree::E_MinimumRecall;
-    bool m_StopCrossValidationEarly = true;
-    TRegularizationOverride m_RegularizationOverride;
-    TOptionalDouble m_DownsampleFactorOverride;
-    TOptionalDouble m_EtaOverride;
-    TOptionalDouble m_EtaGrowthRatePerTreeOverride;
-    TOptionalSize m_NumberFoldsOverride;
-    TOptionalDouble m_TrainFractionPerFoldOverride;
-    TOptionalSize m_MaximumNumberTreesOverride;
-    TOptionalDouble m_FeatureBagFractionOverride;
-    TOptionalStrDoublePrVec m_ClassificationWeightsOverride;
-    TRegularization m_Regularization;
-    TVector m_ClassificationWeights;
-    double m_DownsampleFactor = 0.5;
-    double m_Eta = 0.1;
-    double m_EtaGrowthRatePerTree = 1.05;
-    std::size_t m_NumberFolds = 4;
-    double m_TrainFractionPerFold = 0.75;
-    std::size_t m_MaximumNumberTrees = 20;
-    std::size_t m_MaximumAttemptsToAddTree = 3;
-    std::size_t m_MaximumDeployedSize = std::numeric_limits<std::size_t>::max();
-    std::size_t m_NumberSplitsPerFeature = 75;
-    std::size_t m_MaximumOptimisationRoundsPerHyperparameter = 2;
-    std::size_t m_RowsPerFeature = 50;
-    double m_FeatureBagFraction = 0.5;
+    EInitializationStage m_InitializationStage{E_NotInitialized};
+    std::size_t m_MaximumAttemptsToAddTree{3};
+    CBoostedTreeHyperparameters m_Hyperparameters;
+    //@}
+
+    //! \name Cross-validation
+    //@{
+    TSizeParameter m_NumberFolds{4};
+    TDoubleParameter m_TrainFractionPerFold{0.75};
+    bool m_StopCrossValidationEarly{true};
+    TOptionalDoubleVecVec m_FoldRoundTestLosses;
+    //@}
+
+    //! \name Features
+    //@{
+    std::size_t m_NumberSplitsPerFeature{75};
+    std::size_t m_RowsPerFeature{50};
     TDataFrameCategoryEncoderUPtr m_Encoder;
     TDataTypeVec m_FeatureDataTypes;
     TDoubleVec m_FeatureSampleProbabilities;
     TFloatVecVec m_FixedCandidateSplits;
+    //@}
+
+    //! \name Training Data
+    //@{
     TPackedBitVectorVec m_MissingFeatureRowMasks;
     TPackedBitVectorVec m_TrainingRowMasks;
     TPackedBitVectorVec m_TestingRowMasks;
-    double m_BestForestTestLoss = boosted_tree_detail::INF;
-    TOptionalDoubleVecVec m_FoldRoundTestLosses;
-    CBoostedTreeHyperparameters m_BestHyperparameters;
+    //@}
+
+    //! \name Model
+    //@{
     TNodeVecVec m_BestForest;
-    TBayesinOptimizationUPtr m_BayesianOptimization;
-    std::size_t m_NumberRounds = 1;
-    std::size_t m_CurrentRound = 0;
-    core::CLoopProgress m_TrainingProgress;
-    std::size_t m_NumberTopShapValues = 0;
+    CBoostedTree::EClassAssignmentObjective m_ClassAssignmentObjective{CBoostedTree::E_MinimumRecall};
+    TOptionalStrDoublePrVec m_ClassificationWeightsOverride;
+    TVector m_ClassificationWeights;
+    //@}
+
+    //! \name Feature Importance
+    //@{
+    std::size_t m_NumberTopShapValues{0};
     TTreeShapFeatureImportanceUPtr m_TreeShap;
+    //@}
+
+    //! \name Monitoring
+    //@{
     TAnalysisInstrumentationPtr m_Instrumentation;
-    TMeanAccumulator m_MeanForestSizeAccumulator;
-    TMeanAccumulator m_MeanLossAccumulator;
-    THyperparametersVec m_TunableHyperparameters;
-    TDoubleVecVec m_HyperparameterSamples;
-    bool m_StopHyperparameterOptimizationEarly = true;
+    core::CLoopProgress m_TrainingProgress;
+    //@}
 
 private:
     friend class CBoostedTreeFactory;
+    friend class CBoostedTreeHyperparameters;
     friend class CBoostedTreeImplForTest;
 };
 }

--- a/include/maths/analytics/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/analytics/CBoostedTreeLeafNodeStatistics.h
@@ -91,7 +91,7 @@ public:
     using TSizeDoublePr = std::pair<std::size_t, double>;
     using TFloatVec = std::vector<common::CFloatStorage>;
     using TFloatVecVec = std::vector<TFloatVec>;
-    using TRegularization = CBoostedTreeRegularization<double>;
+    using TRegularization = CBoostedTreeHyperparameters;
     using TPtr = std::shared_ptr<CBoostedTreeLeafNodeStatistics>;
     using TPtrPtrPr = std::pair<TPtr, TPtr>;
     using TMemoryMappedFloatVector =

--- a/include/maths/analytics/CBoostedTreeUtils.h
+++ b/include/maths/analytics/CBoostedTreeUtils.h
@@ -28,6 +28,7 @@ namespace analytics {
 namespace boosted_tree {
 class CLoss;
 }
+class CBoostedTreeNode;
 namespace boosted_tree_detail {
 using TFloatVec = std::vector<common::CFloatStorage>;
 using TSizeVec = std::vector<std::size_t>;
@@ -45,7 +46,7 @@ enum EExtraColumn {
     E_BeginSplits
 };
 
-enum EHyperparameters {
+enum EHyperparameter {
     E_DownsampleFactor = 0,
     E_Alpha,
     E_Lambda,
@@ -58,20 +59,33 @@ enum EHyperparameters {
     E_FeatureBagFraction
 };
 
-constexpr std::size_t NUMBER_EXTRA_COLUMNS = E_BeginSplits + 1; // This must be last extra column
-constexpr std::size_t NUMBER_HYPERPARAMETERS = E_FeatureBagFraction + 1; // This must be last hyperparameter
-constexpr std::size_t UNIT_ROW_WEIGHT_COLUMN = std::numeric_limits<std::size_t>::max();
+constexpr std::size_t NUMBER_EXTRA_COLUMNS{E_BeginSplits + 1}; // This must be last extra column
+constexpr std::size_t NUMBER_HYPERPARAMETERS{E_FeatureBagFraction + 1}; // This must be last hyperparameter
+constexpr std::size_t UNIT_ROW_WEIGHT_COLUMN{std::numeric_limits<std::size_t>::max()};
 
-//! \brief Information related to hyperparameter importance.
-struct SHyperparameterImportance {
+//! \brief Hyperparameter importance information.
+struct MATHS_ANALYTICS_EXPORT SHyperparameterImportance {
     enum EType { E_Double = 0, E_Uint64 };
-    EHyperparameters s_Hyperparameter;
+    EHyperparameter s_Hyperparameter;
     double s_Value;
     double s_AbsoluteImportance;
     double s_RelativeImportance;
     bool s_Supplied;
     EType s_Type;
 };
+
+//! Get the index of the root node in a canonical tree node vector.
+inline std::size_t rootIndex() {
+    return 0;
+}
+
+//! Get the root node of \p tree.
+MATHS_ANALYTICS_EXPORT
+const CBoostedTreeNode& root(const std::vector<CBoostedTreeNode>& tree);
+
+//! Get the root node of \p tree.
+MATHS_ANALYTICS_EXPORT
+CBoostedTreeNode& root(std::vector<CBoostedTreeNode>& tree);
 
 //! Get the split used for storing missing values.
 inline std::size_t missingSplit(const TFloatVec& candidateSplits) {
@@ -83,8 +97,13 @@ inline std::size_t lossHessianUpperTriangleSize(std::size_t numberLossParameters
     return numberLossParameters * (numberLossParameters + 1) / 2;
 }
 
+//! Get the tags for extra columns needed by training.
+inline TSizeVec extraColumnTagsForTrain() {
+    return {E_Prediction, E_Gradient, E_Curvature, E_Weight};
+}
+
 //! Get the extra columns needed by training.
-inline TSizeAlignmentPrVec extraColumns(std::size_t numberLossParameters) {
+inline TSizeAlignmentPrVec extraColumnsForTrain(std::size_t numberLossParameters) {
     return {{numberLossParameters, core::CAlignment::E_Unaligned}, // prediction
             {numberLossParameters, core::CAlignment::E_Aligned16}, // gradient
             {numberLossParameters * numberLossParameters, core::CAlignment::E_Unaligned}}; // curvature
@@ -138,7 +157,7 @@ void zeroLossCurvature(const TRowRef& row, const TSizeVec& extraColumns, std::si
 MATHS_ANALYTICS_EXPORT
 void writeLossCurvature(const TRowRef& row,
                         const TSizeVec& extraColumns,
-                        const boosted_tree::CLoss& curvature,
+                        const boosted_tree::CLoss& loss,
                         const TMemoryMappedFloatVector& prediction,
                         double actual,
                         double weight = 1.0);

--- a/include/maths/analytics/CDataFrameAnalysisInstrumentationInterface.h
+++ b/include/maths/analytics/CDataFrameAnalysisInstrumentationInterface.h
@@ -97,28 +97,15 @@ class MATHS_ANALYTICS_EXPORT CDataFrameTrainBoostedTreeInstrumentationInterface
     : virtual public CDataFrameAnalysisInstrumentationInterface {
 public:
     enum EStatsType { E_Regression, E_Classification };
-    struct SRegularization {
-        SRegularization() = default;
-        SRegularization(double depthPenaltyMultiplier,
-                        double softTreeDepthLimit,
-                        double softTreeDepthTolerance,
-                        double treeSizePenaltyMultiplier,
-                        double leafWeightPenaltyMultiplier)
-            : s_DepthPenaltyMultiplier{depthPenaltyMultiplier},
-              s_SoftTreeDepthLimit{softTreeDepthLimit}, s_SoftTreeDepthTolerance{softTreeDepthTolerance},
-              s_TreeSizePenaltyMultiplier{treeSizePenaltyMultiplier},
-              s_LeafWeightPenaltyMultiplier{leafWeightPenaltyMultiplier} {}
+    struct SHyperparameters {
+        double s_Eta{-1.0};
+        CBoostedTree::EClassAssignmentObjective s_ClassAssignmentObjective{
+            CBoostedTree::E_MinimumRecall};
         double s_DepthPenaltyMultiplier{-1.0};
         double s_SoftTreeDepthLimit{-1.0};
         double s_SoftTreeDepthTolerance{-1.0};
         double s_TreeSizePenaltyMultiplier{-1.0};
         double s_LeafWeightPenaltyMultiplier{-1.0};
-    };
-    struct SHyperparameters {
-        double s_Eta{-1.0};
-        CBoostedTree::EClassAssignmentObjective s_ClassAssignmentObjective =
-            CBoostedTree::E_MinimumRecall;
-        SRegularization s_Regularization;
         double s_DownsampleFactor{-1.0};
         std::size_t s_NumFolds{0};
         std::size_t s_MaxTrees{0};
@@ -183,4 +170,4 @@ private:
 }
 }
 
-#endif //INCLUDED_ml_maths_analytics_CDataFrameAnalysisInstrumentationInterface_h
+#endif // INCLUDED_ml_maths_analytics_CDataFrameAnalysisInstrumentationInterface_h

--- a/include/maths/analytics/CDataFramePredictiveModel.h
+++ b/include/maths/analytics/CDataFramePredictiveModel.h
@@ -70,9 +70,6 @@ public:
     //! Get the number of rows used to train the model.
     virtual std::size_t numberTrainingRows() const = 0;
 
-    //! Get the fraction of data per fold used for training when tuning hyperparameters.
-    virtual double trainFractionPerFold() const = 0;
-
     //! Get the column containing the dependent variable.
     virtual std::size_t columnHoldingDependentVariable() const = 0;
 

--- a/include/maths/common/CBayesianOptimisation.h
+++ b/include/maths/common/CBayesianOptimisation.h
@@ -74,8 +74,9 @@ public:
     static const double NEGLIGIBLE_EXPECTED_IMPROVEMENT;
 
 public:
-    CBayesianOptimisation(TDoubleDoublePrVec parameterBounds, std::size_t restarts = RESTARTS);
-    CBayesianOptimisation(core::CStateRestoreTraverser& traverser);
+    explicit CBayesianOptimisation(TDoubleDoublePrVec parameterBounds,
+                                   std::size_t restarts = RESTARTS);
+    explicit CBayesianOptimisation(core::CStateRestoreTraverser& traverser);
 
     //! Add the result of evaluating the function to be \p fx at \p x where the
     //! variance in the error in \p fx w.r.t. the true value is \p vx.
@@ -92,15 +93,6 @@ public:
     //! function evaluations added so far.
     std::pair<TVector, TOptionalDouble>
     maximumExpectedImprovement(double negligibleExpectedImprovement = NEGLIGIBLE_EXPECTED_IMPROVEMENT);
-
-    //! Persist by passing information to \p inserter.
-    void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
-
-    //! Populate the object from serialized data
-    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
-
-    //! Get the memory used by this object.
-    std::size_t memoryUsage() const;
 
     //! Estimate the maximum booking memory used by this class for optimising
     //! \p numberParameters using \p numberRounds rounds.
@@ -135,6 +127,18 @@ public:
 
     //! Set kernel \p parameters explicitly.
     void kernelParameters(const TVector& parameters);
+
+    //! Get the memory used by this object.
+    std::size_t memoryUsage() const;
+
+    //! Persist by passing information to \p inserter.
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
+
+    //! Populate the object from serialized data
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
+
+    //! Compute a checksum for this object.
+    std::uint64_t checksum(std::uint64_t seed) const;
 
     //! \name Test Interface
     //@{

--- a/include/test/CDataFrameAnalyzerTrainingFactory.h
+++ b/include/test/CDataFrameAnalyzerTrainingFactory.h
@@ -156,28 +156,28 @@ public:
         maths::analytics::CBoostedTreeFactory treeFactory{
             maths::analytics::CBoostedTreeFactory::constructFromParameters(1, std::move(loss))};
         if (alpha >= 0.0) {
-            treeFactory.depthPenaltyMultiplier(alpha);
+            treeFactory.depthPenaltyMultiplier({alpha});
         }
         if (lambda >= 0.0) {
-            treeFactory.leafWeightPenaltyMultiplier(lambda);
+            treeFactory.leafWeightPenaltyMultiplier({lambda});
         }
         if (gamma >= 0.0) {
-            treeFactory.treeSizePenaltyMultiplier(gamma);
+            treeFactory.treeSizePenaltyMultiplier({gamma});
         }
         if (softTreeDepthLimit >= 0.0) {
-            treeFactory.softTreeDepthLimit(softTreeDepthLimit);
+            treeFactory.softTreeDepthLimit({softTreeDepthLimit});
         }
         if (softTreeDepthTolerance >= 0.0) {
-            treeFactory.softTreeDepthTolerance(softTreeDepthTolerance);
+            treeFactory.softTreeDepthTolerance({softTreeDepthTolerance});
         }
         if (eta > 0.0) {
-            treeFactory.eta(eta);
+            treeFactory.eta({eta});
         }
         if (maximumNumberTrees > 0) {
             treeFactory.maximumNumberTrees(maximumNumberTrees);
         }
         if (featureBagFraction > 0.0) {
-            treeFactory.featureBagFraction(featureBagFraction);
+            treeFactory.featureBagFraction({featureBagFraction});
         }
 
         ml::api::CDataFrameTrainBoostedTreeInstrumentation instrumentation(

--- a/lib/api/CDataFrameAnalysisInstrumentation.cc
+++ b/lib/api/CDataFrameAnalysisInstrumentation.cc
@@ -464,7 +464,6 @@ void CDataFrameTrainBoostedTreeInstrumentation::writeHyperparameters(rapidjson::
     auto* writer = this->writer();
 
     if (writer != nullptr) {
-
         writer->addMember(CDataFrameTrainBoostedTreeRunner::ETA,
                           rapidjson::Value(this->m_Hyperparameters.s_Eta).Move(),
                           parentObject);
@@ -477,29 +476,24 @@ void CDataFrameTrainBoostedTreeInstrumentation::writeHyperparameters(rapidjson::
         }
         writer->addMember(
             CDataFrameTrainBoostedTreeRunner::ALPHA,
-            rapidjson::Value(this->m_Hyperparameters.s_Regularization.s_DepthPenaltyMultiplier)
-                .Move(),
+            rapidjson::Value(this->m_Hyperparameters.s_DepthPenaltyMultiplier).Move(),
             parentObject);
         writer->addMember(
             CDataFrameTrainBoostedTreeRunner::SOFT_TREE_DEPTH_LIMIT,
-            rapidjson::Value(this->m_Hyperparameters.s_Regularization.s_SoftTreeDepthLimit)
-                .Move(),
+            rapidjson::Value(this->m_Hyperparameters.s_SoftTreeDepthLimit).Move(),
             parentObject);
         writer->addMember(
             CDataFrameTrainBoostedTreeRunner::SOFT_TREE_DEPTH_TOLERANCE,
-            rapidjson::Value(this->m_Hyperparameters.s_Regularization.s_SoftTreeDepthTolerance)
-                .Move(),
+            rapidjson::Value(this->m_Hyperparameters.s_SoftTreeDepthTolerance).Move(),
             parentObject);
-        writer->addMember(
-            CDataFrameTrainBoostedTreeRunner::GAMMA,
-            rapidjson::Value(this->m_Hyperparameters.s_Regularization.s_TreeSizePenaltyMultiplier)
-                .Move(),
-            parentObject);
-        writer->addMember(
-            CDataFrameTrainBoostedTreeRunner::LAMBDA,
-            rapidjson::Value(this->m_Hyperparameters.s_Regularization.s_LeafWeightPenaltyMultiplier)
-                .Move(),
-            parentObject);
+        writer->addMember(CDataFrameTrainBoostedTreeRunner::GAMMA,
+                          rapidjson::Value(this->m_Hyperparameters.s_TreeSizePenaltyMultiplier)
+                              .Move(),
+                          parentObject);
+        writer->addMember(CDataFrameTrainBoostedTreeRunner::LAMBDA,
+                          rapidjson::Value(this->m_Hyperparameters.s_LeafWeightPenaltyMultiplier)
+                              .Move(),
+                          parentObject);
         writer->addMember(
             CDataFrameTrainBoostedTreeRunner::DOWNSAMPLE_FACTOR,
             rapidjson::Value(this->m_Hyperparameters.s_DownsampleFactor).Move(),
@@ -539,6 +533,7 @@ void CDataFrameTrainBoostedTreeInstrumentation::writeHyperparameters(rapidjson::
             parentObject);
     }
 }
+
 void CDataFrameTrainBoostedTreeInstrumentation::writeValidationLoss(rapidjson::Value& parentObject) {
     auto* writer = this->writer();
     if (writer != nullptr) {

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -335,7 +335,6 @@ CDataFrameTrainBoostedTreeClassifierRunner::inferenceModelMetadata() const {
     m_InferenceModelMetadata.hyperparameterImportance(
         this->boostedTree().hyperparameterImportance());
     m_InferenceModelMetadata.numberTrainingRows(this->boostedTree().numberTrainingRows());
-    m_InferenceModelMetadata.trainFractionPerFold(this->boostedTree().trainFractionPerFold());
     return m_InferenceModelMetadata;
 }
 

--- a/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRegressionRunner.cc
@@ -169,7 +169,6 @@ CDataFrameTrainBoostedTreeRegressionRunner::inferenceModelMetadata() const {
     }
     m_InferenceModelMetadata.hyperparameterImportance(
         this->boostedTree().hyperparameterImportance());
-    m_InferenceModelMetadata.trainFractionPerFold(this->boostedTree().trainFractionPerFold());
     return m_InferenceModelMetadata;
 }
 

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -100,6 +100,8 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     : CDataFrameAnalysisRunner{spec}, m_NumberLossParameters{loss->numberParameters()},
       m_Instrumentation{spec.jobId(), spec.memoryLimit()} {
 
+    using TDoubleVec = std::vector<double>;
+
     m_DependentVariableFieldName = parameters[DEPENDENT_VARIABLE_NAME].as<std::string>();
     m_PredictionFieldName = parameters[PREDICTION_FIELD_NAME].fallback(
         m_DependentVariableFieldName + "_prediction");
@@ -110,6 +112,8 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     std::string rowWeightColumnName{parameters[ROW_WEIGHT_COLUMN].fallback(std::string{})};
     std::size_t numberFolds{parameters[NUM_FOLDS].fallback(std::size_t{0})};
     double trainFractionPerFold{parameters[TRAIN_FRACTION_PER_FOLD].fallback(-1.0)};
+    std::size_t downsampleRowsPerFeature{
+        parameters[DOWNSAMPLE_ROWS_PER_FEATURE].fallback(std::size_t{0})};
     std::size_t numberRoundsPerHyperparameter{
         parameters[MAX_OPTIMIZATION_ROUNDS_PER_HYPERPARAMETER].fallback(
             NUMBER_ROUNDS_PER_HYPERPARAMETER_IS_UNSET)};
@@ -121,48 +125,54 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     std::size_t maximumDeployedSize{parameters[MAX_DEPLOYED_MODEL_SIZE].fallback(
         core::constants::BYTES_IN_GIGABYTES)};
 
-    std::size_t downsampleRowsPerFeature{
-        parameters[DOWNSAMPLE_ROWS_PER_FEATURE].fallback(std::size_t{0})};
-    double downsampleFactor{parameters[DOWNSAMPLE_FACTOR].fallback(-1.0)};
     std::size_t maxTrees{parameters[MAX_TREES].fallback(std::size_t{0})};
-    double alpha{parameters[ALPHA].fallback(-1.0)};
-    double lambda{parameters[LAMBDA].fallback(-1.0)};
-    double gamma{parameters[GAMMA].fallback(-1.0)};
-    double eta{parameters[ETA].fallback(-1.0)};
-    double etaGrowthRatePerTree{parameters[ETA_GROWTH_RATE_PER_TREE].fallback(-1.0)};
-    double softTreeDepthLimit{parameters[SOFT_TREE_DEPTH_LIMIT].fallback(-1.0)};
-    double softTreeDepthTolerance{parameters[SOFT_TREE_DEPTH_TOLERANCE].fallback(-1.0)};
-    double featureBagFraction{parameters[FEATURE_BAG_FRACTION].fallback(-1.0)};
+    auto downsampleFactor = parameters[DOWNSAMPLE_FACTOR].fallback(TDoubleVec{});
+    auto alpha = parameters[ALPHA].fallback(TDoubleVec{});
+    auto lambda = parameters[LAMBDA].fallback(TDoubleVec{});
+    auto gamma = parameters[GAMMA].fallback(TDoubleVec{});
+    auto eta = parameters[ETA].fallback(TDoubleVec{});
+    auto etaGrowthRatePerTree = parameters[ETA_GROWTH_RATE_PER_TREE].fallback(TDoubleVec{});
+    auto softTreeDepthLimit = parameters[SOFT_TREE_DEPTH_LIMIT].fallback(TDoubleVec{});
+    auto softTreeDepthTolerance =
+        parameters[SOFT_TREE_DEPTH_TOLERANCE].fallback(TDoubleVec{});
+    auto featureBagFraction = parameters[FEATURE_BAG_FRACTION].fallback(TDoubleVec{});
+
     if (parameters[FEATURE_PROCESSORS].jsonObject() != nullptr) {
         m_CustomProcessors.CopyFrom(*parameters[FEATURE_PROCESSORS].jsonObject(),
                                     m_CustomProcessors.GetAllocator());
     }
-    if (alpha != -1.0 && alpha < 0.0) {
+    if (std::any_of(alpha.begin(), alpha.end(), [](double x) { return x < 0.0; })) {
         HANDLE_FATAL(<< "Input error: '" << ALPHA << "' should be non-negative.");
     }
-    if (lambda != -1.0 && lambda < 0.0) {
+    if (std::any_of(lambda.begin(), lambda.end(),
+                    [](double x) { return x < 0.0; })) {
         HANDLE_FATAL(<< "Input error: '" << LAMBDA << "' should be non-negative.");
     }
-    if (gamma != -1.0 && gamma < 0.0) {
+    if (std::any_of(gamma.begin(), gamma.end(), [](double x) { return x < 0.0; })) {
         HANDLE_FATAL(<< "Input error: '" << GAMMA << "' should be non-negative.");
     }
-    if (eta != -1.0 && (eta <= 0.0 || eta > 1.0)) {
+    if (std::any_of(eta.begin(), eta.end(),
+                    [](double x) { return x <= 0.0 || x > 1.0; })) {
         HANDLE_FATAL(<< "Input error: '" << ETA << "' should be in the range (0, 1].");
     }
-    if (etaGrowthRatePerTree != -1.0 && etaGrowthRatePerTree <= 0.0) {
+    if (std::any_of(etaGrowthRatePerTree.begin(), etaGrowthRatePerTree.end(),
+                    [](double x) { return x <= 0.0; })) {
         HANDLE_FATAL(<< "Input error: '" << ETA_GROWTH_RATE_PER_TREE << "' should be positive.");
     }
-    if (softTreeDepthLimit != -1.0 && softTreeDepthLimit < 0.0) {
+    if (std::any_of(softTreeDepthLimit.begin(), softTreeDepthLimit.end(),
+                    [](double x) { return x < 0.0; })) {
         HANDLE_FATAL(<< "Input error: '" << SOFT_TREE_DEPTH_LIMIT << "' should be non-negative.");
     }
-    if (softTreeDepthTolerance != -1.0 && softTreeDepthTolerance <= 0.0) {
+    if (std::any_of(softTreeDepthTolerance.begin(), softTreeDepthTolerance.end(),
+                    [](double x) { return x <= 0.0; })) {
         HANDLE_FATAL(<< "Input error: '" << SOFT_TREE_DEPTH_TOLERANCE << "' should be positive.");
     }
-    if (downsampleFactor != -1.0 && (downsampleFactor <= 0.0 || downsampleFactor > 1.0)) {
+    if (std::any_of(downsampleFactor.begin(), downsampleFactor.end(),
+                    [](double x) { return x <= 0.0 || x > 1.0; })) {
         HANDLE_FATAL(<< "Input error: '" << DOWNSAMPLE_FACTOR << "' should be in the range (0, 1]");
     }
-    if (featureBagFraction != -1.0 &&
-        (featureBagFraction <= 0.0 || featureBagFraction > 1.0)) {
+    if (std::any_of(featureBagFraction.begin(), featureBagFraction.end(),
+                    [](double x) { return x <= 0.0 || x > 1.0; })) {
         HANDLE_FATAL(<< "Input error: '" << FEATURE_BAG_FRACTION
                      << "' should be in the range (0, 1]");
     }
@@ -185,6 +195,15 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
         .analysisInstrumentation(m_Instrumentation)
         .trainingStateCallback(this->statePersister())
         .earlyStoppingEnabled(earlyStoppingEnabled)
+        .downsampleFactor(std::move(downsampleFactor))
+        .depthPenaltyMultiplier(std::move(alpha))
+        .treeSizePenaltyMultiplier(std::move(gamma))
+        .leafWeightPenaltyMultiplier(std::move(lambda))
+        .eta(std::move(eta))
+        .etaGrowthRatePerTree(std::move(etaGrowthRatePerTree))
+        .softTreeDepthLimit(std::move(softTreeDepthLimit))
+        .softTreeDepthTolerance(std::move(softTreeDepthTolerance))
+        .featureBagFraction(std::move(featureBagFraction))
         .maximumDeployedSize(maximumDeployedSize)
         .rowWeightColumnName(std::move(rowWeightColumnName));
 
@@ -192,35 +211,8 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
         m_BoostedTreeFactory->initialDownsampleRowsPerFeature(
             static_cast<double>(downsampleRowsPerFeature));
     }
-    if (downsampleFactor > 0.0 && downsampleFactor <= 1.0) {
-        m_BoostedTreeFactory->downsampleFactor(downsampleFactor);
-    }
-    if (alpha >= 0.0) {
-        m_BoostedTreeFactory->depthPenaltyMultiplier(alpha);
-    }
-    if (gamma >= 0.0) {
-        m_BoostedTreeFactory->treeSizePenaltyMultiplier(gamma);
-    }
-    if (lambda >= 0.0) {
-        m_BoostedTreeFactory->leafWeightPenaltyMultiplier(lambda);
-    }
-    if (eta > 0.0 && eta <= 1.0) {
-        m_BoostedTreeFactory->eta(eta);
-    }
-    if (etaGrowthRatePerTree > 0.0) {
-        m_BoostedTreeFactory->etaGrowthRatePerTree(etaGrowthRatePerTree);
-    }
-    if (softTreeDepthLimit >= 0.0) {
-        m_BoostedTreeFactory->softTreeDepthLimit(softTreeDepthLimit);
-    }
-    if (softTreeDepthTolerance > 0.0) {
-        m_BoostedTreeFactory->softTreeDepthTolerance(softTreeDepthTolerance);
-    }
     if (maxTrees > 0) {
         m_BoostedTreeFactory->maximumNumberTrees(maxTrees);
-    }
-    if (featureBagFraction > 0.0 && featureBagFraction <= 1.0) {
-        m_BoostedTreeFactory->featureBagFraction(featureBagFraction);
     }
     if (numberFolds > 1) {
         m_BoostedTreeFactory->numberFolds(numberFolds);
@@ -242,7 +234,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
 CDataFrameTrainBoostedTreeRunner::~CDataFrameTrainBoostedTreeRunner() = default;
 
 std::size_t CDataFrameTrainBoostedTreeRunner::numberExtraColumns() const {
-    return maths::analytics::CBoostedTreeFactory::estimatedExtraColumns(
+    return maths::analytics::CBoostedTreeFactory::estimateExtraColumns(
         this->spec().numberColumns(), m_NumberLossParameters);
 }
 

--- a/lib/api/CInferenceModelMetadata.cc
+++ b/lib/api/CInferenceModelMetadata.cc
@@ -284,10 +284,6 @@ void CInferenceModelMetadata::numberTrainingRows(std::size_t numberRows) {
     m_NumberTrainingRows = numberRows;
 }
 
-void CInferenceModelMetadata::trainFractionPerFold(double fraction) {
-    m_TrainFractionPerFold = fraction;
-}
-
 // clang-format off
 const std::string CInferenceModelMetadata::JSON_ABSOLUTE_IMPORTANCE_TAG{"absolute_importance"};
 const std::string CInferenceModelMetadata::JSON_BASELINE_TAG{"baseline"};

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -175,31 +175,29 @@ void testOneRunOfBoostedTreeTrainingWithStateRecovery(
         targetTransformer);
     restoredAnalyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "$"});
 
-    persistedStates = splitOnNull(std::stringstream{std::move(persistenceStream->str())});
+    persistedStates = splitOnNull(std::stringstream{persistenceStream->str()});
     auto actualTree = restoreTree(std::move(persistedStates.back()), frame, dependentVariable);
 
     // Compare hyperparameters.
 
     rapidjson::Document expectedResults{treeToJsonDocument(*expectedTree)};
-    const auto& expectedHyperparameters =
-        expectedResults[maths::analytics::CBoostedTree::bestHyperparametersName()];
-    const auto& expectedRegularizationHyperparameters =
-        expectedHyperparameters[maths::analytics::CBoostedTree::bestRegularizationHyperparametersName()];
+    const auto& expectedHyperparameters = expectedResults["hyperparameters"];
+    const auto& expectedRegularizationHyperparameters = expectedHyperparameters["hyperparameters"];
 
     rapidjson::Document actualResults{treeToJsonDocument(*actualTree)};
-    const auto& actualHyperparameters =
-        actualResults[maths::analytics::CBoostedTree::bestHyperparametersName()];
-    const auto& actualRegularizationHyperparameters =
-        actualHyperparameters[maths::analytics::CBoostedTree::bestRegularizationHyperparametersName()];
+    const auto& actualHyperparameters = actualResults["hyperparameters"];
+    const auto& actualRegularizationHyperparameters = actualResults["hyperparameters"];
 
-    for (const auto& key : maths::analytics::CBoostedTree::bestHyperparameterNames()) {
+    for (const auto& key : maths::analytics::CBoostedTreeHyperparameters::names()) {
         if (expectedHyperparameters.HasMember(key)) {
-            double expected{std::stod(expectedHyperparameters[key].GetString())};
-            double actual{std::stod(actualHyperparameters[key].GetString())};
+            double expected{std::stod(expectedHyperparameters[key]["value"].GetString())};
+            double actual{std::stod(actualHyperparameters[key]["value"].GetString())};
             BOOST_REQUIRE_CLOSE(expected, actual, 1e-3);
         } else if (expectedRegularizationHyperparameters.HasMember(key)) {
-            double expected{std::stod(expectedRegularizationHyperparameters[key].GetString())};
-            double actual{std::stod(actualRegularizationHyperparameters[key].GetString())};
+            double expected{std::stod(
+                expectedRegularizationHyperparameters[key]["value"].GetString())};
+            double actual{std::stod(
+                actualRegularizationHyperparameters[key]["value"].GetString())};
             BOOST_REQUIRE_CLOSE(expected, actual, 1e-3);
         } else {
             BOOST_FAIL("Missing " + key);
@@ -253,20 +251,18 @@ void testRunBoostedTreeRegressionTrainingWithParams(TLossFunctionType lossFuncti
     // Check best hyperparameters
     const auto* runner{dynamic_cast<const api::CDataFrameTrainBoostedTreeRegressionRunner*>(
         analyzer.runner())};
-    const auto& boostedTree{runner->boostedTree()};
-    const auto& bestHyperparameters{boostedTree.bestHyperparameters()};
-    BOOST_TEST_REQUIRE(bestHyperparameters.eta() == eta);
-    BOOST_TEST_REQUIRE(bestHyperparameters.featureBagFraction() == featureBagFraction);
+    const auto& boostedTree = runner->boostedTree();
+    const auto& bestHyperparameters = boostedTree.hyperparameters();
+    BOOST_TEST_REQUIRE(bestHyperparameters.eta().value() == eta);
+    BOOST_TEST_REQUIRE(bestHyperparameters.featureBagFraction().value() == featureBagFraction);
     // TODO extend to support setting downsampleFactor and etaGrowthRatePerTree
     //    BOOST_TEST_REQUIRE(bestHyperparameters.downsampleFactor() == downsampleFactor);
     //    BOOST_TEST_REQUIRE(bestHyperparameters.etaGrowthRatePerTree() == etaGrowthRatePerTree);
-    BOOST_TEST_REQUIRE(bestHyperparameters.regularization().depthPenaltyMultiplier() == alpha);
-    BOOST_TEST_REQUIRE(
-        bestHyperparameters.regularization().leafWeightPenaltyMultiplier() == lambda);
-    BOOST_TEST_REQUIRE(bestHyperparameters.regularization().treeSizePenaltyMultiplier() == gamma);
-    BOOST_TEST_REQUIRE(bestHyperparameters.regularization().softTreeDepthLimit() ==
-                       softTreeDepthLimit);
-    BOOST_TEST_REQUIRE(bestHyperparameters.regularization().softTreeDepthTolerance() ==
+    BOOST_TEST_REQUIRE(bestHyperparameters.depthPenaltyMultiplier().value() == alpha);
+    BOOST_TEST_REQUIRE(bestHyperparameters.leafWeightPenaltyMultiplier().value() == lambda);
+    BOOST_TEST_REQUIRE(bestHyperparameters.treeSizePenaltyMultiplier().value() == gamma);
+    BOOST_TEST_REQUIRE(bestHyperparameters.softTreeDepthLimit().value() == softTreeDepthLimit);
+    BOOST_TEST_REQUIRE(bestHyperparameters.softTreeDepthTolerance().value() ==
                        softTreeDepthTolerance);
 
     rapidjson::Document results;

--- a/lib/maths/analytics/CBoostedTree.cc
+++ b/lib/maths/analytics/CBoostedTree.cc
@@ -245,15 +245,11 @@ CTreeShapFeatureImportance* CBoostedTree::shap() const {
 }
 
 CBoostedTree::THyperparameterImportanceVec CBoostedTree::hyperparameterImportance() const {
-    return m_Impl->hyperparameterImportance();
+    return m_Impl->hyperparameters().importances();
 }
 
 std::size_t CBoostedTree::numberTrainingRows() const {
     return static_cast<std::size_t>(m_Impl->allTrainingRowsMask().manhattan());
-}
-
-double CBoostedTree::trainFractionPerFold() const {
-    return m_Impl->trainFractionPerFold();
 }
 
 std::size_t CBoostedTree::columnHoldingDependentVariable() const {
@@ -301,18 +297,6 @@ const CBoostedTree::TDoubleVec& CBoostedTree::featureWeightsForTraining() const 
     return m_Impl->featureSampleProbabilities();
 }
 
-const std::string& CBoostedTree::bestHyperparametersName() {
-    return CBoostedTreeImpl::bestHyperparametersName();
-}
-
-const std::string& CBoostedTree::bestRegularizationHyperparametersName() {
-    return CBoostedTreeImpl::bestRegularizationHyperparametersName();
-}
-
-CBoostedTree::TStrVec CBoostedTree::bestHyperparameterNames() {
-    return CBoostedTreeImpl::bestHyperparameterNames();
-}
-
 bool CBoostedTree::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
     return m_Impl->acceptRestoreTraverser(traverser);
 }
@@ -325,8 +309,8 @@ void CBoostedTree::accept(CBoostedTree::CVisitor& visitor) const {
     m_Impl->accept(visitor);
 }
 
-const CBoostedTreeHyperparameters& CBoostedTree::bestHyperparameters() const {
-    return m_Impl->bestHyperparameters();
+const CBoostedTreeHyperparameters& CBoostedTree::hyperparameters() const {
+    return m_Impl->hyperparameters();
 }
 
 CBoostedTree::TDoubleVec CBoostedTree::classificationWeights() const {

--- a/lib/maths/analytics/CBoostedTreeHyperparameters.cc
+++ b/lib/maths/analytics/CBoostedTreeHyperparameters.cc
@@ -11,121 +11,854 @@
 
 #include <maths/analytics/CBoostedTreeHyperparameters.h>
 
+#include <core/CContainerPrinter.h>
 #include <core/CPersistUtils.h>
 #include <core/RestoreMacros.h>
+
+#include <maths/analytics/CBoostedTreeImpl.h>
+#include <maths/analytics/CDataFrameAnalysisInstrumentationInterface.h>
+
+#include <maths/common/CBasicStatisticsPersist.h>
+#include <maths/common/CBayesianOptimisation.h>
+#include <maths/common/CLinearAlgebra.h>
+#include <maths/common/CLowess.h>
+#include <maths/common/CLowessDetail.h>
+
+#include <boost/optional/optional_io.hpp>
+
+#include <cmath>
 
 namespace ml {
 namespace maths {
 namespace analytics {
-const std::string CBoostedTreeHyperparameters::HYPERPARAM_DOWNSAMPLE_FACTOR_TAG{
-    "hyperparam_downsample_factor"};
-const std::string CBoostedTreeHyperparameters::HYPERPARAM_ETA_TAG{"hyperparam_eta"};
-const std::string CBoostedTreeHyperparameters::HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG{
-    "hyperparam_eta_growth_rate_per_tree"};
-const std::string CBoostedTreeHyperparameters::HYPERPARAM_FEATURE_BAG_FRACTION_TAG{
-    "hyperparam_feature_bag_fraction"};
-const std::string CBoostedTreeHyperparameters::HYPERPARAM_MAXIMUM_NUMBER_TREES_TAG{
-    "hyperparam_maximum_number_trees"};
-const std::string CBoostedTreeHyperparameters::HYPERPARAM_REGULARIZATION_TAG{
-    "hyperparam_regularization"};
+using namespace boosted_tree_detail;
+namespace {
+using TVector3x1 = CBoostedTreeHyperparameters::TVector3x1;
+
+const std::size_t MIN_VALUE_INDEX{0};
+const std::size_t MID_VALUE_INDEX{1};
+const std::size_t MAX_VALUE_INDEX{2};
+const double LINE_SEARCH_MINIMUM_RELATIVE_EI_TO_CONTINUE{0.01};
+}
+
+CBoostedTreeHyperparameters::CBoostedTreeHyperparameters() {
+    this->saveCurrent();
+    this->initializeTunableHyperparameters();
+}
+
+double CBoostedTreeHyperparameters::penaltyForDepth(std::size_t depth) const {
+    return std::exp((static_cast<double>(depth) / m_SoftTreeDepthLimit.value() - 1.0) /
+                    m_SoftTreeDepthTolerance.value());
+}
+
+void CBoostedTreeHyperparameters::maximumOptimisationRoundsPerHyperparameter(std::size_t rounds) {
+    m_MaximumOptimisationRoundsPerHyperparameter = rounds;
+}
+
+void CBoostedTreeHyperparameters::stopHyperparameterOptimizationEarly(bool enable) {
+    m_StopHyperparameterOptimizationEarly = enable;
+}
+
+void CBoostedTreeHyperparameters::bayesianOptimisationRestarts(std::size_t restarts) {
+    m_BayesianOptimisationRestarts = restarts;
+}
+
+std::size_t CBoostedTreeHyperparameters::numberToTune() const {
+    std::size_t result((m_DepthPenaltyMultiplier.fixed() ? 0 : 1) +
+                       (m_TreeSizePenaltyMultiplier.fixed() ? 0 : 1) +
+                       (m_LeafWeightPenaltyMultiplier.fixed() ? 0 : 1) +
+                       (m_SoftTreeDepthLimit.fixed() ? 0 : 1) +
+                       (m_SoftTreeDepthTolerance.fixed() ? 0 : 1) +
+                       (m_DownsampleFactor.fixed() ? 0 : 1) +
+                       (m_FeatureBagFraction.fixed() ? 0 : 1) + (m_Eta.fixed() ? 0 : 1) +
+                       (m_EtaGrowthRatePerTree.fixed() ? 0 : 1));
+    return result;
+}
+
+void CBoostedTreeHyperparameters::resetSearch() {
+    m_CurrentRound = 0;
+    m_BestForestTestLoss = boosted_tree_detail::INF;
+    m_MeanForestSizeAccumulator = TMeanAccumulator{};
+    m_MeanTestLossAccumulator = TMeanAccumulator{};
+    this->initializeTunableHyperparameters();
+}
+
+void CBoostedTreeHyperparameters::initializeFineTuneSearchInterval(
+    const CInitializeFineTuneArguments& args,
+    TDoubleParameter& parameter) const {
+
+    if (parameter.valid(args.maxValue())) {
+
+        double maxValue{parameter.toSearchValue(args.maxValue())};
+        double minValue{maxValue - parameter.toSearchValue(args.searchInterval())};
+        double meanValue{(minValue + maxValue) / 2.0};
+        LOG_TRACE(<< "mean value = " << meanValue);
+
+        TVector3x1 fallback;
+        fallback(MIN_VALUE_INDEX) = minValue;
+        fallback(MID_VALUE_INDEX) = meanValue;
+        fallback(MAX_VALUE_INDEX) = maxValue;
+        auto interval = this->testLossLineSearch(args, minValue, maxValue).value_or(fallback);
+        args.truncateParameter()(interval);
+        LOG_TRACE(<< "search interval = [" << interval.toDelimited() << "]");
+
+        parameter.fixToRange(parameter.fromSearchValue(interval(MIN_VALUE_INDEX)),
+                             parameter.fromSearchValue(interval(MAX_VALUE_INDEX)));
+        parameter.set(parameter.fromSearchValue(interval(MID_VALUE_INDEX)));
+
+    } else {
+        parameter.fix();
+    }
+}
+
+CBoostedTreeHyperparameters::TOptionalVector3x1
+CBoostedTreeHyperparameters::testLossLineSearch(const CInitializeFineTuneArguments& args,
+                                                double intervalLeftEnd,
+                                                double intervalRightEnd) const {
+
+    // This has the following steps:
+    //   1. Search the interval [intervalLeftEnd, intervalRightEnd] using fixed
+    //      steps,
+    //   2. Fine tune, via Bayesian Optimisation targeting expected improvement,
+    //      and stop if the expected improvement small compared to the current
+    //      minimum test loss,
+    //   3. Fit a LOWESS model to the test losses and compute the minimum.
+
+    TDoubleDoublePrVec testLosses;
+    this->initialTestLossLineSearch(args, intervalLeftEnd, intervalRightEnd, testLosses);
+    if (testLosses.empty()) {
+        return {};
+    }
+    this->fineTineTestLoss(args, intervalLeftEnd, intervalRightEnd, testLosses);
+    return this->minimizeTestLoss(intervalLeftEnd, intervalRightEnd, std::move(testLosses));
+}
+
+void CBoostedTreeHyperparameters::initialTestLossLineSearch(const CInitializeFineTuneArguments& args,
+                                                            double intervalLeftEnd,
+                                                            double intervalRightEnd,
+                                                            TDoubleDoublePrVec& testLosses) const {
+
+    testLosses.reserve(this->maxLineSearchIterations());
+
+    for (auto parameter :
+         {intervalLeftEnd, (2.0 * intervalLeftEnd + intervalRightEnd) / 3.0,
+          (intervalLeftEnd + 2.0 * intervalRightEnd) / 3.0, intervalRightEnd}) {
+
+        if (args.updateParameter()(args.tree(), parameter) == false) {
+            args.tree().m_TrainingProgress.increment(
+                (this->maxLineSearchIterations() - testLosses.size()) *
+                args.tree().m_Hyperparameters.maximumNumberTrees().value());
+            break;
+        }
+
+        double testLoss{args.tree()
+                            .trainForest(args.frame(), args.tree().m_TrainingRowMasks[0],
+                                         args.tree().m_TestingRowMasks[0],
+                                         args.tree().m_TrainingProgress)
+                            .s_TestLoss};
+        testLosses.emplace_back(parameter, testLoss);
+    }
+}
+
+void CBoostedTreeHyperparameters::fineTineTestLoss(const CInitializeFineTuneArguments& args,
+                                                   double intervalLeftEnd,
+                                                   double intervalRightEnd,
+                                                   TDoubleDoublePrVec& testLosses) const {
+
+    using TMinAccumulator = common::CBasicStatistics::SMin<double>::TAccumulator;
+
+    TMinAccumulator minTestLoss;
+    for (auto[_, testLoss] : testLosses) {
+        minTestLoss.add(testLoss);
+    }
+
+    auto boptVector = [](double parameter) {
+        return common::SConstant<common::CBayesianOptimisation::TVector>::get(1, parameter);
+    };
+    auto adjustTestLoss = [minTestLoss, &args](double parameter, double testLoss) {
+        return args.adjustLoss()(parameter, minTestLoss[0], testLoss);
+    };
+
+    common::CBayesianOptimisation bopt{{{intervalLeftEnd, intervalRightEnd}}};
+    for (auto & [ parameter, testLoss ] : testLosses) {
+        double adjustedTestLoss{adjustTestLoss(parameter, testLoss)};
+        bopt.add(boptVector(parameter), adjustedTestLoss, 0.0);
+        testLoss = adjustedTestLoss;
+    }
+
+    // Ensure we choose one value based on expected improvement.
+    std::size_t minNumberTestLosses{6};
+
+    while (testLosses.size() < this->maxLineSearchIterations()) {
+        common::CBayesianOptimisation::TVector parameter;
+        common::CBayesianOptimisation::TOptionalDouble EI;
+        std::tie(parameter, EI) = bopt.maximumExpectedImprovement();
+        double threshold{LINE_SEARCH_MINIMUM_RELATIVE_EI_TO_CONTINUE * minTestLoss[0]};
+        LOG_TRACE(<< "EI = " << EI << " threshold to continue = " << threshold);
+        if ((testLosses.size() >= minNumberTestLosses && EI != boost::none && *EI < threshold) ||
+            args.updateParameter()(args.tree(), parameter(0)) == false) {
+            args.tree().m_TrainingProgress.increment(
+                (this->maxLineSearchIterations() - testLosses.size()) *
+                args.tree().m_Hyperparameters.maximumNumberTrees().value());
+            break;
+        }
+
+        double testLoss{args.tree()
+                            .trainForest(args.frame(), args.tree().m_TrainingRowMasks[0],
+                                         args.tree().m_TestingRowMasks[0],
+                                         args.tree().m_TrainingProgress)
+                            .s_TestLoss};
+
+        minTestLoss.add(testLoss);
+
+        double adjustedTestLoss{adjustTestLoss(parameter(0), testLoss)};
+        bopt.add(parameter, adjustedTestLoss, 0.0);
+        testLosses.emplace_back(parameter(0), adjustedTestLoss);
+    }
+
+    std::sort(testLosses.begin(), testLosses.end());
+    LOG_TRACE(<< "test losses = " << core::CContainerPrinter::print(testLosses));
+}
+
+CBoostedTreeHyperparameters::TVector3x1
+CBoostedTreeHyperparameters::minimizeTestLoss(double intervalLeftEnd,
+                                              double intervalRightEnd,
+                                              TDoubleDoublePrVec testLosses) const {
+    common::CLowess<2> lowess;
+    lowess.fit(std::move(testLosses), testLosses.size());
+
+    double bestParameter;
+    double bestParameterTestLoss;
+    std::tie(bestParameter, bestParameterTestLoss) = lowess.minimum();
+    LOG_TRACE(<< "best parameter = " << bestParameter << ", test loss = " << bestParameterTestLoss);
+
+    double width{(intervalRightEnd - intervalLeftEnd) /
+                 static_cast<double>(this->maxLineSearchIterations())};
+    intervalLeftEnd = bestParameter - width;
+    intervalRightEnd = bestParameter + width;
+    LOG_TRACE(<< "interval = [" << intervalLeftEnd << "," << intervalRightEnd << "]");
+
+    return TVector3x1{{intervalLeftEnd, bestParameter, intervalRightEnd}};
+}
+
+void CBoostedTreeHyperparameters::initializeSearch() {
+
+    // We need sensible bounds for the region we'll search for optimal values.
+    // For all parameters where we have initial estimates we use bounds of the
+    // form a * initial and b * initial for a < 1 < b. For other parameters we
+    // use a fixed range.
+    //
+    // We also parameterise so the probability any subinterval contains a good
+    // value is proportional to its length. For parameters whose difference is
+    // naturally measured as a ratio, i.e. diff(p_1, p_0) = p_1 / p_0 for p_0
+    // less than p_1, This translates to using log parameter values.
+
+    this->initializeTunableHyperparameters();
+
+    TDoubleDoublePrVec boundingBox;
+    boundingBox.reserve(m_TunableHyperparameters.size());
+    for (const auto& parameter : m_TunableHyperparameters) {
+        switch (parameter) {
+        case E_Alpha:
+            boundingBox.push_back(m_DepthPenaltyMultiplier.searchRange());
+            break;
+        case E_DownsampleFactor:
+            boundingBox.push_back(m_DownsampleFactor.searchRange());
+            break;
+        case E_Eta:
+            boundingBox.push_back(m_Eta.searchRange());
+            break;
+        case E_EtaGrowthRatePerTree:
+            boundingBox.push_back(m_EtaGrowthRatePerTree.searchRange());
+            break;
+        case E_FeatureBagFraction:
+            boundingBox.push_back(m_FeatureBagFraction.searchRange());
+            break;
+        case E_Gamma:
+            boundingBox.push_back(m_TreeSizePenaltyMultiplier.searchRange());
+            break;
+        case E_Lambda:
+            boundingBox.push_back(m_LeafWeightPenaltyMultiplier.searchRange());
+            break;
+        case E_MaximumNumberTrees:
+            // Maximum number trees is not tuned directly and estimated from
+            // loss curves.
+            break;
+        case E_SoftTreeDepthLimit:
+            boundingBox.push_back(m_SoftTreeDepthLimit.searchRange());
+            break;
+        case E_SoftTreeDepthTolerance:
+            boundingBox.push_back(m_SoftTreeDepthTolerance.searchRange());
+            break;
+        }
+    }
+    LOG_TRACE(<< "hyperparameter search bounding box = "
+              << core::CContainerPrinter::print(boundingBox));
+
+    m_BayesianOptimization = std::make_unique<common::CBayesianOptimisation>(
+        std::move(boundingBox),
+        m_BayesianOptimisationRestarts.value_or(common::CBayesianOptimisation::RESTARTS));
+
+    m_CurrentRound = 0;
+    m_NumberRounds = m_MaximumOptimisationRoundsPerHyperparameter *
+                     m_TunableHyperparameters.size();
+    this->saveCurrent();
+}
+
+void CBoostedTreeHyperparameters::startSearch() {
+    std::size_t dimension{m_TunableHyperparameters.size()};
+    std::size_t n{m_NumberRounds / 3 + 1};
+    common::CSampling::sobolSequenceSample(dimension, n, m_HyperparameterSamples);
+}
+
+void CBoostedTreeHyperparameters::addRoundStats(const TMeanAccumulator& meanForestSizeAccumulator,
+                                                double meanTestLoss) {
+    m_MeanForestSizeAccumulator += meanForestSizeAccumulator;
+    m_MeanTestLossAccumulator.add(meanTestLoss);
+}
+
+bool CBoostedTreeHyperparameters::selectNext(const TMeanVarAccumulator& testLossMoments,
+                                             double explainedVariance) {
+
+    using TVector = common::CDenseVector<double>;
+
+    TVector parameters{m_TunableHyperparameters.size()};
+
+    TVector minBoundary;
+    TVector maxBoundary;
+    std::tie(minBoundary, maxBoundary) = m_BayesianOptimization->boundingBox();
+
+    // Read parameters for last round.
+    for (std::size_t i = 0; i < m_TunableHyperparameters.size(); ++i) {
+        switch (m_TunableHyperparameters[i]) {
+        case E_Alpha:
+            parameters(i) = m_DepthPenaltyMultiplier.toSearchValue();
+            break;
+        case E_DownsampleFactor:
+            parameters(i) = m_DownsampleFactor.toSearchValue();
+            break;
+        case E_Eta:
+            parameters(i) = m_Eta.toSearchValue();
+            break;
+        case E_EtaGrowthRatePerTree:
+            parameters(i) = m_EtaGrowthRatePerTree.toSearchValue();
+            break;
+        case E_FeatureBagFraction:
+            parameters(i) = m_FeatureBagFraction.toSearchValue();
+            break;
+        case E_MaximumNumberTrees:
+            parameters(i) = m_MaximumNumberTrees.toSearchValue();
+            break;
+        case E_Gamma:
+            parameters(i) = m_TreeSizePenaltyMultiplier.toSearchValue();
+            break;
+        case E_Lambda:
+            parameters(i) = m_LeafWeightPenaltyMultiplier.toSearchValue();
+            break;
+        case E_SoftTreeDepthLimit:
+            parameters(i) = m_SoftTreeDepthLimit.toSearchValue();
+            break;
+        case E_SoftTreeDepthTolerance:
+            parameters(i) = m_SoftTreeDepthTolerance.toSearchValue();
+            break;
+        }
+    }
+
+    double meanTestLoss{common::CBasicStatistics::mean(testLossMoments)};
+    double testLossVariance{common::CBasicStatistics::variance(testLossMoments)};
+
+    LOG_TRACE(<< "round = " << m_CurrentRound << ", loss = " << meanTestLoss
+              << ", total variance = " << testLossVariance
+              << ", explained variance = " << explainedVariance);
+    LOG_TRACE(<< "parameters = " << this->print());
+
+    m_BayesianOptimization->add(parameters, meanTestLoss, testLossVariance);
+
+    // One fold might have examples which are harder to predict on average than
+    // another fold, particularly if the sample size is small. What we really care
+    // about is the variation between fold loss values after accounting for any
+    // systematic effect due to sampling. Running for multiple rounds allows us
+    // to estimate this effect and we remove it when characterising the uncertainty
+    // in the loss values in the Gaussian Process.
+    m_BayesianOptimization->explainedErrorVariance(explainedVariance);
+
+    if (m_CurrentRound < m_HyperparameterSamples.size()) {
+        std::copy(m_HyperparameterSamples[m_CurrentRound].begin(),
+                  m_HyperparameterSamples[m_CurrentRound].end(), parameters.data());
+        parameters = minBoundary + parameters.cwiseProduct(maxBoundary - minBoundary);
+    } else if (m_StopHyperparameterOptimizationEarly &&
+               m_BayesianOptimization->anovaTotalCoefficientOfVariation() < 1e-3) {
+        return false;
+    } else {
+        std::tie(parameters, std::ignore) =
+            m_BayesianOptimization->maximumExpectedImprovement();
+    }
+
+    // Downsampling directly affects the loss terms: it multiplies the sums over
+    // gradients and Hessians in expectation by the downsample factor. To preserve
+    // the same effect for regularisers we need to scale these terms by the same
+    // multiplier.
+    double scale{1.0};
+    if (m_ScalingDisabled == false && m_DownsampleFactor.fixed() == false) {
+        auto i = std::distance(m_TunableHyperparameters.begin(),
+                               std::find(m_TunableHyperparameters.begin(),
+                                         m_TunableHyperparameters.end(), E_DownsampleFactor));
+        if (static_cast<std::size_t>(i) < m_TunableHyperparameters.size()) {
+            scale = std::min(
+                1.0, 2.0 * m_DownsampleFactor.fromSearchValue(parameters(i)) /
+                         (m_DownsampleFactor.fromSearchValue(minBoundary(i)) +
+                          m_DownsampleFactor.fromSearchValue(maxBoundary(i))));
+        }
+    }
+
+    // Write parameters for next round.
+    for (std::size_t i = 0; i < m_TunableHyperparameters.size(); ++i) {
+        switch (m_TunableHyperparameters[i]) {
+        case E_Alpha:
+            m_DepthPenaltyMultiplier
+                .set(m_DepthPenaltyMultiplier.fromSearchValue(parameters(i)))
+                .scale(scale);
+            break;
+        case E_DownsampleFactor:
+            m_DownsampleFactor.set(m_DownsampleFactor.fromSearchValue(parameters(i)));
+            break;
+        case E_Eta:
+            m_Eta.set(m_Eta.fromSearchValue(parameters(i)));
+            break;
+        case E_EtaGrowthRatePerTree:
+            m_EtaGrowthRatePerTree.set(
+                m_EtaGrowthRatePerTree.fromSearchValue(parameters(i)));
+            break;
+        case E_FeatureBagFraction:
+            m_FeatureBagFraction.set(m_FeatureBagFraction.fromSearchValue(parameters(i)));
+            break;
+        case E_MaximumNumberTrees:
+            m_MaximumNumberTrees.set(
+                m_MaximumNumberTrees.fromSearchValue(std::ceil(parameters(i))));
+            break;
+        case E_Gamma:
+            m_TreeSizePenaltyMultiplier
+                .set(m_TreeSizePenaltyMultiplier.fromSearchValue(parameters(i)))
+                .scale(scale);
+            break;
+        case E_Lambda:
+            m_LeafWeightPenaltyMultiplier
+                .set(m_LeafWeightPenaltyMultiplier.fromSearchValue(parameters(i)))
+                .scale(scale);
+            break;
+        case E_SoftTreeDepthLimit:
+            m_SoftTreeDepthLimit.set(m_SoftTreeDepthLimit.fromSearchValue(parameters(i)));
+            break;
+        case E_SoftTreeDepthTolerance:
+            m_SoftTreeDepthTolerance.set(
+                m_SoftTreeDepthTolerance.fromSearchValue(parameters(i)));
+            break;
+        }
+    }
+
+    return true;
+}
+
+bool CBoostedTreeHyperparameters::captureBest(const TMeanVarAccumulator& testLossMoments,
+                                              std::size_t numberTrees,
+                                              double numberNodes) {
+
+    // We capture the parameters with the lowest error at one standard
+    // deviation above the mean. If the mean error improvement is marginal
+    // we prefer the solution with the least variation across the folds.
+    double testLoss{lossAtNSigma(1.0, testLossMoments) + this->modelSizePenalty(numberNodes)};
+
+    if (testLoss < m_BestForestTestLoss) {
+        m_BestForestTestLoss = testLoss;
+
+        // During hyperparameter search we have a fixed upper bound on
+        // the number of trees which we use for every round and we stop
+        // adding trees early based on cross-validation loss. The stored
+        // number of trees is used for final train when we train on all
+        // the data and so can't measure when to stop.
+        std::size_t numberTreesToRestore{m_MaximumNumberTrees.value()};
+        m_MaximumNumberTrees.set(numberTrees);
+        this->saveCurrent();
+        m_MaximumNumberTrees.set(numberTreesToRestore);
+        return true;
+    }
+    return false;
+}
+
+double CBoostedTreeHyperparameters::modelSizePenalty(double numberNodes) const {
+    // eps * "forest number nodes" * E[GP] / "average forest number nodes" to meanLoss.
+    return RELATIVE_SIZE_PENALTY * numberNodes /
+           common::CBasicStatistics::mean(m_MeanForestSizeAccumulator) *
+           common::CBasicStatistics::mean(m_MeanTestLossAccumulator);
+}
+
+CBoostedTreeHyperparameters::THyperparameterImportanceVec
+CBoostedTreeHyperparameters::importances() const {
+    THyperparameterImportanceVec importances;
+    importances.reserve(m_TunableHyperparameters.size());
+    common::CBayesianOptimisation::TDoubleDoublePrVec anovaMainEffects{
+        m_BayesianOptimization->anovaMainEffects()};
+    for (std::size_t i = 0; i < static_cast<std::size_t>(NUMBER_HYPERPARAMETERS); ++i) {
+        double absoluteImportance{0.0};
+        double relativeImportance{0.0};
+        double hyperparameterValue;
+        SHyperparameterImportance::EType hyperparameterType{
+            boosted_tree_detail::SHyperparameterImportance::E_Double};
+        switch (static_cast<EHyperparameter>(i)) {
+        case E_Alpha:
+            hyperparameterValue = m_DepthPenaltyMultiplier.value();
+            break;
+        case E_DownsampleFactor:
+            hyperparameterValue = m_DownsampleFactor.value();
+            break;
+        case E_Eta:
+            hyperparameterValue = m_Eta.value();
+            break;
+        case E_EtaGrowthRatePerTree:
+            hyperparameterValue = m_EtaGrowthRatePerTree.value();
+            break;
+        case E_FeatureBagFraction:
+            hyperparameterValue = m_FeatureBagFraction.value();
+            break;
+        case E_MaximumNumberTrees:
+            hyperparameterValue = static_cast<double>(m_MaximumNumberTrees.value());
+            hyperparameterType = boosted_tree_detail::SHyperparameterImportance::E_Uint64;
+            break;
+        case E_Gamma:
+            hyperparameterValue = m_TreeSizePenaltyMultiplier.value();
+            break;
+        case E_Lambda:
+            hyperparameterValue = m_LeafWeightPenaltyMultiplier.value();
+            break;
+        case E_SoftTreeDepthLimit:
+            hyperparameterValue = m_SoftTreeDepthLimit.value();
+            break;
+        case E_SoftTreeDepthTolerance:
+            hyperparameterValue = m_SoftTreeDepthTolerance.value();
+            break;
+        }
+        bool supplied{true};
+        auto tunableIndex = std::distance(m_TunableHyperparameters.begin(),
+                                          std::find(m_TunableHyperparameters.begin(),
+                                                    m_TunableHyperparameters.end(), i));
+        if (static_cast<std::size_t>(tunableIndex) < m_TunableHyperparameters.size()) {
+            supplied = false;
+            std::tie(absoluteImportance, relativeImportance) = anovaMainEffects[tunableIndex];
+        }
+        importances.push_back({static_cast<EHyperparameter>(i), hyperparameterValue, absoluteImportance,
+                               relativeImportance, supplied, hyperparameterType});
+    }
+    return importances;
+}
+
+void CBoostedTreeHyperparameters::recordHyperparameters(
+    CDataFrameTrainBoostedTreeInstrumentationInterface& instrumentation) const {
+    auto& hyperparameters = instrumentation.hyperparameters();
+    hyperparameters.s_Eta = m_Eta.value();
+    hyperparameters.s_DepthPenaltyMultiplier = m_DepthPenaltyMultiplier.value();
+    hyperparameters.s_SoftTreeDepthLimit = m_SoftTreeDepthLimit.value();
+    hyperparameters.s_SoftTreeDepthTolerance = m_SoftTreeDepthTolerance.value();
+    hyperparameters.s_TreeSizePenaltyMultiplier = m_TreeSizePenaltyMultiplier.value();
+    hyperparameters.s_LeafWeightPenaltyMultiplier =
+        m_LeafWeightPenaltyMultiplier.value();
+    hyperparameters.s_DownsampleFactor = m_DownsampleFactor.value();
+    hyperparameters.s_MaxTrees = m_MaximumNumberTrees.value();
+    hyperparameters.s_FeatureBagFraction = m_FeatureBagFraction.value();
+    hyperparameters.s_EtaGrowthRatePerTree = m_EtaGrowthRatePerTree.value();
+    hyperparameters.s_MaxOptimizationRoundsPerHyperparameter = m_MaximumOptimisationRoundsPerHyperparameter;
+}
+
+void CBoostedTreeHyperparameters::checkSearchInvariants() const {
+    if (m_BayesianOptimization == nullptr) {
+        HANDLE_FATAL(<< "Internal error: must supply an optimizer. Please report this problem.");
+    }
+}
+
+void CBoostedTreeHyperparameters::checkRestoredInvariants(bool expectOptimizerInitialized) const {
+    if (expectOptimizerInitialized) {
+        VIOLATES_INVARIANT_NO_EVALUATION(m_BayesianOptimization, ==, nullptr);
+    }
+    VIOLATES_INVARIANT(m_CurrentRound, >, m_NumberRounds);
+    for (const auto& samples : m_HyperparameterSamples) {
+        VIOLATES_INVARIANT(m_TunableHyperparameters.size(), !=, samples.size());
+    }
+}
+
+std::size_t CBoostedTreeHyperparameters::estimateMemoryUsage() const {
+    std::size_t numberToTune{this->numberToTune()};
+    return sizeof(*this) + numberToTune * sizeof(int) +
+           (m_NumberRounds / 3 + 1) * numberToTune * sizeof(double) +
+           common::CBayesianOptimisation::estimateMemoryUsage(numberToTune, m_NumberRounds);
+}
+
+std::size_t CBoostedTreeHyperparameters::memoryUsage() const {
+    std::size_t mem{core::CMemory::dynamicSize(m_TunableHyperparameters)};
+    mem += core::CMemory::dynamicSize(m_HyperparameterSamples);
+    mem += core::CMemory::dynamicSize(m_BayesianOptimization);
+    return mem;
+}
 
 void CBoostedTreeHyperparameters::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
-    core::CPersistUtils::persist(HYPERPARAM_DOWNSAMPLE_FACTOR_TAG,
-                                 m_DownsampleFactor, inserter);
-    core::CPersistUtils::persist(HYPERPARAM_ETA_TAG, m_Eta, inserter);
-    core::CPersistUtils::persist(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
+    core::CPersistUtils::persistIfNotNull(BAYESIAN_OPTIMIZATION_TAG,
+                                          m_BayesianOptimization, inserter);
+    core::CPersistUtils::persist(BEST_FOREST_TEST_LOSS_TAG, m_BestForestTestLoss, inserter);
+    core::CPersistUtils::persist(CURRENT_ROUND_TAG, m_CurrentRound, inserter);
+    core::CPersistUtils::persist(DEPTH_PENALTY_MULTIPLIER_TAG,
+                                 m_DepthPenaltyMultiplier, inserter);
+    core::CPersistUtils::persist(DOWNSAMPLE_FACTOR_TAG, m_DownsampleFactor, inserter);
+    core::CPersistUtils::persist(ETA_GROWTH_RATE_PER_TREE_TAG,
                                  m_EtaGrowthRatePerTree, inserter);
-    core::CPersistUtils::persist(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
-                                 m_FeatureBagFraction, inserter);
-    core::CPersistUtils::persist(HYPERPARAM_MAXIMUM_NUMBER_TREES_TAG,
-                                 m_MaximumNumberTrees, inserter);
-    core::CPersistUtils::persist(HYPERPARAM_REGULARIZATION_TAG, m_Regularization, inserter);
+    core::CPersistUtils::persist(ETA_TAG, m_Eta, inserter);
+    core::CPersistUtils::persist(FEATURE_BAG_FRACTION_TAG, m_FeatureBagFraction, inserter);
+    core::CPersistUtils::persist(LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
+                                 m_LeafWeightPenaltyMultiplier, inserter);
+    core::CPersistUtils::persist(MAXIMUM_NUMBER_TREES_TAG, m_MaximumNumberTrees, inserter);
+    core::CPersistUtils::persist(MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG,
+                                 m_MaximumOptimisationRoundsPerHyperparameter, inserter);
+    core::CPersistUtils::persist(MEAN_FOREST_SIZE_ACCUMULATOR_TAG,
+                                 m_MeanForestSizeAccumulator, inserter);
+    core::CPersistUtils::persist(MEAN_TEST_LOSS_ACCUMULATOR_TAG,
+                                 m_MeanTestLossAccumulator, inserter);
+    core::CPersistUtils::persist(NUMBER_ROUNDS_TAG, m_NumberRounds, inserter);
+    core::CPersistUtils::persist(SOFT_TREE_DEPTH_LIMIT_TAG, m_SoftTreeDepthLimit, inserter);
+    core::CPersistUtils::persist(SOFT_TREE_DEPTH_TOLERANCE_TAG,
+                                 m_SoftTreeDepthTolerance, inserter);
+    core::CPersistUtils::persist(STOP_HYPERPARAMETER_OPTIMIZATION_EARLY_TAG,
+                                 m_StopHyperparameterOptimizationEarly, inserter);
+    core::CPersistUtils::persist(TREE_SIZE_PENALTY_MULTIPLIER_TAG,
+                                 m_TreeSizePenaltyMultiplier, inserter);
+    // m_TunableHyperparameters is not persisted explicitly, it is re-generated
+    // from overriden hyperparameters.
+    // m_HyperparameterSamples is not persisted explicitly, it is re-generated.
 }
 
 bool CBoostedTreeHyperparameters::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
     do {
-        const std::string& name = traverser.name();
-        RESTORE(HYPERPARAM_DOWNSAMPLE_FACTOR_TAG,
-                core::CPersistUtils::restore(HYPERPARAM_DOWNSAMPLE_FACTOR_TAG,
-                                             m_DownsampleFactor, traverser))
-        RESTORE(HYPERPARAM_ETA_TAG,
-                core::CPersistUtils::restore(HYPERPARAM_ETA_TAG, m_Eta, traverser))
-        RESTORE(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
-                core::CPersistUtils::restore(HYPERPARAM_ETA_GROWTH_RATE_PER_TREE_TAG,
+        const std::string& name{traverser.name()};
+        RESTORE_NO_ERROR(BAYESIAN_OPTIMIZATION_TAG,
+                         m_BayesianOptimization =
+                             std::make_unique<common::CBayesianOptimisation>(traverser))
+        RESTORE(BEST_FOREST_TEST_LOSS_TAG,
+                core::CPersistUtils::restore(BEST_FOREST_TEST_LOSS_TAG,
+                                             m_BestForestTestLoss, traverser))
+        RESTORE(CURRENT_ROUND_TAG,
+                core::CPersistUtils::restore(CURRENT_ROUND_TAG, m_CurrentRound, traverser))
+        RESTORE(DEPTH_PENALTY_MULTIPLIER_TAG,
+                core::CPersistUtils::restore(DEPTH_PENALTY_MULTIPLIER_TAG,
+                                             m_DepthPenaltyMultiplier, traverser))
+        RESTORE(DOWNSAMPLE_FACTOR_TAG,
+                core::CPersistUtils::restore(DOWNSAMPLE_FACTOR_TAG, m_DownsampleFactor, traverser))
+        RESTORE(ETA_TAG, core::CPersistUtils::restore(ETA_TAG, m_Eta, traverser))
+        RESTORE(ETA_GROWTH_RATE_PER_TREE_TAG,
+                core::CPersistUtils::restore(ETA_GROWTH_RATE_PER_TREE_TAG,
                                              m_EtaGrowthRatePerTree, traverser))
-        RESTORE(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
-                core::CPersistUtils::restore(HYPERPARAM_FEATURE_BAG_FRACTION_TAG,
+        RESTORE(FEATURE_BAG_FRACTION_TAG,
+                core::CPersistUtils::restore(FEATURE_BAG_FRACTION_TAG,
                                              m_FeatureBagFraction, traverser))
-        RESTORE(HYPERPARAM_MAXIMUM_NUMBER_TREES_TAG,
-                core::CPersistUtils::restore(HYPERPARAM_MAXIMUM_NUMBER_TREES_TAG,
+        RESTORE(LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
+                core::CPersistUtils::restore(LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
+                                             m_LeafWeightPenaltyMultiplier, traverser))
+        RESTORE(MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG,
+                core::CPersistUtils::restore(
+                    MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG,
+                    m_MaximumOptimisationRoundsPerHyperparameter, traverser))
+        RESTORE(MAXIMUM_NUMBER_TREES_TAG,
+                core::CPersistUtils::restore(MAXIMUM_NUMBER_TREES_TAG,
                                              m_MaximumNumberTrees, traverser))
-        RESTORE(HYPERPARAM_REGULARIZATION_TAG,
-                core::CPersistUtils::restore(HYPERPARAM_REGULARIZATION_TAG,
-                                             m_Regularization, traverser))
+        RESTORE(MEAN_FOREST_SIZE_ACCUMULATOR_TAG,
+                core::CPersistUtils::restore(MEAN_FOREST_SIZE_ACCUMULATOR_TAG,
+                                             m_MeanForestSizeAccumulator, traverser))
+        RESTORE(MEAN_TEST_LOSS_ACCUMULATOR_TAG,
+                core::CPersistUtils::restore(MEAN_TEST_LOSS_ACCUMULATOR_TAG,
+                                             m_MeanTestLossAccumulator, traverser))
+        RESTORE(NUMBER_ROUNDS_TAG,
+                core::CPersistUtils::restore(NUMBER_ROUNDS_TAG, m_NumberRounds, traverser))
+        RESTORE(SOFT_TREE_DEPTH_LIMIT_TAG,
+                core::CPersistUtils::restore(SOFT_TREE_DEPTH_LIMIT_TAG,
+                                             m_SoftTreeDepthLimit, traverser))
+        RESTORE(SOFT_TREE_DEPTH_TOLERANCE_TAG,
+                core::CPersistUtils::restore(SOFT_TREE_DEPTH_TOLERANCE_TAG,
+                                             m_SoftTreeDepthTolerance, traverser))
+        RESTORE(STOP_HYPERPARAMETER_OPTIMIZATION_EARLY_TAG,
+                core::CPersistUtils::restore(STOP_HYPERPARAMETER_OPTIMIZATION_EARLY_TAG,
+                                             m_StopHyperparameterOptimizationEarly, traverser))
+        RESTORE(TREE_SIZE_PENALTY_MULTIPLIER_TAG,
+                core::CPersistUtils::restore(TREE_SIZE_PENALTY_MULTIPLIER_TAG,
+                                             m_TreeSizePenaltyMultiplier, traverser))
     } while (traverser.next());
+
+    this->initializeTunableHyperparameters();
+
     return true;
 }
 
-const CBoostedTreeHyperparameters::TRegularization&
-CBoostedTreeHyperparameters::regularization() const {
-    return m_Regularization;
+std::uint64_t CBoostedTreeHyperparameters::checksum(std::uint64_t seed) const {
+    seed = common::CChecksum::calculate(seed, m_BayesianOptimization);
+    seed = common::CChecksum::calculate(seed, m_BestForestTestLoss);
+    seed = common::CChecksum::calculate(seed, m_CurrentRound);
+    seed = common::CChecksum::calculate(seed, m_DepthPenaltyMultiplier);
+    seed = common::CChecksum::calculate(seed, m_DownsampleFactor);
+    seed = common::CChecksum::calculate(seed, m_Eta);
+    seed = common::CChecksum::calculate(seed, m_EtaGrowthRatePerTree);
+    seed = common::CChecksum::calculate(seed, m_FeatureBagFraction);
+    seed = common::CChecksum::calculate(seed, m_HyperparameterSamples);
+    seed = common::CChecksum::calculate(seed, m_LeafWeightPenaltyMultiplier);
+    seed = common::CChecksum::calculate(seed, m_MaximumNumberTrees);
+    seed = common::CChecksum::calculate(seed, m_MaximumOptimisationRoundsPerHyperparameter);
+    seed = common::CChecksum::calculate(seed, m_MeanForestSizeAccumulator);
+    seed = common::CChecksum::calculate(seed, m_MeanTestLossAccumulator);
+    seed = common::CChecksum::calculate(seed, m_NumberRounds);
+    seed = common::CChecksum::calculate(seed, m_SoftTreeDepthLimit);
+    seed = common::CChecksum::calculate(seed, m_SoftTreeDepthTolerance);
+    seed = common::CChecksum::calculate(seed, m_StopHyperparameterOptimizationEarly);
+    seed = common::CChecksum::calculate(seed, m_TreeSizePenaltyMultiplier);
+    return common::CChecksum::calculate(seed, m_TunableHyperparameters);
 }
 
-double CBoostedTreeHyperparameters::downsampleFactor() const {
-    return m_DownsampleFactor;
+std::string CBoostedTreeHyperparameters::print() const {
+    return "(\ndepth penalty multiplier = " + m_DepthPenaltyMultiplier.print() +
+           "\nsoft depth limit = " + m_SoftTreeDepthLimit.print() +
+           "\nsoft depth tolerance = " + m_SoftTreeDepthTolerance.print() +
+           "\ntree size penalty multiplier = " + m_TreeSizePenaltyMultiplier.print() +
+           "\nleaf weight penalty multiplier = " + m_LeafWeightPenaltyMultiplier.print() +
+           "\ndownsample factor = " + m_DownsampleFactor.print() +
+           "\nfeature bag fraction = " + m_FeatureBagFraction.print() +
+           "\neta = " + m_Eta.print() +
+           "\neta growth rate per tree = " + m_EtaGrowthRatePerTree.print() +
+           "\nmaximum number trees = " + m_MaximumNumberTrees.print() + "\n)";
 }
 
-double CBoostedTreeHyperparameters::eta() const {
-    return m_Eta;
+CBoostedTreeHyperparameters::TStrVec CBoostedTreeHyperparameters::names() {
+    return {DOWNSAMPLE_FACTOR_TAG,
+            ETA_TAG,
+            ETA_GROWTH_RATE_PER_TREE_TAG,
+            FEATURE_BAG_FRACTION_TAG,
+            DEPTH_PENALTY_MULTIPLIER_TAG,
+            TREE_SIZE_PENALTY_MULTIPLIER_TAG,
+            LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
+            SOFT_TREE_DEPTH_LIMIT_TAG,
+            SOFT_TREE_DEPTH_TOLERANCE_TAG};
 }
 
-double CBoostedTreeHyperparameters::etaGrowthRatePerTree() const {
-    return m_EtaGrowthRatePerTree;
+void CBoostedTreeHyperparameters::initializeTunableHyperparameters() {
+    m_TunableHyperparameters.clear();
+    m_TunableHyperparameters.reserve(NUMBER_HYPERPARAMETERS);
+    for (int i = 0; i < static_cast<int>(NUMBER_HYPERPARAMETERS); ++i) {
+        switch (static_cast<EHyperparameter>(i)) {
+        // Train hyperparameters.
+        case E_DownsampleFactor:
+            if (m_DownsampleFactor.fixed() == false) {
+                m_TunableHyperparameters.push_back(E_DownsampleFactor);
+            }
+            break;
+        case E_Alpha:
+            if (m_DepthPenaltyMultiplier.fixed() == false) {
+                m_TunableHyperparameters.push_back(E_Alpha);
+            }
+            break;
+        case E_Lambda:
+            if (m_LeafWeightPenaltyMultiplier.fixed() == false) {
+                m_TunableHyperparameters.push_back(E_Lambda);
+            }
+            break;
+        case E_Gamma:
+            if (m_TreeSizePenaltyMultiplier.fixed() == false) {
+                m_TunableHyperparameters.push_back(E_Gamma);
+            }
+            break;
+        case E_SoftTreeDepthLimit:
+            if (m_SoftTreeDepthLimit.fixed() == false) {
+                m_TunableHyperparameters.push_back(E_SoftTreeDepthLimit);
+            }
+            break;
+        case E_SoftTreeDepthTolerance:
+            if (m_SoftTreeDepthTolerance.fixed() == false) {
+                m_TunableHyperparameters.push_back(E_SoftTreeDepthTolerance);
+            }
+            break;
+        case E_Eta:
+            if (m_Eta.fixed() == false) {
+                m_TunableHyperparameters.push_back(E_Eta);
+            }
+            break;
+        case E_EtaGrowthRatePerTree:
+            if ((m_Eta.fixed() || m_EtaGrowthRatePerTree.fixed()) == false) {
+                m_TunableHyperparameters.push_back(E_EtaGrowthRatePerTree);
+            }
+            break;
+        case E_FeatureBagFraction:
+            if (m_FeatureBagFraction.fixed() == false) {
+                m_TunableHyperparameters.push_back(E_FeatureBagFraction);
+            }
+            break;
+        // Not tuned directly.
+        case E_MaximumNumberTrees:
+            break;
+        }
+    }
 }
 
-std::size_t CBoostedTreeHyperparameters::maximumNumberTrees() const {
-    return m_MaximumNumberTrees;
+void CBoostedTreeHyperparameters::saveCurrent() {
+    m_DepthPenaltyMultiplier.save();
+    m_TreeSizePenaltyMultiplier.save();
+    m_LeafWeightPenaltyMultiplier.save();
+    m_SoftTreeDepthLimit.save();
+    m_SoftTreeDepthTolerance.save();
+    m_DownsampleFactor.save();
+    m_FeatureBagFraction.save();
+    m_Eta.save();
+    m_EtaGrowthRatePerTree.save();
+    m_MaximumNumberTrees.save();
 }
 
-double CBoostedTreeHyperparameters::featureBagFraction() const {
-    return m_FeatureBagFraction;
+void CBoostedTreeHyperparameters::restoreBest() {
+    m_DepthPenaltyMultiplier.load();
+    m_TreeSizePenaltyMultiplier.load();
+    m_LeafWeightPenaltyMultiplier.load();
+    m_SoftTreeDepthLimit.load();
+    m_SoftTreeDepthTolerance.load();
+    m_DownsampleFactor.load();
+    m_FeatureBagFraction.load();
+    m_Eta.load();
+    m_EtaGrowthRatePerTree.load();
+    m_MaximumNumberTrees.load();
+    LOG_TRACE(<< "loss* = " << m_BestForestTestLoss);
+    LOG_TRACE(<< "parameters*= " << this->print());
 }
 
-void CBoostedTreeHyperparameters::regularization(const TRegularization& regularization) {
-    m_Regularization = regularization;
+void CBoostedTreeHyperparameters::captureScale() {
+    m_DepthPenaltyMultiplier.captureScale();
+    m_TreeSizePenaltyMultiplier.captureScale();
+    m_LeafWeightPenaltyMultiplier.captureScale();
+    m_SoftTreeDepthLimit.captureScale();
+    m_SoftTreeDepthTolerance.captureScale();
+    m_DownsampleFactor.captureScale();
+    m_FeatureBagFraction.captureScale();
+    m_Eta.captureScale();
+    m_EtaGrowthRatePerTree.captureScale();
+    m_MaximumNumberTrees.captureScale();
 }
 
-void CBoostedTreeHyperparameters::downsampleFactor(double downsampleFactor) {
-    m_DownsampleFactor = downsampleFactor;
-}
-
-void CBoostedTreeHyperparameters::eta(double eta) {
-    m_Eta = eta;
-}
-
-void CBoostedTreeHyperparameters::etaGrowthRatePerTree(double etaGrowthRatePerTree) {
-    m_EtaGrowthRatePerTree = etaGrowthRatePerTree;
-}
-
-void CBoostedTreeHyperparameters::maximumNumberTrees(std::size_t maximumNumberTrees) {
-    m_MaximumNumberTrees = maximumNumberTrees;
-}
-
-void CBoostedTreeHyperparameters::featureBagFraction(double featureBagFraction) {
-    m_FeatureBagFraction = featureBagFraction;
-}
-
-CBoostedTreeHyperparameters::CBoostedTreeHyperparameters(
-    const CBoostedTreeHyperparameters::TRegularization& regularization,
-    double downsampleFactor,
-    double eta,
-    double etaGrowthRatePerTree,
-    std::size_t maximumNumberTrees,
-    double featureBagFraction)
-    : m_Regularization{regularization}, m_DownsampleFactor{downsampleFactor}, m_Eta{eta},
-      m_EtaGrowthRatePerTree{etaGrowthRatePerTree},
-      m_MaximumNumberTrees{maximumNumberTrees}, m_FeatureBagFraction{featureBagFraction} {
-}
+// clang-format off
+const std::string CBoostedTreeHyperparameters::BAYESIAN_OPTIMIZATION_TAG{"bayesian_optimization"};
+const std::string CBoostedTreeHyperparameters::BEST_FOREST_TEST_LOSS_TAG{"best_forest_test_loss"};
+const std::string CBoostedTreeHyperparameters::CURRENT_ROUND_TAG{"current_round"};
+const std::string CBoostedTreeHyperparameters::DEPTH_PENALTY_MULTIPLIER_TAG{"depth_penalty_multiplier"};
+const std::string CBoostedTreeHyperparameters::DOWNSAMPLE_FACTOR_TAG{"downsample_factor"};
+const std::string CBoostedTreeHyperparameters::ETA_GROWTH_RATE_PER_TREE_TAG{"eta_growth_rate_per_tree"};
+const std::string CBoostedTreeHyperparameters::ETA_TAG{"eta"};
+const std::string CBoostedTreeHyperparameters::FEATURE_BAG_FRACTION_TAG{"feature_bag_fraction"};
+const std::string CBoostedTreeHyperparameters::LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG{"leaf_weight_penalty_multiplier"};
+const std::string CBoostedTreeHyperparameters::MAXIMUM_NUMBER_TREES_TAG{"maximum_number_trees"};
+const std::string CBoostedTreeHyperparameters::MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG{"maximum_optimisation_rounds_per_hyperparameter"};
+const std::string CBoostedTreeHyperparameters::MEAN_FOREST_SIZE_ACCUMULATOR_TAG{"mean_forest_size_accumulator"};
+const std::string CBoostedTreeHyperparameters::MEAN_TEST_LOSS_ACCUMULATOR_TAG{"mean_test_loss_accumulator"};
+const std::string CBoostedTreeHyperparameters::NUMBER_ROUNDS_TAG{"number_rounds"};
+const std::string CBoostedTreeHyperparameters::SOFT_TREE_DEPTH_LIMIT_TAG{"soft_tree_depth_limit"};
+const std::string CBoostedTreeHyperparameters::SOFT_TREE_DEPTH_TOLERANCE_TAG{"soft_tree_depth_tolerance"};
+const std::string CBoostedTreeHyperparameters::STOP_HYPERPARAMETER_OPTIMIZATION_EARLY_TAG{"stop_hyperparameter_optimization_early"};
+const std::string CBoostedTreeHyperparameters::TREE_SIZE_PENALTY_MULTIPLIER_TAG{"tree_size_penalty_multiplier"};
+// clang-format on
 }
 }
 }

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -1711,7 +1711,7 @@ bool CBoostedTreeImpl::acceptRestoreTraverser(core::CStateRestoreTraverser& trav
     int initializationStage{static_cast<int>(E_FullyInitialized)};
 
     do {
-        const std::string& name = traverser.name();
+        const std::string& name{traverser.name()};
         RESTORE(BEST_FOREST_TAG,
                 core::CPersistUtils::restore(BEST_FOREST_TAG, m_BestForest, traverser))
         RESTORE_SETUP_TEARDOWN(

--- a/lib/maths/analytics/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/analytics/CBoostedTreeLeafNodeStatistics.cc
@@ -374,11 +374,11 @@ CBoostedTreeLeafNodeStatistics::computeBestSplitStatistics(std::size_t numberThr
     }
 
     if (m_Derivatives.numberLossParameters() <= 2 && result.s_Gain > 0) {
-        double lambda{regularization.leafWeightPenaltyMultiplier()};
+        double lambda{regularization.leafWeightPenaltyMultiplier().value()};
         double childPenaltyForDepth{regularization.penaltyForDepth(m_Depth + 1)};
         double childPenaltyForDepthPlusOne{regularization.penaltyForDepth(m_Depth + 2)};
-        double childPenalty{regularization.treeSizePenaltyMultiplier() +
-                            regularization.depthPenaltyMultiplier() *
+        double childPenalty{regularization.treeSizePenaltyMultiplier().value() +
+                            regularization.depthPenaltyMultiplier().value() *
                                 (2.0 * childPenaltyForDepthPlusOne - childPenaltyForDepth)};
         result.s_LeftChildMaxGain =
             0.5 * this->childMaxGain(childrenGainStatisticsGlobal.s_GLeft,
@@ -408,7 +408,7 @@ CBoostedTreeLeafNodeStatistics::featureBestSplitSearch(
     using TDoubleMatrixAry = std::array<TDoubleMatrix, 2>;
 
     int d{static_cast<int>(m_NumberLossParameters)};
-    double lambda{regularization.leafWeightPenaltyMultiplier()};
+    double lambda{regularization.leafWeightPenaltyMultiplier().value()};
     auto minimumLoss_ = TThreading::makeThreadLocalMinimumLossFunction(d, lambda);
 
     TDoubleVector g_{d};
@@ -529,8 +529,8 @@ CBoostedTreeLeafNodeStatistics::featureBestSplitSearch(
         // The gain is the difference between the quadratic minimum for loss with
         // no split and the loss with the minimum loss split we found.
         double totalGain{0.5 * (maximumGain - minimumLoss(g, h)) -
-                         regularization.treeSizePenaltyMultiplier() -
-                         regularization.depthPenaltyMultiplier() *
+                         regularization.treeSizePenaltyMultiplier().value() -
+                         regularization.depthPenaltyMultiplier().value() *
                              (2.0 * penaltyForDepthPlusOne - penaltyForDepth)};
         SSplitStatistics candidateSplitStatistics{
             totalGain,

--- a/lib/maths/analytics/CBoostedTreeUtils.cc
+++ b/lib/maths/analytics/CBoostedTreeUtils.cc
@@ -20,6 +20,14 @@ namespace analytics {
 namespace boosted_tree_detail {
 using namespace boosted_tree;
 
+const CBoostedTreeNode& root(const std::vector<CBoostedTreeNode>& tree) {
+    return tree[rootIndex()];
+}
+
+CBoostedTreeNode& root(std::vector<CBoostedTreeNode>& tree) {
+    return tree[rootIndex()];
+}
+
 void zeroPrediction(const TRowRef& row, const TSizeVec& extraColumns, std::size_t numberLossParameters) {
     for (std::size_t i = 0; i < numberLossParameters; ++i) {
         row.writeColumn(extraColumns[E_Prediction] + i, 0.0);

--- a/lib/maths/analytics/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
@@ -380,7 +380,6 @@ BOOST_AUTO_TEST_CASE(testGainBoundComputation) {
 
     // Check the node gain upper bounds are always larger than the actual node gains.
 
-    using TRegularization = maths::analytics::CBoostedTreeRegularization<double>;
     using TLeafNodeStatisticsPtr = maths::analytics::CBoostedTreeLeafNodeStatistics::TPtr;
     using TNodeVec = maths::analytics::CBoostedTree::TNodeVec;
 
@@ -458,13 +457,14 @@ BOOST_AUTO_TEST_CASE(testGainBoundComputation) {
         TSizeVec treeFeatureBag{0};
         TSizeVec nodeFeatureBag{0};
 
-        TRegularization regularization;
-        regularization.softTreeDepthLimit(1.0).softTreeDepthTolerance(1.0);
+        maths::analytics::CBoostedTreeHyperparameters parameters;
+        parameters.softTreeDepthLimit().set(1.0);
+        parameters.softTreeDepthTolerance().set(1.0);
 
         TNodeVec tree(1);
 
         auto rootSplit = std::make_shared<maths::analytics::CBoostedTreeLeafNodeStatistics>(
-            0 /*root*/, extraColumns, 1, *frame, regularization, featureSplits,
+            0 /*root*/, extraColumns, 1, *frame, parameters, featureSplits,
             treeFeatureBag, nodeFeatureBag, 0 /*depth*/, trainingRowMask, workspace);
 
         std::size_t splitFeature;
@@ -481,8 +481,8 @@ BOOST_AUTO_TEST_CASE(testGainBoundComputation) {
         TLeafNodeStatisticsPtr leftChild;
         TLeafNodeStatisticsPtr rightChild;
         std::tie(leftChild, rightChild) = rootSplit->split(
-            leftChildId, rightChildId, 0.0, *frame, regularization,
-            treeFeatureBag, nodeFeatureBag, tree[rootSplit->id()], workspace);
+            leftChildId, rightChildId, 0.0, *frame, parameters, treeFeatureBag,
+            nodeFeatureBag, tree[rootSplit->id()], workspace);
         if (leftChild != nullptr) {
             BOOST_TEST_REQUIRE(rootSplit->leftChildMaxGain() >= leftChild->gain());
         }

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1514,10 +1514,10 @@ BOOST_AUTO_TEST_CASE(testDepthBasedRegularization) {
         auto regression =
             maths::analytics::CBoostedTreeFactory::constructFromParameters(
                 1, std::make_unique<maths::analytics::boosted_tree::CMse>())
-                .treeSizePenaltyMultiplier(0.0)
-                .leafWeightPenaltyMultiplier(0.0)
-                .softTreeDepthLimit(targetDepth)
-                .softTreeDepthTolerance(0.01)
+                .treeSizePenaltyMultiplier({0.0})
+                .leafWeightPenaltyMultiplier({0.0})
+                .softTreeDepthLimit({targetDepth})
+                .softTreeDepthTolerance({0.01})
                 .buildFor(*frame, cols - 1);
 
         regression->train();
@@ -2288,76 +2288,80 @@ BOOST_AUTO_TEST_CASE(testHyperparameterOverrides) {
                 1, std::make_unique<maths::analytics::boosted_tree::CMse>())
                 .analysisInstrumentation(instrumentation)
                 .maximumNumberTrees(10)
-                .treeSizePenaltyMultiplier(0.1)
-                .leafWeightPenaltyMultiplier(0.01)
+                .treeSizePenaltyMultiplier({0.1})
+                .leafWeightPenaltyMultiplier({0.01})
                 .buildFor(*frame, cols - 1);
 
         regression->train();
 
         // We use a single leaf to centre the data so end up with *at most* limit + 1 trees.
-        BOOST_TEST_REQUIRE(regression->bestHyperparameters().maximumNumberTrees() <= 11);
+        BOOST_TEST_REQUIRE(regression->hyperparameters().maximumNumberTrees().value() <= 11);
         BOOST_REQUIRE_EQUAL(
-            0.1, regression->bestHyperparameters().regularization().treeSizePenaltyMultiplier());
+            0.1, regression->hyperparameters().treeSizePenaltyMultiplier().value());
         BOOST_REQUIRE_EQUAL(
-            0.01, regression->bestHyperparameters().regularization().leafWeightPenaltyMultiplier());
+            0.01, regression->hyperparameters().leafWeightPenaltyMultiplier().value());
     }
     {
         auto regression =
             maths::analytics::CBoostedTreeFactory::constructFromParameters(
                 1, std::make_unique<maths::analytics::boosted_tree::CMse>())
                 .analysisInstrumentation(instrumentation)
-                .eta(0.2)
-                .softTreeDepthLimit(2.0)
-                .softTreeDepthTolerance(0.1)
+                .eta({0.2})
+                .softTreeDepthLimit({2.0})
+                .softTreeDepthTolerance({0.1})
                 .buildFor(*frame, cols - 1);
 
         regression->train();
 
-        BOOST_REQUIRE_EQUAL(0.2, regression->bestHyperparameters().eta());
+        BOOST_REQUIRE_EQUAL(0.2, regression->hyperparameters().eta().value());
         BOOST_REQUIRE_EQUAL(
-            2.0, regression->bestHyperparameters().regularization().softTreeDepthLimit());
+            2.0, regression->hyperparameters().softTreeDepthLimit().value());
         BOOST_REQUIRE_EQUAL(
-            0.1, regression->bestHyperparameters().regularization().softTreeDepthTolerance());
+            0.1, regression->hyperparameters().softTreeDepthTolerance().value());
     }
     {
         auto regression =
             maths::analytics::CBoostedTreeFactory::constructFromParameters(
                 1, std::make_unique<maths::analytics::boosted_tree::CMse>())
                 .analysisInstrumentation(instrumentation)
-                .depthPenaltyMultiplier(1.0)
-                .featureBagFraction(0.4)
-                .downsampleFactor(0.6)
+                .depthPenaltyMultiplier({1.0})
+                .featureBagFraction({0.4})
+                .downsampleFactor({0.6})
                 .buildFor(*frame, cols - 1);
 
         regression->train();
 
         BOOST_REQUIRE_EQUAL(
-            1.0, regression->bestHyperparameters().regularization().depthPenaltyMultiplier());
-        BOOST_REQUIRE_EQUAL(0.4, regression->bestHyperparameters().featureBagFraction());
-        BOOST_REQUIRE_EQUAL(0.6, regression->bestHyperparameters().downsampleFactor());
+            1.0, regression->hyperparameters().depthPenaltyMultiplier().value());
+        BOOST_REQUIRE_EQUAL(
+            0.4, regression->hyperparameters().featureBagFraction().value());
+        BOOST_REQUIRE_EQUAL(
+            0.6, regression->hyperparameters().downsampleFactor().value());
     }
     {
         auto regression =
             maths::analytics::CBoostedTreeFactory::constructFromParameters(
                 1, std::make_unique<maths::analytics::boosted_tree::CMse>())
                 .analysisInstrumentation(instrumentation)
-                .depthPenaltyMultiplier(1.0)
-                .softTreeDepthLimit(3.0)
-                .softTreeDepthTolerance(0.1)
-                .featureBagFraction(0.4)
-                .downsampleFactor(0.6)
-                .etaGrowthRatePerTree(1.1)
+                .depthPenaltyMultiplier({1.0})
+                .softTreeDepthLimit({3.0})
+                .softTreeDepthTolerance({0.1})
+                .featureBagFraction({0.4})
+                .downsampleFactor({0.6})
+                .etaGrowthRatePerTree({1.1})
                 .buildFor(*frame, cols - 1);
 
         regression->train();
         BOOST_REQUIRE_EQUAL(
-            1.0, regression->bestHyperparameters().regularization().depthPenaltyMultiplier());
+            1.0, regression->hyperparameters().depthPenaltyMultiplier().value());
         BOOST_REQUIRE_EQUAL(
-            3.0, regression->bestHyperparameters().regularization().softTreeDepthLimit());
+            3.0, regression->hyperparameters().softTreeDepthLimit().value());
         BOOST_REQUIRE_EQUAL(
-            0.1, regression->bestHyperparameters().regularization().softTreeDepthTolerance());
-        BOOST_REQUIRE_EQUAL(0.4, regression->bestHyperparameters().featureBagFraction());
-        BOOST_REQUIRE_EQUAL(1.1, regression->bestHyperparameters().etaGrowthRatePerTree());
+            0.1, regression->hyperparameters().softTreeDepthTolerance().value());
+        BOOST_REQUIRE_EQUAL(
+            0.4, regression->hyperparameters().featureBagFraction().value());
+        BOOST_REQUIRE_EQUAL(
+            1.1, regression->hyperparameters().etaGrowthRatePerTree().value());
     }
 }
 

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1517,7 +1517,7 @@ BOOST_AUTO_TEST_CASE(testDepthBasedRegularization) {
                 .treeSizePenaltyMultiplier({0.0})
                 .leafWeightPenaltyMultiplier({0.0})
                 .softTreeDepthLimit({targetDepth})
-                .softTreeDepthTolerance({0.01})
+                .softTreeDepthTolerance({0.05})
                 .buildFor(*frame, cols - 1);
 
         regression->train();
@@ -1525,7 +1525,7 @@ BOOST_AUTO_TEST_CASE(testDepthBasedRegularization) {
         TMeanAccumulator meanDepth;
         for (const auto& tree : regression->trainedModel()) {
             BOOST_TEST_REQUIRE(maxDepth(tree, tree[0], 0) <=
-                               static_cast<std::size_t>(targetDepth));
+                               static_cast<std::size_t>(targetDepth + 1));
             meanDepth.add(static_cast<double>(maxDepth(tree, tree[0], 0)));
         }
         LOG_DEBUG(<< "mean depth = " << maths::common::CBasicStatistics::mean(meanDepth));

--- a/lib/maths/analytics/unittest/testfiles/error_bayesian_optimisation_state.json
+++ b/lib/maths/analytics/unittest/testfiles/error_bayesian_optimisation_state.json
@@ -1,116 +1,462 @@
 {
-  "7.8": "",
-  "bayesian_optimization": {
-    "7.5": "",
-    "rng": "16294208416658607535:7960286522194355700",
-    "min_boundary": {
-      "dense_vector": "-6.18966:-2.047204:-4.574167:2:5e-2:-3.506558:1.025:2e-1"
-    },
-    "max_boundary": {
-      "dense_vector": "-1.584489:2.557966:-1.589118e-2:7.321928:2.5e-1:a:1.075:8e-1"
-    },
-    "error_variances": "",
-    "kernel_parameters": {
-      "dense_vector": "1:1:1:1:1:1:1:1:1"
-    },
-    "min_kernel_coordinate_distance_scales": {
-      "dense_vector": "1e-3:1e-3:1e-3:1e-3:1e-3:1e-3:1e-3:1e-3"
-    },
-    "function_mean_values": {
-      "d": "0"
-    },
-    "range_scale": "1",
-    "range_shift": "0",
-    "restarts": "10"
-  },
-  "best_forest_test_loss": "1.797693e308",
-  "current_round": "0",
-  "dependent_variable": "2",
-  "encoder_tag": {
-    "7.5": "",
-    "encoding_vector": {
-      "identity_encoding": {
-        "encoding_input_column_index": "0",
-        "encoding_mic": "3.556275e-1"
+  "8.2": "",
+  "best_forest": {
+      "d": "3",
+      "a": {
+          "d": "1",
+          "a": {
+              "assign_missing_to_left ": "true",
+              "curvature": "0",
+              "gain": "0",
+              "gain_variance": "0",
+              "left_child": "false;0",
+              "missing_split_tag": "0",
+              "node_value": {
+                  "dense_vector": "5.1091489833593347"
+              },
+              "number_samples": "50",
+              "right_child": "false;0",
+              "split_tag": "0",
+              "split_feature": "0",
+              "split_value": "0"
+          }
       },
-      "identity_encoding": {
-        "encoding_input_column_index": "2",
-        "encoding_mic": "0"
+      "a": {
+          "d": "3",
+          "a": {
+              "assign_missing_to_left ": "true",
+              "curvature": "52",
+              "gain": "16.898930513290566",
+              "gain_variance": "0",
+              "left_child": "true;1",
+              "missing_split_tag": "74",
+              "node_value": {
+                  "dense_vector": ""
+              },
+              "number_samples": "50",
+              "right_child": "true;2",
+              "split_tag": "51",
+              "split_feature": "0",
+              "split_value": "5.741978645324707"
+          },
+          "a": {
+              "assign_missing_to_left ": "true",
+              "curvature": "0",
+              "gain": "0",
+              "gain_variance": "0",
+              "left_child": "false;0",
+              "missing_split_tag": "0",
+              "node_value": {
+                  "dense_vector": "-0.007816124099126423"
+              },
+              "number_samples": "32",
+              "right_child": "false;0",
+              "split_tag": "0",
+              "split_feature": "0",
+              "split_value": "0"
+          },
+          "a": {
+              "assign_missing_to_left ": "true",
+              "curvature": "0",
+              "gain": "0",
+              "gain_variance": "0",
+              "left_child": "false;0",
+              "missing_split_tag": "0",
+              "node_value": {
+                  "dense_vector": "0.013140310089309314"
+              },
+              "number_samples": "18",
+              "right_child": "false;0",
+              "split_tag": "0",
+              "split_feature": "0",
+              "split_value": "0"
+          }
+      },
+      "a": {
+          "d": "5",
+          "a": {
+              "assign_missing_to_left ": "true",
+              "curvature": "56",
+              "gain": "17.908863584310794",
+              "gain_variance": "0",
+              "left_child": "true;1",
+              "missing_split_tag": "75",
+              "node_value": {
+                  "dense_vector": ""
+              },
+              "number_samples": "50",
+              "right_child": "true;2",
+              "split_tag": "66",
+              "split_feature": "1",
+              "split_value": "8.6189403533935547"
+          },
+          "a": {
+              "assign_missing_to_left ": "true",
+              "curvature": "52",
+              "gain": "11.190527439403581",
+              "gain_variance": "0",
+              "left_child": "true;3",
+              "missing_split_tag": "75",
+              "node_value": {
+                  "dense_vector": ""
+              },
+              "number_samples": "46",
+              "right_child": "true;4",
+              "split_tag": "39",
+              "split_feature": "1",
+              "split_value": "6.1874055862426758"
+          },
+          "a": {
+              "assign_missing_to_left ": "true",
+              "curvature": "0",
+              "gain": "0",
+              "gain_variance": "0",
+              "left_child": "false;0",
+              "missing_split_tag": "0",
+              "node_value": {
+                  "dense_vector": "-0.064155712452879834"
+              },
+              "number_samples": "4",
+              "right_child": "false;0",
+              "split_tag": "0",
+              "split_feature": "0",
+              "split_value": "0"
+          },
+          "a": {
+              "assign_missing_to_left ": "true",
+              "curvature": "0",
+              "gain": "0",
+              "gain_variance": "0",
+              "left_child": "false;0",
+              "missing_split_tag": "0",
+              "node_value": {
+                  "dense_vector": "-0.0099971100556165583"
+              },
+              "number_samples": "33",
+              "right_child": "false;0",
+              "split_tag": "0",
+              "split_feature": "0",
+              "split_value": "0"
+          },
+          "a": {
+              "assign_missing_to_left ": "true",
+              "curvature": "0",
+              "gain": "0",
+              "gain_variance": "0",
+              "left_child": "false;0",
+              "missing_split_tag": "0",
+              "node_value": {
+                  "dense_vector": "0.049922790302842392"
+              },
+              "number_samples": "13",
+              "right_child": "false;0",
+              "split_tag": "0",
+              "split_feature": "0",
+              "split_value": "0"
+          }
       }
-    }
   },
-  "eta_growth_rate_per_tree": "1.05",
-  "eta": "1e-1",
-  "feature_bag_fraction": "5e-1",
+  "data_summarization_fraction": "0.10000000000000001",
+  "dependent_variable": "2",
+  "encoder": {
+      "7.5": "",
+      "encoding_vector": {
+          "identity_encoding": {
+              "encoding_input_column_index": "0",
+              "encoding_mic": "0.35562752551794907"
+          },
+          "identity_encoding": {
+              "encoding_input_column_index": "1",
+              "encoding_mic": "0.28992695958862941"
+          },
+          "identity_encoding": {
+              "encoding_input_column_index": "2",
+              "encoding_mic": "0"
+          }
+      }
+  },
   "feature_data_types": {
-    "d": "2",
-    "a": "0:2.10813656449318e-1:9.96675395965576:",
-    "a": "0:2.90942788124084e-1:9.86151218414307:"
+      "d": "3",
+      "a": "0:0.21081365644931793:9.9667539596557617:",
+      "a": "0:0.19866824150085449:9.860783576965332:",
+      "a": "0:0.29094278812408447:9.8615121841430664:"
   },
-  "feature_sample_probabilities": "1:0",
+  "feature_sample_probabilities": "0.55088692546104212:0.44911307453895799:0",
+  "fold_round_test_losses": {
+      "d": "2",
+      "a": {
+          "d": "27",
+          "a": "true;9.0144826258579673",
+          "a": "true;9.0499017652547611",
+          "a": "true;9.0178013724720731",
+          "a": "true;9.0241037806794679",
+          "a": "false;0",
+          "a": "true;8.9614964880021901",
+          "a": "true;9.0005776784098526",
+          "a": "true;8.9218660012727113",
+          "a": "false;0",
+          "a": "true;8.9767510653572202",
+          "a": "false;0",
+          "a": "true;9.0104144559652788",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0"
+      },
+      "a": {
+          "d": "27",
+          "a": "true;9.3459522121808618",
+          "a": "true;9.394506320076788",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "true;9.3749161535306058",
+          "a": "true;9.3859495094329297",
+          "a": "true;9.3728466536603445",
+          "a": "true;9.3517225537214959",
+          "a": "true;9.4086228166349812",
+          "a": "true;9.3165126414160273",
+          "a": "true;9.3772605238915538",
+          "a": "true;9.3621189604516672",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0",
+          "a": "false;0"
+      }
+  },
+  "force_accept_incremental_training": "false",
+  "hyperparameters": {
+      "bayesian_optimization": {
+          "7.5": "",
+          "rng": "10183786778186750064:10849986369685223392",
+          "min_boundary": {
+              "dense_vector": "-0.91629073187415488:2.6743017267828022:-0.018170006992743626:-0.97064114072552066:3.3599142212867878:0.050000000000000003:-3.666155111700756:1.00862684655656:0.66666666666666652"
+          },
+          "max_boundary": {
+              "dense_vector": "-0.34657359027997259:3.9745991852578126:0.58097644771805446:0.32965631774948961:4.6886854592417322:0.25:-3.0670086569899579:a:0.80000000000000004"
+          },
+          "error_variances": "87.352987728357988:94.413134861686572:90.621146648945725:90.747780956931933:90.999120221489164:143.235164104012:110.18033252101309:146.90530986961005:118.65505961139908:91.778069063921109:113.93159892893426:98.343634009851712",
+          "kernel_parameters": {
+              "dense_vector": "3.0552871591862582e-8:0.83966865233020715:0.25004011726240716:0.33538169186278649:0.35491586964283839:1.6364091615911243:0.30149666456803925:0.76555007872419489:1.3819973841965436:0.75511173061725645"
+          },
+          "min_kernel_coordinate_distance_scales": {
+              "dense_vector": "0.001:0.001:0.001:0.001:0.001:0.001:0.001:0.001:0.001"
+          },
+          "function_mean_values": {
+              "d": "12",
+              "a": {
+                  "a": {
+                      "dense_vector": "-1.216651439730918:2.6349359854035814:0.6394986173988404:-0.16822481734313297:3.0285874086632774:0.74999999999999989:-5.618963206534155:58.958605931130116:5.999999999999992"
+                  },
+                  "b": "-0.20906288185691863"
+              },
+              "a": {
+                  "a": {
+                      "dense_vector": "-1.108325719865459:2.5566845757887005:0.46967351329565304:-0.24647622695801411:3.0285874086632774:0.75000000000000011:-5.618963206534155:58.958605931130116:5.499999999999992"
+                  },
+                  "b": "1.465190348916235"
+              },
+              "a": {
+                  "a": {
+                      "dense_vector": "-0.85832571986545902:2.3066845757887005:0.21967351329565316:-0.49647622695801408:3.2785874086632769:1:-5.868963206534155:59.208605931130109:5.7499999999999911"
+                  },
+                  "b": "0.043709239257741055"
+              },
+              "a": {
+                  "a": {
+                      "dense_vector": "-1.358325719865459:2.8066845757887005:0.71967351329565288:0.0035237730419857309:2.7785874086632774:0.5:-5.368963206534155:58.708605931130123:5.249999999999992"
+                  },
+                  "b": "0.29972623827831102"
+              },
+              "a": {
+                  "a": {
+                      "dense_vector": "-1.233325719865459:2.4316845757887:0.5946735132956531:0.12852377304198601:2.9035874086632774:0.37500000000000006:-5.743963206534155:59.333605931130109:5.8749999999999911"
+                  },
+                  "b": "0.81129214214899936"
+              },
+              "a": {
+                  "a": {
+                      "dense_vector": "-0.73332571986545902:2.9316845757887005:0.094673513295652573:-0.37147622695801413:3.4035874086632774:0.87499999999999989:-5.243963206534155:58.833605931130109:5.3749999999999911"
+                  },
+                  "b": "-0.46803355461116519"
+              },
+              "a": {
+                  "a": {
+                      "dense_vector": "-0.98332571986545891:2.1816845757887:0.84467351329565288:-0.12147622695801405:3.1535874086632774:1.125:-5.993963206534155:58.583605931130116:5.124999999999992"
+                  },
+                  "b": "0.04992081889624167"
+              },
+              "a": {
+                  "a": {
+                      "dense_vector": "-1.483325719865459:2.6816845757887:0.34467351329565271:-0.62147622695801419:2.6535874086632774:0.625:-5.493963206534155:59.083605931130116:5.624999999999992"
+                  },
+                  "b": "-1.9405985155956018"
+              },
+              "a": {
+                  "a": {
+                      "dense_vector": "-1.420825719865459:2.3691845757887005:0.90717351329565288:-0.30897622695801408:3.0910874086632774:0.5625:-5.6814632065341542:59.396105931130123:5.937499999999992"
+                  },
+                  "b": "1.2806924015185162"
+              },
+              "a": {
+                  "a": {
+                      "dense_vector": "-0.92082571986545891:2.8691845757887:0.40717351329565316:0.19102377304198587:2.5910874086632774:1.0625:-5.1814632065341542:58.896105931130123:5.437499999999992"
+                  },
+                  "b": "-1.5483165985085918"
+              },
+              "a": {
+                  "a": {
+                      "dense_vector": "-0.67082571986545925:2.1191845757887005:0.65717351329565266:-0.55897622695801408:2.8410874086632774:0.8125:-5.9314632065341542:58.646105931130116:5.187499999999992"
+                  },
+                  "b": "0.18332256194219118"
+              },
+              "a": {
+                  "a": {
+                      "dense_vector": "-1.5023791840523408:2.4461221093745866:0.37828349063742128:-0.61602945817350763:3.2707230456253571:1.1117938548911503:-6.049916299750727:58.91036647086441:5.9777160260348676"
+                  },
+                  "b": "0.032157799614608622"
+              }
+          },
+          "range_scale": "39.875872012830158",
+          "range_shift": "9.185460260650304",
+          "restarts": "10"
+      },
+      "best_forest_loss_gap": "1.0621337693570894",
+      "best_forest_test_loss": "9.4761914959470275",
+      "current_round": "11",
+      "depth_penalty_multiplier": {
+          "value": "41.712189982016397",
+          "saved_value": "41.712189982016397",
+          "fixed": "false"
+      },
+      "downsample_factor": {
+          "value": "0.59178599935403775",
+          "saved_value": "0.59178599935403775",
+          "fixed": "false"
+      },
+      "eta_growth_rate_per_tree": {
+          "value": "1.0161753372935503",
+          "saved_value": "1.0161753372935503",
+          "fixed": "false"
+      },
+      "eta": {
+          "value": "0.044848940658558351",
+          "saved_value": "0.044848940658558351",
+          "fixed": "false"
+      },
+      "feature_bag_fraction": {
+          "value": "0.72499999999999998",
+          "saved_value": "0.72499999999999998",
+          "fixed": "false"
+      },
+      "leaf_weight_penalty_multiplier": {
+          "value": "1.2762888961575412",
+          "saved_value": "1.2762888961575412",
+          "fixed": "false"
+      },
+      "maximum_number_trees": {
+          "value": "2",
+          "saved_value": "2",
+          "fixed": "true"
+      },
+      "maximum_optimisation_rounds_per_hyperparameter": "3",
+      "mean_forest_size_accumulator": "19:10.4736843",
+      "mean_test_loss_accumulator": "12:9.18546009",
+      "number_rounds": "27",
+      "prediction_change_cost": {
+          "value": "0.5",
+          "saved_value": "0.5",
+          "fixed": "false"
+      },
+      "retrained_tree_eta": {
+          "value": "1",
+          "saved_value": "1",
+          "fixed": "false"
+      },
+      "soft_tree_depth_limit": {
+          "value": "3.442962423658972",
+          "saved_value": "3.442962423658972",
+          "fixed": "false"
+      },
+      "soft_tree_depth_tolerance": {
+          "value": "0.21250000000000002",
+          "saved_value": "0.21250000000000002",
+          "fixed": "false"
+      },
+      "stop_hyperparameter_optimization_early": "true",
+      "tree_size_penalty_multiplier": {
+          "value": "1.2819568846245164",
+          "saved_value": "1.2819568846245164",
+          "fixed": "false"
+      },
+      "tree_topology_change_penalty": {
+          "value": "0",
+          "saved_value": "0",
+          "fixed": "false"
+      }
+  },
+  "initialization_progress": "8",
+  "loss": {
+      "mse": {}
+  },
   "maximum_attempts_to_add_tree": "3",
-  "maximum_optimisation_rounds_per_hyperparameter": "3",
-  "maximum_tree_size_multiplier": "10",
   "missing_feature_row_masks": {
-    "d": "3",
-    "a": "50:0:1:50",
-    "a": "50:0:1:50",
-    "a": "50:0:1:50"
+      "d": "3",
+      "a": "7.9:50:0:1:1:200",
+      "a": "7.9:50:0:1:1:200",
+      "a": "7.9:50:0:1:1:200"
   },
-  "number_folds": "2",
-  "number_rounds": "24",
+  "new_training_row_mask_tag": "7.9:50:0:1:1:200",
+  "number_folds": {
+      "value": "2",
+      "saved_value": "0",
+      "fixed": "true"
+  },
   "number_splits_per_feature": "75",
   "number_threads": "1",
-  "random_number_generator": "6348936557884334503:6746432788814635579",
-  "regularization_override": {
-    "regularization_depth_penalty_multiplier": "false;0",
-    "regularization_tree_size_penalty_multiplier": "false;0",
-    "regularization_leaf_weight_penalty_multiplier": "false;0",
-    "regularization_soft_tree_depth_limit": "false;0",
-    "regularization_soft_tree_depth_tolerance": "false;0"
-  },
-  "regularization": {
-    "regularization_depth_penalty_multiplier": "2.050525e-2",
-    "regularization_tree_size_penalty_multiplier": "1.031488e-1",
-    "regularization_leaf_weight_penalty_multiplier": "1.290953",
-    "regularization_soft_tree_depth_limit": "3",
-    "regularization_soft_tree_depth_tolerance": "1.5e-1"
-  },
+  "top_shap_values": "0",
+  "previous_train_loss_gap": "0",
+  "previous_train_number_rows": "0",
+  "random_number_generator": "15723264323598070226:5510878494715014656",
+  "retrain_fraction": "0.10000000000000001",
   "rows_per_feature": "50",
+  "seed": "0",
+  "stop_cross_validation_early": "true",
   "testing_row_masks": {
-    "d": "2",
-    "a": "50:1:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2",
-    "a": "50:0:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2"
+      "d": "2",
+      "a": "7.9:50:1:1:1:20:4:4:12:12:12:8:16:4:12:4:12:12:4:8:4:4:16:8:4:8:4:8",
+      "a": "7.9:50:0:1:1:20:4:4:12:12:12:8:16:4:12:4:12:12:4:8:4:4:16:8:4:8:4:8"
   },
-  "maximum_number_trees": "2",
   "training_row_masks": {
-    "d": "2",
-    "a": "50:0:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2",
-    "a": "50:1:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2"
+      "d": "2",
+      "a": "7.9:50:0:1:1:20:4:4:12:12:12:8:16:4:12:4:12:12:4:8:4:4:16:8:4:8:4:8",
+      "a": "7.9:50:1:1:1:20:4:4:12:12:12:8:16:4:12:4:12:12:4:8:4:4:16:8:4:8:4:8"
   },
-  "training_progress": {
-    "loop_size_tag": "76",
-    "progress_steps_tag": "32",
-    "current_step_progress_tag": "3.125e-2",
-    "loop_pos_tag": "26"
+  "train_fraction_per_folds": {
+      "value": "0.5",
+      "saved_value": "0",
+      "fixed": "false"
   },
-  "best_forest": {
-    "d": "0"
-  },
-  "best_hyperparameters": {
-    "hyperparam_eta": "1e-1",
-    "hyperparam_eta_growth_rate_per_tree": "1.05",
-    "hyperparam_feature_bag_fraction": "5e-1",
-    "hyperparam_regularization": {
-      "regularization_depth_penalty_multiplier": "0",
-      "regularization_tree_size_penalty_multiplier": "0",
-      "regularization_leaf_weight_penalty_multiplier": "0",
-      "regularization_soft_tree_depth_limit": "0",
-      "regularization_soft_tree_depth_tolerance": "0"
-    }
-  },
-  "eta_override": "false;0",
-  "feature_bag_fraction_override": "false;0",
-  "maximum_number_trees_override": "true;2",
-  "loss": "mse"
+  "trees_to_retrain": ""
 }

--- a/lib/maths/analytics/unittest/testfiles/error_boosted_tree_impl_state.json
+++ b/lib/maths/analytics/unittest/testfiles/error_boosted_tree_impl_state.json
@@ -1,116 +1,462 @@
 {
-  "7.8": "",
-  "bayesian_optimization": {
-    "7.5": "",
-    "rng": "16294208416658607535:7960286522194355700",
-    "min_boundary": {
-      "dense_vector": "-6.18966:-2.047204:-4.574167:2:5e-2:-3.506558:1.025:2e-1"
+    "8.2": "",
+    "best_forest": {
+        "d": "3",
+        "a": {
+            "d": "1",
+            "a": {
+                "assign_missing_to_left ": "true",
+                "curvature": "0",
+                "gain": "0",
+                "gain_variance": "0",
+                "left_child": "false;0",
+                "missing_split_tag": "0",
+                "node_value": {
+                    "dense_vector": "5.1091489833593347"
+                },
+                "number_samples": "50",
+                "right_child": "false;0",
+                "split_tag": "0",
+                "split_feature": "0",
+                "split_value": "0"
+            }
+        },
+        "a": {
+            "d": "3",
+            "a": {
+                "assign_missing_to_left ": "true",
+                "curvature": "52",
+                "gain": "16.898930513290566",
+                "gain_variance": "0",
+                "left_child": "true;1",
+                "missing_split_tag": "74",
+                "node_value": {
+                    "dense_vector": ""
+                },
+                "number_samples": "50",
+                "right_child": "true;2",
+                "split_tag": "51",
+                "split_feature": "0",
+                "split_value": "5.741978645324707"
+            },
+            "a": {
+                "assign_missing_to_left ": "true",
+                "curvature": "0",
+                "gain": "0",
+                "gain_variance": "0",
+                "left_child": "false;0",
+                "missing_split_tag": "0",
+                "node_value": {
+                    "dense_vector": "-0.007816124099126423"
+                },
+                "number_samples": "32",
+                "right_child": "false;0",
+                "split_tag": "0",
+                "split_feature": "0",
+                "split_value": "0"
+            },
+            "a": {
+                "assign_missing_to_left ": "true",
+                "curvature": "0",
+                "gain": "0",
+                "gain_variance": "0",
+                "left_child": "false;0",
+                "missing_split_tag": "0",
+                "node_value": {
+                    "dense_vector": "0.013140310089309314"
+                },
+                "number_samples": "18",
+                "right_child": "false;0",
+                "split_tag": "0",
+                "split_feature": "0",
+                "split_value": "0"
+            }
+        },
+        "a": {
+            "d": "5",
+            "a": {
+                "assign_missing_to_left ": "true",
+                "curvature": "56",
+                "gain": "17.908863584310794",
+                "gain_variance": "0",
+                "left_child": "true;1",
+                "missing_split_tag": "75",
+                "node_value": {
+                    "dense_vector": ""
+                },
+                "number_samples": "50",
+                "right_child": "true;2",
+                "split_tag": "66",
+                "split_feature": "1",
+                "split_value": "8.6189403533935547"
+            },
+            "a": {
+                "assign_missing_to_left ": "true",
+                "curvature": "52",
+                "gain": "11.190527439403581",
+                "gain_variance": "0",
+                "left_child": "true;3",
+                "missing_split_tag": "75",
+                "node_value": {
+                    "dense_vector": ""
+                },
+                "number_samples": "46",
+                "right_child": "true;4",
+                "split_tag": "39",
+                "split_feature": "1",
+                "split_value": "6.1874055862426758"
+            },
+            "a": {
+                "assign_missing_to_left ": "true",
+                "curvature": "0",
+                "gain": "0",
+                "gain_variance": "0",
+                "left_child": "false;0",
+                "missing_split_tag": "0",
+                "node_value": {
+                    "dense_vector": "-0.064155712452879834"
+                },
+                "number_samples": "4",
+                "right_child": "false;0",
+                "split_tag": "0",
+                "split_feature": "0",
+                "split_value": "0"
+            },
+            "a": {
+                "assign_missing_to_left ": "true",
+                "curvature": "0",
+                "gain": "0",
+                "gain_variance": "0",
+                "left_child": "false;0",
+                "missing_split_tag": "0",
+                "node_value": {
+                    "dense_vector": "-0.0099971100556165583"
+                },
+                "number_samples": "33",
+                "right_child": "false;0",
+                "split_tag": "0",
+                "split_feature": "0",
+                "split_value": "0"
+            },
+            "a": {
+                "assign_missing_to_left ": "true",
+                "curvature": "0",
+                "gain": "0",
+                "gain_variance": "0",
+                "left_child": "false;0",
+                "missing_split_tag": "0",
+                "node_value": {
+                    "dense_vector": "0.049922790302842392"
+                },
+                "number_samples": "13",
+                "right_child": "false;0",
+                "split_tag": "0",
+                "split_feature": "0",
+                "split_value": "0"
+            }
+        }
     },
-    "max_boundary": {
-      "dense_vector": "-1.584489:2.557966:-1.589118e-2:7.321928:2.5e-1:-1.203973:1.075:8e-1"
+    "data_summarization_fraction": "0.10000000000000001",
+    "dependent_variable": "2",
+    "encoder": {
+        "7.5": "",
+        "encoding_vector": {
+            "identity_encoding": {
+                "encoding_input_column_index": "0",
+                "encoding_mic": "0.35562752551794907"
+            },
+            "identity_encoding": {
+                "encoding_input_column_index": "1",
+                "encoding_mic": "0.28992695958862941"
+            },
+            "identity_encoding": {
+                "encoding_input_column_index": "2",
+                "encoding_mic": "0"
+            }
+        }
     },
-    "error_variances": "",
-    "kernel_parameters": {
-      "dense_vector": "1:1:1:1:1:1:1:1:1"
+    "feature_data_types": {
+        "d": "3",
+        "a": "0:0.21081365644931793:9.9667539596557617:",
+        "a": "0:0.19866824150085449:9.860783576965332:",
+        "a": "0:0.29094278812408447:9.8615121841430664:"
     },
-    "min_kernel_coordinate_distance_scales": {
-      "dense_vector": "1e-3:1e-3:1e-3:1e-3:1e-3:1e-3:1e-3:1e-3"
+    "feature_sample_probabilities": "0.55088692546104212:0.44911307453895799:0",
+    "fold_round_test_losses": {
+        "d": "2",
+        "a": {
+            "d": "27",
+            "a": "true;9.0144826258579673",
+            "a": "true;9.0499017652547611",
+            "a": "true;9.0178013724720731",
+            "a": "true;9.0241037806794679",
+            "a": "false;0",
+            "a": "true;8.9614964880021901",
+            "a": "true;9.0005776784098526",
+            "a": "true;8.9218660012727113",
+            "a": "false;0",
+            "a": "true;8.9767510653572202",
+            "a": "false;0",
+            "a": "true;9.0104144559652788",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0"
+        },
+        "a": {
+            "d": "27",
+            "a": "true;9.3459522121808618",
+            "a": "true;9.394506320076788",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "true;9.3749161535306058",
+            "a": "true;9.3859495094329297",
+            "a": "true;9.3728466536603445",
+            "a": "true;9.3517225537214959",
+            "a": "true;9.4086228166349812",
+            "a": "true;9.3165126414160273",
+            "a": "true;9.3772605238915538",
+            "a": "true;9.3621189604516672",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0",
+            "a": "false;0"
+        }
     },
-    "function_mean_values": {
-      "d": "0"
+    "force_accept_incremental_training": "false",
+    "hyperparameters": {
+        "bayesian_optimization": {
+            "7.5": "",
+            "rng": "10183786778186750064:10849986369685223392",
+            "min_boundary": {
+                "dense_vector": "-0.91629073187415488:2.6743017267828022:-0.018170006992743626:-0.97064114072552066:3.3599142212867878:0.050000000000000003:-3.666155111700756:1.00862684655656:0.66666666666666652"
+            },
+            "max_boundary": {
+                "dense_vector": "-0.34657359027997259:3.9745991852578126:0.58097644771805446:0.32965631774948961:4.6886854592417322:0.25:-3.0670086569899579:1.0258805396696804:0.80000000000000004"
+            },
+            "error_variances": "87.352987728357988:94.413134861686572:90.621146648945725:90.747780956931933:90.999120221489164:143.235164104012:110.18033252101309:146.90530986961005:118.65505961139908:91.778069063921109:113.93159892893426:98.343634009851712",
+            "kernel_parameters": {
+                "dense_vector": "3.0552871591862582e-8:0.83966865233020715:0.25004011726240716:0.33538169186278649:0.35491586964283839:1.6364091615911243:0.30149666456803925:0.76555007872419489:1.3819973841965436:0.75511173061725645"
+            },
+            "min_kernel_coordinate_distance_scales": {
+                "dense_vector": "0.001:0.001:0.001:0.001:0.001:0.001:0.001:0.001:0.001"
+            },
+            "function_mean_values": {
+                "d": "12",
+                "a": {
+                    "a": {
+                        "dense_vector": "-1.216651439730918:2.6349359854035814:0.6394986173988404:-0.16822481734313297:3.0285874086632774:0.74999999999999989:-5.618963206534155:58.958605931130116:5.999999999999992"
+                    },
+                    "b": "-0.20906288185691863"
+                },
+                "a": {
+                    "a": {
+                        "dense_vector": "-1.108325719865459:2.5566845757887005:0.46967351329565304:-0.24647622695801411:3.0285874086632774:0.75000000000000011:-5.618963206534155:58.958605931130116:5.499999999999992"
+                    },
+                    "b": "1.465190348916235"
+                },
+                "a": {
+                    "a": {
+                        "dense_vector": "-0.85832571986545902:2.3066845757887005:0.21967351329565316:-0.49647622695801408:3.2785874086632769:1:-5.868963206534155:59.208605931130109:5.7499999999999911"
+                    },
+                    "b": "0.043709239257741055"
+                },
+                "a": {
+                    "a": {
+                        "dense_vector": "-1.358325719865459:2.8066845757887005:0.71967351329565288:0.0035237730419857309:2.7785874086632774:0.5:-5.368963206534155:58.708605931130123:5.249999999999992"
+                    },
+                    "b": "0.29972623827831102"
+                },
+                "a": {
+                    "a": {
+                        "dense_vector": "-1.233325719865459:2.4316845757887:0.5946735132956531:0.12852377304198601:2.9035874086632774:0.37500000000000006:-5.743963206534155:59.333605931130109:5.8749999999999911"
+                    },
+                    "b": "0.81129214214899936"
+                },
+                "a": {
+                    "a": {
+                        "dense_vector": "-0.73332571986545902:2.9316845757887005:0.094673513295652573:-0.37147622695801413:3.4035874086632774:0.87499999999999989:-5.243963206534155:58.833605931130109:5.3749999999999911"
+                    },
+                    "b": "-0.46803355461116519"
+                },
+                "a": {
+                    "a": {
+                        "dense_vector": "-0.98332571986545891:2.1816845757887:0.84467351329565288:-0.12147622695801405:3.1535874086632774:1.125:-5.993963206534155:58.583605931130116:5.124999999999992"
+                    },
+                    "b": "0.04992081889624167"
+                },
+                "a": {
+                    "a": {
+                        "dense_vector": "-1.483325719865459:2.6816845757887:0.34467351329565271:-0.62147622695801419:2.6535874086632774:0.625:-5.493963206534155:59.083605931130116:5.624999999999992"
+                    },
+                    "b": "-1.9405985155956018"
+                },
+                "a": {
+                    "a": {
+                        "dense_vector": "-1.420825719865459:2.3691845757887005:0.90717351329565288:-0.30897622695801408:3.0910874086632774:0.5625:-5.6814632065341542:59.396105931130123:5.937499999999992"
+                    },
+                    "b": "1.2806924015185162"
+                },
+                "a": {
+                    "a": {
+                        "dense_vector": "-0.92082571986545891:2.8691845757887:0.40717351329565316:0.19102377304198587:2.5910874086632774:1.0625:-5.1814632065341542:58.896105931130123:5.437499999999992"
+                    },
+                    "b": "-1.5483165985085918"
+                },
+                "a": {
+                    "a": {
+                        "dense_vector": "-0.67082571986545925:2.1191845757887005:0.65717351329565266:-0.55897622695801408:2.8410874086632774:0.8125:-5.9314632065341542:58.646105931130116:5.187499999999992"
+                    },
+                    "b": "0.18332256194219118"
+                },
+                "a": {
+                    "a": {
+                        "dense_vector": "-1.5023791840523408:2.4461221093745866:0.37828349063742128:-0.61602945817350763:3.2707230456253571:1.1117938548911503:-6.049916299750727:58.91036647086441:5.9777160260348676"
+                    },
+                    "b": "0.032157799614608622"
+                }
+            },
+            "range_scale": "39.875872012830158",
+            "range_shift": "9.185460260650304",
+            "restarts": "10"
+        },
+        "best_forest_loss_gap": "1.0621337693570894",
+        "best_forest_test_loss": "9.4761914959470275",
+        "current_round": "11",
+        "depth_penalty_multiplier": {
+            "value": "41.712189982016397",
+            "saved_value": "41.712189982016397",
+            "fixed": "false"
+        },
+        "downsample_factor": {
+            "value": "0.59178599935403775",
+            "saved_value": "0.59178599935403775",
+            "fixed": "false"
+        },
+        "eta_growth_rate_per_tree": {
+            "value": "1.0161753372935503",
+            "saved_value": "1.0161753372935503",
+            "fixed": "false"
+        },
+        "eta": {
+            "value": "0.044848940658558351",
+            "saved_value": "0.044848940658558351",
+            "fixed": "false"
+        },
+        "feature_bag_fraction": {
+            "value": "0.72499999999999998",
+            "saved_value": "0.72499999999999998",
+            "fixed": "false"
+        },
+        "leaf_weight_penalty_multiplier": {
+            "value": "1.2762888961575412",
+            "saved_value": "1.2762888961575412",
+            "fixed": "false"
+        },
+        "maximum_number_trees": {
+            "value": "2",
+            "saved_value": "2",
+            "fixed": "true"
+        },
+        "maximum_optimisation_rounds_per_hyperparameter": "3",
+        "mean_forest_size_accumulator": "19:10.4736843",
+        "mean_test_loss_accumulator": "12:9.18546009",
+        "number_rounds": "27",
+        "prediction_change_cost": {
+            "value": "0.5",
+            "saved_value": "0.5",
+            "fixed": "false"
+        },
+        "retrained_tree_eta": {
+            "value": "1",
+            "saved_value": "1",
+            "fixed": "false"
+        },
+        "soft_tree_depth_limit": {
+            "value": "3.442962423658972",
+            "saved_value": "3.442962423658972",
+            "fixed": "false"
+        },
+        "soft_tree_depth_tolerance": {
+            "value": "0.21250000000000002",
+            "saved_value": "0.21250000000000002",
+            "fixed": "false"
+        },
+        "stop_hyperparameter_optimization_early": "true",
+        "tree_size_penalty_multiplier": {
+            "value": "1.2819568846245164",
+            "saved_value": "1.2819568846245164",
+            "fixed": "false"
+        },
+        "tree_topology_change_penalty": {
+            "value": "0",
+            "saved_value": "0",
+            "fixed": "false"
+        }
     },
-    "range_scale": "1",
-    "range_shift": "0",
-    "restarts": "10"
-  },
-  "best_forest_test_loss": "1.797693e308",
-  "current_round": "0",
-  "dependent_variable": "2",
-  "encoder_tag": {
-    "7.5": "",
-    "encoding_vector": {
-      "identity_encoding": {
-        "encoding_input_column_index": "0",
-        "encoding_mic": "3.556275e-1"
-      },
-      "identity_encoding": {
-        "encoding_input_column_index": "2",
-        "encoding_mic": "0"
-      }
-    }
-  },
-  "eta_growth_rate_per_tree": "1.05",
-  "eta": "1e-1",
-  "feature_bag_fraction": "5e-1",
-  "feature_data_types": {
-    "d": "2",
-    "a": "0:2.10813656449318e-1:9.96675395965576:",
-    "a": "0:2.90942788124084e-1:9.86151218414307:"
-  },
-  "feature_sample_probabilities": "1:0",
-  "maximum_attempts_to_add_tree": "3",
-  "maximum_optimisation_rounds_per_hyperparameter": "3",
-  "maximum_tree_size_multiplier": "10",
-  "missing_feature_row_masks": {
-    "d": "3",
-    "a": "50:0:1:50",
-    "a": "50:0:1:50",
-    "a": "50:0:1:50"
-  },
-  "number_folds": "",
-  "number_rounds": "24",
-  "number_splits_per_feature": "75",
-  "number_threads": "1",
-  "random_number_generator": "6348936557884334503:6746432788814635579",
-  "regularization_override": {
-    "regularization_depth_penalty_multiplier": "false;0",
-    "regularization_tree_size_penalty_multiplier": "false;0",
-    "regularization_leaf_weight_penalty_multiplier": "false;0",
-    "regularization_soft_tree_depth_limit": "false;0",
-    "regularization_soft_tree_depth_tolerance": "false;0"
-  },
-  "regularization": {
-    "regularization_depth_penalty_multiplier": "2.050525e-2",
-    "regularization_tree_size_penalty_multiplier": "1.031488e-1",
-    "regularization_leaf_weight_penalty_multiplier": "1.290953",
-    "regularization_soft_tree_depth_limit": "3",
-    "regularization_soft_tree_depth_tolerance": "1.5e-1"
-  },
-  "rows_per_feature": "50",
-  "testing_row_masks": {
-    "d": "2",
-    "a": "50:1:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2",
-    "a": "50:0:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2"
-  },
-  "maximum_number_trees": "2",
-  "training_row_masks": {
-    "d": "2",
-    "a": "50:0:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2",
-    "a": "50:1:1:5:1:1:5:3:3:3:1:1:1:1:4:1:4:3:6:1:1:2:1:2"
-  },
-  "training_progress": {
-    "loop_size_tag": "76",
-    "progress_steps_tag": "32",
-    "current_step_progress_tag": "3.125e-2",
-    "loop_pos_tag": "26"
-  },
-  "best_forest": {
-    "d": "0"
-  },
-  "best_hyperparameters": {
-    "hyperparam_eta": "1e-1",
-    "hyperparam_eta_growth_rate_per_tree": "1.05",
-    "hyperparam_feature_bag_fraction": "5e-1",
-    "hyperparam_regularization": {
-      "regularization_depth_penalty_multiplier": "0",
-      "regularization_tree_size_penalty_multiplier": "0",
-      "regularization_leaf_weight_penalty_multiplier": "0",
-      "regularization_soft_tree_depth_limit": "0",
-      "regularization_soft_tree_depth_tolerance": "0"
-    }
-  },
-  "eta_override": "false;0",
-  "feature_bag_fraction_override": "false;0",
-  "maximum_number_trees_override": "true;2",
-  "loss": "mse"
+    "initialization_progress": "8",
+    "loss": {
+        "mse": {}
+    },
+    "maximum_attempts_to_add_tree": "3",
+    "missing_feature_row_masks": {
+        "d": "3",
+        "a": "7.9:50:0:1:1:200",
+        "a": "7.9:50:0:1:1:200",
+        "a": "7.9:50:0:1:1:200"
+    },
+    "new_training_row_mask_tag": "7.9:50:0:1:1:200",
+    "number_folds": {
+        "value": "",
+        "saved_value": "0",
+        "fixed": "true"
+    },
+    "number_splits_per_feature": "75",
+    "number_threads": "1",
+    "top_shap_values": "0",
+    "previous_train_loss_gap": "0",
+    "previous_train_number_rows": "0",
+    "random_number_generator": "15723264323598070226:5510878494715014656",
+    "retrain_fraction": "0.10000000000000001",
+    "rows_per_feature": "50",
+    "seed": "0",
+    "stop_cross_validation_early": "true",
+    "testing_row_masks": {
+        "d": "2",
+        "a": "7.9:50:1:1:1:20:4:4:12:12:12:8:16:4:12:4:12:12:4:8:4:4:16:8:4:8:4:8",
+        "a": "7.9:50:0:1:1:20:4:4:12:12:12:8:16:4:12:4:12:12:4:8:4:4:16:8:4:8:4:8"
+    },
+    "training_row_masks": {
+        "d": "2",
+        "a": "7.9:50:0:1:1:20:4:4:12:12:12:8:16:4:12:4:12:12:4:8:4:4:16:8:4:8:4:8",
+        "a": "7.9:50:1:1:1:20:4:4:12:12:12:8:16:4:12:4:12:12:4:8:4:4:16:8:4:8:4:8"
+    },
+    "train_fraction_per_folds": {
+        "value": "0.5",
+        "saved_value": "0",
+        "fixed": "false"
+    },
+    "trees_to_retrain": ""
 }

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -837,6 +837,20 @@ std::size_t CBayesianOptimisation::estimateMemoryUsage(std::size_t numberParamet
            kernelParametersMemoryUsage + minimumKernelCoordinateDistanceScale;
 }
 
+std::uint64_t CBayesianOptimisation::checksum(std::uint64_t seed) const {
+    seed = CChecksum::calculate(seed, m_Rng);
+    seed = CChecksum::calculate(seed, m_Restarts);
+    seed = CChecksum::calculate(seed, m_RangeShift);
+    seed = CChecksum::calculate(seed, m_RangeScale);
+    seed = CChecksum::calculate(seed, m_ExplainedErrorVariance);
+    seed = CChecksum::calculate(seed, m_MinBoundary);
+    seed = CChecksum::calculate(seed, m_MaxBoundary);
+    seed = CChecksum::calculate(seed, m_FunctionMeanValues);
+    seed = CChecksum::calculate(seed, m_ErrorVariances);
+    seed = CChecksum::calculate(seed, m_KernelParameters);
+    return CChecksum::calculate(seed, m_MinimumKernelCoordinateDistanceScale);
+}
+
 const std::size_t CBayesianOptimisation::RESTARTS{10};
 const double CBayesianOptimisation::NEGLIGIBLE_EXPECTED_IMPROVEMENT{1e-12};
 const double CBayesianOptimisation::MINIMUM_KERNEL_COORDINATE_DISTANCE_SCALE{1e-3};


### PR DESCRIPTION
This migrates the refactoring we did for hyperparameters onto the main branch from the incremental-learning feature branch. The main idea is better separation of concerns managing optimisation of hyperparameter optimisation and the rest of training.

This is a useful precursor to stopping after coarse parameter tuning and I would like to have that available on main sooner than we will have incremental training. It should reduce the overhead and scope for introducing bugs maintaining both branches.