### PR TITLE
[ML] Don't use moved from variable

### DIFF
--- a/lib/maths/analytics/CBoostedTreeHyperparameters.cc
+++ b/lib/maths/analytics/CBoostedTreeHyperparameters.cc
@@ -225,7 +225,8 @@ CBoostedTreeHyperparameters::minimizeTestLoss(double intervalLeftEnd,
                                               double intervalRightEnd,
                                               TDoubleDoublePrVec testLosses) const {
     common::CLowess<2> lowess;
-    lowess.fit(std::move(testLosses), testLosses.size());
+    std::size_t numberFolds{testLosses.size()};
+    lowess.fit(std::move(testLosses), numberFolds);
 
     double bestParameter;
     double bestParameterTestLoss;

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1307,13 +1307,14 @@ BOOST_AUTO_TEST_CASE(testFeatureBags) {
                         std::min(selected[i], selectedSorted[i]);
         }
         return static_cast<double>(distance) /
-               static_cast<double>(std::accumulate(selected.begin(), selected.end(), 0));
+               static_cast<double>(std::accumulate(selected.begin(),
+                                                   selected.end(), std::size_t{0}));
     };
 
     LOG_DEBUG(<< "distanceToSorted(selectedForTree) = " << distanceToSorted(selectedForTree)
               << ", distanceToSorted(selectedForNode) = " << distanceToSorted(selectedForNode));
-    BOOST_TEST_REQUIRE(distanceToSorted(selectedForTree) < 0.014);
-    BOOST_TEST_REQUIRE(distanceToSorted(selectedForNode) < 0.014);
+    BOOST_TEST_REQUIRE(distanceToSorted(selectedForTree) < 0.008);
+    BOOST_TEST_REQUIRE(distanceToSorted(selectedForNode) < 0.01);
 }
 
 BOOST_AUTO_TEST_CASE(testIntegerRegressor) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1313,7 +1313,7 @@ BOOST_AUTO_TEST_CASE(testFeatureBags) {
 
     LOG_DEBUG(<< "distanceToSorted(selectedForTree) = " << distanceToSorted(selectedForTree)
               << ", distanceToSorted(selectedForNode) = " << distanceToSorted(selectedForNode));
-    BOOST_TEST_REQUIRE(distanceToSorted(selectedForTree) < 0.008);
+    BOOST_TEST_REQUIRE(distanceToSorted(selectedForTree) < 0.01);
     BOOST_TEST_REQUIRE(distanceToSorted(selectedForNode) < 0.01);
 }
 


### PR DESCRIPTION
#2245 introduced a using variable after moving it mistake. This corrects that. Since it hasn't been released, I've marked as a non-issue.