### PR TITLE
[7.17] [ML] Adjacency weighting fixes in categorization

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -35,6 +35,10 @@
 * Make ML native processes work with glibc 2.35 (required for Ubuntu 22.04). (See
   {ml-pull}2272[#2272].)
 
+=== Bug Fixes
+
+* Adjacency weighting fixes in categorization. (See {ml-pull}2277[#2277].)
+
 == {es} version 7.17.4
 
 === Bug Fixes

--- a/include/core/CWordDictionary.h
+++ b/include/core/CWordDictionary.h
@@ -11,11 +11,11 @@
 #ifndef INCLUDED_ml_core_CWordDictionary_h
 #define INCLUDED_ml_core_CWordDictionary_h
 
-#include <core/CNonCopyable.h>
 #include <core/ImportExport.h>
 
 #include <boost/unordered_map.hpp>
 
+#include <algorithm>
 #include <string>
 
 namespace ml {
@@ -50,7 +50,7 @@ namespace core {
 //! too to avoid repeated locking in the instance() method (see
 //! Modern C++ Design by Andrei Alexandrescu for details).
 //!
-class CORE_EXPORT CWordDictionary : private CNonCopyable {
+class CORE_EXPORT CWordDictionary {
 public:
     //! Types of words.
     //! The values used are deliberately powers of two so that in the
@@ -84,6 +84,10 @@ public:
         void reset() {
             // NO-OP
         }
+
+        std::size_t minMatchingWeight(std::size_t weight) { return weight; }
+
+        std::size_t maxMatchingWeight(std::size_t weight) { return weight; }
     };
 
     using TWeightAll2 = CWeightAll<2>;
@@ -103,6 +107,10 @@ public:
         void reset() {
             // NO-OP
         }
+
+        std::size_t minMatchingWeight(std::size_t weight) { return weight; }
+
+        std::size_t maxMatchingWeight(std::size_t weight) { return weight; }
     };
 
     using TWeightVerbs5Other2 = CWeightOnePart<E_Verb, 5, 2>;
@@ -120,16 +128,27 @@ public:
             }
 
             std::size_t weight = (partOfSpeech == SPECIAL_PART1) ? EXTRA_WEIGHT1 : DEFAULT_EXTRA_WEIGHT;
-            std::size_t boost =
-                (m_NumOfAdjacentDictionaryWords > 1 ? ADJACENT_PARTS_BOOST : 1);
+            std::size_t boost = (++m_NumOfAdjacentDictionaryWords > 2) ? ADJACENT_PARTS_BOOST
+                                                                       : 1;
             weight *= boost;
-
-            ++m_NumOfAdjacentDictionaryWords;
 
             return weight;
         }
 
         void reset() { m_NumOfAdjacentDictionaryWords = 0; }
+
+        std::size_t minMatchingWeight(std::size_t weight) {
+            return (weight <= ADJACENT_PARTS_BOOST)
+                       ? weight
+                       : (1 + (weight - 1) / ADJACENT_PARTS_BOOST);
+        }
+
+        std::size_t maxMatchingWeight(std::size_t weight) {
+            return (weight <= std::min(EXTRA_WEIGHT1, DEFAULT_EXTRA_WEIGHT) ||
+                    weight > std::max(EXTRA_WEIGHT1 + 1, DEFAULT_EXTRA_WEIGHT + 1))
+                       ? weight
+                       : (1 + (weight - 1) * ADJACENT_PARTS_BOOST);
+        }
 
     private:
         std::size_t m_NumOfAdjacentDictionaryWords = 0;
@@ -155,6 +174,10 @@ public:
         void reset() {
             // NO-OP
         }
+
+        std::size_t minMatchingWeight(std::size_t weight) { return weight; }
+
+        std::size_t maxMatchingWeight(std::size_t weight) { return weight; }
     };
 
     // Similar templates with more arguments can be added as required...
@@ -175,6 +198,10 @@ public:
     //! created Moby.  This method returns E_NotInDictionary for words that
     //! aren't in the dictionary.
     EPartOfSpeech partOfSpeech(const std::string& str) const;
+
+    //! No copying
+    CWordDictionary(const CWordDictionary&) = delete;
+    CWordDictionary& operator=(const CWordDictionary&) = delete;
 
 private:
     //! Constructor for a singleton is private

--- a/include/core/WindowsSafe.h
+++ b/include/core/WindowsSafe.h
@@ -19,12 +19,6 @@
 
 #include <Windows.h>
 
-#ifdef min
-#undef min
-#endif
-#ifdef max
-#undef max
-#endif
 #ifdef TEXT
 #undef TEXT
 #endif

--- a/include/model/CTokenListCategory.h
+++ b/include/model/CTokenListCategory.h
@@ -119,8 +119,7 @@ public:
                                         return testItem.first >= commonItem.first;
                                     });
             if (testIter == uniqueTokenIds.end() ||
-                testIter->first != commonItem.first ||
-                testIter->second != commonItem.second) {
+                testIter->first != commonItem.first) {
                 return false;
             }
             ++testIter;

--- a/include/model/CTokenListDataCategorizer.h
+++ b/include/model/CTokenListDataCategorizer.h
@@ -96,7 +96,9 @@ protected:
                         const std::string& str,
                         TSizeSizePrVec& tokenIds,
                         TSizeSizeMap& tokenUniqueIds,
-                        std::size_t& totalWeight) override {
+                        std::size_t& totalWeight,
+                        std::size_t& minReweightedTotalWeight,
+                        std::size_t& maxReweightedTotalWeight) override {
         tokenIds.clear();
         tokenUniqueIds.clear();
         totalWeight = 0;
@@ -128,8 +130,9 @@ protected:
                 }
             } else {
                 if (!temp.empty()) {
-                    this->considerToken(fields, nonHexPos, temp, tokenIds,
-                                        tokenUniqueIds, totalWeight);
+                    this->considerToken(fields, nonHexPos, temp, tokenIds, tokenUniqueIds,
+                                        totalWeight, minReweightedTotalWeight,
+                                        maxReweightedTotalWeight);
                     temp.clear();
                 }
 
@@ -140,7 +143,8 @@ protected:
         }
 
         if (!temp.empty()) {
-            this->considerToken(fields, nonHexPos, temp, tokenIds, tokenUniqueIds, totalWeight);
+            this->considerToken(fields, nonHexPos, temp, tokenIds, tokenUniqueIds, totalWeight,
+                                minReweightedTotalWeight, maxReweightedTotalWeight);
         }
 
         LOG_TRACE(<< str << " tokenised to " << tokenIds.size() << " tokens with total weight "
@@ -154,7 +158,9 @@ protected:
     void tokenToIdAndWeight(const std::string& token,
                             TSizeSizePrVec& tokenIds,
                             TSizeSizeMap& tokenUniqueIds,
-                            std::size_t& totalWeight) override {
+                            std::size_t& totalWeight,
+                            std::size_t& minReweightedTotalWeight,
+                            std::size_t& maxReweightedTotalWeight) override {
         TSizeSizePr idWithWeight(this->idForToken(token), 1);
 
         if (token.length() >= MIN_DICTIONARY_LENGTH) {
@@ -165,6 +171,10 @@ protected:
         tokenIds.push_back(idWithWeight);
         tokenUniqueIds[idWithWeight.first] += idWithWeight.second;
         totalWeight += idWithWeight.second;
+        minReweightedTotalWeight +=
+            m_DictionaryWeightFunc.minMatchingWeight(idWithWeight.second);
+        maxReweightedTotalWeight +=
+            m_DictionaryWeightFunc.maxMatchingWeight(idWithWeight.second);
     }
 
     void reset() override { m_DictionaryWeightFunc.reset(); }
@@ -225,7 +235,9 @@ private:
                        std::string& token,
                        TSizeSizePrVec& tokenIds,
                        TSizeSizeMap& tokenUniqueIds,
-                       std::size_t& totalWeight) {
+                       std::size_t& totalWeight,
+                       std::size_t& minReweightedTotalWeight,
+                       std::size_t& maxReweightedTotalWeight) {
         if (IGNORE_LEADING_DIGIT && std::isdigit(static_cast<unsigned char>(token[0]))) {
             return;
         }
@@ -262,7 +274,8 @@ private:
             return;
         }
 
-        this->tokenToIdAndWeight(token, tokenIds, tokenUniqueIds, totalWeight);
+        this->tokenToIdAndWeight(token, tokenIds, tokenUniqueIds, totalWeight,
+                                 minReweightedTotalWeight, maxReweightedTotalWeight);
     }
 
 private:

--- a/include/model/CTokenListDataCategorizerBase.h
+++ b/include/model/CTokenListDataCategorizerBase.h
@@ -219,14 +219,18 @@ protected:
                                 const std::string& str,
                                 TSizeSizePrVec& tokenIds,
                                 TSizeSizeMap& tokenUniqueIds,
-                                std::size_t& totalWeight) = 0;
+                                std::size_t& totalWeight,
+                                std::size_t& minReweightedTotalWeight,
+                                std::size_t& maxReweightedTotalWeight) = 0;
 
     //! Take a string token, convert it to a numeric ID and a weighting and
     //! add these to the provided data structures.
     virtual void tokenToIdAndWeight(const std::string& token,
                                     TSizeSizePrVec& tokenIds,
                                     TSizeSizeMap& tokenUniqueIds,
-                                    std::size_t& totalWeight) = 0;
+                                    std::size_t& totalWeight,
+                                    std::size_t& minReweightedTotalWeight,
+                                    std::size_t& maxReweightedTotalWeight) = 0;
 
     virtual void reset() = 0;
 
@@ -339,7 +343,9 @@ private:
     bool addPretokenisedTokens(const std::string& tokensCsv,
                                TSizeSizePrVec& tokenIds,
                                TSizeSizeMap& tokenUniqueIds,
-                               std::size_t& totalWeight);
+                               std::size_t& totalWeight,
+                               std::size_t& minReweightedTotalWeight,
+                               std::size_t& maxReweightedTotalWeight);
 
     //! Get the categories that will never be detected again because the
     //! specified category will always be returned instead.  This overload

--- a/lib/core/unittest/CWordDictionaryTest.cc
+++ b/lib/core/unittest/CWordDictionaryTest.cc
@@ -58,41 +58,91 @@ BOOST_AUTO_TEST_CASE(testPartOfSpeech) {
                         dict.partOfSpeech("a"));
 }
 
-BOOST_AUTO_TEST_CASE(testWeightingFunctors) {
+BOOST_AUTO_TEST_CASE(testSimpleWeightingFunctors) {
     {
         ml::core::CWordDictionary::TWeightAll2 weighter;
 
-        BOOST_REQUIRE_EQUAL(size_t(0), weighter(ml::core::CWordDictionary::E_NotInDictionary));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_UnknownPart));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_Noun));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_Plural));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_Verb));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_Adjective));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_Adverb));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_Conjunction));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_Preposition));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_Interjection));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_Pronoun));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_DefiniteArticle));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_IndefiniteArticle));
+        BOOST_REQUIRE_EQUAL(0, weighter(ml::core::CWordDictionary::E_NotInDictionary));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_UnknownPart));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Noun));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Plural));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Verb));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Adjective));
+        weighter.reset(); // should make no difference
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Adverb));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Conjunction));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Preposition));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Interjection));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Pronoun));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_DefiniteArticle));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_IndefiniteArticle));
+        // Any given token always gives the same weight, so min/max matching
+        // should always be the same as the original
+        for (std::size_t weight = 1; weight < 10; ++weight) {
+            BOOST_REQUIRE_EQUAL(weight, weighter.minMatchingWeight(weight));
+            BOOST_REQUIRE_EQUAL(weight, weighter.maxMatchingWeight(weight));
+        }
     }
     {
         ml::core::CWordDictionary::TWeightVerbs5Other2 weighter;
 
-        BOOST_REQUIRE_EQUAL(size_t(0), weighter(ml::core::CWordDictionary::E_NotInDictionary));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_UnknownPart));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_Noun));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_Plural));
-        BOOST_REQUIRE_EQUAL(size_t(5), weighter(ml::core::CWordDictionary::E_Verb));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_Adjective));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_Adverb));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_Conjunction));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_Preposition));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_Interjection));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_Pronoun));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_DefiniteArticle));
-        BOOST_REQUIRE_EQUAL(size_t(2), weighter(ml::core::CWordDictionary::E_IndefiniteArticle));
+        BOOST_REQUIRE_EQUAL(0, weighter(ml::core::CWordDictionary::E_NotInDictionary));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_UnknownPart));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Noun));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Plural));
+        weighter.reset(); // should make no difference
+        BOOST_REQUIRE_EQUAL(5, weighter(ml::core::CWordDictionary::E_Verb));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Adjective));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Adverb));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Conjunction));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Preposition));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Interjection));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Pronoun));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_DefiniteArticle));
+        BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_IndefiniteArticle));
+        // Any given token always gives the same weight, so min/max matching
+        // should always be the same as the original
+        for (std::size_t weight = 1; weight < 10; ++weight) {
+            BOOST_REQUIRE_EQUAL(weight, weighter.minMatchingWeight(weight));
+            BOOST_REQUIRE_EQUAL(weight, weighter.maxMatchingWeight(weight));
+        }
     }
+}
+
+BOOST_AUTO_TEST_CASE(testAdjacencyDependentWeightingFunctor) {
+    ml::core::CWordDictionary::TWeightVerbs5Other2AdjacentBoost6 weighter;
+
+    BOOST_REQUIRE_EQUAL(0, weighter(ml::core::CWordDictionary::E_NotInDictionary));
+    BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_UnknownPart));
+    BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Noun));
+    BOOST_REQUIRE_EQUAL(12, weighter(ml::core::CWordDictionary::E_Plural));
+    BOOST_REQUIRE_EQUAL(30, weighter(ml::core::CWordDictionary::E_Verb));
+    weighter.reset();
+    // Explicit reset stops adjacency multiplier
+    BOOST_REQUIRE_EQUAL(5, weighter(ml::core::CWordDictionary::E_Verb));
+    BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Adjective));
+    BOOST_REQUIRE_EQUAL(12, weighter(ml::core::CWordDictionary::E_Adverb));
+    BOOST_REQUIRE_EQUAL(12, weighter(ml::core::CWordDictionary::E_Conjunction));
+    BOOST_REQUIRE_EQUAL(0, weighter(ml::core::CWordDictionary::E_NotInDictionary));
+    // Non-dictionary word stops adjacency multiplier
+    BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Noun));
+    BOOST_REQUIRE_EQUAL(5, weighter(ml::core::CWordDictionary::E_Verb));
+    weighter.reset();
+    // Explicit reset stops adjacency multiplier
+    BOOST_REQUIRE_EQUAL(2, weighter(ml::core::CWordDictionary::E_Adjective));
+
+    // Of the possible weights, 3 could map to 13 and 6 to 31 depending on
+    // whether adjacency weighting takes place
+    BOOST_REQUIRE_EQUAL(1, weighter.minMatchingWeight(1));
+    BOOST_REQUIRE_EQUAL(1, weighter.maxMatchingWeight(1));
+    BOOST_REQUIRE_EQUAL(3, weighter.minMatchingWeight(3));
+    BOOST_REQUIRE_EQUAL(13, weighter.maxMatchingWeight(3));
+    BOOST_REQUIRE_EQUAL(6, weighter.minMatchingWeight(6));
+    BOOST_REQUIRE_EQUAL(31, weighter.maxMatchingWeight(6));
+    BOOST_REQUIRE_EQUAL(3, weighter.minMatchingWeight(13));
+    BOOST_REQUIRE_EQUAL(13, weighter.maxMatchingWeight(13));
+    BOOST_REQUIRE_EQUAL(6, weighter.minMatchingWeight(31));
+    BOOST_REQUIRE_EQUAL(31, weighter.maxMatchingWeight(31));
 }
 
 // Disabled because it doesn't assert anything
@@ -104,8 +154,8 @@ BOOST_AUTO_TEST_CASE(testPerformance, *boost::unit_test::disabled()) {
     LOG_INFO(<< "Starting word dictionary throughput test at "
              << ml::core::CTimeUtils::toTimeString(start));
 
-    static const size_t TEST_SIZE(100000);
-    for (size_t count = 0; count < TEST_SIZE; ++count) {
+    static const std::size_t TEST_SIZE(100000);
+    for (std::size_t count = 0; count < TEST_SIZE; ++count) {
         dict.isInDictionary("hello");
         dict.isInDictionary("Hello");
         dict.isInDictionary("HELLO");

--- a/lib/model/CTokenListCategory.cc
+++ b/lib/model/CTokenListCategory.cc
@@ -252,13 +252,7 @@ bool CTokenListCategory::updateCommonUniqueTokenIds(const TSizeSizeMap& newUniqu
             changed = true;
         } else {
             if (commonIter->first == newIter->first) {
-                if (commonIter->second == newIter->second) {
-                    ++commonIter;
-                } else {
-                    m_CommonUniqueTokenWeight -= commonIter->second;
-                    commonIter = m_CommonUniqueTokenIds.erase(commonIter);
-                    changed = true;
-                }
+                ++commonIter;
             }
             ++newIter;
         }
@@ -337,8 +331,7 @@ bool CTokenListCategory::updateOrderedCommonTokenIds(const TSizeSizePrVec& newTo
                 if (newTokenIds[newIndex].first != m_BaseTokenIds[commonIndex].first) {
                     ++newIndex;
                 } else {
-                    tryWeight += (newTokenIds[newIndex].second +
-                                  m_BaseTokenIds[commonIndex].second);
+                    tryWeight += m_BaseTokenIds[commonIndex].second;
                     break;
                 }
             }
@@ -439,17 +432,14 @@ std::size_t CTokenListCategory::missingCommonTokenWeight(const TSizeSizeMap& uni
     while (commonIter != m_CommonUniqueTokenIds.end() &&
            testIter != uniqueTokenIds.end()) {
         if (commonIter->first == testIter->first) {
-            // Don't increment the weight if a given token appears a different
-            // number of times in the two strings
-            if (commonIter->second == testIter->second) {
-                presentWeight += commonIter->second;
-            }
+            // If the token ID matches then consider the token present even if
+            // the weight in the test list is different.
+            presentWeight += commonIter->second;
             ++commonIter;
             ++testIter;
         } else if (commonIter->first < testIter->first) {
             ++commonIter;
-        } else // if (commonIter->first > testIter->first)
-        {
+        } else { // if (commonIter->first > testIter->first)
             ++testIter;
         }
     }

--- a/lib/model/CTokenListDataCategorizerBase.cc
+++ b/lib/model/CTokenListDataCategorizerBase.cc
@@ -67,22 +67,26 @@ CTokenListDataCategorizerBase::computeCategory(bool isDryRun,
                                                std::size_t rawStringLen) {
     // First tokenise string
     std::size_t workWeight{0};
+    std::size_t minReweightedWorkWeight{0};
+    std::size_t maxReweightedWorkWeight{0};
     auto preTokenisedIter = fields.find(PRETOKENISED_TOKEN_FIELD);
     if (preTokenisedIter != fields.end()) {
         if (this->addPretokenisedTokens(preTokenisedIter->second, m_WorkTokenIds,
-                                        m_WorkTokenUniqueIds, workWeight) == false) {
+                                        m_WorkTokenUniqueIds, workWeight, minReweightedWorkWeight,
+                                        maxReweightedWorkWeight) == false) {
             return CLocalCategoryId::softFailure();
         }
     } else {
-        this->tokeniseString(fields, str, m_WorkTokenIds, m_WorkTokenUniqueIds, workWeight);
+        this->tokeniseString(fields, str, m_WorkTokenIds, m_WorkTokenUniqueIds, workWeight,
+                             minReweightedWorkWeight, maxReweightedWorkWeight);
     }
 
     // Determine the minimum and maximum token weight that could possibly
     // match the weight we've got
     std::size_t minWeight{CTokenListDataCategorizerBase::minMatchingWeight(
-        workWeight, m_LowerThreshold)};
+        minReweightedWorkWeight, m_LowerThreshold)};
     std::size_t maxWeight{CTokenListDataCategorizerBase::maxMatchingWeight(
-        workWeight, m_LowerThreshold)};
+        maxReweightedWorkWeight, m_LowerThreshold)};
 
     // We search previous categories in descending order of the number of matches
     // we've seen for them
@@ -109,14 +113,17 @@ CTokenListDataCategorizerBase::computeCategory(bool isDryRun,
 
             // Rule out categories where adding the current string would unacceptably
             // reduce the number of unique common tokens
-            std::size_t origUniqueTokenWeight{compCategory.origUniqueTokenWeight()};
-            std::size_t commonUniqueTokenWeight{compCategory.commonUniqueTokenWeight()};
             std::size_t missingCommonTokenWeight{
                 compCategory.missingCommonTokenWeight(m_WorkTokenUniqueIds)};
-            double proportionOfOrig{static_cast<double>(commonUniqueTokenWeight - missingCommonTokenWeight) /
-                                    static_cast<double>(origUniqueTokenWeight)};
-            if (proportionOfOrig < m_LowerThreshold) {
-                continue;
+            if (missingCommonTokenWeight > 0) {
+                std::size_t origUniqueTokenWeight{compCategory.origUniqueTokenWeight()};
+                std::size_t commonUniqueTokenWeight{compCategory.commonUniqueTokenWeight()};
+                double proportionOfOrig{
+                    static_cast<double>(commonUniqueTokenWeight - missingCommonTokenWeight) /
+                    static_cast<double>(origUniqueTokenWeight)};
+                if (proportionOfOrig < m_LowerThreshold) {
+                    continue;
+                }
             }
         }
 
@@ -148,8 +155,10 @@ CTokenListDataCategorizerBase::computeCategory(bool isDryRun,
 
             // Recalculate the minimum and maximum token counts that might
             // produce a better match
-            minWeight = CTokenListDataCategorizerBase::minMatchingWeight(workWeight, similarity);
-            maxWeight = CTokenListDataCategorizerBase::maxMatchingWeight(workWeight, similarity);
+            minWeight = CTokenListDataCategorizerBase::minMatchingWeight(
+                minReweightedWorkWeight, similarity);
+            maxWeight = CTokenListDataCategorizerBase::maxMatchingWeight(
+                maxReweightedWorkWeight, similarity);
         }
     }
 
@@ -517,7 +526,9 @@ std::size_t CTokenListDataCategorizerBase::idForToken(const std::string& token) 
 bool CTokenListDataCategorizerBase::addPretokenisedTokens(const std::string& tokensCsv,
                                                           TSizeSizePrVec& tokenIds,
                                                           TSizeSizeMap& tokenUniqueIds,
-                                                          std::size_t& totalWeight) {
+                                                          std::size_t& totalWeight,
+                                                          std::size_t& minReweightedTotalWeight,
+                                                          std::size_t& maxReweightedTotalWeight) {
     tokenIds.clear();
     tokenUniqueIds.clear();
     totalWeight = 0;
@@ -529,7 +540,8 @@ bool CTokenListDataCategorizerBase::addPretokenisedTokens(const std::string& tok
             return false;
         }
 
-        this->tokenToIdAndWeight(token, tokenIds, tokenUniqueIds, totalWeight);
+        this->tokenToIdAndWeight(token, tokenIds, tokenUniqueIds, totalWeight,
+                                 minReweightedTotalWeight, maxReweightedTotalWeight);
     }
 
     this->reset();

--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -135,16 +135,16 @@ BOOST_FIXTURE_TEST_CASE(testRmdsData, CTestFixture) {
     BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
                         categorizer.computeCategory(false, "<ml13-4608.1.p2ps: Info: > Source ML_SERVICE2 on 13122:867 has started.",
                                                     500));
-    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
                         categorizer.computeCategory(false, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX, id of 132, has started.",
                                                     500));
-    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
                         categorizer.computeCategory(false, "<ml00-4601.1.p2ps: Info: > Service CUBE_IDEM, id of 232, has started.",
                                                     500));
-    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
                         categorizer.computeCategory(false, "<ml00-4601.1.p2ps: Info: > Service CUBE_IDEM, id of 232, has started.",
                                                     500));
-    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{4},
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
                         categorizer.computeCategory(false, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX has shut down.",
                                                     500));
 
@@ -173,15 +173,15 @@ BOOST_FIXTURE_TEST_CASE(testProxyData, CTestFixture) {
     BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
                         categorizer.computeCategory(false, " [1111529792] INFO  proxy <45409105041220090733@192.168.251.123> - +++++++++++++++ CREATING ProxyCore ++++++++++++++++",
                                                     500));
-    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{4},
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
                         categorizer.computeCategory(false, " [1091504448] INFO  transactionuser <3c26709ab9f0-iih26eh8pxxa> - +++++++++++++++ CREATING PresenceAgent ++++++++++++++++",
                                                     500));
-    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{5},
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{4},
                         categorizer.computeCategory(false,
-                                                    " [1111529792] INFO  session <45409105041220090733@192.168.251.123> - ----------------- PROXY "
-                                                    "Session DESTROYED --------------------",
+                                                    " [1111529792] INFO  session <45409105041220090733@192.168.251.123> - ----------------- "
+                                                    "PROXY Session DESTROYED --------------------",
                                                     500));
-    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{6},
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{4},
                         categorizer.computeCategory(false,
                                                     " [1094662464] INFO  session <ch6z1bho8xeprb3z4ty604iktl6c@dave.proxy.uk> - ----------------- "
                                                     "PROXY Session DESTROYED --------------------",
@@ -330,6 +330,24 @@ BOOST_FIXTURE_TEST_CASE(testVmwareDataLengthGrowth, CTestFixture) {
     BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
                         categorizer.computeCategory(false, "Jul 10 13:04:45 prelert-esxi1.prelert.com Hostd: -->          value = \"naa.644a84202f3712001d0c56a3304f87cf\",",
                                                     109));
+
+    checkMemoryUsageInstrumentation(categorizer);
+}
+
+BOOST_FIXTURE_TEST_CASE(testDreamhostData, CTestFixture) {
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
+
+    // Examples from https://log-sharing.dreamhosters.com
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false, "combo ftpd[7045]: connection from 84.232.2.50 () at Mon Jan  9 23:44:50 2006",
+                                                    76));
+
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
+                        categorizer.computeCategory(false,
+                                                    "combo ftpd[6527]: connection from 60.45.101.89 "
+                                                    "(p15025-ipadfx01yosida.nagano.ocn.ne.jp) at Mon Jan  9 17:39:05 2006",
+                                                    115));
 
     checkMemoryUsageInstrumentation(categorizer);
 }
@@ -605,46 +623,46 @@ BOOST_FIXTURE_TEST_CASE(testPreTokenised, CTestFixture) {
     BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
                         categorizer.computeCategory(false, "<ml13-4608.1.p2ps: Info: > Source ML_SERVICE2 on 13122:867 has started.",
                                                     500));
-    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
                         categorizer.computeCategory(false, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX, id of 132, has started.",
                                                     500));
-    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
                         categorizer.computeCategory(false, "<ml00-4601.1.p2ps: Info: > Service CUBE_IDEM, id of 232, has started.",
                                                     500));
-    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{2},
                         categorizer.computeCategory(false, "<ml00-4601.1.p2ps: Info: > Service CUBE_IDEM, id of 232, has started.",
                                                     500));
-    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{4},
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
                         categorizer.computeCategory(false, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX has shut down.",
                                                     500));
 
     TTokenListDataCategorizerKeepsFields::TStrStrUMap fields;
 
-    // The pre-tokenised tokens exactly match those of the other message in
-    // category 4, so this should get put it category 4
+    // The pre-tokenised tokens exactly match those of the last message in
+    // category 1, so this should get put it category 1
     fields[TTokenListDataCategorizerKeepsFields::PRETOKENISED_TOKEN_FIELD] =
         "ml00-4201.1.p2ps,Info,Service,CUBE_CHIX,has,shut,down";
-    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{4},
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
                         categorizer.computeCategory(false, fields, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX has shut down.",
                                                     500));
 
     // Here we cheat.  The pre-tokenised tokens exactly match those of the
     // first message, so this should get put in category 1.  But the full
-    // message is indentical to that of the category 4 message, so if this test
-    // ever fails with the message being put in category 4 then it probably
+    // message is indentical to that of the last category 2 message, so if this
+    // test ever fails with the message being put in category 4 then it probably
     // means there's a bug where the pre-tokenised tokens are being ignored.
     // (Obviously in production we wouldn't get the discrepancy between the
     // pre-tokenised tokens and the full message.)
     fields[TTokenListDataCategorizerKeepsFields::PRETOKENISED_TOKEN_FIELD] =
         "ml13-4608.1.p2ps,Info,Source,ML_SERVICE2,on,has,shut,down";
     BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{1},
-                        categorizer.computeCategory(false, fields, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX has shut down.",
+                        categorizer.computeCategory(false, fields, "<ml00-4601.1.p2ps: Info: > Service CUBE_IDEM, id of 232, has started.",
                                                     500));
 
     // Similar principle, but with Chinese, Japanese and Korean tokens, so
     // should go in a new category.
     fields[TTokenListDataCategorizerKeepsFields::PRETOKENISED_TOKEN_FIELD] = "编码,コーディング,코딩";
-    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{5},
+    BOOST_REQUIRE_EQUAL(ml::model::CLocalCategoryId{3},
                         categorizer.computeCategory(false, fields, "<ml00-4201.1.p2ps: Info: > Service CUBE_CHIX has shut down.",
                                                     500));
 

--- a/mk/windows.mk
+++ b/mk/windows.mk
@@ -50,7 +50,7 @@ CFLAGS=-nologo $(OPTCFLAGS) -W4 $(CRT_OPT) -EHsc -Zi -Gw -FS -Zc:inline -diagnos
 CXXFLAGS=-TP $(CFLAGS) -Zc:rvalueCast -Zc:strictStrings -wd4127 -we4150 -wd4201 -wd4231 -wd4251 -wd4355 -wd4512 -wd4702 -bigobj
 ANALYZEFLAGS=-nologo -analyze:only -analyze:stacksize100000 $(CRT_OPT)
 
-CPPFLAGS=-X -I$(CPP_SRC_HOME)/3rd_party/include -I$(LOCAL_DRIVE):/usr/local/include $(VCINCLUDES) $(WINSDKINCLUDES) -D$(OS) -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE -DWIN32_LEAN_AND_MEAN -DNTDDI_VERSION=0x06010000 -D_WIN32_WINNT=0x0601 -D_ENABLE_EXTENDED_ALIGNED_STORAGE -DBUILDING_$(basename $(notdir $(TARGET))) $(OPTCPPFLAGS)
+CPPFLAGS=-X -I$(CPP_SRC_HOME)/3rd_party/include -I$(LOCAL_DRIVE):/usr/local/include $(VCINCLUDES) $(WINSDKINCLUDES) -D$(OS) -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE -DWIN32_LEAN_AND_MEAN -DNOMINMAX -DNTDDI_VERSION=0x06010000 -D_WIN32_WINNT=0x0601 -D_ENABLE_EXTENDED_ALIGNED_STORAGE -DBUILDING_$(basename $(notdir $(TARGET))) $(OPTCPPFLAGS)
 # -MD defines _DLL and _MT - for dependency determination we must define these
 # otherwise the Boost headers will throw errors during preprocessing
 ifeq ($(CRT_OPT),-MD)


### PR DESCRIPTION
In #1903 we changed dictionary weighting in categorization to give
higher weighting when there were 3 or more adjacent dictionary
words. This was the first time that we'd ever had the situation
where the same token could have a different weight in different
messages. Unfortunately the way this interacted with us requiring
equal weights when checking for common tokens meant tokens could
be bizarrely removed from categories. For example, with the
following two messages we'd put them in the same category but say
that "started" was not a common token:

- Service abcd was started
- Service reaper was started

This happens because "abcd" is not a dictionary word but "reaper"
is, so then "started" has weight 6 in the first message but weight
31 in the second. Considering "started" to NOT be a common token
in this case is extremely bad both intuitively and for the accuracy
of drilldown searches.

Therefore this PR changes the categorization code to consider
tokens equal if their token IDs are equal but their weights are
different. Weights are now only used to compute distance between
different tokens.

This causes the need for another change. It is no longer as simple
as it used to be to calculate the highest and lowest possible total
weight of a message that might possibly be considered similar to
the current message. This calculation now needs to take account of
possible adjacency weighting, either in the current message or in
the messages being considered as matches. (This also has the side
effect that we'll do a higher number of expensive Levenshtein
distance calculations, as fewer potential matches will be discarded
early by the simple weight check.)

Backport of #2277