### PR TITLE
[ML] Adjust test assertion to print values on failure

### DIFF
--- a/lib/core/unittest/CStaticThreadPoolTest.cc
+++ b/lib/core/unittest/CStaticThreadPoolTest.cc
@@ -237,7 +237,7 @@ BOOST_AUTO_TEST_CASE(testNumberThreadsInUse) {
             if (numberProcessedTasks == 200) {
                 LOG_DEBUG(<< "# threads used = " << executionThreads.size());
                 // A subset of threads can steal all the work.
-                BOOST_REQUIRE(executionThreads.size() <= numberThreadsInUse);
+                BOOST_TEST_REQUIRE(executionThreads.size() <= numberThreadsInUse);
                 numberProcessedTasks = 0;
                 executionThreads.clear();
                 break;


### PR DESCRIPTION
BOOST_REQUIRE is a simple boolean assertion whereas
BOOST_TEST_REQUIRE prints the values either side of
comparison operators when the assertion fails.