### PR TITLE
[ML] Permit new system calls used by Ubuntu 22.04

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -44,10 +44,22 @@
   log errors training classification and regression models. (See {ml-pull}2249[#2249].)
 * Fix some bugs affecting decision to stop optimising hyperparameters for training
   classification and regression models. (See {ml-pull}2259[#2259].)
-* Fix edge case which could cause the model bounds to blow up after detecting seasonality.
-  (See {ml-pull}2261[#2261].)
 * Fix cause of "Must provide points at which to evaluate function" log error training
   classification and regression models. (See {ml-pull}2268[#2268].)
+
+== {es} version 8.2.2
+
+=== Enhancements
+
+* Make ML native processes work with glibc 2.35 (required for Ubuntu 22.04). (See
+  {ml-pull}2272[#2272].)
+
+== {es} version 8.2.1
+
+=== Bug Fixes
+
+* Fix edge case which could cause the model bounds to blow up after detecting seasonality.
+  (See {ml-pull}2261[#2261].)
 
 == {es} version 8.2.0
 


### PR DESCRIPTION
Ubuntu 22.04 uses glibc 2.35 and the implementation of
pthread_create has been changed to use more system calls
than it used to.

In order for pthread_create to work on glibc 2.35 we need
to allow the rt_sigprocmask, rseq and clone3 system calls.

Fixes elastic/elasticsearch#86877