### PR TITLE
[ML] Fix potential use of unintialised value when minimising lowess regression function

### DIFF
--- a/include/maths/common/CLowessDetail.h
+++ b/include/maths/common/CLowessDetail.h
@@ -152,13 +152,17 @@ typename CLowess<N>::TDoubleDoublePr CLowess<N>::minimum() const {
     double range{(xb - xa) / static_cast<double>(X.size())};
     xa = std::max(xa, xmin - 0.5 * range);
     xb = std::min(xb, xmin + 0.5 * range);
+    if (xa == xb) {
+        return {xmin, fmin};
+    }
+
     double dx{2.0 * (xb - xa) / static_cast<double>(X.size())};
     X.clear();
     for (double x = xa; x < xb; x += dx) {
         X.push_back(x);
     }
-    double xcand;
-    double fcand;
+    double xcand{xmin};
+    double fcand{fmin};
     CSolvers::globalMinimize(
         X, [this](double x) -> double { return this->predict(x); }, xcand, fcand, fsd);
 


### PR DESCRIPTION
If for any reason the extrapolation range for lowess regression returns zero then `globalMinimize`, to find the function minimum, would be supplied an empty collection of points and fail. This would then lead to `minimum` returning a uninitialised value for the minimum. This shouldn't normally happen in our usage of it, but we have seen the error message associated with supplying an empty collection to `globalMinimize` in our QA suite.