### PR TITLE
[ML] Build PyTorch without Breakpad

### DIFF
--- a/build-setup/linux.md
+++ b/build-setup/linux.md
@@ -325,7 +325,8 @@ export USE_MKLDNN=ON
 export USE_QNNPACK=OFF
 export USE_PYTORCH_QNNPACK=OFF
 [ $(uname -m) = x86_64 ] && export USE_XNNPACK=OFF
-[ $(uname -m) != x86_64 ] && export USE_BREAKPAD=OFF
+# Breakpad is undesirable as it causes libtorch_cpu to have an executable stack
+export USE_BREAKPAD=OFF
 export PYTORCH_BUILD_VERSION=1.11.0
 export PYTORCH_BUILD_NUMBER=1
 /usr/local/gcc103/bin/python3.7 setup.py install

--- a/dev-tools/docker/build_linux_build_image.sh
+++ b/dev-tools/docker/build_linux_build_image.sh
@@ -34,7 +34,7 @@ sleep 5
 HOST=docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-linux-build
-VERSION=21
+VERSION=22
 
 set -e
 

--- a/dev-tools/docker/linux_builder/Dockerfile
+++ b/dev-tools/docker/linux_builder/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-build:21
+FROM docker.elastic.co/ml-dev/ml-linux-build:22
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -148,6 +148,7 @@ RUN \
   export USE_QNNPACK=OFF && \
   export USE_PYTORCH_QNNPACK=OFF && \
   export USE_XNNPACK=OFF && \
+  export USE_BREAKPAD=OFF && \
   export PYTORCH_BUILD_VERSION=1.11.0 && \
   export PYTORCH_BUILD_NUMBER=1 && \
   /usr/local/bin/python3.7 setup.py install && \

--- a/dev-tools/docker/linux_tester/Dockerfile
+++ b/dev-tools/docker/linux_tester/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-build:21
+FROM docker.elastic.co/ml-dev/ml-linux-build:22
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 


### PR DESCRIPTION
Breakpad causes the libtorch_cpu.so library to have an
executable stack, which is undesirable.

Fixes elastic/elasticsearch#85691