### PR TITLE
[ML] Trap edge case leading to "No values added to quantile sketch" log error

### DIFF
--- a/lib/maths/time_series/CCalendarCyclicTest.cc
+++ b/lib/maths/time_series/CCalendarCyclicTest.cc
@@ -193,8 +193,11 @@ void CCalendarCyclicTest::add(core_t::TTime time, double error, double weight) {
 
 CCalendarCyclicTest::TOptionalFeatureTimePr CCalendarCyclicTest::test() const {
 
-    // The statistics we need in order to be able to test for calendar
-    // features.
+    if (m_ErrorQuantiles.count() == 0) {
+        return {};
+    }
+
+    // The statistics we need in order to be able to test for calendar features.
     struct SStats {
         core_t::TTime s_Offset{0};
         unsigned int s_Repeats{0};


### PR DESCRIPTION
#2270 showed up an edge case which caused us to start generating error messages in one of our QA tests. We simply need to exit early in this case.

Although this could in theory have happened before, we've never seen the error, so I'm marking as a non-issue since it doesn't seem worthwhile documenting.