### PR TITLE
[ML] Correct initialisation of the trend model after detecting seasonality for edge case

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -42,6 +42,8 @@
   classification and regression models. (See {ml-pull}2251[#2251].)
 * Fix possible source of "x = NaN, distribution = class boost::math::normal_distribution<..."
   log errors training classification and regression models. (See {ml-pull}2249[#2249].)
+* Fix edge case which could cause the model bounds to blow up after detecting seasonality.
+  (See {ml-pull}2261[#2261].)
 
 == {es} version 8.2.0
 

--- a/lib/maths/time_series/CTimeSeriesTestForSeasonality.cc
+++ b/lib/maths/time_series/CTimeSeriesTestForSeasonality.cc
@@ -1174,6 +1174,7 @@ CTimeSeriesTestForSeasonality::finalizeHypotheses(const TFloatMeanAccumulatorVec
         std::size_t j{periodsHypotheses[i]};
         const TSizeVec& scaleSegments{hypotheses[j].s_ScaleSegments};
 
+        // Consider falling back to not scaling if scaling fails.
         for (auto scale : {scaleSegments.size() > 2, false}) {
 
             m_TemporaryValues = residuals;
@@ -1222,6 +1223,11 @@ CTimeSeriesTestForSeasonality::finalizeHypotheses(const TFloatMeanAccumulatorVec
                                       period[0].value(component[0], k)};
                     value = prediction + (value - prediction) / overlapping;
                     common::CBasicStatistics::moment<0>(residuals[m_WindowIndices[k]]) -= prediction;
+                } else {
+                    // If we were unable to estimate the value of the seasonal
+                    // component here we should discard it when initialising
+                    // the trend.
+                    residuals[m_WindowIndices[k]] = TFloatMeanAccumulator{};
                 }
                 hypotheses[j].s_InitialValues[m_WindowIndices[k]] = moments;
             }
@@ -2061,7 +2067,8 @@ double CTimeSeriesTestForSeasonality::SHypothesisStats::weight() const {
 }
 
 std::string CTimeSeriesTestForSeasonality::SHypothesisStats::print() const {
-    return s_Period.print();
+    return s_Period.print() + "/" + std::to_string(s_NumberScaleSegments) +
+           "/" + std::to_string(s_NumberTrendSegments);
 }
 
 bool CTimeSeriesTestForSeasonality::SModel::isTestable() const {


### PR DESCRIPTION
There are various reasons we can decide not to remove the seasonal component from a portion of the window we test when we think the seasonality is piecewise linearly scaled. In this case the residual values there are unreliable and should be ignored when reinitialising the trend model. This issue could lead to us to very significantly over estimate the prediction errors and inflate the model bounds after detecting new seasonal components in certain edge cases.