### PR TITLE
[ML] Address the root cause for "actual equals typical equals zero" anomalies

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@
 * Upgrade PyTorch to version 1.11. (See {ml-pull}2233[#2233], {ml-pull}2235[#2235]
   and {ml-pull}2238[#2238].)
 * Upgrade zlib to version 1.2.12 on Windows. (See {ml-pull}2253[#2253].)
+* Address root cause for actuals equals typical equals zero anomalies. (See {ml-pull}2270[#2270].)
 
 === Bug Fixes
 

--- a/include/maths/common/CLinearAlgebraShims.h
+++ b/include/maths/common/CLinearAlgebraShims.h
@@ -255,19 +255,31 @@ typename SCoordinate<VECTOR>::Type L1(const CAnnotatedVector<VECTOR, ANNOTATION>
     return L1(static_cast<const VECTOR&>(x));
 }
 
+//! Get the Manhattan norm of one of our internal vector classes.
+template<typename TENSOR>
+double mean(const TENSOR& x) {
+    return x.mean();
+}
+
+//! Get the mean of the elements of an annotated vector.
+template<typename VECTOR, typename ANNOTATION>
+double mean(const CAnnotatedVector<VECTOR, ANNOTATION>& x) {
+    return mean(static_cast<const VECTOR&>(x));
+}
+
 //! Get the Frobenius norm of one of our internal matrices.
 template<typename MATRIX>
 typename SCoordinate<MATRIX>::Type frobenius(const MATRIX& m) {
     return m.frobenius();
 }
 
-//! Get the Euclidean norm of an Eigen dense vector.
+//! Get the Frobenius norm of an Eigen dense matrix.
 template<typename SCALAR>
 SCALAR frobenius(const CDenseMatrix<SCALAR>& x) {
     return x.norm();
 }
 
-//! Get the Euclidean norm of an Eigen memory mapped matrix.
+//! Get the Frobenius norm of an Eigen memory mapped matrix.
 template<typename SCALAR, Eigen::AlignmentType ALIGNMENT>
 SCALAR frobenius(const CMemoryMappedDenseMatrix<SCALAR, ALIGNMENT>& x) {
     return x.norm();

--- a/include/maths/common/CModel.h
+++ b/include/maths/common/CModel.h
@@ -105,12 +105,12 @@ public:
 
 public:
     //! Set whether or not the data are integer valued.
-    CModelAddSamplesParams& integer(bool integer);
+    CModelAddSamplesParams& isInteger(bool isInteger);
     //! Get the data type.
     maths_t::EDataType type() const;
 
     //! Set whether or not the data are non-negative.
-    CModelAddSamplesParams& nonNegative(bool nonNegative);
+    CModelAddSamplesParams& isNonNegative(bool isNonNegative);
     //! Get the whether the data are non-negative.
     bool isNonNegative() const;
 

--- a/include/maths/time_series/CCalendarComponent.h
+++ b/include/maths/time_series/CCalendarComponent.h
@@ -127,7 +127,7 @@ public:
     //! \param[in] time The time of interest.
     //! \param[in] confidence The symmetric confidence interval for the variance
     //! as a percentage.
-    TDoubleDoublePr value(core_t::TTime time, double confidence) const;
+    TVector2x1 value(core_t::TTime time, double confidence) const;
 
     //! Get the mean value of the component.
     double meanValue() const;
@@ -137,13 +137,13 @@ public:
     //! \param[in] time The time of interest.
     //! \param[in] confidence The symmetric confidence interval for the
     //! variance as a percentage.
-    TDoubleDoublePr variance(core_t::TTime time, double confidence) const;
+    TVector2x1 variance(core_t::TTime time, double confidence) const;
 
     //! Get the mean variance of the component residuals.
     double meanVariance() const;
 
     //! Get a checksum for this object.
-    uint64_t checksum(uint64_t seed = 0) const;
+    std::uint64_t checksum(std::uint64_t seed = 0) const;
 
     //! Debug the memory used by this component.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;

--- a/include/maths/time_series/CDecompositionComponent.h
+++ b/include/maths/time_series/CDecompositionComponent.h
@@ -15,12 +15,11 @@
 #include <core/CMemory.h>
 #include <core/CoreTypes.h>
 
+#include <maths/common/CLinearAlgebraFwd.h>
 #include <maths/common/CPRNG.h>
 #include <maths/common/CSpline.h>
 
 #include <maths/time_series/ImportExport.h>
-
-#include <boost/optional.hpp>
 
 #include <array>
 #include <cstddef>
@@ -38,7 +37,7 @@ namespace time_series {
 //! \brief Common functionality used by our decomposition component classes.
 class MATHS_TIME_SERIES_EXPORT CDecompositionComponent {
 public:
-    using TDoubleDoublePr = maths_t::TDoubleDoublePr;
+    using TVector2x1 = common::CVectorNx1<double, 2>;
     using TDoubleVec = std::vector<double>;
     using TFloatVec = std::vector<common::CFloatStorage>;
     using TSplineCRef = common::CSpline<std::reference_wrapper<const TFloatVec>,
@@ -104,7 +103,7 @@ protected:
                          common::CSplineTypes::EBoundaryCondition boundary);
 
         //! Get a checksum for this object.
-        uint64_t checksum(uint64_t seed) const;
+        std::uint64_t checksum(std::uint64_t seed) const;
 
         //! Debug the memory used by the splines.
         void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
@@ -165,7 +164,7 @@ protected:
     //! \param[in] n The bucket count containing \p offset.
     //! \param[in] confidence The symmetric confidence interval for the variance
     //! as a percentage.
-    TDoubleDoublePr value(double offset, double n, double confidence) const;
+    TVector2x1 value(double offset, double n, double confidence) const;
 
     //! Get the mean value of the function.
     double meanValue() const;
@@ -176,7 +175,7 @@ protected:
     //! \param[in] n The bucket count containing \p offset.
     //! \param[in] confidence The symmetric confidence interval for the
     //! variance as a percentage.
-    TDoubleDoublePr variance(double offset, double n, double confidence) const;
+    TVector2x1 variance(double offset, double n, double confidence) const;
 
     //! Get the mean variance of the function residuals.
     double meanVariance() const;
@@ -197,7 +196,7 @@ protected:
     const CPackedSplines& splines() const;
 
     //! Get a checksum for this object.
-    uint64_t checksum(uint64_t seed) const;
+    std::uint64_t checksum(std::uint64_t seed) const;
 
 private:
     //! The minimum permitted size for the points sketch.

--- a/include/maths/time_series/CSeasonalComponent.h
+++ b/include/maths/time_series/CSeasonalComponent.h
@@ -167,7 +167,7 @@ public:
     //! \param[in] time The time of interest.
     //! \param[in] confidence The symmetric confidence interval for the variance
     //! as a percentage.
-    TDoubleDoublePr value(core_t::TTime time, double confidence) const;
+    TVector2x1 value(core_t::TTime time, double confidence) const;
 
     //! Get the mean value of the component.
     double meanValue() const;
@@ -188,7 +188,7 @@ public:
     //! \param[in] time The time of interest.
     //! \param[in] confidence The symmetric confidence interval for the
     //! variance as a percentage.
-    TDoubleDoublePr variance(core_t::TTime time, double confidence) const;
+    TVector2x1 variance(core_t::TTime time, double confidence) const;
 
     //! Get the mean variance of the component residuals.
     double meanVariance() const;

--- a/include/maths/time_series/CTimeSeriesDecomposition.h
+++ b/include/maths/time_series/CTimeSeriesDecomposition.h
@@ -240,11 +240,7 @@ private:
                                 core::CStateRestoreTraverser& traverser);
 
     //! Get the predicted value of the time series at \p time.
-    TVector2x1 value(core_t::TTime time,
-                     double confidence,
-                     int components,
-                     const TBoolVec& removedSeasonalMask = {},
-                     bool smooth = true) const;
+    TVector2x1 value(core_t::TTime time, double confidence, int components, bool smooth = true) const;
 
     //! Compute the variance scale weight to apply at \p time.
     TVector2x1
@@ -253,7 +249,8 @@ private:
     //! The correction to produce a smooth join between periodic
     //! repeats and partitions.
     template<typename F>
-    TVector2x1 smooth(const F& f, core_t::TTime time, int components) const;
+    auto smooth(const F& f, core_t::TTime time, int components) const
+        -> decltype(f(time));
 
 private:
     //! The time over which discontinuities between weekdays

--- a/include/maths/time_series/CTimeSeriesDecomposition.h
+++ b/include/maths/time_series/CTimeSeriesDecomposition.h
@@ -240,7 +240,7 @@ private:
                                 core::CStateRestoreTraverser& traverser);
 
     //! Get the predicted value of the time series at \p time.
-    TVector2x1 value(core_t::TTime time, double confidence, int components, bool smooth = true) const;
+    TVector2x1 value(core_t::TTime time, double confidence, int components, bool smooth) const;
 
     //! Compute the variance scale weight to apply at \p time.
     TVector2x1

--- a/include/maths/time_series/CTimeSeriesDecomposition.h
+++ b/include/maths/time_series/CTimeSeriesDecomposition.h
@@ -131,15 +131,9 @@ public:
     //! \param[in] time The time of interest.
     //! \param[in] confidence The symmetric confidence interval for the prediction
     //! the baseline as a percentage.
-    //! \param[in] components The components to include in the baseline.
-    //! \param[in] removedSeasonalMask A bit mask of specific seasonal components
-    //! to remove. This is only intended for use by CTimeSeriesTestForSeasonlity.
-    //! \param[in] smooth Detail do not supply.
-    maths_t::TDoubleDoublePr value(core_t::TTime time,
-                                   double confidence = 0.0,
-                                   int components = E_All,
-                                   const TBoolVec& removedSeasonalMask = {},
-                                   bool smooth = true) const override;
+    //! \param[in] isNonNegative True if the data being modelled are known to be
+    //! non-negative.
+    TVector2x1 value(core_t::TTime time, double confidence, bool isNonNegative) const override;
 
     //! Get a function which returns the decomposition value as a function of time.
     //!
@@ -159,29 +153,33 @@ public:
     //! \param[in] step The time increment.
     //! \param[in] confidence The forecast confidence interval.
     //! \param[in] minimumScale The minimum permitted seasonal scale.
+    //! \param[in] isNonNegative True if the data being modelled are known to be
+    //! non-negative.
     //! \param[in] writer Forecast results are passed to this callback.
     void forecast(core_t::TTime startTime,
                   core_t::TTime endTime,
                   core_t::TTime step,
                   double confidence,
                   double minimumScale,
+                  bool isNonNegative,
                   const TWriteForecastResult& writer) override;
 
     //! Remove the prediction of the component models at \p time from \p value.
     //!
     //! \param[in] time The time of \p value.
+    //! \param[in] value The value from which to remove the prediction.
     //! \param[in] confidence The prediction confidence interval as a percentage.
     //! The closest point to \p value in the confidence interval is removed.
+    //! \param[in] isNonNegative True if the data being modelled are known to be
+    //! non-negative.
     //! \param[in] maximumTimeShift The maximum amount by which we will shift
     //! \p time in order to minimize the difference between the prediction and
     //! \p value.
-    //! \param[in] components A bit mask of the type of components to remove.
-    //! \note That detrending preserves the time series mean.
     double detrend(core_t::TTime time,
                    double value,
                    double confidence,
-                   core_t::TTime maximumTimeShift = 0,
-                   int components = E_All) const override;
+                   bool isNonNegative,
+                   core_t::TTime maximumTimeShift = 0) const override;
 
     //! Get the mean variance of the baseline.
     double meanVariance() const override;
@@ -192,10 +190,7 @@ public:
     //! \param[in] variance The variance of the distribution to scale.
     //! \param[in] confidence The symmetric confidence interval for the variance
     //! scale as a percentage.
-    maths_t::TDoubleDoublePr varianceScaleWeight(core_t::TTime time,
-                                                 double variance,
-                                                 double confidence,
-                                                 bool smooth = true) const override;
+    TVector2x1 varianceScaleWeight(core_t::TTime time, double variance, double confidence) const override;
 
     //! Get the count weight to apply at \p time.
     double countWeight(core_t::TTime time) const override;
@@ -204,7 +199,10 @@ public:
     double winsorisationDerate(core_t::TTime time) const override;
 
     //! Get the prediction residuals in a recent time window.
-    TFloatMeanAccumulatorVec residuals() const override;
+    //!
+    //! \param[in] isNonNegative True if the data being modelled are known to be
+    //! non-negative.
+    TFloatMeanAccumulatorVec residuals(bool isNonNegative) const override;
 
     //! Roll time forwards by \p skipInterval.
     void skipTime(core_t::TTime skipInterval) override;
@@ -241,10 +239,21 @@ private:
     bool acceptRestoreTraverser(const common::SDistributionRestoreParams& params,
                                 core::CStateRestoreTraverser& traverser);
 
+    //! Get the predicted value of the time series at \p time.
+    TVector2x1 value(core_t::TTime time,
+                     double confidence,
+                     int components,
+                     const TBoolVec& removedSeasonalMask = {},
+                     bool smooth = true) const;
+
+    //! Compute the variance scale weight to apply at \p time.
+    TVector2x1
+    varianceScaleWeight(core_t::TTime time, double variance, double confidence, bool smooth) const;
+
     //! The correction to produce a smooth join between periodic
     //! repeats and partitions.
     template<typename F>
-    maths_t::TDoubleDoublePr smooth(const F& f, core_t::TTime time, int components) const;
+    TVector2x1 smooth(const F& f, core_t::TTime time, int components) const;
 
 private:
     //! The time over which discontinuities between weekdays

--- a/include/maths/time_series/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/time_series/CTimeSeriesDecompositionDetail.h
@@ -52,6 +52,7 @@ class MATHS_TIME_SERIES_EXPORT CTimeSeriesDecompositionDetail
 public:
     using TDoubleVec = std::vector<double>;
     using TMakePredictor = std::function<TPredictor()>;
+    using TFilteredPredictor = std::function<double(core_t::TTime, const TBoolVec&)>;
     using TMakeFilteredPredictor = std::function<TFilteredPredictor()>;
     using TChangePointUPtr = std::unique_ptr<CChangePoint>;
 
@@ -586,7 +587,8 @@ public:
         void useTrendForPrediction();
 
         //! Get a factory for the seasonal components test.
-        TMakeTestForSeasonality makeTestForSeasonality(const TFilteredPredictor& predictor) const;
+        TMakeTestForSeasonality
+        makeTestForSeasonality(const TMakeFilteredPredictor& makePredictor) const;
 
         //! Get the mean value of the baseline in the vicinity of \p time.
         double meanValue(core_t::TTime time) const;

--- a/include/maths/time_series/CTimeSeriesDecompositionInterface.h
+++ b/include/maths/time_series/CTimeSeriesDecompositionInterface.h
@@ -45,7 +45,6 @@ class MATHS_TIME_SERIES_EXPORT CTimeSeriesDecompositionTypes {
 public:
     using TBoolVec = std::vector<bool>;
     using TPredictor = std::function<double(core_t::TTime)>;
-    using TFilteredPredictor = std::function<double(core_t::TTime, const TBoolVec&)>;
     using TFloatMeanAccumulator =
         common::CBasicStatistics::SSampleMean<common::CFloatStorage>::TAccumulator;
     using TFloatMeanAccumulatorVec = std::vector<TFloatMeanAccumulator>;

--- a/include/maths/time_series/CTimeSeriesDecompositionInterface.h
+++ b/include/maths/time_series/CTimeSeriesDecompositionInterface.h
@@ -57,6 +57,7 @@ public:
 class MATHS_TIME_SERIES_EXPORT CTimeSeriesDecompositionInterface
     : public CTimeSeriesDecompositionTypes {
 public:
+    using TVector2x1 = common::CVectorNx1<double, 2>;
     using TDouble3Vec = core::CSmallVector<double, 3>;
     using TDouble3VecVec = std::vector<TDouble3Vec>;
     using TWeights = maths_t::CUnitWeights;
@@ -122,14 +123,10 @@ public:
     //! \param[in] time The time of interest.
     //! \param[in] confidence The symmetric confidence interval for the prediction
     //! the baseline as a percentage.
-    //! \param[in] components The components to include in the baseline.
-    //! \param[in] removedSeasonalMask A bit mask of specific seasonal components
-    //! to remove. This is only intended for use by CTimeSeriesTestForSeasonlity.
-    virtual maths_t::TDoubleDoublePr value(core_t::TTime time,
-                                           double confidence = 0.0,
-                                           int components = E_All,
-                                           const TBoolVec& removedSeasonalMask = {},
-                                           bool smooth = true) const = 0;
+    //! \param[in] isNonNegative True if the data being modelled are known to be
+    //! non-negative.
+    virtual TVector2x1
+    value(core_t::TTime time, double confidence, bool isNonNegative) const = 0;
 
     //! Get the maximum interval for which the time series can be forecast.
     virtual core_t::TTime maximumForecastInterval() const = 0;
@@ -141,29 +138,33 @@ public:
     //! \param[in] step The time increment.
     //! \param[in] confidence The forecast confidence interval.
     //! \param[in] minimumScale The minimum permitted seasonal scale.
+    //! \param[in] isNonNegative True if the data being modelled are known to be
+    //! non-negative.
     //! \param[in] writer Forecast results are passed to this callback.
     virtual void forecast(core_t::TTime startTime,
                           core_t::TTime endTime,
                           core_t::TTime step,
                           double confidence,
                           double minimumScale,
+                          bool isNonNegative,
                           const TWriteForecastResult& writer) = 0;
 
     //! Remove the prediction of the component models at \p time from \p value.
     //!
     //! \param[in] time The time of \p value.
+    //! \param[in] value The value from which to remove the prediction.
     //! \param[in] confidence The prediction confidence interval as a percentage.
     //! The closest point to \p value in the confidence interval is removed.
+    //! \param[in] isNonNegative True if the data being modelled are known to be
+    //! non-negative.
     //! \param[in] maximumTimeShift The maximum amount by which we will shift
     //! \p time in order to minimize the difference between the prediction and
     //! \p value.
-    //! \param[in] components A bit mask of the type of components to remove.
-    //! \note That detrending preserves the time series mean.
     virtual double detrend(core_t::TTime time,
                            double value,
                            double confidence,
-                           core_t::TTime maximumTimeShift = 0,
-                           int components = E_All) const = 0;
+                           bool isNonNegative,
+                           core_t::TTime maximumTimeShift = 0) const = 0;
 
     //! Get the mean variance of the baseline.
     virtual double meanVariance() const = 0;
@@ -174,10 +175,8 @@ public:
     //! \param[in] variance The variance of the distribution to scale.
     //! \param[in] confidence The symmetric confidence interval for the variance
     //! scale as a percentage.
-    virtual maths_t::TDoubleDoublePr varianceScaleWeight(core_t::TTime time,
-                                                         double variance,
-                                                         double confidence,
-                                                         bool smooth = true) const = 0;
+    virtual TVector2x1
+    varianceScaleWeight(core_t::TTime time, double variance, double confidence) const = 0;
 
     //! Get the count weight to apply at \p time.
     virtual double countWeight(core_t::TTime time) const = 0;
@@ -186,7 +185,10 @@ public:
     virtual double winsorisationDerate(core_t::TTime time) const = 0;
 
     //! Get the prediction residuals in a recent time window.
-    virtual TFloatMeanAccumulatorVec residuals() const = 0;
+    //!
+    //! \param[in] isNonNegative True if the data being modelled are known to be
+    //! non-negative.
+    virtual TFloatMeanAccumulatorVec residuals(bool isNonNegative) const = 0;
 
     //! Roll time forwards by \p skipInterval.
     virtual void skipTime(core_t::TTime skipInterval) = 0;

--- a/include/maths/time_series/CTimeSeriesDecompositionStub.h
+++ b/include/maths/time_series/CTimeSeriesDecompositionStub.h
@@ -61,12 +61,10 @@ public:
     //! Returns 0.
     double meanValue(core_t::TTime time) const override;
 
-    //! Returns (0.0, 0.0).
-    maths_t::TDoubleDoublePr value(core_t::TTime time,
-                                   double confidence = 0.0,
-                                   int components = E_All,
-                                   const TBoolVec& removedSeasonalMask = {},
-                                   bool smooth = true) const override;
+    //! Returns zero vector.
+    TVector2x1 value(core_t::TTime time,
+                     double confidence = 0.0,
+                     bool isNonNegative = false) const override;
 
     //! Returns 0.
     core_t::TTime maximumForecastInterval() const override;
@@ -77,23 +75,21 @@ public:
                   core_t::TTime step,
                   double confidence,
                   double minimumScale,
+                  bool isNonNegative,
                   const TWriteForecastResult& writer) override;
 
     //! Returns \p value.
     double detrend(core_t::TTime time,
                    double value,
                    double confidence,
-                   core_t::TTime maximumTimeShift = 0,
-                   int components = E_All) const override;
+                   bool isNonNegative,
+                   core_t::TTime maximumTimeShift = 0) const override;
 
     //! Returns 0.0.
     double meanVariance() const override;
 
-    //! Returns (1.0, 1.0).
-    maths_t::TDoubleDoublePr varianceScaleWeight(core_t::TTime time,
-                                                 double variance,
-                                                 double confidence,
-                                                 bool smooth = true) const override;
+    //! Returns ones vector.
+    TVector2x1 varianceScaleWeight(core_t::TTime time, double variance, double confidence) const override;
 
     //! Returns 1.0.
     double countWeight(core_t::TTime time) const override;
@@ -102,7 +98,7 @@ public:
     double winsorisationDerate(core_t::TTime time) const override;
 
     //! Returns an empty vector.
-    TFloatMeanAccumulatorVec residuals() const override;
+    TFloatMeanAccumulatorVec residuals(bool isNonNegative) const override;
 
     //! No-op.
     void skipTime(core_t::TTime skipInterval) override;

--- a/include/maths/time_series/CTimeSeriesDecompositionStub.h
+++ b/include/maths/time_series/CTimeSeriesDecompositionStub.h
@@ -62,9 +62,7 @@ public:
     double meanValue(core_t::TTime time) const override;
 
     //! Returns zero vector.
-    TVector2x1 value(core_t::TTime time,
-                     double confidence = 0.0,
-                     bool isNonNegative = false) const override;
+    TVector2x1 value(core_t::TTime time, double confidence, bool isNonNegative) const override;
 
     //! Returns 0.
     core_t::TTime maximumForecastInterval() const override;

--- a/include/maths/time_series/CTimeSeriesModel.h
+++ b/include/maths/time_series/CTimeSeriesModel.h
@@ -278,10 +278,10 @@ private:
     std::size_t m_Id;
 
     //! True if the data are non-negative.
-    bool m_IsNonNegative;
+    bool m_IsNonNegative{false};
 
     //! True if the model can be forecast.
-    bool m_IsForecastable;
+    bool m_IsForecastable{true};
 
     //! These control the trend and residual model decay rates (see
     //! CDecayRateController for more details).
@@ -308,7 +308,7 @@ private:
     TAnomalyModelPtr m_AnomalyModel;
 
     //! Models the correlations between time series.
-    CTimeSeriesCorrelations* m_Correlations;
+    CTimeSeriesCorrelations* m_Correlations{nullptr};
 };
 
 //! \brief Manages the creation correlate models.
@@ -730,7 +730,7 @@ private:
 
 private:
     //! True if the data are non-negative.
-    bool m_IsNonNegative;
+    bool m_IsNonNegative{false};
 
     //! These control the trend and residual model decay rates (see
     //! CDecayRateController for more details).

--- a/include/maths/time_series/CTimeSeriesTestForSeasonality.h
+++ b/include/maths/time_series/CTimeSeriesTestForSeasonality.h
@@ -243,7 +243,7 @@ public:
                                 std::size_t size);
 
     //! Add a predictor for the currently modelled seasonal conponents.
-    void modelledSeasonalityPredictor(const TPredictor& predictor);
+    void modelledSeasonalityPredictor(TPredictor predictor);
 
     //! Fit and remove any seasonality we're modelling and can't test.
     void prepareWindowForDecompose();

--- a/lib/maths/common/CModel.cc
+++ b/lib/maths/common/CModel.cc
@@ -87,8 +87,8 @@ core_t::TTime CModelParams::maximumTimeToTestForChange() const {
 
 //////// CModelAddSamplesParams ////////
 
-CModelAddSamplesParams& CModelAddSamplesParams::integer(bool integer) {
-    m_Type = integer ? maths_t::E_IntegerData : maths_t::E_ContinuousData;
+CModelAddSamplesParams& CModelAddSamplesParams::isInteger(bool isInteger) {
+    m_Type = isInteger ? maths_t::E_IntegerData : maths_t::E_ContinuousData;
     return *this;
 }
 
@@ -96,8 +96,8 @@ maths_t::EDataType CModelAddSamplesParams::type() const {
     return m_Type;
 }
 
-CModelAddSamplesParams& CModelAddSamplesParams::nonNegative(bool nonNegative) {
-    m_IsNonNegative = nonNegative;
+CModelAddSamplesParams& CModelAddSamplesParams::isNonNegative(bool isNonNegative) {
+    m_IsNonNegative = isNonNegative;
     return *this;
 }
 

--- a/lib/maths/common/unittest/CLinearAlgebraTest.cc
+++ b/lib/maths/common/unittest/CLinearAlgebraTest.cc
@@ -73,8 +73,7 @@ BOOST_AUTO_TEST_CASE(testSymmetricMatrixNxN) {
         BOOST_REQUIRE_EQUAL(10.8, matrix.trace());
     }
     {
-        double v[]{1.0, 2.0, 3.0, 4.0};
-        maths::common::CVectorNx1<double, 4> vector(v);
+        maths::common::CVectorNx1<double, 4> vector{{1.0, 2.0, 3.0, 4.0}};
         maths::common::CSymmetricMatrixNxN<double, 4> matrix(
             maths::common::E_OuterProduct, vector);
         LOG_DEBUG(<< "matrix = " << matrix);
@@ -86,8 +85,7 @@ BOOST_AUTO_TEST_CASE(testSymmetricMatrixNxN) {
         BOOST_REQUIRE_EQUAL(30.0, matrix.trace());
     }
     {
-        double v[]{1.0, 2.0, 3.0, 4.0};
-        maths::common::CVectorNx1<double, 4> vector(v);
+        maths::common::CVectorNx1<double, 4> vector{{1.0, 2.0, 3.0, 4.0}};
         maths::common::CSymmetricMatrixNxN<double, 4> matrix(maths::common::E_Diagonal, vector);
         LOG_DEBUG(<< "matrix = " << matrix);
         for (std::size_t i = 0; i < 4; ++i) {
@@ -133,8 +131,7 @@ BOOST_AUTO_TEST_CASE(testSymmetricMatrixNxN) {
     {
         LOG_DEBUG(<< "Matrix Scalar Multiplication");
 
-        double v[]{1.0, 2.0, 3.0, 4.0, 5.0};
-        maths::common::CVectorNx1<double, 5> vector(v);
+        maths::common::CVectorNx1<double, 5> vector{{1.0, 2.0, 3.0, 4.0, 5.0}};
         maths::common::CSymmetricMatrixNxN<double, 5> m(maths::common::E_OuterProduct, vector);
         maths::common::CSymmetricMatrixNxN<double, 5> ms = m * 3.0;
         LOG_DEBUG(<< "3 * m = " << ms);
@@ -148,8 +145,7 @@ BOOST_AUTO_TEST_CASE(testSymmetricMatrixNxN) {
     {
         LOG_DEBUG(<< "Matrix Scalar Division");
 
-        double v[]{1.0, 2.0, 3.0, 4.0, 5.0};
-        maths::common::CVectorNx1<double, 5> vector(v);
+        maths::common::CVectorNx1<double, 5> vector{{1.0, 2.0, 3.0, 4.0, 5.0}};
         maths::common::CSymmetricMatrixNxN<double, 5> m(maths::common::E_OuterProduct, vector);
         maths::common::CSymmetricMatrixNxN<double, 5> ms = m / 4.0;
         LOG_DEBUG(<< "m / 4.0 = " << ms);
@@ -159,6 +155,23 @@ BOOST_AUTO_TEST_CASE(testSymmetricMatrixNxN) {
                                     ms(i, j));
             }
         }
+    }
+    {
+        LOG_DEBUG(<< "Mean");
+
+        double m[][5]{{1.1, 2.4, 1.4, 3.7, 4.0},
+                      {2.4, 3.2, 1.8, 0.7, 1.0},
+                      {1.4, 1.8, 0.8, 4.7, 3.1},
+                      {3.7, 0.7, 4.7, 4.7, 1.1},
+                      {4.0, 1.0, 3.1, 1.1, 1.0}};
+        maths::common::CSymmetricMatrixNxN<double, 5> matrix(m);
+
+        double expectedMean{
+            (5.0 * maths::common::CBasicStatistics::mean({1.1, 3.2, 0.8, 4.7, 1.0}) +
+             20.0 * maths::common::CBasicStatistics::mean(
+                        {2.4, 1.4, 3.7, 4.0, 1.8, 0.7, 1.0, 4.7, 3.1, 1.1})) /
+            25.0};
+        BOOST_REQUIRE_CLOSE(expectedMean, matrix.mean(), 1e-6);
     }
 }
 
@@ -191,25 +204,22 @@ BOOST_AUTO_TEST_CASE(testVectorNx1) {
     {
         LOG_DEBUG(<< "Sum");
 
-        double v[]{1.1, 2.4, 1.4, 3.7, 4.0};
-        maths::common::CVectorNx1<double, 5> vector(v);
+        maths::common::CVectorNx1<double, 5> vector{{1.1, 2.4, 1.4, 3.7, 4.0}};
         maths::common::CVectorNx1<double, 5> sum = vector + vector;
         LOG_DEBUG(<< "vector = " << sum);
         for (std::size_t i = 0; i < 5; ++i) {
-            BOOST_REQUIRE_EQUAL(2.0 * v[i], sum(i));
+            BOOST_REQUIRE_EQUAL(2.0 * vector(i), sum(i));
         }
     }
     {
         LOG_DEBUG(<< "Difference");
 
-        double v1[]{1.1, 0.4, 1.4};
-        double v2[]{2.1, 0.3, 0.4};
-        maths::common::CVectorNx1<double, 3> vector1(v1);
-        maths::common::CVectorNx1<double, 3> vector2(v2);
+        maths::common::CVectorNx1<double, 3> vector1{{1.1, 0.4, 1.4}};
+        maths::common::CVectorNx1<double, 3> vector2{{2.1, 0.3, 0.4}};
         maths::common::CVectorNx1<double, 3> difference = vector1 - vector2;
         LOG_DEBUG(<< "vector = " << difference);
         for (std::size_t i = 0; i < 3; ++i) {
-            BOOST_REQUIRE_EQUAL(v1[i] - v2[i], difference(i));
+            BOOST_REQUIRE_EQUAL(vector1(i) - vector2(i), difference(i));
         }
     }
     {
@@ -241,8 +251,7 @@ BOOST_AUTO_TEST_CASE(testVectorNx1) {
     {
         LOG_DEBUG(<< "Vector Scalar Multiplication");
 
-        double v[]{1.0, 2.0, 3.0, 4.0, 5.0};
-        maths::common::CVectorNx1<double, 5> vector(v);
+        maths::common::CVectorNx1<double, 5> vector{{1.0, 2.0, 3.0, 4.0, 5.0}};
         maths::common::CVectorNx1<double, 5> vs = vector * 3.0;
         LOG_DEBUG(<< "3 * v = " << vs);
         for (std::size_t i = 0; i < 5; ++i) {
@@ -252,13 +261,20 @@ BOOST_AUTO_TEST_CASE(testVectorNx1) {
     {
         LOG_DEBUG(<< "Matrix Scalar Division");
 
-        double v[]{1.0, 2.0, 3.0, 4.0, 5.0};
-        maths::common::CVectorNx1<double, 5> vector(v);
+        maths::common::CVectorNx1<double, 5> vector({1.0, 2.0, 3.0, 4.0, 5.0});
         maths::common::CVectorNx1<double, 5> vs = vector / 4.0;
         LOG_DEBUG(<< "v / 4.0 = " << vs);
         for (std::size_t i = 0; i < 5; ++i) {
             BOOST_REQUIRE_EQUAL(static_cast<double>((i + 1)) / 4.0, vs(i));
         }
+    }
+    {
+        LOG_DEBUG(<< "Mean");
+
+        maths::common::CVectorNx1<double, 5> vector{{1.0, 2.0, 3.0, 4.0, 5.0}};
+
+        double expectedMean{maths::common::CBasicStatistics::mean({1.0, 2.0, 3.0, 4.0, 5.0})};
+        BOOST_REQUIRE_EQUAL(expectedMean, vector.mean());
     }
 }
 
@@ -267,8 +283,8 @@ BOOST_AUTO_TEST_CASE(testSymmetricMatrix) {
     {
         maths::common::CSymmetricMatrix<double> matrix(3);
         LOG_DEBUG(<< "matrix = " << matrix);
-        BOOST_REQUIRE_EQUAL(std::size_t(3), matrix.rows());
-        BOOST_REQUIRE_EQUAL(std::size_t(3), matrix.columns());
+        BOOST_REQUIRE_EQUAL(3, matrix.rows());
+        BOOST_REQUIRE_EQUAL(3, matrix.columns());
         for (std::size_t i = 0; i < 3; ++i) {
             for (std::size_t j = 0; j < 3; ++j) {
                 BOOST_REQUIRE_EQUAL(0.0, matrix(i, j));
@@ -278,8 +294,8 @@ BOOST_AUTO_TEST_CASE(testSymmetricMatrix) {
     {
         maths::common::CSymmetricMatrix<double> matrix(4, 3.0);
         LOG_DEBUG(<< "matrix = " << matrix);
-        BOOST_REQUIRE_EQUAL(std::size_t(4), matrix.rows());
-        BOOST_REQUIRE_EQUAL(std::size_t(4), matrix.columns());
+        BOOST_REQUIRE_EQUAL(4, matrix.rows());
+        BOOST_REQUIRE_EQUAL(4, matrix.columns());
         for (std::size_t i = 0; i < 4; ++i) {
             for (std::size_t j = 0; j < 4; ++j) {
                 BOOST_REQUIRE_EQUAL(3.0, matrix(i, j));
@@ -287,21 +303,15 @@ BOOST_AUTO_TEST_CASE(testSymmetricMatrix) {
         }
     }
     {
-        double m_[][5]{{1.1, 2.4, 1.4, 3.7, 4.0},
-                       {2.4, 3.2, 1.8, 0.7, 1.0},
-                       {1.4, 1.8, 0.8, 4.7, 3.1},
-                       {3.7, 0.7, 4.7, 4.7, 1.1},
-                       {4.0, 1.0, 3.1, 1.1, 1.0}};
-        TDoubleVecVec m(5, TDoubleVec(5));
-        for (std::size_t i = 0; i < 5; ++i) {
-            for (std::size_t j = 0; j < 5; ++j) {
-                m[i][j] = m_[i][j];
-            }
-        }
+        TDoubleVecVec m{{1.1, 2.4, 1.4, 3.7, 4.0},
+                        {2.4, 3.2, 1.8, 0.7, 1.0},
+                        {1.4, 1.8, 0.8, 4.7, 3.1},
+                        {3.7, 0.7, 4.7, 4.7, 1.1},
+                        {4.0, 1.0, 3.1, 1.1, 1.0}};
         maths::common::CSymmetricMatrix<double> matrix(m);
         LOG_DEBUG(<< "matrix = " << matrix);
-        BOOST_REQUIRE_EQUAL(std::size_t(5), matrix.rows());
-        BOOST_REQUIRE_EQUAL(std::size_t(5), matrix.columns());
+        BOOST_REQUIRE_EQUAL(5, matrix.rows());
+        BOOST_REQUIRE_EQUAL(5, matrix.columns());
         for (std::size_t i = 0; i < 5; ++i) {
             for (std::size_t j = 0; j < 5; ++j) {
                 BOOST_REQUIRE_EQUAL(m[i][j], matrix(i, j));
@@ -314,9 +324,9 @@ BOOST_AUTO_TEST_CASE(testSymmetricMatrix) {
                    4.7, 4.7, 4.0, 1.0, 3.1, 1.1, 1.0};
         maths::common::CSymmetricMatrix<double> matrix(std::begin(m), std::end(m));
         LOG_DEBUG(<< "matrix = " << matrix);
-        BOOST_REQUIRE_EQUAL(std::size_t(5), matrix.rows());
-        BOOST_REQUIRE_EQUAL(std::size_t(5), matrix.columns());
-        for (std::size_t i = 0u, k = 0; i < 5; ++i) {
+        BOOST_REQUIRE_EQUAL(5, matrix.rows());
+        BOOST_REQUIRE_EQUAL(5, matrix.columns());
+        for (std::size_t i = 0, k = 0; i < 5; ++i) {
             for (std::size_t j = 0; j <= i; ++j, ++k) {
                 BOOST_REQUIRE_EQUAL(m[k], matrix(i, j));
                 BOOST_REQUIRE_EQUAL(m[k], matrix(j, i));
@@ -325,12 +335,12 @@ BOOST_AUTO_TEST_CASE(testSymmetricMatrix) {
         BOOST_REQUIRE_EQUAL(10.8, matrix.trace());
     }
     {
-        double v[]{1.0, 2.0, 3.0, 4.0};
-        maths::common::CVector<double> vector(std::begin(v), std::end(v));
+        TDoubleVec v{1.0, 2.0, 3.0, 4.0};
+        maths::common::CVector<double> vector{v};
         maths::common::CSymmetricMatrix<double> matrix(maths::common::E_OuterProduct, vector);
         LOG_DEBUG(<< "matrix = " << matrix);
-        BOOST_REQUIRE_EQUAL(std::size_t(4), matrix.rows());
-        BOOST_REQUIRE_EQUAL(std::size_t(4), matrix.columns());
+        BOOST_REQUIRE_EQUAL(4, matrix.rows());
+        BOOST_REQUIRE_EQUAL(4, matrix.columns());
         for (std::size_t i = 0; i < 4; ++i) {
             for (std::size_t j = 0; j < 4; ++j) {
                 BOOST_REQUIRE_EQUAL(static_cast<double>((i + 1) * (j + 1)), matrix(i, j));
@@ -339,12 +349,12 @@ BOOST_AUTO_TEST_CASE(testSymmetricMatrix) {
         BOOST_REQUIRE_EQUAL(30.0, matrix.trace());
     }
     {
-        double v[]{1.0, 2.0, 3.0, 4.0};
-        maths::common::CVector<double> vector(std::begin(v), std::end(v));
+        TDoubleVec v{1.0, 2.0, 3.0, 4.0};
+        maths::common::CVector<double> vector{v};
         maths::common::CSymmetricMatrix<double> matrix(maths::common::E_Diagonal, vector);
         LOG_DEBUG(<< "matrix = " << matrix);
-        BOOST_REQUIRE_EQUAL(std::size_t(4), matrix.rows());
-        BOOST_REQUIRE_EQUAL(std::size_t(4), matrix.columns());
+        BOOST_REQUIRE_EQUAL(4, matrix.rows());
+        BOOST_REQUIRE_EQUAL(4, matrix.columns());
         for (std::size_t i = 0; i < 4; ++i) {
             for (std::size_t j = 0; j < 4; ++j) {
                 BOOST_REQUIRE_EQUAL(i == j ? vector(i) : 0.0, matrix(i, j));
@@ -361,7 +371,7 @@ BOOST_AUTO_TEST_CASE(testSymmetricMatrix) {
         maths::common::CSymmetricMatrix<double> matrix(std::begin(m), std::end(m));
         maths::common::CSymmetricMatrix<double> sum = matrix + matrix;
         LOG_DEBUG(<< "sum = " << sum);
-        for (std::size_t i = 0u, k = 0; i < 5; ++i) {
+        for (std::size_t i = 0, k = 0; i < 5; ++i) {
             for (std::size_t j = 0; j <= i; ++j, ++k) {
                 BOOST_REQUIRE_EQUAL(2.0 * m[k], sum(i, j));
                 BOOST_REQUIRE_EQUAL(2.0 * m[k], sum(j, i));
@@ -387,8 +397,8 @@ BOOST_AUTO_TEST_CASE(testSymmetricMatrix) {
     {
         LOG_DEBUG(<< "Matrix Scalar Multiplication");
 
-        double v[]{1.0, 2.0, 3.0, 4.0, 5.0};
-        maths::common::CVector<double> vector(std::begin(v), std::end(v));
+        TDoubleVec v{1.0, 2.0, 3.0, 4.0, 5.0};
+        maths::common::CVector<double> vector{v};
         maths::common::CSymmetricMatrix<double> m(maths::common::E_OuterProduct, vector);
         maths::common::CSymmetricMatrix<double> ms = m * 3.0;
         LOG_DEBUG(<< "3 * m = " << ms);
@@ -402,8 +412,8 @@ BOOST_AUTO_TEST_CASE(testSymmetricMatrix) {
     {
         LOG_DEBUG(<< "Matrix Scalar Division");
 
-        double v[]{1.0, 2.0, 3.0, 4.0, 5.0};
-        maths::common::CVector<double> vector(std::begin(v), std::end(v));
+        TDoubleVec v{1.0, 2.0, 3.0, 4.0, 5.0};
+        maths::common::CVector<double> vector{v};
         maths::common::CSymmetricMatrix<double> m(maths::common::E_OuterProduct, vector);
         maths::common::CSymmetricMatrix<double> ms = m / 4.0;
         LOG_DEBUG(<< "m / 4.0 = " << ms);
@@ -414,6 +424,23 @@ BOOST_AUTO_TEST_CASE(testSymmetricMatrix) {
             }
         }
     }
+    {
+        LOG_DEBUG(<< "Mean");
+
+        TDoubleVecVec m{{1.1, 2.4, 1.4, 3.7, 4.0},
+                        {2.4, 3.2, 1.8, 0.7, 1.0},
+                        {1.4, 1.8, 0.8, 4.7, 3.1},
+                        {3.7, 0.7, 4.7, 4.7, 1.1},
+                        {4.0, 1.0, 3.1, 1.1, 1.0}};
+        maths::common::CSymmetricMatrix<double> matrix(m);
+
+        double expectedMean{
+            (5.0 * maths::common::CBasicStatistics::mean({1.1, 3.2, 0.8, 4.7, 1.0}) +
+             20.0 * maths::common::CBasicStatistics::mean(
+                        {2.4, 1.4, 3.7, 4.0, 1.8, 0.7, 1.0, 4.7, 3.1, 1.1})) /
+            25.0};
+        BOOST_REQUIRE_CLOSE(expectedMean, matrix.mean(), 1e-6);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(testVector) {
@@ -421,7 +448,7 @@ BOOST_AUTO_TEST_CASE(testVector) {
     {
         maths::common::CVector<double> vector(3);
         LOG_DEBUG(<< "vector = " << vector);
-        BOOST_REQUIRE_EQUAL(std::size_t(3), vector.dimension());
+        BOOST_REQUIRE_EQUAL(3, vector.dimension());
         for (std::size_t i = 0; i < 3; ++i) {
             BOOST_REQUIRE_EQUAL(0.0, vector(i));
         }
@@ -429,25 +456,24 @@ BOOST_AUTO_TEST_CASE(testVector) {
     {
         maths::common::CVector<double> vector(4, 3.0);
         LOG_DEBUG(<< "vector = " << vector);
-        BOOST_REQUIRE_EQUAL(std::size_t(4), vector.dimension());
+        BOOST_REQUIRE_EQUAL(4, vector.dimension());
         for (std::size_t i = 0; i < 4; ++i) {
             BOOST_REQUIRE_EQUAL(3.0, vector(i));
         }
     }
     {
-        double v_[]{1.1, 2.4, 1.4, 3.7, 4.0};
-        TDoubleVec v(std::begin(v_), std::end(v_));
+        TDoubleVec v{1.1, 2.4, 1.4, 3.7, 4.0};
         maths::common::CVector<double> vector(v);
-        BOOST_REQUIRE_EQUAL(std::size_t(5), vector.dimension());
+        BOOST_REQUIRE_EQUAL(5, vector.dimension());
         LOG_DEBUG(<< "vector = " << vector);
         for (std::size_t i = 0; i < 5; ++i) {
             BOOST_REQUIRE_EQUAL(v[i], vector(i));
         }
     }
     {
-        double v[]{1.1, 2.4, 1.4, 3.7, 4.0};
-        maths::common::CVector<double> vector(std::begin(v), std::end(v));
-        BOOST_REQUIRE_EQUAL(std::size_t(5), vector.dimension());
+        TDoubleVec v{1.1, 2.4, 1.4, 3.7, 4.0};
+        maths::common::CVector<double> vector{v.begin(), v.end()};
+        BOOST_REQUIRE_EQUAL(5, vector.dimension());
         LOG_DEBUG(<< "vector = " << vector);
         for (std::size_t i = 0; i < 5; ++i) {
             BOOST_REQUIRE_EQUAL(v[i], vector(i));
@@ -458,8 +484,8 @@ BOOST_AUTO_TEST_CASE(testVector) {
     {
         LOG_DEBUG(<< "Sum");
 
-        double v[]{1.1, 2.4, 1.4, 3.7, 4.0};
-        maths::common::CVector<double> vector(std::begin(v), std::end(v));
+        TDoubleVec v{1.1, 2.4, 1.4, 3.7, 4.0};
+        maths::common::CVector<double> vector{v};
         maths::common::CVector<double> sum = vector + vector;
         LOG_DEBUG(<< "vector = " << sum);
         for (std::size_t i = 0; i < 5; ++i) {
@@ -469,10 +495,10 @@ BOOST_AUTO_TEST_CASE(testVector) {
     {
         LOG_DEBUG(<< "Difference");
 
-        double v1[]{1.1, 0.4, 1.4};
-        double v2[]{2.1, 0.3, 0.4};
-        maths::common::CVector<double> vector1(std::begin(v1), std::end(v1));
-        maths::common::CVector<double> vector2(std::begin(v2), std::end(v2));
+        TDoubleVec v1{1.1, 0.4, 1.4};
+        TDoubleVec v2{2.1, 0.3, 0.4};
+        maths::common::CVector<double> vector1{v1};
+        maths::common::CVector<double> vector2{v2};
         maths::common::CVector<double> difference = vector1 - vector2;
         LOG_DEBUG(<< "vector = " << difference);
         for (std::size_t i = 0; i < 3; ++i) {
@@ -482,7 +508,7 @@ BOOST_AUTO_TEST_CASE(testVector) {
     {
         LOG_DEBUG(<< "Matrix Vector Multiplication");
 
-        Eigen::MatrixXd randomMatrix(std::size_t(4), std::size_t(4));
+        Eigen::MatrixXd randomMatrix(4, 4);
         Eigen::VectorXd randomVector(4);
         for (std::size_t t = 0; t < 20; ++t) {
             randomMatrix.setRandom();
@@ -508,8 +534,8 @@ BOOST_AUTO_TEST_CASE(testVector) {
     {
         LOG_DEBUG(<< "Vector Scalar Multiplication");
 
-        double v[]{1.0, 2.0, 3.0, 4.0, 5.0};
-        maths::common::CVector<double> vector(std::begin(v), std::end(v));
+        TDoubleVec v{1.0, 2.0, 3.0, 4.0, 5.0};
+        maths::common::CVector<double> vector{v};
         maths::common::CVector<double> vs = vector * 3.0;
         LOG_DEBUG(<< "3 * v = " << vs);
         for (std::size_t i = 0; i < 5; ++i) {
@@ -519,13 +545,22 @@ BOOST_AUTO_TEST_CASE(testVector) {
     {
         LOG_DEBUG(<< "Matrix Scalar Division");
 
-        double v[]{1.0, 2.0, 3.0, 4.0, 5.0};
-        maths::common::CVector<double> vector(std::begin(v), std::end(v));
+        TDoubleVec v{1.0, 2.0, 3.0, 4.0, 5.0};
+        maths::common::CVector<double> vector{v};
         maths::common::CVector<double> vs = vector / 4.0;
         LOG_DEBUG(<< "v / 4.0 = " << vs);
         for (std::size_t i = 0; i < 5; ++i) {
             BOOST_REQUIRE_EQUAL(static_cast<double>((i + 1)) / 4.0, vs(i));
         }
+    }
+    {
+        LOG_DEBUG(<< "Mean");
+
+        TDoubleVec v{1.0, 2.0, 3.0, 4.0, 5.0};
+        maths::common::CVector<double> vector{v};
+
+        double expectedMean{maths::common::CBasicStatistics::mean({1.0, 2.0, 3.0, 4.0, 5.0})};
+        BOOST_REQUIRE_EQUAL(expectedMean, vector.mean());
     }
 }
 
@@ -1143,10 +1178,10 @@ BOOST_AUTO_TEST_CASE(testShims) {
 
     LOG_DEBUG(<< "Test dimension");
     {
-        BOOST_REQUIRE_EQUAL(std::size_t(4), maths::common::las::dimension(vector1));
-        BOOST_REQUIRE_EQUAL(std::size_t(4), maths::common::las::dimension(vector2));
-        BOOST_REQUIRE_EQUAL(std::size_t(4), maths::common::las::dimension(vector3));
-        BOOST_REQUIRE_EQUAL(std::size_t(4), maths::common::las::dimension(vector4));
+        BOOST_REQUIRE_EQUAL(4, maths::common::las::dimension(vector1));
+        BOOST_REQUIRE_EQUAL(4, maths::common::las::dimension(vector2));
+        BOOST_REQUIRE_EQUAL(4, maths::common::las::dimension(vector3));
+        BOOST_REQUIRE_EQUAL(4, maths::common::las::dimension(vector4));
     }
     LOG_DEBUG(<< "Test zero");
     {

--- a/lib/maths/common/unittest/CModelTest.cc
+++ b/lib/maths/common/unittest/CModelTest.cc
@@ -51,7 +51,10 @@ BOOST_AUTO_TEST_CASE(testAll) {
         TDouble2VecWeightsAryVec trendWeights{weight1};
         TDouble2VecWeightsAryVec priorWeights{weight2};
         maths::common::CModelAddSamplesParams params;
-        params.integer(true).propagationInterval(1.5).trendWeights(trendWeights).priorWeights(priorWeights);
+        params.isInteger(true)
+            .propagationInterval(1.5)
+            .trendWeights(trendWeights)
+            .priorWeights(priorWeights);
         BOOST_REQUIRE_EQUAL(maths_t::E_IntegerData, params.type());
         BOOST_REQUIRE_EQUAL(1.5, params.propagationInterval());
         BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(trendWeights),

--- a/lib/maths/time_series/CCalendarComponent.cc
+++ b/lib/maths/time_series/CCalendarComponent.cc
@@ -20,6 +20,7 @@
 
 #include <maths/common/CChecksum.h>
 #include <maths/common/CIntegerTools.h>
+#include <maths/common/CLinearAlgebra.h>
 #include <maths/common/CSampling.h>
 
 #include <maths/time_series/CSeasonalTime.h>
@@ -32,7 +33,6 @@ namespace ml {
 namespace maths {
 namespace time_series {
 namespace {
-using TDoubleDoublePr = maths_t::TDoubleDoublePr;
 const core::TPersistenceTag DECOMPOSITION_COMPONENT_TAG{"a", "decomposition_component"};
 const core::TPersistenceTag BUCKETING_TAG{"b", "bucketing"};
 const core::TPersistenceTag LAST_INTERPOLATION_TAG{"c", "last_interpolation_time"};
@@ -167,7 +167,8 @@ CCalendarFeatureAndTZ CCalendarComponent::feature() const {
     return m_Bucketing.feature();
 }
 
-TDoubleDoublePr CCalendarComponent::value(core_t::TTime time, double confidence) const {
+CCalendarComponent::TVector2x1 CCalendarComponent::value(core_t::TTime time,
+                                                         double confidence) const {
     double offset{static_cast<double>(this->feature().offset(time))};
     double n{m_Bucketing.count(time)};
     return this->CDecompositionComponent::value(offset, n, confidence);
@@ -177,7 +178,8 @@ double CCalendarComponent::meanValue() const {
     return this->CDecompositionComponent::meanValue();
 }
 
-TDoubleDoublePr CCalendarComponent::variance(core_t::TTime time, double confidence) const {
+CCalendarComponent::TVector2x1
+CCalendarComponent::variance(core_t::TTime time, double confidence) const {
     double offset{static_cast<double>(this->feature().offset(time))};
     double n{m_Bucketing.count(time)};
     return this->CDecompositionComponent::variance(offset, n, confidence);

--- a/lib/maths/time_series/CCalendarCyclicTest.cc
+++ b/lib/maths/time_series/CCalendarCyclicTest.cc
@@ -183,9 +183,9 @@ void CCalendarCyclicTest::add(core_t::TTime time, double error, double weight) {
             bool isVeryLarge{100.0 * (1.0 - this->survivalFunction(error)) >=
                              VERY_LARGE_ERROR_PERCENTILE};
             m_CurrentBucketErrorStats.s_LargeErrorCount +=
-                std::min(std::numeric_limits<std::size_t>::max() -
+                std::min(std::numeric_limits<std::uint32_t>::max() -
                              m_CurrentBucketErrorStats.s_LargeErrorCount,
-                         static_cast<std::size_t>(isVeryLarge ? (1 << 17) + 1 : 1));
+                         static_cast<std::uint32_t>(isVeryLarge ? (1 << 17) + 1 : 1));
             m_CurrentBucketErrorStats.s_LargeErrorSum += this->winsorise(error);
         }
     }

--- a/lib/maths/time_series/CCalendarCyclicTest.cc
+++ b/lib/maths/time_series/CCalendarCyclicTest.cc
@@ -182,10 +182,10 @@ void CCalendarCyclicTest::add(core_t::TTime time, double error, double weight) {
         if (error >= largeError) {
             bool isVeryLarge{100.0 * (1.0 - this->survivalFunction(error)) >=
                              VERY_LARGE_ERROR_PERCENTILE};
-            m_CurrentBucketErrorStats.s_LargeErrorCount +=
-                std::min(std::numeric_limits<std::uint32_t>::max() -
-                             m_CurrentBucketErrorStats.s_LargeErrorCount,
-                         static_cast<std::uint32_t>(isVeryLarge ? (1 << 17) + 1 : 1));
+            m_CurrentBucketErrorStats.s_LargeErrorCount += std::min(
+                std::numeric_limits<std::uint32_t>::max() -
+                    m_CurrentBucketErrorStats.s_LargeErrorCount,
+                static_cast<std::uint32_t>(isVeryLarge ? (1 << 17) + 1 : 1));
             m_CurrentBucketErrorStats.s_LargeErrorSum += this->winsorise(error);
         }
     }

--- a/lib/maths/time_series/CSeasonalComponent.cc
+++ b/lib/maths/time_series/CSeasonalComponent.cc
@@ -22,6 +22,7 @@
 #include <maths/common/CChecksum.h>
 #include <maths/common/CIntegerTools.h>
 #include <maths/common/CLeastSquaresOnlineRegressionDetail.h>
+#include <maths/common/CLinearAlgebra.h>
 #include <maths/common/CSampling.h>
 #include <maths/common/CSolvers.h>
 
@@ -34,7 +35,6 @@ namespace ml {
 namespace maths {
 namespace time_series {
 namespace {
-using TDoubleDoublePr = maths_t::TDoubleDoublePr;
 const core::TPersistenceTag DECOMPOSITION_COMPONENT_TAG{"a", "decomposition_component"};
 const core::TPersistenceTag RNG_TAG{"b", "rng"};
 const core::TPersistenceTag BUCKETING_TAG{"c", "bucketing"};
@@ -197,7 +197,7 @@ void CSeasonalComponent::add(core_t::TTime time, double value, double weight, do
     double shiftWeight;
     std::tie(shift, shiftWeight) = this->likelyShift(time, value);
     m_CurrentMeanShift.add(static_cast<double>(shift), weight * shiftWeight);
-    double prediction{common::CBasicStatistics::mean(this->value(this->jitter(time), 0.0))};
+    double prediction{this->value(this->jitter(time), 0.0).mean()};
     m_Bucketing.add(time + m_TotalShift, value, prediction, weight, gradientLearnRate);
 }
 
@@ -251,7 +251,8 @@ const CSeasonalComponentAdaptiveBucketing& CSeasonalComponent::bucketing() const
     return m_Bucketing;
 }
 
-TDoubleDoublePr CSeasonalComponent::value(core_t::TTime time, double confidence) const {
+CSeasonalComponent::TVector2x1 CSeasonalComponent::value(core_t::TTime time,
+                                                         double confidence) const {
     time += m_TotalShift;
     double offset{this->time().periodic(time)};
     double n{m_Bucketing.count(time)};
@@ -294,7 +295,7 @@ double CSeasonalComponent::delta(core_t::TTime time,
         double mean{this->CDecompositionComponent::meanValue()};
         for (core_t::TTime t = time; t < time + longPeriod; t += shortPeriod) {
             if (time_.inWindow(t)) {
-                double difference{common::CBasicStatistics::mean(this->value(t, 0.0)) - mean};
+                double difference{this->value(t, 0.0).mean() - mean};
                 bias.add(difference);
                 amplitude = std::max(amplitude, std::fabs(difference));
                 if (shortDifference * difference < 0.0) {
@@ -314,7 +315,8 @@ double CSeasonalComponent::delta(core_t::TTime time,
     return 0.0;
 }
 
-TDoubleDoublePr CSeasonalComponent::variance(core_t::TTime time, double confidence) const {
+CSeasonalComponent::TVector2x1
+CSeasonalComponent::variance(core_t::TTime time, double confidence) const {
     time += m_TotalShift;
     double offset{this->time().periodic(time)};
     double n{m_Bucketing.count(time)};
@@ -334,7 +336,7 @@ bool CSeasonalComponent::covariances(core_t::TTime time, TMatrix& result) const 
 
     time += m_TotalShift;
     if (const auto* r = m_Bucketing.regression(time)) {
-        double variance{common::CBasicStatistics::mean(this->variance(time, 0.0))};
+        double variance{this->variance(time, 0.0).mean()};
         return r->covariances(variance, result);
     }
 
@@ -408,11 +410,10 @@ CSeasonalComponent::likelyShift(core_t::TTime time, double value) const {
     // If the change due to the shift is small compared to the prediction
     // error force it to zero.
     double noise{0.2 * std::sqrt(this->meanVariance()) / range};
-    auto loss = [&](double offset) {
-        return std::fabs(common::CBasicStatistics::mean(this->value(
-                             time + static_cast<core_t::TTime>(offset + 0.5), 0.0)) -
-                         value) +
-               noise * std::fabs(offset);
+    auto loss = [&](double shift) {
+        auto shift_ = static_cast<core_t::TTime>(shift + 0.5);
+        return std::fabs(this->value(time + shift_, 0.0).mean() - value) +
+               noise * std::fabs(shift);
     };
 
     return likelyShift(m_MaxTimeShiftPerPeriod, 0, loss);

--- a/lib/maths/time_series/CTimeSeriesDecomposition.cc
+++ b/lib/maths/time_series/CTimeSeriesDecomposition.cc
@@ -244,9 +244,9 @@ void CTimeSeriesDecomposition::addPoint(core_t::TTime time,
                       m_TimeShift,
                       value,
                       weights,
-                      this->value(time, 0.0, E_TrendForced).mean(),
-                      this->value(time, 0.0, E_Seasonal).mean(),
-                      this->value(time, 0.0, E_Calendar).mean(),
+                      this->value(time, 0.0, E_TrendForced, true).mean(),
+                      this->value(time, 0.0, E_Seasonal, true).mean(),
+                      this->value(time, 0.0, E_Calendar, true).mean(),
                       *this,
                       [this] {
                           auto predictor_ = this->predictor(E_All | E_TrendForced);
@@ -329,7 +329,7 @@ CTimeSeriesDecomposition::value(core_t::TTime time, double confidence, int compo
 
 CTimeSeriesDecomposition::TVector2x1
 CTimeSeriesDecomposition::value(core_t::TTime time, double confidence, bool isNonNegative) const {
-    auto result = this->value(time, confidence, E_All);
+    auto result = this->value(time, confidence, E_All, true);
     return isNonNegative ? max(result, 0.0) : result;
 }
 
@@ -449,9 +449,9 @@ double CTimeSeriesDecomposition::detrend(core_t::TTime time,
         return value;
     }
 
-    TVector2x1 interval{this->value(time, confidence, E_All ^ E_Seasonal)};
-    auto shiftedInterval = [=](core_t::TTime shift) {
-        TVector2x1 result{interval + this->value(time + shift, confidence, E_Seasonal)};
+    TVector2x1 interval{this->value(time, confidence, E_All ^ E_Seasonal, true)};
+    auto shiftedInterval = [&](core_t::TTime shift) {
+        TVector2x1 result{interval + this->value(time + shift, confidence, E_Seasonal, true)};
         return isNonNegative ? max(result, 0.0) : result;
     };
 

--- a/lib/maths/time_series/CTimeSeriesDecomposition.cc
+++ b/lib/maths/time_series/CTimeSeriesDecomposition.cc
@@ -333,18 +333,21 @@ CTimeSeriesDecomposition::value(core_t::TTime time, double confidence, bool isNo
 
 CTimeSeriesDecomposition::TFilteredPredictor
 CTimeSeriesDecomposition::predictor(int components) const {
+
     CTrendComponent::TPredictor trend_{m_Components.trend().predictor()};
+
     return [ components, trend = std::move(trend_),
              this ](core_t::TTime time, const TBoolVec& removedSeasonalMask) {
-        double baseline{0.0};
+
+        double result{0.0};
 
         time += m_TimeShift;
 
         if ((components & E_TrendForced) != 0) {
-            baseline += trend(time);
+            result += trend(time);
         } else if ((components & E_Trend) != 0) {
             if (m_Components.usingTrendForPrediction()) {
-                baseline += trend(time);
+                result += trend(time);
             }
         }
 
@@ -354,7 +357,7 @@ CTimeSeriesDecomposition::predictor(int components) const {
                 if (seasonal[i].initialized() &&
                     (removedSeasonalMask.empty() || removedSeasonalMask[i] == false) &&
                     seasonal[i].time().inWindow(time)) {
-                    baseline += seasonal[i].value(time, 0.0).mean();
+                    result += seasonal[i].value(time, 0.0).mean();
                 }
             }
         }
@@ -362,12 +365,12 @@ CTimeSeriesDecomposition::predictor(int components) const {
         if ((components & E_Calendar) != 0) {
             for (const auto& component : m_Components.calendar()) {
                 if (component.initialized() && component.feature().inWindow(time)) {
-                    baseline += component.value(time, 0.0).mean();
+                    result += component.value(time, 0.0).mean();
                 }
             }
         }
 
-        return baseline;
+        return result;
     };
 }
 

--- a/lib/maths/time_series/CTimeSeriesDecomposition.cc
+++ b/lib/maths/time_series/CTimeSeriesDecomposition.cc
@@ -226,8 +226,9 @@ void CTimeSeriesDecomposition::addPoint(core_t::TTime time,
     m_LastValueTime = std::max(m_LastValueTime, time);
     this->propagateForwardsTo(time);
 
-    auto testForSeasonality = m_Components.makeTestForSeasonality([this]() {
-        return [ predictor = this->predictor(E_Seasonal),
+    auto testForSeasonality = m_Components.makeTestForSeasonality([this] {
+        auto predictor_ = this->predictor(E_Seasonal);
+        return [ predictor = std::move(predictor_),
                  this ](core_t::TTime time_, const TBoolVec& removedSeasonalMask) {
             return predictor(time_, removedSeasonalMask) +
                    this->smooth(
@@ -248,8 +249,8 @@ void CTimeSeriesDecomposition::addPoint(core_t::TTime time,
                       this->value(time, 0.0, E_Calendar).mean(),
                       *this,
                       [this] {
-                          return [predictor = this->predictor(E_All | E_TrendForced)](
-                              core_t::TTime time_) {
+                          auto predictor_ = this->predictor(E_All | E_TrendForced);
+                          return [predictor = std::move(predictor_)](core_t::TTime time_) {
                               return predictor(time_, {});
                           };
                       },

--- a/lib/maths/time_series/CTimeSeriesDecomposition.cc
+++ b/lib/maths/time_series/CTimeSeriesDecomposition.cc
@@ -29,6 +29,7 @@
 
 #include <maths/time_series/CSeasonalTime.h>
 
+#include <algorithm>
 #include <cmath>
 #include <string>
 #include <utility>
@@ -37,22 +38,6 @@ namespace ml {
 namespace maths {
 namespace time_series {
 namespace {
-
-using TDoubleDoublePr = maths_t::TDoubleDoublePr;
-using TVector2x1 = common::CVectorNx1<double, 2>;
-
-//! Convert a double pair to a 2x1 vector.
-TVector2x1 vector2x1(const TDoubleDoublePr& p) {
-    TVector2x1 result;
-    result(0) = p.first;
-    result(1) = p.second;
-    return result;
-}
-
-//! Convert a 2x1 vector to a double pair.
-TDoubleDoublePr pair(const TVector2x1& v) {
-    return {v(0), v(1)};
-}
 
 // Version 7.11
 const std::string VERSION_7_11_TAG("7.11");
@@ -243,28 +228,26 @@ void CTimeSeriesDecomposition::addPoint(core_t::TTime time,
 
     auto testForSeasonality = m_Components.makeTestForSeasonality(
         [this](core_t::TTime time_, const TBoolVec& removedSeasonalMask) {
-            return common::CBasicStatistics::mean(
-                this->value(time_, 0.0, E_Seasonal, removedSeasonalMask));
+            return this->value(time_, 0.0, E_Seasonal, removedSeasonalMask).mean();
         });
 
-    SAddValue message{
-        time,
-        lastTime,
-        m_TimeShift,
-        value,
-        weights,
-        common::CBasicStatistics::mean(this->value(time, 0.0, E_TrendForced)),
-        common::CBasicStatistics::mean(this->value(time, 0.0, E_Seasonal)),
-        common::CBasicStatistics::mean(this->value(time, 0.0, E_Calendar)),
-        *this,
-        [this] {
-            auto predictor_ = this->predictor(E_All | E_TrendForced);
-            return [predictor = std::move(predictor_)](core_t::TTime time_) {
-                return predictor(time_, {});
-            };
-        },
-        [this] { return this->predictor(E_Seasonal | E_Calendar); },
-        testForSeasonality};
+    SAddValue message{time,
+                      lastTime,
+                      m_TimeShift,
+                      value,
+                      weights,
+                      this->value(time, 0.0, E_TrendForced).mean(),
+                      this->value(time, 0.0, E_Seasonal).mean(),
+                      this->value(time, 0.0, E_Calendar).mean(),
+                      *this,
+                      [this] {
+                          auto predictor_ = this->predictor(E_All | E_TrendForced);
+                          return [predictor = std::move(predictor_)](core_t::TTime time_) {
+                              return predictor(time_, {});
+                          };
+                      },
+                      [this] { return this->predictor(E_Seasonal | E_Calendar); },
+                      testForSeasonality};
 
     m_ChangePointTest.handle(message);
     m_Components.handle(message);
@@ -293,20 +276,21 @@ double CTimeSeriesDecomposition::meanValue(core_t::TTime time) const {
     return m_Components.meanValue(time);
 }
 
-TDoubleDoublePr CTimeSeriesDecomposition::value(core_t::TTime time,
-                                                double confidence,
-                                                int components,
-                                                const TBoolVec& removedSeasonalMask,
-                                                bool smooth) const {
-    TVector2x1 baseline{0.0};
+CTimeSeriesDecomposition::TVector2x1
+CTimeSeriesDecomposition::value(core_t::TTime time,
+                                double confidence,
+                                int components,
+                                const TBoolVec& removedSeasonalMask,
+                                bool smooth) const {
+    TVector2x1 result{0.0};
 
     time += m_TimeShift;
 
     if ((components & E_TrendForced) != 0) {
-        baseline += vector2x1(m_Components.trend().value(time, confidence));
+        result += m_Components.trend().value(time, confidence);
     } else if ((components & E_Trend) != 0) {
         if (m_Components.usingTrendForPrediction()) {
-            baseline += vector2x1(m_Components.trend().value(time, confidence));
+            result += m_Components.trend().value(time, confidence);
         }
     }
 
@@ -316,7 +300,7 @@ TDoubleDoublePr CTimeSeriesDecomposition::value(core_t::TTime time,
             if (seasonal[i].initialized() &&
                 (removedSeasonalMask.empty() || removedSeasonalMask[i] == false) &&
                 seasonal[i].time().inWindow(time)) {
-                baseline += vector2x1(seasonal[i].value(time, confidence));
+                result += seasonal[i].value(time, confidence);
             }
         }
     }
@@ -324,21 +308,27 @@ TDoubleDoublePr CTimeSeriesDecomposition::value(core_t::TTime time,
     if ((components & E_Calendar) != 0) {
         for (const auto& component : m_Components.calendar()) {
             if (component.initialized() && component.feature().inWindow(time)) {
-                baseline += vector2x1(component.value(time, confidence));
+                result += component.value(time, confidence);
             }
         }
     }
 
     if (smooth) {
-        baseline += vector2x1(this->smooth(
+        result += this->smooth(
             [&](core_t::TTime time_) {
                 return this->value(time_ - m_TimeShift, confidence,
                                    components & E_Seasonal, removedSeasonalMask, false);
             },
-            time, components));
+            time, components);
     }
 
-    return pair(baseline);
+    return result;
+}
+
+CTimeSeriesDecomposition::TVector2x1
+CTimeSeriesDecomposition::value(core_t::TTime time, double confidence, bool isNonNegative) const {
+    auto result = this->value(time, confidence, E_All);
+    return isNonNegative ? max(result, 0.0) : result;
 }
 
 CTimeSeriesDecomposition::TFilteredPredictor
@@ -364,7 +354,7 @@ CTimeSeriesDecomposition::predictor(int components) const {
                 if (seasonal[i].initialized() &&
                     (removedSeasonalMask.empty() || removedSeasonalMask[i] == false) &&
                     seasonal[i].time().inWindow(time)) {
-                    baseline += common::CBasicStatistics::mean(seasonal[i].value(time, 0.0));
+                    baseline += seasonal[i].value(time, 0.0).mean();
                 }
             }
         }
@@ -372,7 +362,7 @@ CTimeSeriesDecomposition::predictor(int components) const {
         if ((components & E_Calendar) != 0) {
             for (const auto& component : m_Components.calendar()) {
                 if (component.initialized() && component.feature().inWindow(time)) {
-                    baseline += common::CBasicStatistics::mean(component.value(time, 0.0));
+                    baseline += component.value(time, 0.0).mean();
                 }
             }
         }
@@ -390,6 +380,7 @@ void CTimeSeriesDecomposition::forecast(core_t::TTime startTime,
                                         core_t::TTime step,
                                         double confidence,
                                         double minimumScale,
+                                        bool isNonNegative,
                                         const TWriteForecastResult& writer) {
     if (endTime < startTime) {
         LOG_ERROR(<< "Bad forecast range: [" << startTime << "," << endTime << "]");
@@ -404,15 +395,15 @@ void CTimeSeriesDecomposition::forecast(core_t::TTime startTime,
         TVector2x1 prediction{0.0};
         for (const auto& component : m_Components.seasonal()) {
             if (component.initialized() && component.time().inWindow(time)) {
-                prediction += vector2x1(component.value(time, confidence));
+                prediction += component.value(time, confidence);
             }
         }
         for (const auto& component : m_Components.calendar()) {
             if (component.initialized() && component.feature().inWindow(time)) {
-                prediction += vector2x1(component.value(time, confidence));
+                prediction += component.value(time, confidence);
             }
         }
-        return pair(prediction);
+        return prediction;
     };
 
     startTime += m_TimeShift;
@@ -422,19 +413,18 @@ void CTimeSeriesDecomposition::forecast(core_t::TTime startTime,
     auto forecastSeasonal = [&](core_t::TTime time) -> TDouble3Vec {
         m_Components.interpolateForForecast(time);
 
-        TVector2x1 bounds{vector2x1(seasonal(time))};
+        TVector2x1 bounds{seasonal(time)};
 
         // Decompose the smoothing into shift plus stretch and ensure that the
         // smoothed interval between the prediction bounds remains positive length.
-        TDoubleDoublePr smoothing{this->smooth(seasonal, time, E_Seasonal)};
-        double shift{common::CBasicStatistics::mean(smoothing)};
-        double stretch{std::max(smoothing.second - smoothing.first, bounds(0) - bounds(1))};
+        TVector2x1 smoothing{this->smooth(seasonal, time, E_Seasonal)};
+        double shift{smoothing.mean()};
+        double stretch{std::max(smoothing(1) - smoothing(0), bounds(0) - bounds(1))};
         bounds += TVector2x1{{shift - stretch / 2.0, shift + stretch / 2.0}};
 
         double variance{this->meanVariance()};
         double boundsScale{std::sqrt(std::max(
-            minimumScale, common::CBasicStatistics::mean(
-                              this->varianceScaleWeight(time, variance, 0.0))))};
+            minimumScale, this->varianceScaleWeight(time, variance, 0.0).mean()))};
         double prediction{(bounds(0) + bounds(1)) / 2.0};
         double interval{boundsScale * (bounds(1) - bounds(0))};
 
@@ -442,60 +432,60 @@ void CTimeSeriesDecomposition::forecast(core_t::TTime startTime,
     };
 
     m_Components.trend().forecast(startTime, endTime, step, confidence,
-                                  forecastSeasonal, writer);
+                                  isNonNegative, forecastSeasonal, writer);
 }
 
 double CTimeSeriesDecomposition::detrend(core_t::TTime time,
                                          double value,
                                          double confidence,
-                                         core_t::TTime maximumTimeShift,
-                                         int components) const {
+                                         bool isNonNegative,
+                                         core_t::TTime maximumTimeShift) const {
     if (this->initialized() == false) {
         return value;
     }
 
-    TDoubleDoublePr interval{this->value(time, confidence, (E_All ^ E_Seasonal) & components)};
-    value = std::min(value - interval.first, 0.0) + std::max(value - interval.second, 0.0);
-
-    if ((components & E_Seasonal) == 0) {
-        return value;
-    }
+    TVector2x1 interval{this->value(time, confidence, E_All ^ E_Seasonal)};
+    auto shiftedInterval = [=](core_t::TTime shift) {
+        TVector2x1 result{interval + this->value(time + shift, confidence, E_Seasonal)};
+        return isNonNegative ? max(result, 0.0) : result;
+    };
 
     core_t::TTime shift{0};
     if (maximumTimeShift > 0) {
-        auto loss = [&](double offset) {
-            TDoubleDoublePr seasonalInterval{this->value(
-                time + static_cast<core_t::TTime>(offset + 0.5), confidence, E_Seasonal)};
-            return std::fabs(std::min(value - seasonalInterval.first, 0.0) +
-                             std::max(value - seasonalInterval.second, 0.0));
+        auto loss = [&](double shift_) {
+            TVector2x1 interval_{shiftedInterval(static_cast<core_t::TTime>(shift_ + 0.5))};
+            return std::fabs(std::min(value - interval_(0), 0.0) +
+                             std::max(value - interval_(1), 0.0));
         };
         std::tie(shift, std::ignore) =
             CSeasonalComponent::likelyShift(maximumTimeShift, 0, loss);
     }
 
-    interval = this->value(time + shift, confidence, E_Seasonal);
-    return std::min(value - interval.first, 0.0) + std::max(value - interval.second, 0.0);
+    interval = shiftedInterval(shift);
+
+    return std::min(value - interval(0), 0.0) + std::max(value - interval(1), 0.0);
 }
 
 double CTimeSeriesDecomposition::meanVariance() const {
     return m_Components.meanVarianceScale() * m_Components.meanVariance();
 }
 
-TDoubleDoublePr CTimeSeriesDecomposition::varianceScaleWeight(core_t::TTime time,
-                                                              double variance,
-                                                              double confidence,
-                                                              bool smooth) const {
+CTimeSeriesDecomposition::TVector2x1
+CTimeSeriesDecomposition::varianceScaleWeight(core_t::TTime time,
+                                              double variance,
+                                              double confidence,
+                                              bool smooth) const {
     if (this->initialized() == false) {
-        return {1.0, 1.0};
+        return TVector2x1{1.0};
     }
 
     if (common::CMathsFuncs::isFinite(variance) == false) {
         LOG_ERROR(<< "Supplied variance is " << variance << ".");
-        return {1.0, 1.0};
+        return TVector2x1{1.0};
     }
     double mean{this->meanVariance()};
     if (mean <= 0.0 || variance <= 0.0) {
-        return {1.0, 1.0};
+        return TVector2x1{1.0};
     }
 
     time += m_TimeShift;
@@ -503,17 +493,17 @@ TDoubleDoublePr CTimeSeriesDecomposition::varianceScaleWeight(core_t::TTime time
     double components{0.0};
     TVector2x1 scale(0.0);
     if (m_Components.usingTrendForPrediction()) {
-        scale += vector2x1(m_Components.trend().variance(confidence));
+        scale += m_Components.trend().variance(confidence);
     }
     for (const auto& component : m_Components.seasonal()) {
         if (component.initialized() && component.time().inWindow(time)) {
-            scale += vector2x1(component.variance(time, confidence));
+            scale += component.variance(time, confidence);
             components += 1.0;
         }
     }
     for (const auto& component : m_Components.calendar()) {
         if (component.initialized() && component.feature().inWindow(time)) {
-            scale += vector2x1(component.variance(time, confidence));
+            scale += component.variance(time, confidence);
             components += 1.0;
         }
     }
@@ -529,16 +519,23 @@ TDoubleDoublePr CTimeSeriesDecomposition::varianceScaleWeight(core_t::TTime time
     scale = max(TVector2x1{1.0} + bias * (scale - TVector2x1{1.0}), TVector2x1{0.0});
 
     if (smooth) {
-        scale += vector2x1(this->smooth(
+        scale += this->smooth(
             [&](core_t::TTime time_) {
                 return this->varianceScaleWeight(time_ - m_TimeShift, variance,
                                                  confidence, false);
             },
-            time, E_All));
+            time, E_All);
     }
 
     // If anything overflowed just bail and don't scale.
-    return pair(common::CMathsFuncs::isFinite(scale) ? scale : TVector2x1{1.0});
+    return common::CMathsFuncs::isFinite(scale) ? scale : TVector2x1{1.0};
+}
+
+CTimeSeriesDecomposition::TVector2x1
+CTimeSeriesDecomposition::varianceScaleWeight(core_t::TTime time,
+                                              double variance,
+                                              double confidence) const {
+    return this->varianceScaleWeight(time, variance, confidence, true);
 }
 
 double CTimeSeriesDecomposition::countWeight(core_t::TTime time) const {
@@ -549,9 +546,10 @@ double CTimeSeriesDecomposition::winsorisationDerate(core_t::TTime time) const {
     return m_ChangePointTest.winsorisationDerate(time);
 }
 
-CTimeSeriesDecomposition::TFloatMeanAccumulatorVec CTimeSeriesDecomposition::residuals() const {
-    return m_SeasonalityTest.residuals([this](core_t::TTime time) {
-        return common::CBasicStatistics::mean(this->value(time, 0.0));
+CTimeSeriesDecomposition::TFloatMeanAccumulatorVec
+CTimeSeriesDecomposition::residuals(bool isNonNegative) const {
+    return m_SeasonalityTest.residuals([&](core_t::TTime time) {
+        return this->value(time, 0.0, isNonNegative).mean();
     });
 }
 
@@ -611,15 +609,15 @@ void CTimeSeriesDecomposition::initializeMediator() {
 }
 
 template<typename F>
-TDoubleDoublePr
+CTimeSeriesDecomposition::TVector2x1
 CTimeSeriesDecomposition::smooth(const F& f, core_t::TTime time, int components) const {
     if ((components & E_Seasonal) != E_Seasonal) {
-        return {0.0, 0.0};
+        return TVector2x1{0.0};
     }
 
     auto offset = [&f, time](core_t::TTime discontinuity) {
-        TVector2x1 baselineMinusEps{vector2x1(f(discontinuity - 1))};
-        TVector2x1 baselinePlusEps{vector2x1(f(discontinuity + 1))};
+        TVector2x1 baselineMinusEps{f(discontinuity - 1)};
+        TVector2x1 baselinePlusEps{f(discontinuity + 1)};
         return 0.5 *
                std::max((1.0 - static_cast<double>(std::abs(time - discontinuity)) /
                                    static_cast<double>(SMOOTHING_INTERVAL)),
@@ -641,15 +639,15 @@ CTimeSeriesDecomposition::smooth(const F& f, core_t::TTime time, int components)
         if (timeInWindow == false && inWindowBefore) {
             core_t::TTime discontinuity{times.startOfWindow(time - SMOOTHING_INTERVAL) +
                                         times.windowLength()};
-            return pair(-offset(discontinuity));
+            return -offset(discontinuity);
         }
         if (timeInWindow == false && inWindowAfter) {
             core_t::TTime discontinuity{component.time().startOfWindow(time + SMOOTHING_INTERVAL)};
-            return pair(offset(discontinuity));
+            return offset(discontinuity);
         }
     }
 
-    return {0.0, 0.0};
+    return TVector2x1{0.0};
 }
 
 const core_t::TTime CTimeSeriesDecomposition::SMOOTHING_INTERVAL{14400};

--- a/lib/maths/time_series/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/time_series/CTimeSeriesDecompositionDetail.cc
@@ -1927,10 +1927,11 @@ void CTimeSeriesDecompositionDetail::CComponents::useTrendForPrediction() {
 }
 
 CTimeSeriesDecompositionDetail::TMakeTestForSeasonality
-CTimeSeriesDecompositionDetail::CComponents::makeTestForSeasonality(const TFilteredPredictor& predictor) const {
-    return [predictor, this](const CExpandingWindow& window, core_t::TTime minimumPeriod,
-                             std::size_t minimumResolutionToTestModelledComponent,
-                             const TFilteredPredictor& preconditioner) {
+CTimeSeriesDecompositionDetail::CComponents::makeTestForSeasonality(
+    const TMakeFilteredPredictor& makePredictor) const {
+    return [makePredictor, this](const CExpandingWindow& window, core_t::TTime minimumPeriod,
+                                 std::size_t minimumResolutionToTestModelledComponent,
+                                 const TFilteredPredictor& preconditioner) {
         core_t::TTime valuesStartTime{window.beginValuesTime()};
         core_t::TTime windowBucketStartTime{window.bucketStartTime()};
         core_t::TTime windowBucketLength{window.bucketLength()};
@@ -1950,7 +1951,7 @@ CTimeSeriesDecompositionDetail::CComponents::makeTestForSeasonality(const TFilte
         test.minimumPeriod(minimumPeriod)
             .minimumModelSize(2 * m_SeasonalComponentSize / 3)
             .maximumModelSize(2 * m_SeasonalComponentSize)
-            .modelledSeasonalityPredictor(predictor);
+            .modelledSeasonalityPredictor(makePredictor());
         std::ptrdiff_t maximumNumberComponents{MAXIMUM_COMPONENTS};
         for (const auto& component : this->seasonal()) {
             test.addModelledSeasonality(component.time(), minimumResolutionToTestModelledComponent,

--- a/lib/maths/time_series/CTimeSeriesDecompositionStub.cc
+++ b/lib/maths/time_series/CTimeSeriesDecompositionStub.cc
@@ -57,12 +57,11 @@ double CTimeSeriesDecompositionStub::meanValue(core_t::TTime /*time*/) const {
     return 0.0;
 }
 
-maths_t::TDoubleDoublePr CTimeSeriesDecompositionStub::value(core_t::TTime /*time*/,
-                                                             double /*confidence*/,
-                                                             int /*components*/,
-                                                             const TBoolVec& /*removedSeasonalMask*/,
-                                                             bool /*smooth*/) const {
-    return {0.0, 0.0};
+CTimeSeriesDecompositionStub::TVector2x1
+CTimeSeriesDecompositionStub::value(core_t::TTime /*time*/,
+                                    double /*confidence*/,
+                                    bool /*isNonNegative*/) const {
+    return TVector2x1{0.0};
 }
 
 core_t::TTime CTimeSeriesDecompositionStub::maximumForecastInterval() const {
@@ -74,14 +73,15 @@ void CTimeSeriesDecompositionStub::forecast(core_t::TTime /*startTime*/,
                                             core_t::TTime /*step*/,
                                             double /*confidence*/,
                                             double /*minimumScale*/,
+                                            bool /*isNonNegative*/,
                                             const TWriteForecastResult& /*writer*/) {
 }
 
 double CTimeSeriesDecompositionStub::detrend(core_t::TTime /*time*/,
                                              double value,
                                              double /*confidence*/,
-                                             core_t::TTime /*maximumTimeShift*/,
-                                             int /*components*/) const {
+                                             bool /*isNonNegative*/,
+                                             core_t::TTime /*maximumTimeShift*/) const {
     return value;
 }
 
@@ -89,12 +89,11 @@ double CTimeSeriesDecompositionStub::meanVariance() const {
     return 0.0;
 }
 
-maths_t::TDoubleDoublePr
+CTimeSeriesDecompositionStub::TVector2x1
 CTimeSeriesDecompositionStub::varianceScaleWeight(core_t::TTime /*time*/,
                                                   double /*variance*/,
-                                                  double /*confidence*/,
-                                                  bool /*smooth*/) const {
-    return {1.0, 1.0};
+                                                  double /*confidence*/) const {
+    return TVector2x1{1.0};
 }
 
 double CTimeSeriesDecompositionStub::countWeight(core_t::TTime /*time*/) const {
@@ -106,7 +105,7 @@ double CTimeSeriesDecompositionStub::winsorisationDerate(core_t::TTime /*time*/)
 }
 
 CTimeSeriesDecompositionStub::TFloatMeanAccumulatorVec
-CTimeSeriesDecompositionStub::residuals() const {
+CTimeSeriesDecompositionStub::residuals(bool /*isNonNegative*/) const {
     return {};
 }
 

--- a/lib/maths/time_series/CTimeSeriesModel.cc
+++ b/lib/maths/time_series/CTimeSeriesModel.cc
@@ -593,16 +593,15 @@ CUnivariateTimeSeriesModel::CUnivariateTimeSeriesModel(
     const TDecayRateController2Ary* controllers,
     const TMultibucketFeature* multibucketFeature,
     bool modelAnomalies)
-    : common::CModel(params), m_Id(id), m_IsNonNegative(false), m_IsForecastable(true),
-      m_TrendModel(trendModel.clone()), m_ResidualModel(residualModel.clone()),
+    : common::CModel(params), m_Id(id), m_TrendModel(trendModel.clone()),
+      m_ResidualModel(residualModel.clone()),
       m_MultibucketFeature(multibucketFeature != nullptr ? multibucketFeature->clone()
                                                          : nullptr),
       m_MultibucketFeatureModel(multibucketFeature != nullptr ? residualModel.clone() : nullptr),
       m_AnomalyModel(modelAnomalies ? std::make_unique<CTimeSeriesAnomalyModel>(
                                           params.bucketLength(),
                                           params.decayRate())
-                                    : nullptr),
-      m_Correlations(nullptr) {
+                                    : nullptr) {
     if (controllers != nullptr) {
         m_Controllers = std::make_unique<TDecayRateController2Ary>(*controllers);
     }
@@ -610,8 +609,7 @@ CUnivariateTimeSeriesModel::CUnivariateTimeSeriesModel(
 
 CUnivariateTimeSeriesModel::CUnivariateTimeSeriesModel(const common::SModelRestoreParams& params,
                                                        core::CStateRestoreTraverser& traverser)
-    : common::CModel(params.s_Params), m_IsForecastable(false),
-      m_Correlations(nullptr) {
+    : common::CModel(params.s_Params), m_IsForecastable(false) {
     if (traverser.traverseSubLevel([&](auto& traverser_) {
             return this->acceptRestoreTraverser(params, traverser_);
         }) == false) {
@@ -1410,8 +1408,7 @@ CUnivariateTimeSeriesModel::CUnivariateTimeSeriesModel(const CUnivariateTimeSeri
                                     : nullptr),
       m_AnomalyModel(!isForForecast && other.m_AnomalyModel != nullptr
                          ? std::make_unique<CTimeSeriesAnomalyModel>(*other.m_AnomalyModel)
-                         : nullptr),
-      m_Correlations(nullptr) {
+                         : nullptr) {
     if (!isForForecast && other.m_Controllers != nullptr) {
         m_Controllers = std::make_unique<TDecayRateController2Ary>(*other.m_Controllers);
     }
@@ -2128,8 +2125,7 @@ CMultivariateTimeSeriesModel::CMultivariateTimeSeriesModel(
     const TDecayRateController2Ary* controllers,
     const TMultibucketFeature* multibucketFeature,
     bool modelAnomalies)
-    : common::CModel(params), m_IsNonNegative(false),
-      m_ResidualModel(residualModel.clone()),
+    : common::CModel(params), m_ResidualModel(residualModel.clone()),
       m_MultibucketFeature(multibucketFeature != nullptr ? multibucketFeature->clone()
                                                          : nullptr),
       m_MultibucketFeatureModel(multibucketFeature != nullptr ? residualModel.clone() : nullptr),

--- a/lib/maths/time_series/CTimeSeriesModel.cc
+++ b/lib/maths/time_series/CTimeSeriesModel.cc
@@ -758,7 +758,7 @@ CUnivariateTimeSeriesModel::residualModes(const TDouble2VecWeightsAry& weights) 
     TDouble1Vec modes(m_ResidualModel->marginalLikelihoodModes(unpack(weights)));
     result.reserve(modes.size());
     for (auto mode : modes) {
-        result.emplace_back(mode);
+        result.push_back({mode});
     }
     return result;
 }
@@ -2268,7 +2268,7 @@ CMultivariateTimeSeriesModel::mode(core_t::TTime time,
 CMultivariateTimeSeriesModel::TDouble2Vec1Vec
 CMultivariateTimeSeriesModel::correlateModes(core_t::TTime /*time*/,
                                              const TDouble2VecWeightsAry1Vec& /*weights*/) const {
-    return TDouble2Vec1Vec();
+    return {};
 }
 
 CMultivariateTimeSeriesModel::TDouble2Vec1Vec
@@ -2277,7 +2277,7 @@ CMultivariateTimeSeriesModel::residualModes(const TDouble2VecWeightsAry& weights
     TDouble2Vec1Vec result;
     result.reserve(modes.size());
     for (const auto& mode : modes) {
-        result.push_back(TDouble2Vec(mode));
+        result.push_back(mode);
     }
     return result;
 }

--- a/lib/maths/time_series/CTimeSeriesModel.cc
+++ b/lib/maths/time_series/CTimeSeriesModel.cc
@@ -15,7 +15,6 @@
 #include <core/CFunctional.h>
 #include <core/CPersistUtils.h>
 #include <core/RestoreMacros.h>
-#include <core/UnwrapRef.h>
 
 #include <maths/common/CBasicStatistics.h>
 #include <maths/common/CBasicStatisticsPersist.h>
@@ -25,7 +24,6 @@
 #include <maths/common/COrderings.h>
 #include <maths/common/CPrior.h>
 #include <maths/common/CPriorStateSerialiser.h>
-#include <maths/common/CRestoreParams.h>
 #include <maths/common/CTools.h>
 #include <maths/common/Constants.h>
 #include <maths/common/MathsTypes.h>
@@ -35,7 +33,6 @@
 #include <maths/time_series/CTimeSeriesDecompositionStateSerialiser.h>
 #include <maths/time_series/CTimeSeriesMultibucketFeatureSerialiser.h>
 #include <maths/time_series/CTimeSeriesMultibucketFeatures.h>
-#include <maths/time_series/CTimeSeriesSegmentation.h>
 
 #include <cmath>
 #include <cstddef>
@@ -48,22 +45,21 @@ namespace maths {
 namespace time_series {
 namespace {
 
+using TDoubleVec = std::vector<double>;
 using TSizeDoublePr = std::pair<std::size_t, double>;
-using TTimeDoublePr = std::pair<core_t::TTime, double>;
 using TSizeVec = std::vector<std::size_t>;
-using TBool2Vec = core::CSmallVector<bool, 2>;
-using TDouble2Vec = core::CSmallVector<double, 2>;
 using TDouble4Vec = core::CSmallVector<double, 4>;
 using TDouble10Vec = core::CSmallVector<double, 10>;
+using TDouble10VecVec = std::vector<TDouble10Vec>;
 using TDouble10Vec1Vec = core::CSmallVector<TDouble10Vec, 1>;
 using TDouble10Vec2Vec = core::CSmallVector<TDouble10Vec, 2>;
 using TSize10Vec = core::CSmallVector<std::size_t, 10>;
-using TTime1Vec = core::CSmallVector<core_t::TTime, 1>;
 using TDoubleDoublePr = std::pair<double, double>;
 using TSizeDoublePr10Vec = core::CSmallVector<TSizeDoublePr, 10>;
 using TCalculation2Vec = core::CSmallVector<maths_t::EProbabilityCalculation, 2>;
 using TTail10Vec = core::CSmallVector<maths_t::ETail, 10>;
 using TMeanAccumulator = common::CBasicStatistics::SSampleMean<double>::TAccumulator;
+using TUnivariatePriorPtr = std::shared_ptr<common::CPrior>;
 using TMultivariatePriorCPtrSizePr1Vec = CTimeSeriesCorrelations::TMultivariatePriorCPtrSizePr1Vec;
 
 //! The decay rate controllers we maintain.
@@ -127,16 +123,10 @@ const std::string VERSION_7_11_TAG("7.11");
 const std::string ID_6_3_TAG{"a"};
 const std::string IS_NON_NEGATIVE_6_3_TAG{"b"};
 const std::string IS_FORECASTABLE_6_3_TAG{"c"};
-//const std::string RNG_6_3_TAG{"d"}; Removed in 6.5
 const std::string CONTROLLER_6_3_TAG{"e"};
 const core::TPersistenceTag TREND_MODEL_6_3_TAG{"f", "trend_model"};
 const core::TPersistenceTag RESIDUAL_MODEL_6_3_TAG{"g", "residual_model"};
 const std::string ANOMALY_MODEL_6_3_TAG{"h"};
-
-//const std::string RECENT_SAMPLES_6_3_TAG{"i"}; Removed in 6.5
-//const std::string CANDIDATE_CHANGE_POINT_6_3_TAG{"j"}; Removed in 7.11
-//const std::string CURRENT_CHANGE_INTERVAL_6_3_TAG{"k"}; Removed in 7.11
-//const std::string CHANGE_DETECTOR_6_3_TAG{"l"}; Removed in 7.11
 const std::string MULTIBUCKET_FEATURE_6_3_TAG{"m"};
 const std::string MULTIBUCKET_FEATURE_MODEL_6_3_TAG{"n"};
 
@@ -346,14 +336,14 @@ private:
 
     private:
         //! The time at which the first anomalous bucket was detected.
-        core_t::TTime m_FirstAnomalousBucketTime = 0;
+        core_t::TTime m_FirstAnomalousBucketTime{0};
 
         //! The time at which the last anomalous bucket was detected.
-        core_t::TTime m_LastAnomalousBucketTime = 0;
+        core_t::TTime m_LastAnomalousBucketTime{0};
 
         //! The sum of the errors in our base model predictions for the
         //! anomaly.
-        double m_SumPredictionError = 0.0;
+        double m_SumPredictionError{0.0};
 
         //! The mean of minus the log probabilities from our base model
         //! in the anomaly.
@@ -385,7 +375,7 @@ private:
 
 private:
     //! The data bucketing interval.
-    core_t::TTime m_BucketLength;
+    core_t::TTime m_BucketLength{0};
 
     //! The current anomaly (if there is one).
     TOptionalAnomaly m_Anomaly;
@@ -394,7 +384,7 @@ private:
     TMultivariateNormalConjugateVec m_AnomalyFeatureModels;
 };
 
-CTimeSeriesAnomalyModel::CTimeSeriesAnomalyModel() : m_BucketLength(0) {
+CTimeSeriesAnomalyModel::CTimeSeriesAnomalyModel() {
     m_AnomalyFeatureModels.reserve(2);
     m_AnomalyFeatureModels.push_back(
         TMultivariateNormalConjugate::nonInformativePrior(maths_t::E_ContinuousData));
@@ -682,7 +672,7 @@ CUnivariateTimeSeriesModel::TSize2Vec1Vec CUnivariateTimeSeriesModel::correlates
 void CUnivariateTimeSeriesModel::addBucketValue(const TTimeDouble2VecSizeTrVec& values) {
     for (const auto& value : values) {
         m_ResidualModel->adjustOffset(
-            {m_TrendModel->detrend(value.first, value.second[0], 0.0)},
+            {m_TrendModel->detrend(value.first, value.second[0], 0.0, m_IsNonNegative)},
             maths_t::CUnitWeights::SINGLE_UNIT);
     }
 }
@@ -730,7 +720,7 @@ void CUnivariateTimeSeriesModel::skipTime(core_t::TTime gap) {
 CUnivariateTimeSeriesModel::TDouble2Vec
 CUnivariateTimeSeriesModel::mode(core_t::TTime time, const TDouble2VecWeightsAry& weights) const {
     return {m_ResidualModel->marginalLikelihoodMode(unpack(weights)) +
-            common::CBasicStatistics::mean(m_TrendModel->value(time))};
+            m_TrendModel->value(time, 0.0, m_IsNonNegative).mean()};
 }
 
 CUnivariateTimeSeriesModel::TDouble2Vec1Vec
@@ -745,16 +735,19 @@ CUnivariateTimeSeriesModel::correlateModes(core_t::TTime time,
     if (this->correlationModels(correlated, variables, correlationModels,
                                 correlatedTimeSeriesModels)) {
         result.resize(correlated.size(), TDouble10Vec(2));
-
         double baseline[2];
-        baseline[0] = common::CBasicStatistics::mean(m_TrendModel->value(time));
+        baseline[0] = m_TrendModel->value(time, 0.0, m_IsNonNegative).mean();
         for (std::size_t i = 0; i < correlated.size(); ++i) {
-            baseline[1] = common::CBasicStatistics::mean(
-                correlatedTimeSeriesModels[i]->m_TrendModel->value(time));
+            baseline[1] = correlatedTimeSeriesModels[i]
+                              ->m_TrendModel
+                              ->value(time, 0.0, correlatedTimeSeriesModels[i]->m_IsNonNegative)
+                              .mean();
             TDouble10Vec mode(correlationModels[i].first->marginalLikelihoodMode(
                 CMultivariateTimeSeriesModel::unpack(weights[i])));
-            result[i][variables[i][0]] = baseline[0] + mode[variables[i][0]];
-            result[i][variables[i][1]] = baseline[1] + mode[variables[i][1]];
+            std::size_t v0{variables[i][0]};
+            std::size_t v1{variables[i][1]};
+            result[i][v0] = baseline[0] + mode[v0];
+            result[i][v1] = baseline[1] + mode[v1];
         }
     }
 
@@ -767,7 +760,7 @@ CUnivariateTimeSeriesModel::residualModes(const TDouble2VecWeightsAry& weights) 
     TDouble1Vec modes(m_ResidualModel->marginalLikelihoodModes(unpack(weights)));
     result.reserve(modes.size());
     for (auto mode : modes) {
-        result.push_back({mode});
+        result.emplace_back(mode);
     }
     return result;
 }
@@ -780,23 +773,26 @@ void CUnivariateTimeSeriesModel::detrend(const TTime2Vec1Vec& time,
     }
 
     if (value[0].size() == 1) {
-        value[0][0] = m_TrendModel->detrend(time[0][0], value[0][0], confidenceInterval);
-    } else {
-        TSize1Vec correlated;
-        TSize2Vec1Vec variables;
-        TMultivariatePriorCPtrSizePr1Vec correlationModels;
-        TModelCPtr1Vec correlatedTimeSeriesModels;
-        if (this->correlationModels(correlated, variables, correlationModels,
-                                    correlatedTimeSeriesModels)) {
-            for (std::size_t i = 0; i < variables.size(); ++i) {
-                if (!value[i].empty()) {
-                    value[i][variables[i][0]] = m_TrendModel->detrend(
-                        time[i][variables[i][0]], value[i][variables[i][0]], confidenceInterval);
-                    value[i][variables[i][1]] =
-                        correlatedTimeSeriesModels[i]->m_TrendModel->detrend(
-                            time[i][variables[i][1]], value[i][variables[i][1]],
-                            confidenceInterval);
-                }
+        value[0][0] = m_TrendModel->detrend(time[0][0], value[0][0],
+                                            confidenceInterval, m_IsNonNegative);
+        return;
+    }
+
+    TSize1Vec correlated;
+    TSize2Vec1Vec variables;
+    TMultivariatePriorCPtrSizePr1Vec correlationModels;
+    TModelCPtr1Vec correlatedTimeSeriesModels;
+    if (this->correlationModels(correlated, variables, correlationModels,
+                                correlatedTimeSeriesModels)) {
+        for (std::size_t i = 0; i < variables.size(); ++i) {
+            if (value[i].empty() == false) {
+                std::size_t v0{variables[i][0]};
+                std::size_t v1{variables[i][1]};
+                value[i][v0] = m_TrendModel->detrend(
+                    time[i][v0], value[i][v0], confidenceInterval, m_IsNonNegative);
+                value[i][v1] = correlatedTimeSeriesModels[i]->m_TrendModel->detrend(
+                    time[i][v1], value[i][v1], confidenceInterval,
+                    correlatedTimeSeriesModels[i]->m_IsNonNegative);
             }
         }
     }
@@ -807,15 +803,16 @@ CUnivariateTimeSeriesModel::predict(core_t::TTime time,
                                     const TSizeDoublePr1Vec& correlatedValue,
                                     TDouble2Vec hint) const {
     double correlateCorrection{0.0};
-    if (!correlatedValue.empty()) {
+    if (correlatedValue.empty() == false) {
         TSize1Vec correlated{correlatedValue[0].first};
         TSize2Vec1Vec variables;
         TMultivariatePriorCPtrSizePr1Vec correlationModel;
-        TModelCPtr1Vec correlatedModel;
-        if (m_Correlations->correlationModels(m_Id, correlated, variables,
-                                              correlationModel, correlatedModel)) {
-            double sample{correlatedModel[0]->m_TrendModel->detrend(
-                time, correlatedValue[0].second, 0.0)};
+        TModelCPtr1Vec correlatedTimeSeriesModels;
+        if (m_Correlations->correlationModels(m_Id, correlated, variables, correlationModel,
+                                              correlatedTimeSeriesModels)) {
+            double sample{correlatedTimeSeriesModels[0]->m_TrendModel->detrend(
+                time, correlatedValue[0].second, 0.0,
+                correlatedTimeSeriesModels[0]->m_IsNonNegative)};
             TSize10Vec marginalize{variables[0][1]};
             TSizeDoublePr10Vec condition{{variables[0][1], sample}};
             const common::CMultivariatePrior* joint{correlationModel[0].first};
@@ -830,11 +827,11 @@ CUnivariateTimeSeriesModel::predict(core_t::TTime time,
 
     double trend{0.0};
     if (m_TrendModel->initialized()) {
-        trend = common::CBasicStatistics::mean(m_TrendModel->value(time));
+        trend = m_TrendModel->value(time, 0.0, m_IsNonNegative).mean();
     }
 
     if (hint.size() == 1) {
-        hint[0] = m_TrendModel->detrend(time, hint[0], 0.0);
+        hint[0] = m_TrendModel->detrend(time, hint[0], 0.0, m_IsNonNegative);
     }
 
     double median{
@@ -854,11 +851,11 @@ CUnivariateTimeSeriesModel::confidenceInterval(core_t::TTime time,
                                                double confidenceInterval,
                                                const TDouble2VecWeightsAry& weights_) const {
     if (m_ResidualModel->isNonInformative()) {
-        return TDouble2Vec3Vec();
+        return {};
     }
 
     double trend{m_TrendModel->initialized()
-                     ? common::CBasicStatistics::mean(m_TrendModel->value(time, confidenceInterval))
+                     ? m_TrendModel->value(time, 0.0, m_IsNonNegative).mean()
                      : 0.0};
 
     TDoubleWeightsAry weights(unpack(weights_));
@@ -915,7 +912,8 @@ bool CUnivariateTimeSeriesModel::forecast(core_t::TTime firstDataTime,
     };
 
     m_TrendModel->forecast(startTime, endTime, bucketLength, confidenceInterval,
-                           this->params().minimumSeasonalVarianceScale(), writer);
+                           this->params().minimumSeasonalVarianceScale(),
+                           m_IsNonNegative, writer);
 
     return true;
 }
@@ -949,8 +947,8 @@ bool CUnivariateTimeSeriesModel::uncorrelatedProbability(
     double pu;
     maths_t::ETail tail;
     core_t::TTime time{time_[0][0]};
-    TDouble1Vec sample{m_TrendModel->detrend(time, value[0][0],
-                                             params.seasonalConfidenceInterval())};
+    TDouble1Vec sample{m_TrendModel->detrend(
+        time, value[0][0], params.seasonalConfidenceInterval(), m_IsNonNegative)};
     if (m_ResidualModel->probabilityOfLessLikelySamples(calculation, sample,
                                                         weights, pl, pu, tail)) {
         LOG_TRACE(<< "P(" << sample << " | weight = " << weights
@@ -970,7 +968,7 @@ bool CUnivariateTimeSeriesModel::uncorrelatedProbability(
         double pMultiBucket{1.0};
         TDouble1Vec feature;
         std::tie(feature, std::ignore) = m_MultibucketFeature->value();
-        if (feature.size() > 0) {
+        if (feature.empty() == false) {
             for (auto calculation_ : expand(calculation)) {
                 maths_t::ETail dummy;
                 if (m_MultibucketFeatureModel->probabilityOfLessLikelySamples(
@@ -1073,11 +1071,16 @@ bool CUnivariateTimeSeriesModel::correlatedProbability(
             trendModels[v0] = m_TrendModel;
             trendModels[v1] = correlatedTimeSeriesModels[correlateIndex]->m_TrendModel;
             const auto& correlationModel = correlationModels[correlateIndex].first;
+            bool isNonNegative[2];
+            isNonNegative[v0] = m_IsNonNegative;
+            isNonNegative[v1] = correlatedTimeSeriesModels[correlateIndex]->m_IsNonNegative;
 
-            sample[0][0] = trendModels[0]->detrend(
-                time[i][0], value[i][0], params.seasonalConfidenceInterval());
-            sample[0][1] = trendModels[1]->detrend(
-                time[i][1], value[i][1], params.seasonalConfidenceInterval());
+            sample[0][0] = trendModels[0]->detrend(time[i][0], value[i][0],
+                                                   params.seasonalConfidenceInterval(),
+                                                   isNonNegative[0]);
+            sample[0][1] = trendModels[1]->detrend(time[i][1], value[i][1],
+                                                   params.seasonalConfidenceInterval(),
+                                                   isNonNegative[1]);
             weights[0] = CMultivariateTimeSeriesModel::unpack(params.weights()[i]);
 
             if (correlationModel->probabilityOfLessLikelySamples(
@@ -1159,13 +1162,13 @@ void CUnivariateTimeSeriesModel::countWeights(core_t::TTime time,
                                               double countVarianceScale,
                                               TDouble2VecWeightsAry& trendWeights,
                                               TDouble2VecWeightsAry& residuaWeights) const {
-    if (m_TrendModel->seasonalComponents().size() > 0) {
+    if (m_TrendModel->seasonalComponents().empty() == false) {
         countVarianceScale = 1.0;
     }
 
     TDouble2Vec seasonalWeight;
     this->seasonalWeight(0.0, time, seasonalWeight);
-    double sample{m_TrendModel->detrend(time, value[0], 0.0)};
+    double sample{m_TrendModel->detrend(time, value[0], 0.0, m_IsNonNegative)};
     auto weights = maths_t::CUnitWeights::UNIT;
     maths_t::setCount(std::min(residualCountWeight / trendCountWeight, 1.0), weights);
     maths_t::setSeasonalVarianceScale(seasonalWeight[0], weights);
@@ -1208,9 +1211,8 @@ void CUnivariateTimeSeriesModel::addCountWeights(core_t::TTime time,
 void CUnivariateTimeSeriesModel::seasonalWeight(double confidence,
                                                 core_t::TTime time,
                                                 TDouble2Vec& weight) const {
-    double scale{m_TrendModel
-                     ->varianceScaleWeight(time, m_ResidualModel->marginalLikelihoodVariance(), confidence)
-                     .second};
+    double scale{m_TrendModel->varianceScaleWeight(
+        time, m_ResidualModel->marginalLikelihoodVariance(), confidence)(1)};
     weight.assign(1, std::max(scale, this->params().minimumSeasonalVarianceScale()));
 }
 
@@ -1471,7 +1473,8 @@ CUnivariateTimeSeriesModel::updateResidualModels(const common::CModelAddSamplesP
                                                  TTimeDouble2VecSizeTrVec samples) {
 
     for (auto& residual : samples) {
-        residual.second[0] = m_TrendModel->detrend(residual.first, residual.second[0], 0.0);
+        residual.second[0] = m_TrendModel->detrend(
+            residual.first, residual.second[0], 0.0, m_IsNonNegative);
     }
 
     // We add the samples in value order since it makes clustering more stable.
@@ -1604,7 +1607,7 @@ void CUnivariateTimeSeriesModel::reinitializeStateGivenNewComponent(TFloatMeanAc
     m_ResidualModel->setToNonInformative(0.0, m_ResidualModel->decayRate());
 
     // Reinitialize the residual model with any values we've been given.
-    if (residuals.size() > 0) {
+    if (residuals.empty() == false) {
         maths_t::TDoubleWeightsAry1Vec weights(1);
         double buckets{std::accumulate(residuals.begin(), residuals.end(), 0.0,
                                        [](auto partialBuckets, const auto& residual) {
@@ -1648,12 +1651,12 @@ bool CUnivariateTimeSeriesModel::correlationModels(TSize1Vec& correlated,
                                                    TSize2Vec1Vec& variables,
                                                    TMultivariatePriorCPtrSizePr1Vec& correlationModels,
                                                    TModelCPtr1Vec& correlatedTimeSeriesModels) const {
-    if (m_Correlations) {
+    if (m_Correlations != nullptr) {
         correlated = m_Correlations->correlated(m_Id);
         m_Correlations->correlationModels(m_Id, correlated, variables, correlationModels,
                                           correlatedTimeSeriesModels);
     }
-    return correlated.size() > 0;
+    return correlated.empty() == false;
 }
 
 CTimeSeriesCorrelations::CTimeSeriesCorrelations(double minimumSignificantCorrelation,
@@ -1721,7 +1724,7 @@ void CTimeSeriesCorrelations::processSamples() {
         SSampleData* samples2{&i2->second};
         std::size_t n1{samples1->s_Times.size()};
         std::size_t n2{samples2->s_Times.size()};
-        std::size_t indices[] = {0, 1};
+        std::size_t indices[]{0, 1};
         if (n1 < n2) {
             std::swap(samples1, samples2);
             std::swap(n1, n2);
@@ -1747,7 +1750,7 @@ void CTimeSeriesCorrelations::processSamples() {
         }
 
         for (std::size_t j1 = 0; j1 < n1; ++j1) {
-            std::size_t j2{0u};
+            std::size_t j2{0};
             if (n2 > 1) {
                 std::size_t tag{samples1->s_Tags[j1]};
                 core_t::TTime time{samples1->s_Times[j1]};
@@ -1791,7 +1794,6 @@ void CTimeSeriesCorrelations::processSamples() {
 }
 
 void CTimeSeriesCorrelations::refresh(const CTimeSeriesCorrelateModelAllocator& allocator) {
-    using TDoubleVec = std::vector<double>;
     using TSizeSizePrVec = std::vector<TSizeSizePr>;
 
     if (m_Correlations.changed()) {
@@ -2103,7 +2105,7 @@ bool CTimeSeriesCorrelations::correlationModels(std::size_t id,
         correlatedTimeSeriesModels.push_back(m_TimeSeriesModels[correlate]);
     }
 
-    return correlationModels.size() > 0;
+    return correlationModels.empty() == false;
 }
 
 void CTimeSeriesCorrelations::refreshLookup() {
@@ -2262,7 +2264,7 @@ CMultivariateTimeSeriesModel::mode(core_t::TTime time,
     TDouble2Vec result(dimension);
     TDouble10Vec mode(m_ResidualModel->marginalLikelihoodMode(unpack(weights)));
     for (std::size_t d = 0; d < dimension; ++d) {
-        result[d] = mode[d] + common::CBasicStatistics::mean(m_TrendModel[d]->value(time));
+        result[d] = mode[d] + m_TrendModel[d]->value(time, 0.0, m_IsNonNegative).mean();
     }
     return result;
 }
@@ -2290,7 +2292,8 @@ void CMultivariateTimeSeriesModel::detrend(const TTime2Vec1Vec& time_,
     std::size_t dimension{this->dimension()};
     core_t::TTime time{time_[0][0]};
     for (std::size_t d = 0; d < dimension; ++d) {
-        value[0][d] = m_TrendModel[d]->detrend(time, value[0][d], confidenceInterval);
+        value[0][d] = m_TrendModel[d]->detrend(time, value[0][d],
+                                               confidenceInterval, m_IsNonNegative);
     }
 }
 
@@ -2298,13 +2301,11 @@ CMultivariateTimeSeriesModel::TDouble2Vec
 CMultivariateTimeSeriesModel::predict(core_t::TTime time,
                                       const TSizeDoublePr1Vec& /*correlated*/,
                                       TDouble2Vec hint) const {
-    using TUnivariatePriorPtr = std::shared_ptr<common::CPrior>;
-
     std::size_t dimension{this->dimension()};
 
     if (hint.size() == dimension) {
         for (std::size_t d = 0; d < dimension; ++d) {
-            hint[d] = m_TrendModel[d]->detrend(time, hint[d], 0.0);
+            hint[d] = m_TrendModel[d]->detrend(time, hint[d], 0.0, m_IsNonNegative);
         }
     }
 
@@ -2316,10 +2317,10 @@ CMultivariateTimeSeriesModel::predict(core_t::TTime time,
     for (std::size_t d = 0; d < dimension; --marginalize[std::min(d, dimension - 2)], ++d) {
         double trend{0.0};
         if (m_TrendModel[d]->initialized()) {
-            trend = common::CBasicStatistics::mean(m_TrendModel[d]->value(time));
+            trend = m_TrendModel[d]->value(time, 0.0, m_IsNonNegative).mean();
         }
         double median{mean[d]};
-        if (!m_ResidualModel->isNonInformative()) {
+        if (m_ResidualModel->isNonInformative() == false) {
             TUnivariatePriorPtr marginal{
                 m_ResidualModel->univariate(marginalize, NOTHING_TO_CONDITION).first};
             median = hint.empty()
@@ -2342,10 +2343,8 @@ CMultivariateTimeSeriesModel::confidenceInterval(core_t::TTime time,
                                                  const TDouble2VecWeightsAry& weights_) const {
 
     if (m_ResidualModel->isNonInformative()) {
-        return TDouble2Vec3Vec();
+        return {};
     }
-
-    using TUnivariatePriorPtr = std::shared_ptr<common::CPrior>;
 
     std::size_t dimension{this->dimension()};
 
@@ -2357,7 +2356,7 @@ CMultivariateTimeSeriesModel::confidenceInterval(core_t::TTime time,
     maths_t::TDoubleWeightsAry weights{maths_t::CUnitWeights::UNIT};
     for (std::size_t d = 0; d < dimension; --marginalize[std::min(d, dimension - 2)], ++d) {
         double trend{m_TrendModel[d]->initialized()
-                         ? common::CBasicStatistics::mean(m_TrendModel[d]->value(time, confidenceInterval))
+                         ? m_TrendModel[d]->value(time, 0.0, m_IsNonNegative).mean()
                          : 0.0};
 
         for (std::size_t i = 0; i < maths_t::NUMBER_WEIGHT_STYLES; ++i) {
@@ -2417,7 +2416,7 @@ bool CMultivariateTimeSeriesModel::probability(const common::CModelProbabilityPa
     TDouble10Vec1Vec sample{TDouble10Vec(dimension)};
     for (std::size_t d = 0; d < dimension; ++d) {
         sample[0][d] = m_TrendModel[d]->detrend(
-            time, value[0][d], params.seasonalConfidenceInterval());
+            time, value[0][d], params.seasonalConfidenceInterval(), m_IsNonNegative);
     }
     maths_t::TDouble10VecWeightsAry1Vec weights{unpack(params.weights()[0])};
 
@@ -2460,7 +2459,7 @@ bool CMultivariateTimeSeriesModel::probability(const common::CModelProbabilityPa
         if (m_MultibucketFeatureModel != nullptr && params.useMultibucketFeatures()) {
             TDouble10Vec1Vec feature;
             std::tie(feature, std::ignore) = m_MultibucketFeature->value();
-            if (feature.size() > 0) {
+            if (feature.empty() == false) {
                 TDouble10Vec2Vec pMultiBucket[2]{{{1.0}, {1.0}}, {{1.0}, {1.0}}};
                 for (auto calculation_ : expand(calculation)) {
                     TDouble10Vec2Vec pl;
@@ -2559,8 +2558,8 @@ void CMultivariateTimeSeriesModel::countWeights(core_t::TTime time,
     TDouble2Vec countVarianceScales(dimension, 1.0);
     TDouble10Vec sample(dimension);
     for (std::size_t d = 0; d < dimension; ++d) {
-        sample[d] = m_TrendModel[d]->detrend(time, value[d], 0.0);
-        if (m_TrendModel[d]->seasonalComponents().size() == 0) {
+        sample[d] = m_TrendModel[d]->detrend(time, value[d], 0.0, m_IsNonNegative);
+        if (m_TrendModel[d]->seasonalComponents().empty()) {
             trendCountWeights[d] /= countVarianceScale;
             countVarianceScales[d] = countVarianceScale;
         }
@@ -2615,8 +2614,8 @@ void CMultivariateTimeSeriesModel::seasonalWeight(double confidence,
     weight.resize(dimension);
     TDouble10Vec variances(m_ResidualModel->marginalLikelihoodVariances());
     for (std::size_t d = 0; d < dimension; ++d) {
-        double scale{
-            m_TrendModel[d]->varianceScaleWeight(time, variances[d], confidence).second};
+        double scale{m_TrendModel[d]->varianceScaleWeight(time, variances[d],
+                                                          confidence)(1)};
         weight[d] = std::max(scale, this->params().minimumSeasonalVarianceScale());
     }
 }
@@ -2847,7 +2846,7 @@ CMultivariateTimeSeriesModel::updateTrend(const common::CModelAddSamplesParams& 
     if (result == E_Reset) {
         TFloatMeanAccumulatorVec10Vec window(dimension);
         for (std::size_t d = 0; d < dimension; ++d) {
-            window[d] = m_TrendModel[d]->residuals();
+            window[d] = m_TrendModel[d]->residuals(m_IsNonNegative);
         }
         this->reinitializeStateGivenNewComponent(std::move(window));
     }
@@ -2863,7 +2862,8 @@ void CMultivariateTimeSeriesModel::updateResidualModels(const common::CModelAddS
     for (auto& residual : samples) {
         core_t::TTime time{residual.first};
         for (std::size_t d = 0; d < dimension; ++d) {
-            residual.second[d] = m_TrendModel[d]->detrend(time, residual.second[d], 0.0);
+            residual.second[d] = m_TrendModel[d]->detrend(time, residual.second[d],
+                                                          0.0, m_IsNonNegative);
         }
     }
 
@@ -2967,9 +2967,6 @@ void CMultivariateTimeSeriesModel::appendPredictionErrors(double interval,
 
 void CMultivariateTimeSeriesModel::reinitializeStateGivenNewComponent(TFloatMeanAccumulatorVec10Vec residuals) {
 
-    using TDoubleVec = std::vector<double>;
-    using TDouble10VecVec = std::vector<TDouble10Vec>;
-
     if (m_Controllers != nullptr) {
         m_ResidualModel->decayRate(m_ResidualModel->decayRate() /
                                    (*m_Controllers)[E_ResidualControl].multiplier());
@@ -2984,7 +2981,7 @@ void CMultivariateTimeSeriesModel::reinitializeStateGivenNewComponent(TFloatMean
 
     // Reinitialize the residual model with any values we've been given.
     m_ResidualModel->setToNonInformative(0.0, m_ResidualModel->decayRate());
-    if (residuals.size() > 0) {
+    if (residuals.empty() == false) {
         std::size_t dimension{this->dimension()};
 
         TDouble10VecVec samples;

--- a/lib/maths/time_series/CTimeSeriesModel.cc
+++ b/lib/maths/time_series/CTimeSeriesModel.cc
@@ -123,10 +123,15 @@ const std::string VERSION_7_11_TAG("7.11");
 const std::string ID_6_3_TAG{"a"};
 const std::string IS_NON_NEGATIVE_6_3_TAG{"b"};
 const std::string IS_FORECASTABLE_6_3_TAG{"c"};
+//const std::string RNG_6_3_TAG{"d"}; Removed in 6.5
 const std::string CONTROLLER_6_3_TAG{"e"};
 const core::TPersistenceTag TREND_MODEL_6_3_TAG{"f", "trend_model"};
 const core::TPersistenceTag RESIDUAL_MODEL_6_3_TAG{"g", "residual_model"};
 const std::string ANOMALY_MODEL_6_3_TAG{"h"};
+//const std::string RECENT_SAMPLES_6_3_TAG{"i"}; Removed in 6.5
+//const std::string CANDIDATE_CHANGE_POINT_6_3_TAG{"j"}; Removed in 7.11
+//const std::string CURRENT_CHANGE_INTERVAL_6_3_TAG{"k"}; Removed in 7.11
+//const std::string CHANGE_DETECTOR_6_3_TAG{"l"}; Removed in 7.11
 const std::string MULTIBUCKET_FEATURE_6_3_TAG{"m"};
 const std::string MULTIBUCKET_FEATURE_MODEL_6_3_TAG{"n"};
 

--- a/lib/maths/time_series/CTimeSeriesModel.cc
+++ b/lib/maths/time_series/CTimeSeriesModel.cc
@@ -609,7 +609,7 @@ CUnivariateTimeSeriesModel::CUnivariateTimeSeriesModel(
 
 CUnivariateTimeSeriesModel::CUnivariateTimeSeriesModel(const common::SModelRestoreParams& params,
                                                        core::CStateRestoreTraverser& traverser)
-    : common::CModel(params.s_Params), m_IsForecastable(false) {
+    : common::CModel(params.s_Params) {
     if (traverser.traverseSubLevel([&](auto& traverser_) {
             return this->acceptRestoreTraverser(params, traverser_);
         }) == false) {

--- a/lib/maths/time_series/CTimeSeriesTestForSeasonality.cc
+++ b/lib/maths/time_series/CTimeSeriesTestForSeasonality.cc
@@ -301,8 +301,8 @@ void CTimeSeriesTestForSeasonality::addModelledSeasonality(const CSeasonalTime& 
     }
 }
 
-void CTimeSeriesTestForSeasonality::modelledSeasonalityPredictor(const TPredictor& predictor) {
-    m_ModelledPredictor = predictor;
+void CTimeSeriesTestForSeasonality::modelledSeasonalityPredictor(TPredictor predictor) {
+    m_ModelledPredictor = std::move(predictor);
 }
 
 void CTimeSeriesTestForSeasonality::prepareWindowForDecompose() {

--- a/lib/maths/time_series/unittest/CCalendarComponentTest.cc
+++ b/lib/maths/time_series/unittest/CCalendarComponentTest.cc
@@ -142,9 +142,7 @@ BOOST_FIXTURE_TEST_CASE(testFit, CTestFixture) {
         TMeanAccumulator mae;
         for (core_t::TTime time = 15724800 - timeZoneOffset;
              time < 15724800 - timeZoneOffset + DAY; time += HOUR) {
-            mae.add(std::fabs(
-                (maths::common::CBasicStatistics::mean(component.value(time, 0.0)) - trend(time)) /
-                trend(time)));
+            mae.add(std::fabs((component.value(time, 0.0).mean() - trend(time)) / trend(time)));
         }
         BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(mae) < 0.06);
     }

--- a/lib/maths/time_series/unittest/CForecastTest.cc
+++ b/lib/maths/time_series/unittest/CForecastTest.cc
@@ -197,7 +197,7 @@ public:
 
             for (std::size_t i = 0; i < noise.size(); ++i, time += m_BucketLength) {
                 maths::common::CModelAddSamplesParams params;
-                params.integer(false)
+                params.isInteger(false)
                     .propagationInterval(1.0)
                     .trendWeights(weights)
                     .priorWeights(weights);
@@ -442,8 +442,8 @@ BOOST_AUTO_TEST_CASE(testNonNegative) {
         rng.generateNormalSamples(2.0, 3.0, 48, noise);
         for (auto value = noise.begin(); value != noise.end(); ++value, time += bucketLength) {
             maths::common::CModelAddSamplesParams params;
-            params.integer(false)
-                .nonNegative(true)
+            params.isInteger(false)
+                .isNonNegative(true)
                 .propagationInterval(1.0)
                 .trendWeights(weights)
                 .priorWeights(weights);
@@ -526,7 +526,7 @@ BOOST_AUTO_TEST_CASE(testFinancialIndex) {
     TDouble2VecWeightsAryVec weights{maths_t::CUnitWeights::unit<TDouble2Vec>(1)};
     for (std::size_t i = 0; i < n; ++i) {
         maths::common::CModelAddSamplesParams params;
-        params.integer(false).propagationInterval(1.0).trendWeights(weights).priorWeights(weights);
+        params.isInteger(false).propagationInterval(1.0).trendWeights(weights).priorWeights(weights);
         model.addSamples(
             params, {core::make_triple(timeseries[i].first,
                                        TDouble2Vec{timeseries[i].second}, TAG)});
@@ -588,7 +588,10 @@ BOOST_AUTO_TEST_CASE(testTruncation) {
 
         for (core_t::TTime time = 0; time < dataEndTime; time += bucketLength) {
             maths::common::CModelAddSamplesParams params;
-            params.integer(false).propagationInterval(1.0).trendWeights(weights).priorWeights(weights);
+            params.isInteger(false)
+                .propagationInterval(1.0)
+                .trendWeights(weights)
+                .priorWeights(weights);
             double yi{static_cast<double>(time)};
             model.addSamples(params, {core::make_triple(time, TDouble2Vec{yi}, TAG)});
         }

--- a/lib/maths/time_series/unittest/CSeasonalComponentTest.cc
+++ b/lib/maths/time_series/unittest/CSeasonalComponentTest.cc
@@ -109,10 +109,6 @@ void generateSeasonalValues(test::CRandomNumbers& rng,
     }
 }
 
-double mean(const TDoubleDoublePr& x) {
-    return (x.first + x.second) / 2.0;
-}
-
 const core_t::TTime FIVE_MINUTES{5 * core::constants::MINUTE};
 const core_t::TTime TWO_HOURS{2 * core::constants::HOUR};
 }
@@ -171,9 +167,9 @@ BOOST_AUTO_TEST_CASE(testInitialize) {
 
     TMeanAccumulator meanError;
     for (std::size_t i = 20; i < 30; ++i) {
-        meanError.add(std::fabs(maths::common::CBasicStatistics::mean(component.value(
-                                    2 * static_cast<core_t::TTime>(i), 0.0)) -
-                                static_cast<double>(i % 10)));
+        meanError.add(
+            std::fabs(component.value(2 * static_cast<core_t::TTime>(i), 0.0).mean() -
+                      static_cast<double>(i % 10)));
     }
     BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.3);
 }
@@ -283,20 +279,21 @@ BOOST_AUTO_TEST_CASE(testConstant) {
             double error1 = 0.0;
             double error2 = 0.0;
             for (std::size_t j = 0; j < function.size(); ++j) {
-                TDoubleDoublePr interval = seasonal.value(time + function[j].first, 70.0);
+                auto interval = seasonal.value(time + function[j].first, 70.0);
                 double f = function[j].second + residualMean;
 
-                double e = mean(interval) - f;
+                double e = interval.mean() - f;
                 error1 += std::fabs(e);
-                error2 += std::max(std::max(interval.first - f, f - interval.second), 0.0);
+                error2 += std::max(std::max(interval(0) - f, f - interval(1)), 0.0);
             }
 
             if (d > 1) {
-                LOG_TRACE(<< "f(0) = " << mean(seasonal.value(time, 0.0)) << ", f(T) = "
-                          << mean(seasonal.value(time + core::constants::DAY - 1, 0.0)));
+                LOG_TRACE(
+                    << "f(0) = " << seasonal.value(time, 0.0).mean() << ", f(T) = "
+                    << seasonal.value(time + core::constants::DAY - 1, 0.0).mean());
                 BOOST_REQUIRE_CLOSE_ABSOLUTE(
-                    mean(seasonal.value(time, 0.0)),
-                    mean(seasonal.value(time + core::constants::DAY - 1, 0.0)), 0.1);
+                    seasonal.value(time, 0.0).mean(),
+                    seasonal.value(time + core::constants::DAY - 1, 0.0).mean(), 0.1);
             }
             error1 /= static_cast<double>(function.size());
             error2 /= static_cast<double>(function.size());
@@ -360,19 +357,20 @@ BOOST_AUTO_TEST_CASE(testStablePeriodic) {
                 double error1 = 0.0;
                 double error2 = 0.0;
                 for (std::size_t j = 0; j < function.size(); ++j) {
-                    TDoubleDoublePr interval = seasonal.value(time + function[j].first, 70.0);
+                    auto interval = seasonal.value(time + function[j].first, 70.0);
                     double f = residualMean + function[j].second;
-                    double e = mean(interval) - f;
+                    double e = interval.mean() - f;
                     error1 += std::fabs(e);
-                    error2 += std::max(std::max(interval.first - f, f - interval.second), 0.0);
+                    error2 += std::max(std::max(interval(0) - f, f - interval(1)), 0.0);
                 }
 
                 if (d > 1) {
-                    LOG_TRACE(<< "f(0) = " << mean(seasonal.value(time, 0.0)) << ", f(T) = "
-                              << mean(seasonal.value(time + core::constants::DAY - 1, 0.0)));
+                    LOG_TRACE(
+                        << "f(0) = " << seasonal.value(time, 0.0).mean() << ", f(T) = "
+                        << seasonal.value(time + core::constants::DAY - 1, 0.0).mean());
                     BOOST_REQUIRE_CLOSE_ABSOLUTE(
-                        mean(seasonal.value(time, 0.0)),
-                        mean(seasonal.value(time + core::constants::DAY - 1, 0.0)), 0.1);
+                        seasonal.value(time, 0.0).mean(),
+                        seasonal.value(time + core::constants::DAY - 1, 0.0).mean(), 0.1);
                 }
 
                 error1 /= static_cast<double>(function.size());
@@ -452,20 +450,21 @@ BOOST_AUTO_TEST_CASE(testStablePeriodic) {
                 double error1 = 0.0;
                 double error2 = 0.0;
                 for (std::size_t j = 0; j < function.size(); ++j) {
-                    TDoubleDoublePr interval = seasonal.value(time + function[j].first, 70.0);
+                    auto interval = seasonal.value(time + function[j].first, 70.0);
                     double f = residualMean + function[j].second;
 
-                    double e = mean(interval) - f;
+                    double e = interval.mean() - f;
                     error1 += std::fabs(e);
-                    error2 += std::max(std::max(interval.first - f, f - interval.second), 0.0);
+                    error2 += std::max(std::max(interval(0) - f, f - interval(1)), 0.0);
                 }
 
                 if (d > 1) {
-                    LOG_TRACE(<< "f(0) = " << mean(seasonal.value(time, 0.0)) << ", f(T) = "
-                              << mean(seasonal.value(time + core::constants::DAY - 1, 0.0)));
+                    LOG_TRACE(
+                        << "f(0) = " << seasonal.value(time, 0.0).mean() << ", f(T) = "
+                        << seasonal.value(time + core::constants::DAY - 1, 0.0).mean());
                     BOOST_REQUIRE_CLOSE_ABSOLUTE(
-                        mean(seasonal.value(time, 0.0)),
-                        mean(seasonal.value(time + core::constants::DAY - 1, 0.0)), 0.1);
+                        seasonal.value(time, 0.0).mean(),
+                        seasonal.value(time + core::constants::DAY - 1, 0.0).mean(), 0.1);
                 }
 
                 error1 /= static_cast<double>(function.size());
@@ -556,20 +555,21 @@ BOOST_AUTO_TEST_CASE(testTimeVaryingPeriodic) {
             double error1 = 0.0;
             double error2 = 0.0;
             for (std::size_t j = 0; j < function.size(); ++j) {
-                TDoubleDoublePr interval = seasonal.value(time + function[j].first, 70.0);
+                auto interval = seasonal.value(time + function[j].first, 70.0);
                 double f = residualMean + scale * function[j].second;
 
-                double e = mean(interval) - f;
+                double e = interval.mean() - f;
                 error1 += std::fabs(e);
-                error2 += std::max(std::max(interval.first - f, f - interval.second), 0.0);
+                error2 += std::max(std::max(interval(0) - f, f - interval(1)), 0.0);
             }
 
             if (d > 1) {
-                LOG_TRACE(<< "f(0) = " << mean(seasonal.value(time, 0.0)) << ", f(T) = "
-                          << mean(seasonal.value(time + core::constants::DAY - 1, 0.0)));
+                LOG_TRACE(
+                    << "f(0) = " << seasonal.value(time, 0.0).mean() << ", f(T) = "
+                    << seasonal.value(time + core::constants::DAY - 1, 0.0).mean());
                 BOOST_REQUIRE_CLOSE_ABSOLUTE(
-                    mean(seasonal.value(time, 0.0)),
-                    mean(seasonal.value(time + core::constants::DAY - 1, 0.0)), 0.4);
+                    seasonal.value(time, 0.0).mean(),
+                    seasonal.value(time + core::constants::DAY - 1, 0.0).mean(), 0.4);
             }
 
             error1 /= static_cast<double>(function.size());
@@ -634,8 +634,7 @@ BOOST_AUTO_TEST_CASE(testWindowed) {
                 for (core_t::TTime t = 0; t < core::constants::DAY; t += bucketLength) {
                     double rt{weekendComponent.time().regression(time + t)};
                     error += std::fabs(
-                        maths::common::CBasicStatistics::mean(
-                            weekendComponent.value(time + t, 0.0)) -
+                        weekendComponent.value(time + t, 0.0).mean() -
                         weekendComponent.bucketing().regression(time + t)->predict(rt));
                 }
                 error /= 48.0;
@@ -653,8 +652,7 @@ BOOST_AUTO_TEST_CASE(testWindowed) {
                 for (core_t::TTime t = 0; t < core::constants::DAY; t += bucketLength) {
                     double rt{weekdayComponent.time().regression(time + t)};
                     error += std::fabs(
-                        maths::common::CBasicStatistics::mean(
-                            weekdayComponent.value(time + t, 0.0)) -
+                        weekdayComponent.value(time + t, 0.0).mean() -
                         weekdayComponent.bucketing().regression(time + t)->predict(rt));
                 }
                 error /= 48.0;
@@ -696,7 +694,7 @@ BOOST_AUTO_TEST_CASE(testVeryLowVariation) {
     double totalError1 = 0.0;
     double totalError2 = 0.0;
     core_t::TTime time = startTime;
-    for (std::size_t i = 0u, d = 0; i < n; ++i) {
+    for (std::size_t i = 0, d = 0; i < n; ++i) {
         seasonal.addPoint(samples[i].first, samples[i].second + residuals[i]);
 
         if (samples[i].first >= time + core::constants::DAY) {
@@ -707,20 +705,21 @@ BOOST_AUTO_TEST_CASE(testVeryLowVariation) {
             double error1 = 0.0;
             double error2 = 0.0;
             for (std::size_t j = 0; j < function.size(); ++j) {
-                TDoubleDoublePr interval = seasonal.value(time + function[j].first, 70.0);
+                auto interval = seasonal.value(time + function[j].first, 70.0);
                 double f = residualMean + function[j].second;
 
-                double e = mean(interval) - f;
+                double e = interval.mean() - f;
                 error1 += std::fabs(e);
-                error2 += std::max(std::max(interval.first - f, f - interval.second), 0.0);
+                error2 += std::max(std::max(interval(0) - f, f - interval(1)), 0.0);
             }
 
             if (d > 1) {
-                LOG_TRACE(<< "f(0) = " << mean(seasonal.value(time, 0.0)) << ", f(T) = "
-                          << mean(seasonal.value(time + core::constants::DAY - 1, 0.0)));
+                LOG_TRACE(
+                    << "f(0) = " << seasonal.value(time, 0.0).mean() << ", f(T) = "
+                    << seasonal.value(time + core::constants::DAY - 1, 0.0).mean());
                 BOOST_REQUIRE_CLOSE_ABSOLUTE(
-                    mean(seasonal.value(time, 0.0)),
-                    mean(seasonal.value(time + core::constants::DAY - 1, 0.0)), 0.1);
+                    seasonal.value(time, 0.0).mean(),
+                    seasonal.value(time + core::constants::DAY - 1, 0.0).mean(), 0.1);
             }
             error1 /= static_cast<double>(function.size());
             error2 /= static_cast<double>(function.size());
@@ -769,14 +768,14 @@ BOOST_AUTO_TEST_CASE(testVariance) {
         core_t::TTime t = (i * core::constants::DAY) / 48;
         double v_ = 80.0 + 20.0 * std::sin(boost::math::double_constants::two_pi *
                                            static_cast<double>(i) / 48.0);
-        TDoubleDoublePr vv = seasonal.variance(t, 98.0);
-        double v = (vv.first + vv.second) / 2.0;
-        LOG_TRACE(<< "v_ = " << v_ << ", v = " << core::CContainerPrinter::print(vv)
+        auto interval = seasonal.variance(t, 98.0);
+        double v = interval.mean();
+        LOG_TRACE(<< "v_ = " << v_ << ", v = " << interval
                   << ", relative error = " << std::fabs(v - v_) / v_);
 
         BOOST_REQUIRE_CLOSE_ABSOLUTE(v_, v, 0.5 * v_);
-        BOOST_TEST_REQUIRE(v_ > vv.first);
-        BOOST_TEST_REQUIRE(v_ < vv.second);
+        BOOST_TEST_REQUIRE(v_ > interval(0));
+        BOOST_TEST_REQUIRE(v_ < interval(1));
         error.add(std::fabs(v - v_) / v_);
     }
 
@@ -823,12 +822,8 @@ BOOST_AUTO_TEST_CASE(testPrecession) {
     for (core_t::TTime time = TWO_HOURS; time < core::constants::WEEK; time += FIVE_MINUTES) {
         seasonalWithShift.addPoint(time, trend(time));
         seasonalWithoutShift.addPoint(time, trend(time));
-        double errorWithShift{
-            maths::common::CBasicStatistics::mean(seasonalWithShift.value(time, 0.0)) -
-            trend(time)};
-        double errorWithoutShift{maths::common::CBasicStatistics::mean(
-                                     seasonalWithoutShift.value(time, 0.0)) -
-                                 trend(time)};
+        double errorWithShift{seasonalWithShift.value(time, 0.0).mean() - trend(time)};
+        double errorWithoutShift{seasonalWithoutShift.value(time, 0.0).mean() - trend(time)};
         meanErrorWithShift.add(std::fabs(errorWithShift));
         meanErrorWithoutShift.add(std::fabs(errorWithoutShift));
     }
@@ -883,12 +878,8 @@ BOOST_AUTO_TEST_CASE(testWithRandomShifts) {
     for (core_t::TTime time = TWO_HOURS; time < core::constants::WEEK; time += FIVE_MINUTES) {
         seasonalWithShift.addPoint(time, trend(time));
         seasonalWithoutShift.addPoint(time, trend(time));
-        double errorWithShift{
-            maths::common::CBasicStatistics::mean(seasonalWithShift.value(time, 0.0)) -
-            trend(time)};
-        double errorWithoutShift{maths::common::CBasicStatistics::mean(
-                                     seasonalWithoutShift.value(time, 0.0)) -
-                                 trend(time)};
+        double errorWithShift{seasonalWithShift.value(time, 0.0).mean() - trend(time)};
+        double errorWithoutShift{seasonalWithoutShift.value(time, 0.0).mean() - trend(time)};
         meanErrorWithShift.add(std::fabs(errorWithShift));
         meanErrorWithoutShift.add(std::fabs(errorWithoutShift));
 

--- a/lib/maths/time_series/unittest/CTimeSeriesDecompositionTest.cc
+++ b/lib/maths/time_series/unittest/CTimeSeriesDecompositionTest.cc
@@ -1005,7 +1005,7 @@ BOOST_FIXTURE_TEST_CASE(testSpikeyDataProblemCase, CTestFixture) {
                                       lastWeekTimeseries[j].second - prediction(1)),
                              0.0);
                 debug.addPrediction(lastWeekTimeseries[j].first, prediction.mean(), residual);
-                    }
+            }
 
             LOG_TRACE(<< "'sum residual' / 'sum value' = "
                       << (sumResidual == 0.0 ? 0.0 : sumResidual / sumValue));
@@ -1133,7 +1133,7 @@ BOOST_FIXTURE_TEST_CASE(testVeryLargeValuesProblemCase, CTestFixture) {
                                       lastWeekTimeseries[j].second - prediction(1)),
                              0.0);
                 debug.addPrediction(lastWeekTimeseries[j].first, prediction.mean(), residual);
-                    }
+            }
 
             LOG_DEBUG(<< "'sum residual' / 'sum value' = " << sumResidual / sumValue);
             LOG_DEBUG(<< "'max residual' / 'max value' = " << maxResidual / maxValue);
@@ -1232,7 +1232,7 @@ BOOST_FIXTURE_TEST_CASE(testMixedSmoothAndSpikeyDataProblemCase, CTestFixture) {
                                       lastWeekTimeseries[j].second - prediction(1)),
                              0.0);
                 debug.addPrediction(lastWeekTimeseries[j].first, prediction.mean(), residual);
-                    }
+            }
 
             LOG_DEBUG(<< "'sum residual' / 'sum value' = "
                       << (sumResidual == 0.0 ? 0.0 : sumResidual / sumValue));
@@ -1435,7 +1435,7 @@ BOOST_FIXTURE_TEST_CASE(testLongTermTrend, CTestFixture) {
     LOG_DEBUG(<< "Saw Tooth Not Periodic");
     {
         core_t::TTime drops[]{0,        30 * DAY,  50 * DAY,  60 * DAY,
-                       85 * DAY, 100 * DAY, 115 * DAY, 120 * DAY};
+                              85 * DAY, 100 * DAY, 115 * DAY, 120 * DAY};
 
         times.clear();
         trend.clear();
@@ -2284,7 +2284,7 @@ BOOST_FIXTURE_TEST_CASE(testFastAndSlowSeasonality, CTestFixture) {
 
 BOOST_FIXTURE_TEST_CASE(testNonNegative, CTestFixture) {
 
-    // Test if we state the tie series is non-negative then we never predict
+    // Test if we specify the time series is non-negative then we never predict
     // a negative value for it.
 
     test::CRandomNumbers rng;

--- a/lib/maths/time_series/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/time_series/unittest/CTimeSeriesModelTest.cc
@@ -255,7 +255,7 @@ void reinitializeResidualModel(double learnRate,
     std::size_t dimension{residualModel.dimension()};
     TFloatMeanAccumulatorVecVec residuals(dimension);
     for (std::size_t d = 0; d < dimension; ++d) {
-        residuals[d] = trends[d]->residuals();
+        residuals[d] = trends[d]->residuals(false);
     }
     if (residuals.size() > 0) {
         TDouble10Vec1Vec samples;
@@ -445,7 +445,7 @@ BOOST_AUTO_TEST_CASE(testMode) {
         core_t::TTime time{0};
         for (auto sample : samples) {
             trend.addPoint(time, sample);
-            TDouble1Vec sample_{trend.detrend(time, sample, 0.0)};
+            TDouble1Vec sample_{trend.detrend(time, sample, 0.0, false)};
             prior.addSamples(sample_, maths_t::CUnitWeights::SINGLE_UNIT);
             prior.propagateForwardsByTime(1.0);
             time += bucketLength;
@@ -458,7 +458,7 @@ BOOST_AUTO_TEST_CASE(testMode) {
                              {core::make_triple(time, TDouble2Vec{sample}, TAG)});
             time += bucketLength;
         }
-        double expectedMode{maths::common::CBasicStatistics::mean(trend.value(time)) +
+        double expectedMode{trend.value(time, 0.0, false).mean() +
                             prior.marginalLikelihoodMode()};
         TDouble2Vec mode(model.mode(time, maths_t::CUnitWeights::unit<TDouble2Vec>(1)));
 
@@ -493,13 +493,13 @@ BOOST_AUTO_TEST_CASE(testMode) {
                              {core::make_triple(time, TDouble2Vec{sample}, TAG)});
             trend.addPoint(time, sample, maths_t::CUnitWeights::UNIT,
                            makeComponentDetectedCallback(params.learnRate(), prior));
-            prior.addSamples({trend.detrend(time, sample, 0.0)},
+            prior.addSamples({trend.detrend(time, sample, 0.0, false)},
                              maths_t::CUnitWeights::SINGLE_UNIT);
             prior.propagateForwardsByTime(1.0);
             time += bucketLength;
         }
 
-        double expectedMode{maths::common::CBasicStatistics::mean(trend.value(time)) +
+        double expectedMode{trend.value(time, 0.0, false).mean() +
                             prior.marginalLikelihoodMode()};
         TDouble2Vec mode(model.mode(time, maths_t::CUnitWeights::unit<TDouble2Vec>(1)));
 
@@ -532,7 +532,7 @@ BOOST_AUTO_TEST_CASE(testMode) {
             TDouble10Vec1Vec detrended{TDouble10Vec(3)};
             for (std::size_t i = 0; i < sample.size(); ++i) {
                 trends[i]->addPoint(time, sample[i]);
-                detrended[0][i] = trends[i]->detrend(time, sample[i], 0.0);
+                detrended[0][i] = trends[i]->detrend(time, sample[i], 0.0, false);
             }
             prior.addSamples(detrended,
                              maths_t::CUnitWeights::singleUnit<TDouble10Vec>(3));
@@ -549,8 +549,7 @@ BOOST_AUTO_TEST_CASE(testMode) {
         TDouble2Vec expectedMode(prior.marginalLikelihoodMode(
             maths_t::CUnitWeights::unit<TDouble10Vec>(3)));
         for (std::size_t i = 0; i < trends.size(); ++i) {
-            expectedMode[i] +=
-                maths::common::CBasicStatistics::mean(trends[i]->value(time));
+            expectedMode[i] += trends[i]->value(time, 0.0, false).mean();
         }
         TDouble2Vec mode(model.mode(time, maths_t::CUnitWeights::unit<TDouble2Vec>(3)));
 
@@ -606,7 +605,7 @@ BOOST_AUTO_TEST_CASE(testMode) {
                                     [&reinitialize](TFloatMeanAccumulatorVec) {
                                         reinitialize = true;
                                     });
-                detrended[0][i] = trends[i]->detrend(time, sample[i], 0.0);
+                detrended[0][i] = trends[i]->detrend(time, sample[i], 0.0, false);
             }
             if (reinitialize) {
                 reinitializeResidualModel(params.learnRate(), trends, prior);
@@ -621,8 +620,7 @@ BOOST_AUTO_TEST_CASE(testMode) {
         TDouble2Vec expectedMode(prior.marginalLikelihoodMode(
             maths_t::CUnitWeights::unit<TDouble10Vec>(3)));
         for (std::size_t i = 0; i < trends.size(); ++i) {
-            expectedMode[i] +=
-                maths::common::CBasicStatistics::mean(trends[i]->value(time));
+            expectedMode[i] += trends[i]->value(time, 0.0, false).mean();
         }
         TDouble2Vec mode(model.mode(time, maths_t::CUnitWeights::unit<TDouble2Vec>(3)));
 
@@ -872,7 +870,7 @@ BOOST_AUTO_TEST_CASE(testAddSamples) {
                            makeComponentDetectedCallback(params.learnRate(),
                                                          prior, &controllers));
 
-            double detrended{trend.detrend(time, sample, 0.0)};
+            double detrended{trend.detrend(time, sample, 0.0, false)};
             prior.addSamples({detrended}, maths_t::CUnitWeights::SINGLE_UNIT);
             prior.propagateForwardsByTime(1.0);
 
@@ -950,7 +948,7 @@ BOOST_AUTO_TEST_CASE(testAddSamples) {
                                     [&reinitialize](TFloatMeanAccumulatorVec) {
                                         reinitialize = true;
                                     });
-                detrended[0][i] = trends[i]->detrend(time, sample[i], 0.0);
+                detrended[0][i] = trends[i]->detrend(time, sample[i], 0.0, false);
                 mean[i] = trends[i]->meanValue(time);
                 hasTrend |= true;
             }
@@ -1024,7 +1022,7 @@ BOOST_AUTO_TEST_CASE(testPredict) {
             trend.addPoint(time, sample, maths_t::CUnitWeights::UNIT,
                            makeComponentDetectedCallback(params.learnRate(), prior));
 
-            prior.addSamples({trend.detrend(time, sample, 0.0)},
+            prior.addSamples({trend.detrend(time, sample, 0.0, false)},
                              maths_t::CUnitWeights::SINGLE_UNIT);
             prior.propagateForwardsByTime(1.0);
 
@@ -1035,7 +1033,7 @@ BOOST_AUTO_TEST_CASE(testPredict) {
         for (core_t::TTime time_ = time; time_ < time + 86400; time_ += 3600) {
             double trend_{10.0 + 10.0 * std::sin(boost::math::double_constants::two_pi *
                                                  static_cast<double>(time_) / 86400.0)};
-            double expected{maths::common::CBasicStatistics::mean(trend.value(time_)) +
+            double expected{trend.value(time_, 0.0, false).mean() +
                             maths::common::CBasicStatistics::mean(
                                 prior.marginalLikelihoodConfidenceInterval(0.0))};
             double predicted{model.predict(time_)[0]};
@@ -1127,7 +1125,7 @@ BOOST_AUTO_TEST_CASE(testPredict) {
                                     [&reinitialize](TFloatMeanAccumulatorVec) {
                                         reinitialize = true;
                                     });
-                detrended.push_back(trends[i]->detrend(time, sample[i], 0.0));
+                detrended.push_back(trends[i]->detrend(time, sample[i], 0.0, false));
             }
             if (reinitialize) {
                 reinitializeResidualModel(params.learnRate(), trends, prior);
@@ -1150,10 +1148,9 @@ BOOST_AUTO_TEST_CASE(testPredict) {
                                               static_cast<double>(time_) / 86400.0)};
                 maths::common::CMultivariatePrior::TUnivariatePriorPtr margin{
                     prior.univariate(marginalize, condition).first};
-                double expected{
-                    maths::common::CBasicStatistics::mean(trends[i]->value(time_)) +
-                    maths::common::CBasicStatistics::mean(
-                        margin->marginalLikelihoodConfidenceInterval(0.0))};
+                double expected{trends[i]->value(time_, 0.0, false).mean() +
+                                maths::common::CBasicStatistics::mean(
+                                    margin->marginalLikelihoodConfidenceInterval(0.0))};
                 double predicted{model.predict(time_)[i]};
                 --marginalize[std::min(i, marginalize.size() - 1)];
                 LOG_DEBUG(<< "expected = " << expected << " predicted = " << predicted
@@ -1300,12 +1297,13 @@ BOOST_AUTO_TEST_CASE(testProbability) {
                         for (std::size_t i = 0; i < weight.size(); ++i) {
                             weight_[i] = weight[i][0];
                         }
-                        double lb[2], ub[2];
+                        double lb[2];
+                        double ub[2];
                         model0.residualModel().probabilityOfLessLikelySamples(
                             calculation, sample, {weight_}, lb[0], ub[0], expectedTail[0]);
                         model1.residualModel().probabilityOfLessLikelySamples(
                             calculation,
-                            {model1.trendModel().detrend(time, sample[0], confidence)},
+                            {model1.trendModel().detrend(time, sample[0], confidence, false)},
                             {weight_}, lb[1], ub[1], expectedTail[1]);
                         expectedProbability[0] = (lb[0] + ub[0]) / 2.0;
                         expectedProbability[1] = (lb[1] + ub[1]) / 2.0;
@@ -1403,7 +1401,7 @@ BOOST_AUTO_TEST_CASE(testProbability) {
                         TDouble10Vec detrended;
                         for (std::size_t j = 0; j < sample.size(); ++j) {
                             detrended.push_back(model1.trendModel()[j]->detrend(
-                                time, sample[j], confidence));
+                                time, sample[j], confidence, false));
                         }
                         model1.residualModel().probabilityOfLessLikelySamples(
                             calculation, {detrended}, {weight_}, lb[1], ub[1],
@@ -1517,11 +1515,8 @@ BOOST_AUTO_TEST_CASE(testWeights) {
                                      static_cast<double>(time_) / 86400.0),
                 2.0)};
 
-            double expectedScale{
-                model.trendModel()
-                    .varianceScaleWeight(
-                        time_, model.residualModel().marginalLikelihoodVariance(), 0.0)
-                    .second};
+            double expectedScale{model.trendModel().varianceScaleWeight(
+                time_, model.residualModel().marginalLikelihoodVariance(), 0.0)(1)};
             model.seasonalWeight(0.0, time_, scale);
 
             LOG_DEBUG(<< "expected weight = " << expectedScale << ", scale = " << scale
@@ -1591,11 +1586,8 @@ BOOST_AUTO_TEST_CASE(testWeights) {
 
             model.seasonalWeight(0.0, time_, scale);
             for (std::size_t i = 0; i < 3; ++i) {
-                double expectedScale{
-                    model.trendModel()[i]
-                        ->varianceScaleWeight(
-                            time_, model.residualModel().marginalLikelihoodVariances()[i], 0.0)
-                        .second};
+                double expectedScale{model.trendModel()[i]->varianceScaleWeight(
+                    time_, model.residualModel().marginalLikelihoodVariances()[i], 0.0)(1)};
                 LOG_DEBUG(<< "expected weight = " << expectedScale << ", weight = " << scale
                           << " (data weight = " << dataScale << ")");
                 BOOST_REQUIRE_EQUAL(std::max(expectedScale, MINIMUM_SEASONAL_SCALE),

--- a/lib/maths/time_series/unittest/CTrendComponentTest.cc
+++ b/lib/maths/time_series/unittest/CTrendComponentTest.cc
@@ -183,7 +183,7 @@ auto trainModel(ITR beginValues, ITR endValues) {
         component.add(time, *value);
         component.propagateForwardsByTime(BUCKET_LENGTH);
 
-        double prediction{maths::common::CBasicStatistics::mean(component.value(time, 0.0))};
+        double prediction{component.value(time, 0.0).mean()};
         controller.multiplier({prediction}, {{*value - prediction}},
                               BUCKET_LENGTH, 0.3, 0.012);
         component.decayRate(0.012 * controller.multiplier());
@@ -203,7 +203,7 @@ auto forecastErrors(ITR actual,
     core_t::TTime interval(std::distance(actual, endActual) * BUCKET_LENGTH);
 
     TDouble3VecVec forecast;
-    component.forecast(time, time + interval, BUCKET_LENGTH, 95.0,
+    component.forecast(time, time + interval, BUCKET_LENGTH, 95.0, false,
                        [](core_t::TTime) { return TDouble3Vec(3, 0.0); },
                        [&forecast](core_t::TTime, const TDouble3Vec& value) {
                            forecast.push_back(value);
@@ -248,10 +248,10 @@ BOOST_AUTO_TEST_CASE(testValueAndVariance) {
     TMeanVarAccumulator normalisedResiduals;
     for (core_t::TTime time = start; time < end; time += BUCKET_LENGTH) {
         double value{values[(time - start) / BUCKET_LENGTH]};
-        double prediction{maths::common::CBasicStatistics::mean(component.value(time, 0.0))};
+        double prediction{component.value(time, 0.0).mean()};
 
         if (time > start + BUCKET_LENGTH) {
-            double variance{maths::common::CBasicStatistics::mean(component.variance(0.0))};
+            double variance{component.variance(0.0).mean()};
             normalisedResiduals.add((value - prediction) / std::sqrt(variance));
         }
 
@@ -296,7 +296,7 @@ BOOST_AUTO_TEST_CASE(testDecayRate) {
         regression.add(static_cast<double>(time) / 604800.0, value);
 
         double expectedPrediction{regression.predict(static_cast<double>(time) / 604800.0)};
-        double prediction{maths::common::CBasicStatistics::mean(component.value(time, 0.0))};
+        double prediction{component.value(time, 0.0).mean()};
         error.add(std::fabs(prediction - expectedPrediction));
         level.add(value);
 

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -352,8 +352,8 @@ void CEventRateModel::sample(core_t::TTime startTime,
                 };
 
                 maths::common::CModelAddSamplesParams params;
-                params.integer(true)
-                    .nonNegative(true)
+                params.isInteger(true)
+                    .isNonNegative(true)
                     .propagationInterval(scaledInterval)
                     .trendWeights(trendWeights)
                     .priorWeights(priorWeights)

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -508,8 +508,8 @@ void CEventRatePopulationModel::sample(core_t::TTime startTime,
                 };
 
                 maths::common::CModelAddSamplesParams params;
-                params.integer(true)
-                    .nonNegative(true)
+                params.isInteger(true)
+                    .isNonNegative(true)
                     .propagationInterval(this->propagationTime(cid, sampleTime))
                     .trendWeights(attribute.second.s_TrendWeights)
                     .priorWeights(attribute.second.s_ResidualWeights)

--- a/lib/model/CIndividualModel.cc
+++ b/lib/model/CIndividualModel.cc
@@ -409,8 +409,8 @@ bool CIndividualModel::doAcceptRestoreTraverser(core::CStateRestoreTraverser& tr
             maths_t::CUnitWeights::unit<TDouble2Vec>(dimension)};
         maths_t::setCount(TDouble2Vec(dimension, 50.0), weights[0]);
         maths::common::CModelAddSamplesParams params;
-        params.integer(true)
-            .nonNegative(true)
+        params.isInteger(true)
+            .isNonNegative(true)
             .propagationInterval(1.0)
             .trendWeights(weights)
             .priorWeights(weights);

--- a/lib/model/CInterimBucketCorrector.cc
+++ b/lib/model/CInterimBucketCorrector.cc
@@ -123,10 +123,9 @@ double CInterimBucketCorrector::estimateBucketCompleteness(core_t::TTime time,
                                                            std::uint64_t count_) const {
     double count{static_cast<double>(count_)};
     core_t::TTime bucketMidPoint{this->calcBucketMidPoint(time)};
-    double bucketCount{
-        m_FinalCountTrend.initialized()
-            ? maths::common::CBasicStatistics::mean(m_FinalCountTrend.value(bucketMidPoint))
-            : maths::common::CBasicStatistics::mean(m_FinalCountMean)};
+    double bucketCount{m_FinalCountTrend.initialized()
+                           ? m_FinalCountTrend.value(bucketMidPoint, 0.0, true).mean()
+                           : maths::common::CBasicStatistics::mean(m_FinalCountMean)};
     return bucketCount > 0.0
                ? maths::common::CTools::truncate(count / bucketCount, 0.0, 1.0)
                : 1.0;

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -331,8 +331,8 @@ void CMetricModel::sample(core_t::TTime startTime,
                 };
 
                 maths::common::CModelAddSamplesParams params;
-                params.integer(data_.second.s_IsInteger)
-                    .nonNegative(data_.second.s_IsNonNegative)
+                params.isInteger(data_.second.s_IsInteger)
+                    .isNonNegative(data_.second.s_IsNonNegative)
                     .propagationInterval(scaledInterval)
                     .trendWeights(trendWeights)
                     .priorWeights(priorWeights)

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -495,8 +495,8 @@ void CMetricPopulationModel::sample(core_t::TTime startTime,
                 };
 
                 maths::common::CModelAddSamplesParams params;
-                params.integer(attribute.second.s_IsInteger)
-                    .nonNegative(attribute.second.s_IsNonNegative)
+                params.isInteger(attribute.second.s_IsInteger)
+                    .isNonNegative(attribute.second.s_IsNonNegative)
                     .propagationInterval(this->propagationTime(cid, latest))
                     .trendWeights(attribute.second.s_TrendWeights)
                     .priorWeights(attribute.second.s_ResidualWeights)

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -231,8 +231,8 @@ BOOST_FIXTURE_TEST_CASE(testCountSample, CTestFixture) {
     LOG_DEBUG(<< "startTime = " << startTime << ", endTime = " << endTime
               << ", # events = " << eventTimes.size());
 
-    std::size_t i{0u};
-    std::size_t j{0u};
+    std::size_t i{0};
+    std::size_t j{0};
     for (core_t::TTime bucketStartTime = startTime; bucketStartTime < endTime;
          bucketStartTime += bucketLength, ++j) {
         core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
@@ -248,8 +248,8 @@ BOOST_FIXTURE_TEST_CASE(testCountSample, CTestFixture) {
         model->sample(bucketStartTime, bucketEndTime, m_ResourceMonitor);
 
         maths::common::CModelAddSamplesParams params_;
-        params_.integer(true)
-            .nonNegative(true)
+        params_.isInteger(true)
+            .isNonNegative(true)
             .propagationInterval(1.0)
             .trendWeights(weights)
             .priorWeights(weights);
@@ -326,8 +326,8 @@ BOOST_FIXTURE_TEST_CASE(testNonZeroCountSample, CTestFixture) {
     LOG_DEBUG(<< "startTime = " << startTime << ", endTime = " << endTime
               << ", # events = " << eventTimes.size());
 
-    std::size_t i{0u};
-    std::size_t j{0u};
+    std::size_t i{0};
+    std::size_t j{0};
     for (core_t::TTime bucketStartTime = startTime; bucketStartTime < endTime;
          bucketStartTime += bucketLength) {
         core_t::TTime bucketEndTime = bucketStartTime + bucketLength;
@@ -344,8 +344,8 @@ BOOST_FIXTURE_TEST_CASE(testNonZeroCountSample, CTestFixture) {
 
         if (*model->currentBucketCount(0, bucketStartTime) > 0) {
             maths::common::CModelAddSamplesParams params_;
-            params_.integer(true)
-                .nonNegative(true)
+            params_.isInteger(true)
+                .isNonNegative(true)
                 .propagationInterval(1.0)
                 .trendWeights(weights)
                 .priorWeights(weights);

--- a/lib/model/unittest/CEventRatePopulationModelTest.cc
+++ b/lib/model/unittest/CEventRatePopulationModelTest.cc
@@ -371,8 +371,8 @@ BOOST_FIXTURE_TEST_CASE(testFeatures, CTestFixture) {
                     samples.emplace_back(startTime + bucketLength / 2, sample, 0);
                 }
                 maths::common::CModelAddSamplesParams params_;
-                params_.integer(true)
-                    .nonNegative(true)
+                params_.isInteger(true)
+                    .isNonNegative(true)
                     .propagationInterval(1.0)
                     .trendWeights(trendWeights)
                     .priorWeights(residualWeights);

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -191,8 +191,8 @@ BOOST_FIXTURE_TEST_CASE(testSample, CTestFixture) {
                         maths::common::CModelAddSamplesParams::TDouble2VecWeightsAryVec weights(
                             numberSamples, maths_t::CUnitWeights::unit<TDouble2Vec>(1));
                         maths::common::CModelAddSamplesParams params_;
-                        params_.integer(false)
-                            .nonNegative(true)
+                        params_.isInteger(false)
+                            .isNonNegative(true)
                             .propagationInterval(1.0)
                             .trendWeights(weights)
                             .priorWeights(weights);

--- a/lib/model/unittest/CMetricPopulationModelTest.cc
+++ b/lib/model/unittest/CMetricPopulationModelTest.cc
@@ -365,7 +365,7 @@ BOOST_FIXTURE_TEST_CASE(testMinMaxAndMean, CTestFixture) {
     TSizeSizePrDoubleVecMap expectedSampleTimes;
     TSizeSizePrDoubleVecMap expectedSamples[3];
     TSizeMathsModelPtrMap expectedPopulationModels[3];
-    bool nonNegative = true;
+    bool isNonNegative = true;
 
     for (const auto& message : messages) {
         if (message.s_Time >= startTime + bucketLength) {
@@ -408,8 +408,8 @@ BOOST_FIXTURE_TEST_CASE(testMinMaxAndMean, CTestFixture) {
                         attribute.second.s_Values, attribute.second.s_TrendWeights,
                         attribute.second.s_ResidualWeights);
                     maths::common::CModelAddSamplesParams params_;
-                    params_.integer(false)
-                        .nonNegative(nonNegative)
+                    params_.isInteger(false)
+                        .isNonNegative(isNonNegative)
                         .propagationInterval(1.0)
                         .trendWeights(attribute.second.s_TrendWeights)
                         .priorWeights(attribute.second.s_ResidualWeights);
@@ -442,7 +442,7 @@ BOOST_FIXTURE_TEST_CASE(testMinMaxAndMean, CTestFixture) {
         CEventData eventData = this->addArrival(message, m_Gatherer);
         std::size_t pid = *eventData.personId();
         std::size_t cid = *eventData.attributeId();
-        nonNegative &= message.s_Dbl1Vec.get()[0] < 0.0;
+        isNonNegative &= message.s_Dbl1Vec.get()[0] < 0.0;
 
         double sampleCount = m_Gatherer->sampleCount(cid);
         if (sampleCount > 0.0) {

--- a/lib/model/unittest/CModelToolsTest.cc
+++ b/lib/model/unittest/CModelToolsTest.cc
@@ -200,7 +200,10 @@ BOOST_AUTO_TEST_CASE(testProbabilityCache) {
         rng.random_shuffle(samples.begin(), samples.end());
         for (auto sample : samples) {
             maths::common::CModelAddSamplesParams params;
-            params.integer(false).propagationInterval(1.0).trendWeights(weights).priorWeights(weights);
+            params.isInteger(false)
+                .propagationInterval(1.0)
+                .trendWeights(weights)
+                .priorWeights(weights);
             model.addSamples(
                 params, {core::make_triple(time_, TDouble2Vec(1, sample), TAG)});
         }

--- a/lib/model/unittest/CProbabilityAndInfluenceCalculatorTest.cc
+++ b/lib/model/unittest/CProbabilityAndInfluenceCalculatorTest.cc
@@ -117,7 +117,7 @@ addSamples(core_t::TTime bucketLength, const SAMPLES& samples, maths::common::CM
     TDouble2VecWeightsAryVec weights{
         maths_t::CUnitWeights::unit<TDouble2Vec>(dimension(samples[0]))};
     maths::common::CModelAddSamplesParams params;
-    params.integer(false).propagationInterval(1.0).trendWeights(weights).priorWeights(weights);
+    params.isInteger(false).propagationInterval(1.0).trendWeights(weights).priorWeights(weights);
     core_t::TTime time{0};
     for (const auto& sample_ : samples) {
         model.addSamples(params, {sample(time, sample_)});
@@ -280,7 +280,8 @@ void testProbabilityAndGetInfluences(model_t::EFeature feature,
     double probability;
     BOOST_TEST_REQUIRE(calculator.calculate(probability, influences));
 
-    double pj, pe;
+    double pj;
+    double pe;
     BOOST_TEST_REQUIRE(pJoint.calculate(pj));
     BOOST_TEST_REQUIRE(pExtreme.calculate(pe));
 


### PR DESCRIPTION
We've had multiple issues reported in the past where we report high anomaly scores when the actual is the same as the typical and both are equal to zero. This has been exacerbated in the past because we've also had some instabilities in the modelling when we stop receiving data for a partition, which was an edge case when this could occur.

In all problematic cases, the underlying reason is the if we know the data are non-negative we truncate the prediction when we report the typical value. However, up until now we haven't truncated when computing probabilities.

This changes switches to always truncating our prediction. (This is a halfway house to a more rigorous approach which would condition the predicted distribution to be non-negative.) This should be good enough to ensure we never create non-zero anomaly scores for cases where actual equals typical equals zero except when the result is a multi-bucket anomaly.