### PR TITLE
[ML] Some corrections to ANOVA for Bayesian Optimisation

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -40,6 +40,8 @@
 
 * Correct logic for restart from failover fine tuning hyperparameters for training
   classification and regression models. (See {ml-pull}2251[#2251].)
+* Fix some bugs affecting decision to stop optimising hyperparameters for training
+  classification and regression models. (See {ml-pull}2259[#2259].)
 
 == {es} version 8.2.0
 

--- a/include/maths/common/CBayesianOptimisation.h
+++ b/include/maths/common/CBayesianOptimisation.h
@@ -189,7 +189,6 @@ private:
     TVectorDoublePr kernelCovariates(const TVector& a, const TVector& x, double vx) const;
     double kernel(const TVector& a, const TVector& x, const TVector& y) const;
     TVector kinvf() const;
-    TVector transformTo01(const TVector& x) const;
     double dissimilarity(const TVector& x) const;
     void checkRestoredInvariants() const;
 

--- a/include/maths/common/CBayesianOptimisation.h
+++ b/include/maths/common/CBayesianOptimisation.h
@@ -190,6 +190,8 @@ private:
     double kernel(const TVector& a, const TVector& x, const TVector& y) const;
     TVector kinvf() const;
     double dissimilarity(const TVector& x) const;
+    TVector to01(TVector x) const;
+    TVector from01(TVector x) const;
     void checkRestoredInvariants() const;
 
 private:

--- a/include/maths/common/CBayesianOptimisation.h
+++ b/include/maths/common/CBayesianOptimisation.h
@@ -125,9 +125,6 @@ public:
     //! of the total variance.
     TDoubleDoublePrVec anovaMainEffects() const;
 
-    //! Set kernel \p parameters explicitly.
-    void kernelParameters(const TVector& parameters);
-
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;
 
@@ -142,6 +139,9 @@ public:
 
     //! \name Test Interface
     //@{
+    //! Set kernel \p parameters explicitly.
+    void kernelParameters(const TVector& parameters);
+
     //! Get minus the data likelihood and its gradient as a function of the kernel
     //! hyperparameters.
     std::pair<TLikelihoodFunc, TLikelihoodGradientFunc> minusLikelihoodAndGradient() const;

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1189,7 +1189,7 @@ BOOST_AUTO_TEST_CASE(testCategoricalRegressors) {
     LOG_DEBUG(<< "bias = " << modelBias);
     LOG_DEBUG(<< " R^2 = " << modelRSquared);
     BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, modelBias, 0.1);
-    BOOST_TEST_REQUIRE(modelRSquared > 0.98);
+    BOOST_TEST_REQUIRE(modelRSquared > 0.97);
 }
 
 BOOST_AUTO_TEST_CASE(testFeatureBags) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -698,7 +698,7 @@ BOOST_AUTO_TEST_CASE(testHuber) {
             0.0, modelBias[i],
             6.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i] > 0.92);
+        BOOST_TEST_REQUIRE(modelRSquared[i] > 0.94);
 
         meanModelRSquared.add(modelRSquared[i]);
     }
@@ -879,7 +879,7 @@ BOOST_AUTO_TEST_CASE(testLowCardinalityFeatures) {
         target, noiseVariance / static_cast<double>(rows));
     LOG_DEBUG(<< "bias = " << bias << ", rSquared = " << rSquared);
 
-    BOOST_TEST_REQUIRE(rSquared > 0.96);
+    BOOST_TEST_REQUIRE(rSquared > 0.95);
 }
 
 BOOST_AUTO_TEST_CASE(testLowTrainFractionPerFold) {
@@ -1313,8 +1313,8 @@ BOOST_AUTO_TEST_CASE(testFeatureBags) {
 
     LOG_DEBUG(<< "distanceToSorted(selectedForTree) = " << distanceToSorted(selectedForTree)
               << ", distanceToSorted(selectedForNode) = " << distanceToSorted(selectedForNode));
-    BOOST_TEST_REQUIRE(distanceToSorted(selectedForTree) < 0.015);
-    BOOST_TEST_REQUIRE(distanceToSorted(selectedForNode) < 0.015);
+    BOOST_TEST_REQUIRE(distanceToSorted(selectedForTree) < 0.01);
+    BOOST_TEST_REQUIRE(distanceToSorted(selectedForNode) < 0.01);
 }
 
 BOOST_AUTO_TEST_CASE(testIntegerRegressor) {
@@ -1850,7 +1850,7 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {
         LOG_DEBUG(<< "log relative error = "
                   << maths::common::CBasicStatistics::mean(logRelativeError));
 
-        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 2.0);
+        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 1.9);
         meanLogRelativeError.add(maths::common::CBasicStatistics::mean(logRelativeError));
     }
 

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1313,8 +1313,8 @@ BOOST_AUTO_TEST_CASE(testFeatureBags) {
 
     LOG_DEBUG(<< "distanceToSorted(selectedForTree) = " << distanceToSorted(selectedForTree)
               << ", distanceToSorted(selectedForNode) = " << distanceToSorted(selectedForNode));
-    BOOST_TEST_REQUIRE(distanceToSorted(selectedForTree) < 0.01);
-    BOOST_TEST_REQUIRE(distanceToSorted(selectedForNode) < 0.01);
+    BOOST_TEST_REQUIRE(distanceToSorted(selectedForTree) < 0.015);
+    BOOST_TEST_REQUIRE(distanceToSorted(selectedForNode) < 0.015);
 }
 
 BOOST_AUTO_TEST_CASE(testIntegerRegressor) {
@@ -1850,7 +1850,7 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {
         LOG_DEBUG(<< "log relative error = "
                   << maths::common::CBasicStatistics::mean(logRelativeError));
 
-        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 1.9);
+        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 2.0);
         meanLogRelativeError.add(maths::common::CBasicStatistics::mean(logRelativeError));
     }
 

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -574,7 +574,7 @@ BOOST_AUTO_TEST_CASE(testLinear) {
         meanModelRSquared.add(modelRSquared[i][0]);
     }
     LOG_DEBUG(<< "mean R^2 = " << maths::common::CBasicStatistics::mean(meanModelRSquared));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.96);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.97);
 }
 
 BOOST_AUTO_TEST_CASE(testNonLinear) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -698,7 +698,7 @@ BOOST_AUTO_TEST_CASE(testHuber) {
             0.0, modelBias[i],
             6.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i] > 0.94);
+        BOOST_TEST_REQUIRE(modelRSquared[i] > 0.92);
 
         meanModelRSquared.add(modelRSquared[i]);
     }

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -569,12 +569,12 @@ BOOST_AUTO_TEST_CASE(testLinear) {
             0.0, modelBias[i][0],
             6.0 * std::sqrt(noiseVariance / static_cast<double>(trainRows)));
         // Good R^2...
-        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.97);
+        BOOST_TEST_REQUIRE(modelRSquared[i][0] > 0.94);
 
         meanModelRSquared.add(modelRSquared[i][0]);
     }
     LOG_DEBUG(<< "mean R^2 = " << maths::common::CBasicStatistics::mean(meanModelRSquared));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.97);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.96);
 }
 
 BOOST_AUTO_TEST_CASE(testNonLinear) {

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -375,11 +375,11 @@ double CBayesianOptimisation::anovaMainEffect(const TVector& Kinvf, int dimensio
                 integrate1dKernel(m_KernelParameters(dimension + 1), xi(dimension)) *
                 prodXt(xi, dimension);
     }
-    double shift2{CTools::pow2(m_RangeShift)};
+    double scale2{CTools::pow2(m_RangeScale)};
     double theta02{CTools::pow2(m_KernelParameters(0))};
     double f0{this->anovaConstantFactor()};
     double f02{CTools::pow2(f0)};
-    return (theta02 * (theta02 * sum1 - 2.0 * f0 * sum2) + f02) / shift2;
+    return (theta02 * (theta02 * sum1 - 2.0 * f0 * sum2) + f02) / scale2;
 }
 
 double CBayesianOptimisation::anovaMainEffect(int dimension) const {

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -68,7 +68,7 @@ double toScaled(double shift, double scale, double fx) {
     return scale * (fx - shift);
 }
 
-//! Affine transform \p shift + \p scale * \p fx.
+//! Affine transform \p shift + \p scale / \p fx.
 double fromScaled(double shift, double scale, double fx) {
     return shift + fx / scale;
 }
@@ -293,6 +293,9 @@ double CBayesianOptimisation::evaluate1D(const TVector& Kinvf, double input, int
     }
     double f2{this->anovaConstantFactor(Kinvf)};
 
+    // We only get cancellation if the signs are the same (and we need also
+    // to take the square root of both sum and f2 for which they need to be
+    // positive).
     if (std::signbit(sum) == std::signbit(f2)) {
         // We rewrite theta_0^2 sum - f_0 as (theta + f) * (theta - f) where
         // theta = theta_0 sum^(1/2) and f = f_0^(1/2) because it has better

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -486,7 +486,7 @@ CBayesianOptimisation::minusLikelihoodAndGradient() const {
         ones = TVector::Ones(f.size());
         Kinv.noalias() = Kqr.solve(TMatrix::Identity(f.size(), f.size()));
 
-        K.diagonal() -= v * ones;
+        K.diagonal() -= (v + eps) * ones;
 
         gradient = TVector::Zero(a.size());
         for (int i = 0; i < Kinvf.size(); ++i) {

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -407,8 +407,8 @@ CBayesianOptimisation::TDoubleDoublePrVec CBayesianOptimisation::anovaMainEffect
 void CBayesianOptimisation::kernelParameters(const TVector& parameters) {
     if (m_KernelParameters.size() == parameters.size()) {
         m_KernelParameters = parameters;
-        /*m_RangeShift = 0.0;
-        m_RangeScale = 1.0;*/
+        m_RangeShift = 0.0;
+        m_RangeScale = 1.0;
     }
 }
 

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -16,6 +16,7 @@
 #include <core/CJsonStateRestoreTraverser.h>
 #include <core/CMemory.h>
 #include <core/CPersistUtils.h>
+#include <core/Constants.h>
 #include <core/RestoreMacros.h>
 
 #include <maths/common/CBasicStatistics.h>
@@ -62,10 +63,12 @@ const std::string RNG_TAG{"rng"};
 // narrow deep valley that the Gaussian Process hasn't sampled.
 const double MINIMUM_KERNEL_SCALE_FOR_EXPECTATION_MAXIMISATION{1e-8};
 
+//! Affine transform \p scale * (\p fx - \p shift).
 double toScaled(double shift, double scale, double fx) {
     return scale * (fx - shift);
 }
 
+//! Affine transform \p shift + \p scale * \p fx.
 double fromScaled(double shift, double scale, double fx) {
     return shift + fx / scale;
 }
@@ -123,9 +126,32 @@ CBayesianOptimisation::CBayesianOptimisation(core::CStateRestoreTraverser& trave
 }
 
 void CBayesianOptimisation::add(TVector x, double fx, double vx) {
-    m_FunctionMeanValues.emplace_back(this->to01(std::move(x)),
-                                      toScaled(m_RangeShift, m_RangeScale, fx));
-    m_ErrorVariances.push_back(CTools::pow2(m_RangeScale) * vx);
+    if (CMathsFuncs::isFinite(fx) == false || CMathsFuncs::isFinite(vx) == false) {
+        LOG_ERROR(<< "Discarding point (" << x.transpose() << "," << fx << "," << vx << ")");
+        return;
+    }
+
+    x = this->to01(std::move(x));
+    fx = toScaled(m_RangeShift, m_RangeScale, fx);
+    vx = CTools::pow2(m_RangeScale) * vx;
+
+    std::size_t duplicate(std::find_if(m_FunctionMeanValues.begin(),
+                                       m_FunctionMeanValues.end(),
+                                       [&](const auto& value) {
+                                           return (x - value.first).norm() == 0.0;
+                                       }) -
+                          m_FunctionMeanValues.begin());
+    if (duplicate < m_FunctionMeanValues.size()) {
+        auto& f = m_FunctionMeanValues[duplicate].second;
+        auto& v = m_ErrorVariances[duplicate];
+        auto moments = CBasicStatistics::momentsAccumulator(1.0, f, v) +
+                       CBasicStatistics::momentsAccumulator(1.0, fx, vx);
+        f = CBasicStatistics::mean(moments);
+        v = CBasicStatistics::maximumLikelihoodVariance(moments);
+    } else {
+        m_FunctionMeanValues.emplace_back(std::move(x), fx);
+        m_ErrorVariances.push_back(vx);
+    }
 }
 
 void CBayesianOptimisation::explainedErrorVariance(double vx) {
@@ -419,38 +445,50 @@ CBayesianOptimisation::minusLikelihoodAndGradient() const {
     double v{this->meanErrorVariance()};
     TVector ones;
     TVector gradient;
-    Eigen::LDLT<Eigen::MatrixXd> Kldl;
+    Eigen::ColPivHouseholderQR<Eigen::MatrixXd> Kqr;
     TMatrix K;
     TVector Kinvf;
     TMatrix Kinv;
     TMatrix dKdai;
 
+    // We need to be careful when we compute the kernel decomposition. Basically,
+    // if the kernel matrix is singular to working precision then if the function
+    // value vector projection onto the null-space has non-zero length the likelihood
+    // function is effectively -infinity. This follow from the fact that although
+    // log(1 / lambda_i) -> +infinity, -1/2 sum_i{ ||f_i||^2 / lambda_i } -> -infinity
+    // faster for all ||f_i|| > 0 and lambda_i sufficiently small. Here {lambda_i}
+    // denote the Eigenvalues of the nullspace. We use a rank revealing decomposition
+    // and compute the likelihood on the complement of the row space and add on a
+    // large penalty to discourage choosing kernel parameters for which the kernel
+    // is singular.
+
     auto minusLogLikelihood = [=](const TVector& a) mutable -> double {
         K = this->kernel(a, v);
-        Kldl.compute(K);
-        Kinvf.noalias() = f;
-        Kldl.solveInPlace(Kinvf);
-
-        // We can only determine values up to eps * "max diagonal". If the diagonal
-        // has a zero it blows up the determinant term. In practice, we know the
-        // kernel can't be singular by construction so we perturb the diagonal by
-        // the numerical error in such a way as to recover a non-singular matrix.
-        // (Note that the solve routine deals with the zero for us.)
-        double eps{std::numeric_limits<double>::epsilon() * Kldl.vectorD().maxCoeff()};
-        return 0.5 * (f.transpose() * Kinvf +
-                      Kldl.vectorD().cwiseMax(eps).array().log().sum());
+        Kqr.compute(K);
+        Kinvf.noalias() = Kqr.solve(f);
+        // Note that Kqr.logAbsDeterminant() = -infinity if K is singular.
+        double logAbsDet{0.0};
+        for (int i = 0; i < Kqr.rank(); ++i) {
+            logAbsDet += std::log(std::fabs(Kqr.matrixR()(i, i)));
+        }
+        logAbsDet = CTools::stable(logAbsDet);
+        // We just need a _positive_ number which will dominate the smallest
+        // possible value for logAbsDet, which is rank * log(min double).
+        double singularPenalty{Kqr.isInvertible()
+                                   ? 0.0
+                                   : -static_cast<double>(Kqr.rank() + 1) *
+                                         core::constants::LOG_MIN_DOUBLE};
+        return 0.5 * (f.transpose() * Kinvf + logAbsDet + singularPenalty);
     };
 
     auto minusLogLikelihoodGradient = [=](const TVector& a) mutable -> TVector {
         K = this->kernel(a, v);
-        Kldl.compute(K);
+        Kqr.compute(K);
 
-        Kinvf.noalias() = f;
-        Kldl.solveInPlace(Kinvf);
+        Kinvf.noalias() = Kqr.solve(f);
 
         ones = TVector::Ones(f.size());
-        Kinv.noalias() = TMatrix::Identity(f.size(), f.size());
-        Kldl.solveInPlace(Kinv);
+        Kinv.noalias() = Kqr.solve(TMatrix::Identity(f.size(), f.size()));
 
         K.diagonal() -= v * ones;
 

--- a/lib/maths/common/unittest/CBayesianOptimisationTest.cc
+++ b/lib/maths/common/unittest/CBayesianOptimisationTest.cc
@@ -187,16 +187,14 @@ BOOST_AUTO_TEST_CASE(testMaximumLikelihoodKernel) {
     for (std::size_t test = 0; test < 50; ++test) {
 
         maths::common::CBayesianOptimisation bopt{
-            {{-10.0, 10.0}, {-10.0, 10.0}, {-10.0, 10.0}, {-10.0, 10.0}}};
-
-        double scale{5.0 / std::sqrt(static_cast<double>(test + 1))};
+            {{0.0, 10.0}, {0.0, 10.0}, {0.0, 10.0}, {0.0, 10.0}}};
 
         for (std::size_t i = 0; i < 10; ++i) {
             rng.generateUniformSamples(-10.0, 10.0, 4, coordinates);
             rng.generateNormalSamples(0.0, 2.0, 1, noise);
             TVector x{vector(coordinates)};
-            double fx{scale * x.squaredNorm() + noise[0]};
-            bopt.add(x, fx, 1.0);
+            double fx{x.squaredNorm() + noise[0]};
+            bopt.add(x, fx, 0.1);
         }
 
         TVector parameters{bopt.maximumLikelihoodKernel()};
@@ -213,9 +211,9 @@ BOOST_AUTO_TEST_CASE(testMaximumLikelihoodKernel) {
         TVector eps{parameters.size()};
         eps.setZero();
         for (std::size_t i = 0; i < 4; ++i) {
-            eps(i) = 0.1;
+            eps(i) = 0.01;
             double minusLPlusEps{l(parameters + eps)};
-            eps(i) = -0.1;
+            eps(i) = -0.01;
             double minusLMinusEps{l(parameters + eps)};
             eps(i) = 0.0;
             BOOST_TEST_REQUIRE(minusML < minusLPlusEps);

--- a/lib/maths/common/unittest/CBayesianOptimisationTest.cc
+++ b/lib/maths/common/unittest/CBayesianOptimisationTest.cc
@@ -482,7 +482,7 @@ BOOST_AUTO_TEST_CASE(testForSingularKernel) {
 
     // Check that the decay rate is not significantly changed.
     BOOST_TEST_REQUIRE(std::fabs(kernelAfter(1) - kernelBefore(1)) <
-                       0.01 * std::fabs(kernelBefore(1)));
+                       0.001 * std::fabs(kernelBefore(1)));
 }
 
 BOOST_AUTO_TEST_CASE(testPersistRestore) {

--- a/lib/maths/common/unittest/CBayesianOptimisationTest.cc
+++ b/lib/maths/common/unittest/CBayesianOptimisationTest.cc
@@ -373,8 +373,8 @@ BOOST_AUTO_TEST_CASE(testMaximumExpectedImprovement) {
 BOOST_AUTO_TEST_CASE(testKernelInvariants) {
 
     // Test that the kernel parameters we estimate do not change when:
-    //   1. Changing the function range,
-    //   2. Changing the function domain,
+    //   1. Changing the function domain,
+    //   2. Changing the function level,
     //   3. Linearly scaling the function.
 
     TFunctionParamsVec tests{{0.0, 100.0, 0.0, 1.0},
@@ -589,7 +589,7 @@ BOOST_AUTO_TEST_CASE(testAnovaMainEffect) {
 BOOST_AUTO_TEST_CASE(testAnovaInvariants) {
 
     // Test that the various parts of ANOVA change as we expect when:
-    //   1. Changing the function domain,
+    //   1. Changing the function level,
     //   2. Linearly scaling the function.
 
     TFunctionParamsVec tests{


### PR DESCRIPTION
This corrects the handling of the shifting and scaling of the function values when computing various quantities related to the GP. In particular, we were not properly undoing the transform in `evaluate`, `evaluate1D` and various ANOVA related functionality. We could end up computing square roots of negative numbers in `evaluate1D` and `anovaTotalVariance`. At the same time I took the opportunity to ensure GP domain is [0, 1]^n rather than just scaling. This leads to more predictable numerics for ML and also simplifies the code.

I've added tests that the kernel parameters are invariant under operations to the function range which should preserve its value: changing level and scale. I also do the same for `evaluate`, `evaluate1D` and various ANOVA related functionality.