### PR TITLE
[7.17][ML] Fix potential use of unintialised value when minimising lowess regression function

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -34,6 +34,8 @@
 
 * Fix edge case which could cause the model bounds to blow up after detecting seasonality.
   (See {ml-pull}2261[#2261].)
+* Fix cause of "Must provide points at which to evaluate function" log error training
+  classification and regression models. (See {ml-pull}2268[#2268].)
 
 == {es} version 7.17.1
 

--- a/include/maths/common/CLowessDetail.h
+++ b/include/maths/common/CLowessDetail.h
@@ -144,13 +144,17 @@ typename CLowess<N>::TDoubleDoublePr CLowess<N>::minimum() const {
     double range{(xb - xa) / static_cast<double>(X.size())};
     xa = std::max(xa, xmin - 0.5 * range);
     xb = std::min(xb, xmin + 0.5 * range);
+    if (xa == xb) {
+        return {xmin, fmin};
+    }
+
     double dx{2.0 * (xb - xa) / static_cast<double>(X.size())};
     X.clear();
     for (double x = xa; x < xb; x += dx) {
         X.push_back(x);
     }
-    double xcand;
-    double fcand;
+    double xcand{xmin};
+    double fcand{fmin};
     CSolvers::globalMinimize(
         X, [this](double x) -> double { return this->predict(x); }, xcand, fcand);
 


### PR DESCRIPTION
Backport #2268.