### PR TITLE
[ML] Fix error message for failure to create reverse search

### DIFF
--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -953,4 +953,21 @@ BOOST_FIXTURE_TEST_CASE(testStatsWriteUrgentDueToManyCategories, CTestFixture) {
                         categorizerStats.s_CategorizationStatus);
 }
 
+BOOST_FIXTURE_TEST_CASE(testReverseSearchImpossibleDueToLongToken, CTestFixture) {
+
+    TTokenListDataCategorizerKeepsFields::TTokenListReverseSearchCreatorCPtr reverseSearchCreator =
+        std::make_shared<ml::model::CTokenListReverseSearchCreator>("whatever");
+    TTokenListDataCategorizerKeepsFields categorizer{m_Limits, reverseSearchCreator,
+                                                     0.7, "whatever"};
+
+    // Create a message with one token that is as long as the available cost
+    // (and then the overhead will push it over the limit)
+    std::string singleMessage(reverseSearchCreator->availableCost(), 'z');
+    BOOST_REQUIRE_EQUAL(
+        ml::model::CLocalCategoryId{1},
+        categorizer.computeCategory(false, singleMessage, singleMessage.length()));
+    BOOST_REQUIRE_EQUAL(
+        false, categorizer.cacheReverseSearch(ml::model::CLocalCategoryId{1}));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The reverse search for categorization is limited to a certain
length (currently 10000 characters).

It's possible that we cannot create a reverse search for a
category if the cost of including any token in that reverse
search would be higher than this maximum cost.

This PR corrects that logic for logging that edge case.
Previously there was a chance we'd erroneously log an error
reporting an inconsistency between two variables in the code.
Now we should correctly always log a message reporting the
actual problem. Additionally, the message that reports the
problem is downgraded from error to warning to fit better
with the overall Elasticsearch log level policy.