### PR TITLE
[ML] Improve naming

### DIFF
--- a/include/maths/common/CModel.h
+++ b/include/maths/common/CModel.h
@@ -440,7 +440,7 @@ public:
                               const TDouble2Vec& value,
                               double trendCountWeight,
                               double residualCountWeight,
-                              double winsorisationDerate,
+                              double outlierWeightDerate,
                               double countVarianceScale,
                               TDouble2VecWeightsAry& trendWeights,
                               TDouble2VecWeightsAry& residualWeights) const = 0;
@@ -592,7 +592,7 @@ public:
                       const TDouble2Vec& value,
                       double trendCountWeight,
                       double residualCountWeight,
-                      double winsorisationDerate,
+                      double outlierWeightDerate,
                       double countVarianceScale,
                       TDouble2VecWeightsAry& trendWeights,
                       TDouble2VecWeightsAry& residualWeights) const override;

--- a/include/maths/common/CMultivariateMultimodalPrior.h
+++ b/include/maths/common/CMultivariateMultimodalPrior.h
@@ -358,12 +358,12 @@ public:
                     }
                     maths_t::setCount(cluster.second, N, weight[0]);
                     if (maths_t::isWinsorised(weight)) {
-                        TDouble10Vec ww = maths_t::winsorisationWeight(weight[0]);
+                        TDouble10Vec ww = maths_t::outlierWeight(weight[0]);
                         double f = (k->weight() + cluster.second) / Z;
                         for (auto& w : ww) {
                             w = std::max(1.0 - (1.0 - w) / f, w * f);
                         }
-                        maths_t::setWinsorisationWeight(ww, weight[0]);
+                        maths_t::setOutlierWeight(ww, weight[0]);
                     }
                     k->s_Prior->addSamples(sample, weight);
                     n += this->smallest(maths_t::countForUpdate(weight[0]));

--- a/include/maths/common/CMultivariateNormalConjugate.h
+++ b/include/maths/common/CMultivariateNormalConjugate.h
@@ -207,7 +207,7 @@ public:
 
         this->CMultivariatePrior::addSamples(samples, weights);
 
-        // Note that if either count weight or Winsorisation weights are supplied
+        // Note that if either count weight or outlier weights are supplied
         // the weight of the sample x(i) is interpreted as its count, so for example
         // updating with {(x, 2)} is equivalent to updating with {x, x}.
         //

--- a/include/maths/common/CXMeansOnline.h
+++ b/include/maths/common/CXMeansOnline.h
@@ -1198,7 +1198,7 @@ private:
     static const core::TPersistenceTag WEIGHT_CALC_TAG;
     static const core::TPersistenceTag MINIMUM_CLUSTER_FRACTION_TAG;
     static const core::TPersistenceTag MINIMUM_CLUSTER_COUNT_TAG;
-    static const core::TPersistenceTag WINSORISATION_CONFIDENCE_INTERVAL_TAG;
+    static const core::TPersistenceTag WINSORIZATION_CONFIDENCE_INTERVAL_TAG;
     static const core::TPersistenceTag CLUSTER_INDEX_GENERATOR_TAG;
     static const core::TPersistenceTag CLUSTER_TAG;
     static const core::TPersistenceTag RNG_TAG;

--- a/include/maths/common/CXMeansOnline1d.h
+++ b/include/maths/common/CXMeansOnline1d.h
@@ -176,7 +176,7 @@ public:
         //! \param[in] minimumCount The minimum count of a cluster
         //! in the split.
         //! \param[in] smallest The smallest sample added to date.
-        //! \param[in] interval The Winsorisation interval.
+        //! \param[in] interval The Winsorization interval.
         //! \param[in] indexGenerator The unique cluster identifier
         //! generator.
         TOptionalClusterClusterPr split(CAvailableModeDistributions distributions,
@@ -191,7 +191,7 @@ public:
         //! \param[in] distributions The distributions available to
         //! model the clusters.
         //! \param[in] smallest The smallest sample added to date.
-        //! \param[in] interval The Winsorisation interval.
+        //! \param[in] interval The Winsorization interval.
         bool shouldMerge(CCluster& other,
                          CAvailableModeDistributions distributions,
                          double smallest,
@@ -234,7 +234,7 @@ public:
 
 public:
     //! The central confidence interval on which to Winsorise.
-    static const double WINSORISATION_CONFIDENCE_INTERVAL;
+    static const double WINSORIZATION_CONFIDENCE_INTERVAL;
 
 public:
     //! Construct a new clusterer.
@@ -252,7 +252,7 @@ public:
     //! cluster.
     //! \param[in] minimumCategoryCount The minimum count of a category
     //! in the sketch to cluster.
-    //! \param[in] winsorisationConfidenceInterval The central confidence
+    //! \param[in] winsorizationConfidenceInterval The central confidence
     //! interval on which to Winsorise.
     //! \param[in] splitFunc Optional callback for when a cluster is split.
     //! \param[in] mergeFunc Optional callback for when two clusters are
@@ -263,7 +263,7 @@ public:
                     double minimumClusterFraction = MINIMUM_CLUSTER_SPLIT_FRACTION,
                     double minimumClusterCount = MINIMUM_CLUSTER_SPLIT_COUNT,
                     double minimumCategoryCount = MINIMUM_CATEGORY_COUNT,
-                    double winsorisationConfidenceInterval = WINSORISATION_CONFIDENCE_INTERVAL,
+                    double winsorizationConfidenceInterval = WINSORIZATION_CONFIDENCE_INTERVAL,
                     const TSplitFunc& splitFunc = CDoNothing(),
                     const TMergeFunc& mergeFunc = CDoNothing());
 
@@ -427,8 +427,8 @@ private:
     //! Remove any clusters which are effectively dead.
     bool prune();
 
-    //! Get the Winsorisation interval.
-    TDoubleDoublePr winsorisationInterval() const;
+    //! Get the Winsorization interval.
+    TDoubleDoublePr winsorizationInterval() const;
 
 private:
     //! The type of data being clustered.
@@ -459,7 +459,7 @@ private:
     CFloatStorage m_MinimumCategoryCount;
 
     //! The data central confidence interval on which to Winsorise.
-    CFloatStorage m_WinsorisationConfidenceInterval;
+    CFloatStorage m_WinsorizationConfidenceInterval;
 
     //! A generator of unique cluster indices.
     CIndexGenerator m_ClusterIndexGenerator;

--- a/include/maths/common/MathsTypes.h
+++ b/include/maths/common/MathsTypes.h
@@ -67,14 +67,14 @@ enum EDataType { E_DiscreteData, E_IntegerData, E_ContinuousData, E_MixedData };
 //!      to the sample likelihood function having its variance scaled
 //!      by "weight" w.r.t. the likelihood function corresponding
 //!      to the prior parameters.
-//!   -# WinsorisationWeight: only affects update where it basically
+//!   -# OutlierWeight: only affects update where it basically
 //!      behaves like CountWeight except for the way it interacts
 //!      with clustering.
 enum ESampleWeightStyle {
     E_SampleCountWeight,
     E_SampleSeasonalVarianceScaleWeight,
     E_SampleCountVarianceScaleWeight,
-    E_SampleWinsorisationWeight
+    E_SampleOutlierWeight
 };
 
 //! IMPORTANT: this must be kept this up-to-date with ESampleWeightStyle.
@@ -210,55 +210,55 @@ double countForUpdate(const TDoubleWeightsAry& weights);
 MATHS_COMMON_EXPORT
 TDouble10Vec countForUpdate(const TDouble10VecWeightsAry& weights);
 
-//! Get a weights array with Winsorisation weight \p weight.
+//! Get a weights array with outlier weight \p weight.
 template<typename VECTOR>
-TWeightsAry<VECTOR> winsorisationWeight(const VECTOR& weight) {
+TWeightsAry<VECTOR> outlierWeight(const VECTOR& weight) {
     TWeightsAry<VECTOR> result(CUnitWeights::unit<VECTOR>(weight));
-    result[E_SampleWinsorisationWeight] = weight;
+    result[E_SampleOutlierWeight] = weight;
     return result;
 }
 
-//! Get a weights array with Winsorisation weight \p weight.
+//! Get a weights array with outlier weight \p weight.
 MATHS_COMMON_EXPORT
-TDoubleWeightsAry winsorisationWeight(double weight);
+TDoubleWeightsAry outlierWeight(double weight);
 
-//! Get a weights array with Winsorisation weight \p weight.
+//! Get a weights array with outlier weight \p weight.
 MATHS_COMMON_EXPORT
-TDouble10VecWeightsAry winsorisationWeight(double weight, std::size_t dimension);
+TDouble10VecWeightsAry outlierWeight(double weight, std::size_t dimension);
 
-//! Set the Winsorisation weight in \p weights to \p weight.
+//! Set the outlier weight in \p weights to \p weight.
 template<typename VECTOR>
-void setWinsorisationWeight(const VECTOR& weight, TWeightsAry<VECTOR>& weights) {
-    weights[E_SampleWinsorisationWeight] = weight;
+void setOutlierWeight(const VECTOR& weight, TWeightsAry<VECTOR>& weights) {
+    weights[E_SampleOutlierWeight] = weight;
 }
 
-//! Set the Winsorisation weight in \p weights to \p weight.
+//! Set the outlier weight in \p weights to \p weight.
 MATHS_COMMON_EXPORT
-void setWinsorisationWeight(double weight, std::size_t dimension, TDouble10VecWeightsAry& weights);
+void setOutlierWeight(double weight, std::size_t dimension, TDouble10VecWeightsAry& weights);
 
-//! Extract the Winsorisation weight from a collection of weights.
+//! Extract the outlier weight from a collection of weights.
 template<typename VECTOR>
-const VECTOR& winsorisationWeight(const TWeightsAry<VECTOR>& weights) {
-    return weights[E_SampleWinsorisationWeight];
+const VECTOR& outlierWeight(const TWeightsAry<VECTOR>& weights) {
+    return weights[E_SampleOutlierWeight];
 }
 
-//! Check if a non-unit Winsorisation weight applies.
+//! Check if a non-unit outlier weight applies.
 MATHS_COMMON_EXPORT
 bool isWinsorised(const TDoubleWeightsAry& weights);
 
-//! Check if a non-unit Winsorisation weight applies.
+//! Check if a non-unit outlier weight applies.
 MATHS_COMMON_EXPORT
 bool isWinsorised(const TDoubleWeightsAry1Vec& weights);
 
-//! Check if a non-unit Winsorisation weight applies.
+//! Check if a non-unit outlier weight applies.
 template<typename VECTOR>
 bool isWinsorised(const TWeightsAry<VECTOR>& weights) {
-    return std::any_of(weights[E_SampleWinsorisationWeight].begin(),
-                       weights[E_SampleWinsorisationWeight].end(),
+    return std::any_of(weights[E_SampleOutlierWeight].begin(),
+                       weights[E_SampleOutlierWeight].end(),
                        [](double weight) { return weight != 1.0; });
 }
 
-//! Check if a non-unit Winsorisation weight applies.
+//! Check if a non-unit outlier weight applies.
 template<typename VECTOR>
 bool isWinsorised(const core::CSmallVector<TWeightsAry<VECTOR>, 1>& weights) {
     return std::any_of(weights.begin(), weights.end(), [](const TWeightsAry<VECTOR>& weight) {

--- a/include/maths/time_series/CTimeSeriesDecomposition.h
+++ b/include/maths/time_series/CTimeSeriesDecomposition.h
@@ -199,8 +199,8 @@ public:
     //! Get the count weight to apply at \p time.
     double countWeight(core_t::TTime time) const override;
 
-    //! Get the derate to apply to the Winsorisation weight at \p time.
-    double winsorisationDerate(core_t::TTime time, double error) const override;
+    //! Get the derate to apply to the outlier weight at \p time.
+    double outlierWeightDerate(core_t::TTime time, double error) const override;
 
     //! Get the prediction residuals in a recent time window.
     //!

--- a/include/maths/time_series/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/time_series/CTimeSeriesDecompositionDetail.h
@@ -256,9 +256,9 @@ public:
         //! Get the count weight to apply to samples.
         double countWeight(core_t::TTime time) const;
 
-        //! Get the derate to apply to the Winsorization weight for a prediction error
+        //! Get the derate to apply to the outlier weight for a prediction error
         //! of size \p error.
-        double winsorisationDerate(core_t::TTime time, double error) const;
+        double outlierWeightDerate(core_t::TTime time, double error) const;
 
         //! Age the test to account for the interval \p end - \p start elapsed time.
         void propagateForwards(core_t::TTime start, core_t::TTime end);
@@ -366,8 +366,8 @@ public:
         //! which can be undone.
         TChangePointUPtr m_UndoableLastChange;
 
-        //! The derate to apply to the Winsorization immediately after the last change point.
-        CWinsorizationDerate m_LastChangeWinsorizationDerate;
+        //! The derate to apply to the outlier weight immediately after the last change point.
+        COutlierWeightDerate m_LastChangeOutlierWeightDerate;
     };
 
     //! \brief Scans through increasingly low frequencies looking for significant

--- a/include/maths/time_series/CTimeSeriesDecompositionInterface.h
+++ b/include/maths/time_series/CTimeSeriesDecompositionInterface.h
@@ -188,8 +188,8 @@ public:
     //! Get the count weight to apply at \p time.
     virtual double countWeight(core_t::TTime time) const = 0;
 
-    //! Get the derate to apply to the Winsorisation weight at \p time.
-    virtual double winsorisationDerate(core_t::TTime time, double derate) const = 0;
+    //! Get the derate to apply to the outlier weight at \p time.
+    virtual double outlierWeightDerate(core_t::TTime time, double derate) const = 0;
 
     //! Get the prediction residuals in a recent time window.
     //!

--- a/include/maths/time_series/CTimeSeriesDecompositionStub.h
+++ b/include/maths/time_series/CTimeSeriesDecompositionStub.h
@@ -95,7 +95,7 @@ public:
     double countWeight(core_t::TTime time) const override;
 
     //! Returns 0.0.
-    double winsorisationDerate(core_t::TTime time, double error) const override;
+    double outlierWeightDerate(core_t::TTime time, double error) const override;
 
     //! Returns an empty vector.
     TFloatMeanAccumulatorVec residuals(bool isNonNegative) const override;

--- a/include/maths/time_series/CTimeSeriesModel.h
+++ b/include/maths/time_series/CTimeSeriesModel.h
@@ -156,7 +156,7 @@ public:
                       const TDouble2Vec& value,
                       double trendCountWeight,
                       double residualCountWeight,
-                      double winsorisationDerate,
+                      double outlierWeightDerate,
                       double countVarianceScale,
                       TDouble2VecWeightsAry& trendWeights,
                       TDouble2VecWeightsAry& residualWeights) const override;
@@ -637,7 +637,7 @@ public:
                       const TDouble2Vec& value,
                       double trendCountWeight,
                       double residualCountWeight,
-                      double winsorisationDerate,
+                      double outlierWeightDerate,
                       double countVarianceScale,
                       TDouble2VecWeightsAry& trendWeights,
                       TDouble2VecWeightsAry& residualWeights) const override;

--- a/include/maths/time_series/CTimeSeriesTestForChange.h
+++ b/include/maths/time_series/CTimeSeriesTestForChange.h
@@ -38,11 +38,11 @@ class CSeasonalComponent;
 class CTimeSeriesDecomposition;
 class CTrendComponent;
 
-//! \brief Determines the Winsorization derate which should apply after a change.
-class MATHS_TIME_SERIES_EXPORT CWinsorizationDerate {
+//! \brief Determines the outlier weight derate which should apply after a change.
+class MATHS_TIME_SERIES_EXPORT COutlierWeightDerate {
 public:
-    CWinsorizationDerate() = default;
-    explicit CWinsorizationDerate(double magnitude);
+    COutlierWeightDerate() = default;
+    explicit COutlierWeightDerate(double magnitude);
     double value(double error) const;
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
@@ -66,7 +66,7 @@ public:
     virtual ~CChangePoint();
 
     virtual TChangePointUPtr undoable() const = 0;
-    virtual CWinsorizationDerate winsorizationDerate(core_t::TTime startTime,
+    virtual COutlierWeightDerate outlierWeightDerate(core_t::TTime startTime,
                                                      core_t::TTime endTime,
                                                      const TPredictor& predictor) const = 0;
     virtual bool largeEnough(double threshold) const = 0;
@@ -125,9 +125,9 @@ public:
                 double significantPValue);
 
     TChangePointUPtr undoable() const override;
-    CWinsorizationDerate
-    winsorizationDerate(core_t::TTime, core_t::TTime, const TPredictor&) const override {
-        return CWinsorizationDerate{m_Shift};
+    COutlierWeightDerate
+    outlierWeightDerate(core_t::TTime, core_t::TTime, const TPredictor&) const override {
+        return COutlierWeightDerate{m_Shift};
     }
     bool largeEnough(double threshold) const override;
     bool longEnough(core_t::TTime time, core_t::TTime minimumDuration) const override;
@@ -160,9 +160,9 @@ public:
            double significantPValue);
 
     TChangePointUPtr undoable() const override;
-    CWinsorizationDerate
-    winsorizationDerate(core_t::TTime, core_t::TTime, const TPredictor&) const override {
-        return CWinsorizationDerate{m_Magnitude};
+    COutlierWeightDerate
+    outlierWeightDerate(core_t::TTime, core_t::TTime, const TPredictor&) const override {
+        return COutlierWeightDerate{m_Magnitude};
     }
     bool largeEnough(double threshold) const override;
     bool longEnough(core_t::TTime time, core_t::TTime minimumDuration) const override;
@@ -194,7 +194,7 @@ public:
     CTimeShift(core_t::TTime time, core_t::TTime shift, double significantPValue);
 
     TChangePointUPtr undoable() const override;
-    CWinsorizationDerate winsorizationDerate(core_t::TTime startTime,
+    COutlierWeightDerate outlierWeightDerate(core_t::TTime startTime,
                                              core_t::TTime endTime,
                                              const TPredictor& predictor) const override;
     bool largeEnough(double) const override { return m_Shift != 0; }

--- a/include/model/CIndividualModel.h
+++ b/include/model/CIndividualModel.h
@@ -262,7 +262,7 @@ protected:
                                    TDouble1Vec& baseline) const;
 
     //! Get the amount by which to derate the initial decay rate
-    //! and the minimum Winsorisation weight for \p pid at \p time.
+    //! and the minimum outlier weight for \p pid at \p time.
     double derate(std::size_t pid, core_t::TTime time) const;
 
     //! Print the current bucketing interval.

--- a/lib/maths/common/CModel.cc
+++ b/lib/maths/common/CModel.cc
@@ -400,7 +400,7 @@ void CModelStub::countWeights(core_t::TTime /*time*/,
                               const TDouble2Vec& /*value*/,
                               double /*trendCountWeight*/,
                               double /*residualCountWeight*/,
-                              double /*winsorisationDerate*/,
+                              double /*outlierWeightDerate*/,
                               double /*countVarianceScale*/,
                               TDouble2VecWeightsAry& /*trendWeights*/,
                               TDouble2VecWeightsAry& /*residualWeights*/) const {

--- a/lib/maths/common/CMultimodalPrior.cc
+++ b/lib/maths/common/CMultimodalPrior.cc
@@ -429,10 +429,10 @@ void CMultimodalPrior::addSamples(const TDouble1Vec& samples,
                 }
                 maths_t::setCount(cluster.second, weight[0]);
                 if (maths_t::isWinsorised(weight)) {
-                    double ww = maths_t::winsorisationWeight(weight[0]);
+                    double ww = maths_t::outlierWeight(weight[0]);
                     double f = (k->weight() + cluster.second) / Z;
-                    maths_t::setWinsorisationWeight(
-                        std::max(1.0 - (1.0 - ww) / f, ww * f), weight[0]);
+                    maths_t::setOutlierWeight(std::max(1.0 - (1.0 - ww) / f, ww * f),
+                                              weight[0]);
                 }
                 k->s_Prior->addSamples(sample, weight);
                 n += maths_t::countForUpdate(weight[0]);

--- a/lib/maths/common/CXMeansOnline1d.cc
+++ b/lib/maths/common/CXMeansOnline1d.cc
@@ -405,7 +405,7 @@ void BICGain(maths_t::EDataType dataType,
 
 //! Update the mean and variance of \p category to represent
 //! truncating the values to the interval \p interval. This
-//! is done by Winsorisation, i.e. rather than discarding values
+//! is done by Winsorization, i.e. rather than discarding values
 //! outside the interval we restrict them to the closest interval
 //! end point. To approximate the effect on the category mean and
 //! variance we assume that the underlying distribution is normal
@@ -418,7 +418,7 @@ void BICGain(maths_t::EDataType dataType,
 //!    \f$m_{a,b} = (a-m_{a,b})^2 F(a) + \int_a^b{(x-m_{a,b})^2 f(x)}dx + (b-m_{a,b})^2 (1 - F(b))\f$
 //! </pre>
 //!
-//! \param[in] interval The Winsorisation interval.
+//! \param[in] interval The Winsorization interval.
 //! \param[in,out] category The category to Winsorise.
 void winsorise(const TDoubleDoublePr& interval, TTuple& category) {
 
@@ -598,7 +598,7 @@ const core::TPersistenceTag WEIGHT_CALC_TAG("a", "weight");
 const core::TPersistenceTag MINIMUM_CLUSTER_FRACTION_TAG("b", "cluster_fraction");
 const core::TPersistenceTag MINIMUM_CLUSTER_COUNT_TAG("c", "minimum_cluster_count");
 const core::TPersistenceTag
-    WINSORISATION_CONFIDENCE_INTERVAL_TAG("d", "winsorisation_confidence_interval");
+    WINSORIZATION_CONFIDENCE_INTERVAL_TAG("d", "winsorisation_confidence_interval");
 const core::TPersistenceTag CLUSTER_INDEX_GENERATOR_TAG("e", "index_generator");
 const core::TPersistenceTag CLUSTER_TAG("f", "cluster");
 const core::TPersistenceTag AVAILABLE_DISTRIBUTIONS_TAG("g", "available_distributions");
@@ -657,7 +657,7 @@ CXMeansOnline1d::CXMeansOnline1d(maths_t::EDataType dataType,
                                  double minimumClusterFraction,
                                  double minimumClusterCount,
                                  double minimumCategoryCount,
-                                 double winsorisationConfidenceInterval,
+                                 double winsorizationConfidenceInterval,
                                  const TSplitFunc& splitFunc,
                                  const TMergeFunc& mergeFunc)
     : CClusterer1d(splitFunc, mergeFunc), m_DataType(dataType),
@@ -666,7 +666,7 @@ CXMeansOnline1d::CXMeansOnline1d(maths_t::EDataType dataType,
       m_HistoryLength(0.0), m_MinimumClusterFraction(minimumClusterFraction),
       m_MinimumClusterCount(minimumClusterCount),
       m_MinimumCategoryCount(minimumCategoryCount),
-      m_WinsorisationConfidenceInterval(winsorisationConfidenceInterval),
+      m_WinsorizationConfidenceInterval(winsorizationConfidenceInterval),
       m_Clusters(1, CCluster(*this)) {
 }
 
@@ -710,7 +710,7 @@ CXMeansOnline1d::CXMeansOnline1d(const CXMeansOnline1d& other)
       m_MinimumClusterFraction(other.m_MinimumClusterFraction),
       m_MinimumClusterCount(other.m_MinimumClusterCount),
       m_MinimumCategoryCount(other.m_MinimumCategoryCount),
-      m_WinsorisationConfidenceInterval(other.m_WinsorisationConfidenceInterval),
+      m_WinsorizationConfidenceInterval(other.m_WinsorizationConfidenceInterval),
       m_ClusterIndexGenerator(other.m_ClusterIndexGenerator.deepCopy()),
       m_Smallest(other.m_Smallest), m_Largest(other.m_Largest),
       m_Clusters(other.m_Clusters) {
@@ -734,7 +734,7 @@ void CXMeansOnline1d::swap(CXMeansOnline1d& other) {
     std::swap(m_MinimumClusterFraction, other.m_MinimumClusterFraction);
     std::swap(m_MinimumClusterCount, other.m_MinimumClusterCount);
     std::swap(m_MinimumCategoryCount, other.m_MinimumCategoryCount);
-    std::swap(m_WinsorisationConfidenceInterval, other.m_WinsorisationConfidenceInterval);
+    std::swap(m_WinsorizationConfidenceInterval, other.m_WinsorizationConfidenceInterval);
     std::swap(m_AvailableDistributions, other.m_AvailableDistributions);
     std::swap(m_ClusterIndexGenerator, other.m_ClusterIndexGenerator);
     std::swap(m_Smallest, other.m_Smallest);
@@ -760,8 +760,8 @@ void CXMeansOnline1d::acceptPersistInserter(core::CStatePersistInserter& inserte
     inserter.insertValue(WEIGHT_CALC_TAG, static_cast<int>(m_WeightCalc));
     inserter.insertValue(MINIMUM_CLUSTER_FRACTION_TAG, m_MinimumClusterFraction.toString());
     inserter.insertValue(MINIMUM_CLUSTER_COUNT_TAG, m_MinimumClusterCount.toString());
-    inserter.insertValue(WINSORISATION_CONFIDENCE_INTERVAL_TAG,
-                         m_WinsorisationConfidenceInterval.toString());
+    inserter.insertValue(WINSORIZATION_CONFIDENCE_INTERVAL_TAG,
+                         m_WinsorizationConfidenceInterval.toString());
     inserter.insertLevel(CLUSTER_INDEX_GENERATOR_TAG, [this](auto& inserter_) {
         m_ClusterIndexGenerator.acceptPersistInserter(inserter_);
     });
@@ -775,7 +775,7 @@ void CXMeansOnline1d::clear() {
     *this = CXMeansOnline1d(
         m_DataType, m_AvailableDistributions, m_WeightCalc, m_InitialDecayRate,
         m_MinimumClusterFraction, m_MinimumClusterCount, m_MinimumCategoryCount,
-        m_WinsorisationConfidenceInterval, this->splitFunc(), this->mergeFunc());
+        m_WinsorizationConfidenceInterval, this->splitFunc(), this->mergeFunc());
 }
 
 std::size_t CXMeansOnline1d::numberClusters() const {
@@ -1134,8 +1134,8 @@ bool CXMeansOnline1d::acceptRestoreTraverser(const SDistributionRestoreParams& p
                 m_MinimumClusterFraction.fromString(traverser.value()))
         RESTORE(MINIMUM_CLUSTER_COUNT_TAG,
                 m_MinimumClusterCount.fromString(traverser.value()))
-        RESTORE(WINSORISATION_CONFIDENCE_INTERVAL_TAG,
-                m_WinsorisationConfidenceInterval.fromString(traverser.value()))
+        RESTORE(WINSORIZATION_CONFIDENCE_INTERVAL_TAG,
+                m_WinsorizationConfidenceInterval.fromString(traverser.value()))
     } while (traverser.next());
 
     return true;
@@ -1166,7 +1166,7 @@ bool CXMeansOnline1d::maybeSplit(TClusterVecItr cluster) {
     if (cluster == m_Clusters.end()) {
         return false;
     }
-    TDoubleDoublePr interval = this->winsorisationInterval();
+    TDoubleDoublePr interval = this->winsorizationInterval();
     if (TOptionalClusterClusterPr split =
             cluster->split(m_AvailableDistributions, this->minimumSplitCount(),
                            m_Smallest[0], interval, m_ClusterIndexGenerator)) {
@@ -1185,7 +1185,7 @@ bool CXMeansOnline1d::maybeMerge(TClusterVecItr cluster1, TClusterVecItr cluster
     if (cluster1 == m_Clusters.end() || cluster2 == m_Clusters.end()) {
         return false;
     }
-    TDoubleDoublePr interval = this->winsorisationInterval();
+    TDoubleDoublePr interval = this->winsorizationInterval();
     if (cluster1->shouldMerge(*cluster2, m_AvailableDistributions, m_Smallest[0], interval)) {
         LOG_TRACE(<< "Merging cluster " << cluster1->index() << " at "
                   << cluster1->centre() << " and cluster " << cluster2->index()
@@ -1260,20 +1260,20 @@ bool CXMeansOnline1d::remove(std::size_t index) {
     return false;
 }
 
-TDoubleDoublePr CXMeansOnline1d::winsorisationInterval() const {
+TDoubleDoublePr CXMeansOnline1d::winsorizationInterval() const {
 
-    double f = (1.0 - m_WinsorisationConfidenceInterval) / 2.0;
+    double f = (1.0 - m_WinsorizationConfidenceInterval) / 2.0;
 
     if (f * this->count() < 1.0) {
         // Don't bother if we don't expect a sample outside the
-        // Winsorisation interval.
+        // Winsorization interval.
         return {boost::numeric::bounds<double>::lowest() / 2.0,
                 boost::numeric::bounds<double>::highest() / 2.0};
     }
 
-    // The Winsorisation interval are the positions corresponding
+    // The Winsorization interval are the positions corresponding
     // to the f/2 and 1 - f/2 percentile counts where f is the
-    // Winsorisation confidence interval, i.e. we truncate the
+    // Winsorization confidence interval, i.e. we truncate the
     // data to the 1 - f central confidence interval.
 
     double totalCount = this->count();
@@ -1300,7 +1300,7 @@ TDoubleDoublePr CXMeansOnline1d::winsorisationInterval() const {
         partialCount += count;
     }
 
-    LOG_TRACE(<< "Winsorisation interval = [" << result.first << "," << result.second << "]");
+    LOG_TRACE(<< "Winsorization interval = [" << result.first << "," << result.second << "]");
 
     return result;
 }
@@ -1570,11 +1570,11 @@ std::size_t CXMeansOnline1d::CCluster::memoryUsage() const {
     return mem;
 }
 
-const double CXMeansOnline1d::WINSORISATION_CONFIDENCE_INTERVAL(1.0);
+const double CXMeansOnline1d::WINSORIZATION_CONFIDENCE_INTERVAL(1.0);
 const double CXMeansOnline1d::MINIMUM_SPLIT_DISTANCE(6.0);
 const double CXMeansOnline1d::MAXIMUM_MERGE_DISTANCE(2.0);
 const double CXMeansOnline1d::CLUSTER_DELETE_FRACTION(0.8);
-const std::size_t CXMeansOnline1d::STRUCTURE_SIZE(12u);
+const std::size_t CXMeansOnline1d::STRUCTURE_SIZE(12);
 }
 }
 }

--- a/lib/maths/common/MathsTypes.cc
+++ b/lib/maths/common/MathsTypes.cc
@@ -51,35 +51,35 @@ void setCount(double weight, std::size_t dimension, TDouble10VecWeightsAry& weig
 }
 
 double countForUpdate(const TDoubleWeightsAry& weights) {
-    return weights[E_SampleCountWeight] * weights[E_SampleWinsorisationWeight];
+    return weights[E_SampleCountWeight] * weights[E_SampleOutlierWeight];
 }
 
 TDouble10Vec countForUpdate(const TDouble10VecWeightsAry& weights) {
     TDouble10Vec result(weights[E_SampleCountWeight]);
-    for (std::size_t i = 0; i < weights[E_SampleWinsorisationWeight].size(); ++i) {
-        result[i] *= weights[E_SampleWinsorisationWeight][i];
+    for (std::size_t i = 0; i < weights[E_SampleOutlierWeight].size(); ++i) {
+        result[i] *= weights[E_SampleOutlierWeight][i];
     }
     return result;
 }
 
-TDoubleWeightsAry winsorisationWeight(double weight) {
+TDoubleWeightsAry outlierWeight(double weight) {
     TDoubleWeightsAry result(CUnitWeights::UNIT);
-    result[E_SampleWinsorisationWeight] = weight;
+    result[E_SampleOutlierWeight] = weight;
     return result;
 }
 
-TDouble10VecWeightsAry winsorisationWeight(double weight, std::size_t dimension) {
+TDouble10VecWeightsAry outlierWeight(double weight, std::size_t dimension) {
     TDouble10VecWeightsAry result(CUnitWeights::unit<TDouble10Vec>(dimension));
-    result[E_SampleWinsorisationWeight] = TDouble10Vec(dimension, weight);
+    result[E_SampleOutlierWeight] = TDouble10Vec(dimension, weight);
     return result;
 }
 
-void setWinsorisationWeight(double weight, std::size_t dimension, TDouble10VecWeightsAry& weights) {
-    weights[E_SampleWinsorisationWeight] = TDouble10Vec(dimension, weight);
+void setOutlierWeight(double weight, std::size_t dimension, TDouble10VecWeightsAry& weights) {
+    weights[E_SampleOutlierWeight] = TDouble10Vec(dimension, weight);
 }
 
 bool isWinsorised(const TDoubleWeightsAry& weights) {
-    return weights[E_SampleWinsorisationWeight] != 1.0;
+    return weights[E_SampleOutlierWeight] != 1.0;
 }
 
 bool isWinsorised(const TDoubleWeightsAry1Vec& weights) {

--- a/lib/maths/common/unittest/CGammaRateConjugateTest.cc
+++ b/lib/maths/common/unittest/CGammaRateConjugateTest.cc
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE(testMarginalLikelihood) {
         filter.addSamples(samples);
 
         TWeightFunc weightsFuncs[]{static_cast<TWeightFunc>(maths_t::countWeight),
-                                   static_cast<TWeightFunc>(maths_t::winsorisationWeight)};
+                                   static_cast<TWeightFunc>(maths_t::outlierWeight)};
         double weights[]{0.1, 0.9, 10.0};
 
         for (std::size_t i = 0; i < boost::size(weightsFuncs); ++i) {

--- a/lib/maths/common/unittest/CLogNormalMeanPrecConjugateTest.cc
+++ b/lib/maths/common/unittest/CLogNormalMeanPrecConjugateTest.cc
@@ -310,7 +310,7 @@ BOOST_AUTO_TEST_CASE(testMarginalLikelihood) {
         filter.addSamples(samples);
 
         TWeightFunc weightsFuncs[]{static_cast<TWeightFunc>(maths_t::countWeight),
-                                   static_cast<TWeightFunc>(maths_t::winsorisationWeight)};
+                                   static_cast<TWeightFunc>(maths_t::outlierWeight)};
         double weights[]{0.1, 1.0, 10.0};
 
         for (std::size_t i = 0; i < boost::size(weightsFuncs); ++i) {

--- a/lib/maths/common/unittest/CMultimodalPriorTest.cc
+++ b/lib/maths/common/unittest/CMultimodalPriorTest.cc
@@ -709,7 +709,7 @@ BOOST_AUTO_TEST_CASE(testMarginalLikelihood) {
         filter.addSamples(samples);
 
         TWeightFunc weightsFuncs[]{static_cast<TWeightFunc>(maths_t::countWeight),
-                                   static_cast<TWeightFunc>(maths_t::winsorisationWeight)};
+                                   static_cast<TWeightFunc>(maths_t::outlierWeight)};
         double weights[]{0.1, 1.0, 10.0};
 
         for (std::size_t i = 0; i < boost::size(weightsFuncs); ++i) {

--- a/lib/maths/common/unittest/CNormalMeanPrecConjugateTest.cc
+++ b/lib/maths/common/unittest/CNormalMeanPrecConjugateTest.cc
@@ -292,7 +292,7 @@ BOOST_AUTO_TEST_CASE(testMarginalLikelihood) {
         filter.addSamples(samples);
 
         TWeightFunc weightsFuncs[]{static_cast<TWeightFunc>(maths_t::countWeight),
-                                   static_cast<TWeightFunc>(maths_t::winsorisationWeight)};
+                                   static_cast<TWeightFunc>(maths_t::outlierWeight)};
         double weights[]{0.1, 1.0, 10.0};
 
         for (std::size_t i = 0; i < boost::size(weightsFuncs); ++i) {

--- a/lib/maths/common/unittest/COneOfNPriorTest.cc
+++ b/lib/maths/common/unittest/COneOfNPriorTest.cc
@@ -552,7 +552,7 @@ BOOST_AUTO_TEST_CASE(testMarginalLikelihood) {
         filter.addSamples(samples);
 
         TWeightFunc weightsFuncs[]{static_cast<TWeightFunc>(maths_t::countWeight),
-                                   static_cast<TWeightFunc>(maths_t::winsorisationWeight)};
+                                   static_cast<TWeightFunc>(maths_t::outlierWeight)};
         double weights[]{0.1, 1.0, 10.0};
 
         for (std::size_t i = 0; i < boost::size(weightsFuncs); ++i) {

--- a/lib/maths/time_series/CTimeSeriesDecomposition.cc
+++ b/lib/maths/time_series/CTimeSeriesDecomposition.cc
@@ -553,8 +553,8 @@ double CTimeSeriesDecomposition::countWeight(core_t::TTime time) const {
     return m_ChangePointTest.countWeight(time);
 }
 
-double CTimeSeriesDecomposition::winsorisationDerate(core_t::TTime time, double error) const {
-    return m_ChangePointTest.winsorisationDerate(time, error);
+double CTimeSeriesDecomposition::outlierWeightDerate(core_t::TTime time, double error) const {
+    return m_ChangePointTest.outlierWeightDerate(time, error);
 }
 
 CTimeSeriesDecomposition::TFloatMeanAccumulatorVec

--- a/lib/maths/time_series/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/time_series/CTimeSeriesDecompositionDetail.cc
@@ -318,7 +318,7 @@ const core::TPersistenceTag LAST_CANDIDATE_CHANGE_POINT_TIME_7_11_TAG{
     "j", "last_candidate_change_point_time"};
 const core::TPersistenceTag LAST_CHANGE_POINT_7_11_TAG{"k", "last_change_point"};
 // Version 8.3
-const core::TPersistenceTag OUTLIER_WEIGHT_DERATE_8_3_TAG{"l", "outlier_weight_derate"};
+const core::TPersistenceTag OUTLIER_WEIGHT_DERATE_8_3_TAG{"l", "winsorization_derate"};
 
 // Seasonality Test Tags
 // Version 7.9

--- a/lib/maths/time_series/CTimeSeriesDecompositionStub.cc
+++ b/lib/maths/time_series/CTimeSeriesDecompositionStub.cc
@@ -101,7 +101,7 @@ double CTimeSeriesDecompositionStub::countWeight(core_t::TTime /*time*/) const {
     return 1.0;
 }
 
-double CTimeSeriesDecompositionStub::winsorisationDerate(core_t::TTime /*time*/,
+double CTimeSeriesDecompositionStub::outlierWeightDerate(core_t::TTime /*time*/,
                                                          double /*error*/) const {
     return 0.0;
 }

--- a/lib/maths/time_series/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/time_series/unittest/CTimeSeriesModelTest.cc
@@ -784,7 +784,7 @@ BOOST_AUTO_TEST_CASE(testNonUnitPropagationIntervalInAddSamples) {
         TDouble2Vec samples[]{{10.0}, {13.9}, {27.1}};
         TDouble2VecWeightsAryVec weights{maths_t::CUnitWeights::unit<TDouble2Vec>(1)};
         maths_t::setCount(TDouble2Vec{1.5}, weights[0]);
-        maths_t::setWinsorisationWeight(TDouble2Vec{0.9}, weights[0]);
+        maths_t::setOutlierWeight(TDouble2Vec{0.9}, weights[0]);
         maths_t::setCountVarianceScale(TDouble2Vec{1.1}, weights[0]);
 
         core_t::TTime time{0};
@@ -822,7 +822,7 @@ BOOST_AUTO_TEST_CASE(testNonUnitPropagationIntervalInAddSamples) {
         TDouble2Vec samples[]{{13.5, 13.4, 13.3}, {13.9, 13.8, 13.7}, {20.1, 20.0, 10.9}};
         TDouble2VecWeightsAryVec weights{maths_t::CUnitWeights::unit<TDouble2Vec>(3)};
         maths_t::setCount(TDouble2Vec{1.0, 1.1, 1.2}, weights[0]);
-        maths_t::setWinsorisationWeight(TDouble2Vec{0.1, 0.1, 0.2}, weights[0]);
+        maths_t::setOutlierWeight(TDouble2Vec{0.1, 0.1, 0.2}, weights[0]);
         maths_t::setCountVarianceScale(TDouble2Vec{2.0, 2.1, 2.2}, weights[0]);
 
         core_t::TTime time{0};
@@ -1493,7 +1493,7 @@ BOOST_AUTO_TEST_CASE(testWeights) {
     //   1) the trend and residual model
     //   2) the variation in the input data
     //
-    // And that the Winsorisation weight is monotonic decreasing with
+    // And that the outlier weight is monotonic decreasing with
     // increasing distance from the expected value.
 
     core_t::TTime bucketLength{1800};
@@ -1542,24 +1542,23 @@ BOOST_AUTO_TEST_CASE(testWeights) {
         LOG_DEBUG(<< "error = " << maths::common::CBasicStatistics::mean(error));
         BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(error) < 0.26);
 
-        LOG_DEBUG(<< "Winsorisation");
+        LOG_DEBUG(<< "Outlier reweighting");
         TDouble2Vec prediction(model.predict(time));
         TDouble2VecWeightsAry trendWeights;
         TDouble2VecWeightsAry residualWeights;
-        double lastTrendWinsorisationWeight{1.0};
-        double lastResidualWinsorisationWeight{1.0};
+        double lastTrendOutlierWeight{1.0};
+        double lastResidualOutlierWeight{1.0};
         for (std::size_t i = 0; i < 10; ++i) {
             model.countWeights(time, prediction, 1.0, 1.0, 1.0, 1.0,
                                trendWeights, residualWeights);
-            double trendWinsorisationWeight{maths_t::winsorisationWeight(trendWeights)[0]};
-            double residualWinsorisationWeight{
-                maths_t::winsorisationWeight(residualWeights)[0]};
-            LOG_DEBUG(<< "trend weight = " << trendWinsorisationWeight
-                      << ", residual weight = " << residualWinsorisationWeight);
-            BOOST_TEST_REQUIRE(trendWinsorisationWeight <= lastTrendWinsorisationWeight);
-            BOOST_TEST_REQUIRE(residualWinsorisationWeight <= lastResidualWinsorisationWeight);
-            lastTrendWinsorisationWeight = trendWinsorisationWeight;
-            lastResidualWinsorisationWeight = residualWinsorisationWeight;
+            double trendOutlierWeight{maths_t::outlierWeight(trendWeights)[0]};
+            double residualOutlierWeight{maths_t::outlierWeight(residualWeights)[0]};
+            LOG_DEBUG(<< "trend weight = " << trendOutlierWeight
+                      << ", residual weight = " << residualOutlierWeight);
+            BOOST_TEST_REQUIRE(trendOutlierWeight <= lastTrendOutlierWeight);
+            BOOST_TEST_REQUIRE(residualOutlierWeight <= lastResidualOutlierWeight);
+            lastTrendOutlierWeight = trendOutlierWeight;
+            lastResidualOutlierWeight = residualOutlierWeight;
             prediction[0] *= 1.1;
         }
     }
@@ -1612,24 +1611,23 @@ BOOST_AUTO_TEST_CASE(testWeights) {
         LOG_DEBUG(<< "error = " << maths::common::CBasicStatistics::mean(error));
         BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(error) < 0.3);
 
-        LOG_DEBUG(<< "Winsorisation");
+        LOG_DEBUG(<< "Outlier reweighting");
         TDouble2Vec prediction(model.predict(time));
         TDouble2VecWeightsAry trendWeights;
         TDouble2VecWeightsAry residualWeights;
-        double lastTrendWinsorisationWeight{1.0};
-        double lastResidualWinsorisationWeight{1.0};
+        double lastTrendOutlierWeight{1.0};
+        double lastResidualOutlierWeight{1.0};
         for (std::size_t i = 0; i < 10; ++i) {
             model.countWeights(time, prediction, 1.0, 1.0, 1.0, 1.0,
                                trendWeights, residualWeights);
-            double trendWinsorisationWeight{maths_t::winsorisationWeight(trendWeights)[0]};
-            double residualWinsorisationWeight{
-                maths_t::winsorisationWeight(residualWeights)[0]};
-            LOG_DEBUG(<< "trend weight = " << trendWinsorisationWeight
-                      << ", residual weight = " << residualWinsorisationWeight);
-            BOOST_TEST_REQUIRE(trendWinsorisationWeight <= lastTrendWinsorisationWeight);
-            BOOST_TEST_REQUIRE(residualWinsorisationWeight <= lastResidualWinsorisationWeight);
-            lastTrendWinsorisationWeight = trendWinsorisationWeight;
-            lastResidualWinsorisationWeight = residualWinsorisationWeight;
+            double trendOutlierWeight{maths_t::outlierWeight(trendWeights)[0]};
+            double residualOutlierWeight{maths_t::outlierWeight(residualWeights)[0]};
+            LOG_DEBUG(<< "trend weight = " << trendOutlierWeight
+                      << ", residual weight = " << residualOutlierWeight);
+            BOOST_TEST_REQUIRE(trendOutlierWeight <= lastTrendOutlierWeight);
+            BOOST_TEST_REQUIRE(residualOutlierWeight <= lastResidualOutlierWeight);
+            lastTrendOutlierWeight = trendOutlierWeight;
+            lastResidualOutlierWeight = residualOutlierWeight;
             prediction[0] *= 1.1;
         }
     }

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -317,7 +317,7 @@ void CEventRateModel::sample(core_t::TTime startTime,
                 double count = model_t::offsetCountToZero(
                     feature, static_cast<double>(data_.second.s_Count));
                 TDouble2Vec value{count};
-                double winsorisationDerate = this->derate(pid, sampleTime);
+                double outlierWeightDerate = this->derate(pid, sampleTime);
                 double countWeight = initialCountWeight * this->learnRate(feature);
                 // Note we need to scale the amount of data we'll "age out" of the residual
                 // model in one bucket by the empty bucket weight so the posterior doesn't
@@ -337,7 +337,7 @@ void CEventRateModel::sample(core_t::TTime startTime,
                 trendWeights.resize(1, maths_t::CUnitWeights::unit<TDouble2Vec>(dimension));
                 priorWeights.resize(1, maths_t::CUnitWeights::unit<TDouble2Vec>(dimension));
                 model->countWeights(sampleTime, value, countWeight, scaledCountWeight,
-                                    winsorisationDerate, 1.0, // count variance scale
+                                    outlierWeightDerate, 1.0, // count variance scale
                                     trendWeights[0], priorWeights[0]);
 
                 auto annotationCallback = [&](const std::string& annotation) {

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -433,7 +433,7 @@ void CEventRatePopulationModel::sample(core_t::TTime startTime,
                 std::size_t cid = CDataGatherer::extractAttributeId(data_);
 
                 maths::common::CModel* model{this->model(feature, cid)};
-                if (!model) {
+                if (model != nullptr) {
                     LOG_ERROR(<< "Missing model for " << this->attributeName(cid));
                     continue;
                 }
@@ -485,7 +485,7 @@ void CEventRatePopulationModel::sample(core_t::TTime startTime,
                     attribute.s_ResidualWeights.push_back(
                         maths_t::CUnitWeights::unit<TDouble2Vec>(1));
                     model->countWeights(sampleTime, {value}, countWeight,
-                                        countWeight, 1.0, // winsorisation derate
+                                        countWeight, 1.0, // outlier weight derate
                                         1.0, // count variance scale
                                         attribute.s_TrendWeights.back(),
                                         attribute.s_ResidualWeights.back());

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -280,7 +280,7 @@ CEventRatePopulationModel::baselineBucketMean(model_t::EFeature feature,
                                               const TSizeDoublePr1Vec& correlated,
                                               core_t::TTime time) const {
     const maths::common::CModel* model{this->model(feature, cid)};
-    if (!model) {
+    if (model == nullptr) {
         return TDouble1Vec();
     }
 
@@ -433,7 +433,7 @@ void CEventRatePopulationModel::sample(core_t::TTime startTime,
                 std::size_t cid = CDataGatherer::extractAttributeId(data_);
 
                 maths::common::CModel* model{this->model(feature, cid)};
-                if (model != nullptr) {
+                if (model == nullptr) {
                     LOG_ERROR(<< "Missing model for " << this->attributeName(cid));
                     continue;
                 }

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -286,7 +286,7 @@ void CMetricModel::sample(core_t::TTime startTime,
                          ? this->params().s_MaximumUpdatesPerBucket / static_cast<double>(n)
                          : 1.0) *
                     this->learnRate(feature) * initialCountWeight;
-                double winsorisationDerate = this->derate(pid, sampleTime);
+                double outlierWeightDerate = this->derate(pid, sampleTime);
                 // Note we need to scale the amount of data we'll "age out" of the residual
                 // model in one bucket by the empty bucket weight so the posterior doesn't
                 // end up too flat.
@@ -314,7 +314,7 @@ void CMetricModel::sample(core_t::TTime startTime,
                         ithSampleValue, model_t::INDIVIDUAL_ANALYSIS_ATTRIBUTE_ID);
                     model->countWeights(ithSampleTime, ithSampleValue,
                                         countWeight, scaledCountWeight,
-                                        winsorisationDerate, countVarianceScale,
+                                        outlierWeightDerate, countVarianceScale,
                                         trendWeights[i], priorWeights[i]);
                 }
 

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -468,7 +468,7 @@ void CMetricPopulationModel::sample(core_t::TTime startTime,
                         auto& trendWeight = attribute.s_TrendWeights.back();
                         auto& residualWeight = attribute.s_ResidualWeights.back();
                         model->countWeights(sample.time(), value, countWeight,
-                                            countWeight, 1.0, // winsorisation derate
+                                            countWeight, 1.0, // outlier weight derate
                                             countVarianceScale, trendWeight, residualWeight);
                     }
                 }

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -259,7 +259,7 @@ CMetricPopulationModel::baselineBucketMean(model_t::EFeature feature,
                                            const TSizeDoublePr1Vec& correlated,
                                            core_t::TTime time) const {
     const maths::common::CModel* model{this->model(feature, cid)};
-    if (!model) {
+    if (model == nullptr) {
         return TDouble1Vec();
     }
     static const TSizeDoublePr1Vec NO_CORRELATED;
@@ -382,7 +382,7 @@ void CMetricPopulationModel::sample(core_t::TTime startTime,
                 std::size_t cid = CDataGatherer::extractAttributeId(data_);
 
                 maths::common::CModel* model{this->model(feature, cid)};
-                if (!model) {
+                if (model == nullptr) {
                     LOG_ERROR(<< "Missing model for " << this->attributeName(cid));
                     continue;
                 }


### PR DESCRIPTION
We were using Winsorization to refer to the weight we apply to outlying data when updating time series models. Morally, what we do is much closer to iterative reweighting of outliers. It is therefore less confusing to refer to this as an outlier weight. We were also misspelling Winsorization as Winsorisation. Since we do actually do Winsorization in some of our clustering code I've also corrected this typo.