### PR TITLE
[8.2] [ML] Permit new system calls used by Ubuntu 22.04

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,13 @@
 
 //=== Regressions
 
+== {es} version 8.2.2
+
+=== Enhancements
+
+* Make ML native processes work with glibc 2.35 (required for Ubuntu 22.04). (See
+  {ml-pull}2272[#2272].)
+
 == {es} version 8.2.1
 
 === Bug Fixes


### PR DESCRIPTION
Ubuntu 22.04 uses glibc 2.35 and the implementation of
pthread_create has been changed to use more system calls
than it used to.

In order for pthread_create to work on glibc 2.35 we need
to allow the rt_sigprocmask, rseq and clone3 system calls.

Backport of #2272