### PR TITLE
[ML] Improve normalisation of anomaly detection results for short bucket lengths

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,14 @@
 
 //=== Regressions
 
+== {es} version 8.4.0
+
+=== Enhancements
+
+* Improve normalization of anomaly detection results for short bucket lengths. This
+  corrects bias which could cause our scoring to be too low for these jobs. (See,
+  {ml-pull}2285[#2285], issue: {ml-issue}2276[#2276].)
+
 == {es} version 8.3.0
 
 === Enhancements

--- a/include/model/CAnomalyScore.h
+++ b/include/model/CAnomalyScore.h
@@ -23,14 +23,13 @@
 #include <boost/optional.hpp>
 #include <boost/unordered_map.hpp>
 
+#include <cstdint>
 #include <functional>
 #include <iosfwd>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <stdint.h>
 
 namespace CAnomalyScoreTest {
 struct testNormalizerGetMaxScore;
@@ -138,7 +137,7 @@ public:
         };
 
     public:
-        CNormalizer(const CAnomalyDetectorModelConfig& config);
+        explicit CNormalizer(const CAnomalyDetectorModelConfig& config);
 
         //! Does this normalizer have enough information to normalize
         //! anomaly scores?
@@ -196,6 +195,7 @@ public:
     private:
         using TDoubleDoublePr = std::pair<double, double>;
         using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+
         //! \brief Wraps a maximum score.
         class CMaxScore {
         public:
@@ -229,26 +229,26 @@ public:
     private:
         //! Used to convert raw scores in to integers so that we
         //! can use the q-digest.
-        constexpr static double DISCRETIZATION_FACTOR = 1000.0;
+        constexpr static double DISCRETIZATION_FACTOR{1000.0};
 
         //! We maintain a separate digest for the scores greater
         //! than some high percentile (specified by this constant).
         //! This is because we want the highest resolution in the
         //! scores for the extreme (high quantile) raw scores.
-        constexpr static double HIGH_PERCENTILE = 90.0;
+        constexpr static double HIGH_PERCENTILE{90.0};
 
         //! The time between aging quantiles. These age at a slower
         //! rate which we achieve by only aging them after a certain
         //! period has elapsed.
-        constexpr static double QUANTILE_DECAY_TIME = 20.0;
+        constexpr static double QUANTILE_DECAY_TIME{20.0};
 
         //! The number of "buckets" we'll remember maximum scores
         //! for without receiving a new value.
-        constexpr static double FORGET_MAX_SCORE_INTERVAL = 50.0;
+        constexpr static double FORGET_MAX_SCORE_INTERVAL{50.0};
 
         //! The increase in maximum score that will be considered a
         //! big change when updating the quantiles.
-        constexpr static double BIG_CHANGE_FACTOR = 1.1;
+        constexpr static double BIG_CHANGE_FACTOR{1.1};
 
     private:
         //! Compute the discrete score from a raw score.
@@ -268,13 +268,13 @@ public:
         //! The normalized anomaly score knot points.
         TDoubleDoublePrVec m_NormalizedScoreKnotPoints;
         //! The maximum possible normalized score.
-        double m_MaximumNormalizedScore = 100.0;
+        double m_MaximumNormalizedScore{100.0};
 
         //! The approximate HIGH_PERCENTILE percentile raw score.
         uint32_t m_HighPercentileScore;
         //! The number of scores less than the approximate
         //! HIGH_PERCENTILE percentile raw score.
-        uint64_t m_HighPercentileCount = 0;
+        uint64_t m_HighPercentileCount{0};
 
         //! True if this normalizer applies to results for individual
         //! members of a population analysis.
@@ -284,13 +284,11 @@ public:
         //! The set of maximum scores ever received for partitions.
         TWordMaxScoreUMap m_MaxScores;
 
-        //! The factor used to scale the quantile scores to convert
-        //! values per bucket length to values in absolute time. We
-        //! scale all values to an effective bucket length 30 mins.
-        //! So, a percentile of 99% would correspond to a 1 in 50
-        //! hours event.
-        double m_BucketNormalizationFactor;
-
+        //! We update the quantiles with one in every count per sample.
+        std::size_t m_CountPerSample{1};
+        std::size_t m_CountSinceLastSample{0};
+        //! The we sample the maximum score in every count per sample.
+        double m_Sample{0.0};
         //! A quantile summary of the raw scores.
         maths::common::CQDigest m_RawScoreQuantileSummary;
         //! A quantile summary of the raw score greater than the

--- a/lib/api/unittest/CResultNormalizerTest.cc
+++ b/lib/api/unittest/CResultNormalizerTest.cc
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(testInitNormalizerPartitioned) {
     std::string results(outputWriter.internalString());
     LOG_INFO(<< "Results:\n" << results);
 
-    // Results are new line separated so read all the docs into an  array
+    // Results are new line separated so read all the docs into an array.
     std::vector<rapidjson::Document> resultDocs;
     std::stringstream ss(results);
     std::string docString;
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(testInitNormalizerPartitioned) {
 
     // The maximum bucket_time influencer probability in the farequote data used to initialise
     // the normaliser is 2.1305076675260463E-24, so this should map to the highest normalised
-    // score which is 90.69091
+    // score which is 90.69091.
     {
         const rapidjson::Document& doc = resultDocs[13];
         BOOST_REQUIRE_EQUAL(std::string(""),
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(testInitNormalizerPartitioned) {
         BOOST_REQUIRE_EQUAL(std::string(""),
                             std::string(doc["partition_field_value"].GetString()));
         BOOST_REQUIRE_EQUAL(std::string("root"), std::string(doc["level"].GetString()));
-        BOOST_REQUIRE_EQUAL(std::string("90.69091"),
+        BOOST_REQUIRE_EQUAL(std::string("93.9542"),
                             std::string(doc["normalized_score"].GetString()));
     }
     {
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(testInitNormalizerPartitioned) {
         BOOST_REQUIRE_EQUAL(std::string(""),
                             std::string(doc["partition_field_value"].GetString()));
         BOOST_REQUIRE_EQUAL(std::string("inflb"), std::string(doc["level"].GetString()));
-        BOOST_REQUIRE_EQUAL(std::string("69.60219"),
+        BOOST_REQUIRE_EQUAL(std::string("81.65058"),
                             std::string(doc["normalized_score"].GetString()));
     }
     {
@@ -258,7 +258,7 @@ BOOST_AUTO_TEST_CASE(testInitNormalizerPartitioned) {
         BOOST_REQUIRE_EQUAL(std::string("AAL"),
                             std::string(doc["partition_field_value"].GetString()));
         BOOST_REQUIRE_EQUAL(std::string("leaf"), std::string(doc["level"].GetString()));
-        BOOST_REQUIRE_EQUAL(std::string("99.22667"),
+        BOOST_REQUIRE_EQUAL(std::string("99.61332"),
                             std::string(doc["normalized_score"].GetString()));
     }
     {
@@ -358,7 +358,7 @@ BOOST_AUTO_TEST_CASE(testInitNormalizerPartitioned) {
         BOOST_REQUIRE_EQUAL(std::string(""),
                             std::string(doc["partition_field_value"].GetString()));
         BOOST_REQUIRE_EQUAL(std::string("infl"), std::string(doc["level"].GetString()));
-        BOOST_REQUIRE_EQUAL(std::string("96.89889"),
+        BOOST_REQUIRE_EQUAL(std::string("98.44925"),
                             std::string(doc["normalized_score"].GetString()));
     }
     {

--- a/lib/api/unittest/CResultNormalizerTest.cc
+++ b/lib/api/unittest/CResultNormalizerTest.cc
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(testInitNormalizerPartitioned) {
 
     // The maximum bucket_time influencer probability in the farequote data used to initialise
     // the normaliser is 2.1305076675260463E-24, so this should map to the highest normalised
-    // score which is 90.69091.
+    // score which is 93.9542.
     {
         const rapidjson::Document& doc = resultDocs[13];
         BOOST_REQUIRE_EQUAL(std::string(""),

--- a/lib/model/CAnomalyScore.cc
+++ b/lib/model/CAnomalyScore.cc
@@ -9,10 +9,10 @@
  * limitation.
  */
 
-#include "core/CIEEE754.h"
 #include <model/CAnomalyScore.h>
 
 #include <core/CContainerPrinter.h>
+#include <core/CIEEE754.h>
 #include <core/CJsonStatePersistInserter.h>
 #include <core/CJsonStateRestoreTraverser.h>
 #include <core/CLogger.h>

--- a/lib/model/CAnomalyScore.cc
+++ b/lib/model/CAnomalyScore.cc
@@ -9,6 +9,7 @@
  * limitation.
  */
 
+#include "core/CIEEE754.h"
 #include <model/CAnomalyScore.h>
 
 #include <core/CContainerPrinter.h>
@@ -16,6 +17,7 @@
 #include <core/CJsonStateRestoreTraverser.h>
 #include <core/CLogger.h>
 #include <core/CPersistUtils.h>
+#include <core/Constants.h>
 #include <core/RestoreMacros.h>
 
 #include <maths/common/CBasicStatistics.h>
@@ -31,6 +33,7 @@
 
 #include <boost/optional.hpp>
 
+#include <cstdint>
 #include <numeric>
 #include <ostream>
 #include <sstream>
@@ -48,8 +51,7 @@ using TDoubleVec = std::vector<double>;
 template<typename AGGREGATOR>
 std::size_t addProbabilities(const TDoubleVec& probabilities, AGGREGATOR& aggregator) {
     std::size_t n = 0;
-    for (std::size_t i = 0; i < probabilities.size(); ++i) {
-        double p = probabilities[i];
+    for (auto p : probabilities) {
         if (!(p >= 0.0 && p <= 1.0)) {
             LOG_ERROR(<< "Invalid probability " << p);
         } else {
@@ -80,6 +82,9 @@ const std::string TIME_TO_QUANTILE_DECAY_TAG("f");
 // Since version >= 6.5
 const std::string MAX_SCORES_PER_PARTITION_TAG("g");
 const std::string IS_FOR_MEMBERS_OF_POPULATION_TAG("h");
+// Since version >= 8.4
+const std::string COUNT_SINCE_LAST_SAMPLE_TAG("i");
+const std::string SAMPLE_TAG("j");
 // Nested
 const std::string MAX_SCORE_TAG("a");
 const std::string TIME_SINCE_LAST_SCORE_TAG("b");
@@ -145,7 +150,7 @@ bool CAnomalyScore::compute(double jointProbabilityWeight,
     }
 
     double logPExtreme = 0.0;
-    for (std::size_t m = 1u, i = maths::common::CTools::truncate(minExtremeSamples, m, n);
+    for (std::size_t m = 1, i = maths::common::CTools::truncate(minExtremeSamples, m, n);
          i <= n; ++i) {
         maths::common::CLogProbabilityOfMFromNExtremeSamples logPExtremeCalculator(i);
         addProbabilities(probabilities, logPExtremeCalculator);
@@ -255,7 +260,10 @@ CAnomalyScore::CNormalizer::CNormalizer(const CAnomalyDetectorModelConfig& confi
       m_NoiseMultiplier(config.noiseMultiplier()),
       m_NormalizedScoreKnotPoints(config.normalizedScoreKnotPoints()),
       m_HighPercentileScore(std::numeric_limits<uint32_t>::max()),
-      m_BucketNormalizationFactor(config.bucketNormalizationFactor()),
+      m_CountPerSample(core::constants::HOUR /
+                       maths::common::CTools::truncate(2 * config.bucketLength(),
+                                                       5 * core::constants::MINUTE,
+                                                       core::constants::HOUR)),
       m_RawScoreQuantileSummary(201, config.decayRate()),
       m_RawScoreHighQuantileSummary(201, config.decayRate()),
       m_DecayRate(config.decayRate() *
@@ -271,23 +279,19 @@ bool CAnomalyScore::CNormalizer::canNormalize() const {
 
 bool CAnomalyScore::CNormalizer::normalize(const CMaximumScoreScope& scope,
                                            double& score) const {
-
     if (score == 0.0) {
         // Nothing to do.
         return true;
     }
-
     if (m_RawScoreQuantileSummary.n() == 0) {
-        LOG_ERROR(<< "No scores have been added to the quantile summary");
-        return false;
+        score = 0.0;
+        return true;
     }
 
     LOG_TRACE(<< "Normalising " << score);
 
-    static const double CONFIDENCE_INTERVAL = 70.0;
-
-    double normalizedScores[] = {m_MaximumNormalizedScore, m_MaximumNormalizedScore,
-                                 m_MaximumNormalizedScore, m_MaximumNormalizedScore};
+    double normalizedScores[]{m_MaximumNormalizedScore, m_MaximumNormalizedScore,
+                              m_MaximumNormalizedScore, m_MaximumNormalizedScore};
 
     uint32_t discreteScore = this->discreteScore(score);
 
@@ -348,16 +352,12 @@ bool CAnomalyScore::CNormalizer::normalize(const CMaximumScoreScope& scope,
               << ", noiseScore = " << noiseScore << ", l(0) = " << l0
               << ", u(0) = " << u0 << ", signalStrength = " << signalStrength);
 
-    // Compute the raw normalized score. Note we compute the probability
-    // of seeing a lower score on the normal bucket length and convert
-    // this to an equivalent percentile. This is just the probability
-    // that all n buckets in a normal bucket length have a lower quantile
-    // which is P^n where P is the quantile expressed as a probability.
-    double lowerBound;
-    double upperBound;
-    this->quantile(score, CONFIDENCE_INTERVAL, lowerBound, upperBound);
-    double lowerPercentile = 100.0 * std::pow(lowerBound, 1.0 / m_BucketNormalizationFactor);
-    double upperPercentile = 100.0 * std::pow(upperBound, 1.0 / m_BucketNormalizationFactor);
+    // Compute the raw normalized score percentile compared to historic values.
+    double lowerPercentile;
+    double upperPercentile;
+    this->quantile(score, 70.0 /*confidence interval*/, lowerPercentile, upperPercentile);
+    lowerPercentile *= 100.0;
+    upperPercentile *= 100.0;
     if (lowerPercentile > upperPercentile) {
         std::swap(lowerPercentile, upperPercentile);
     }
@@ -379,44 +379,36 @@ bool CAnomalyScore::CNormalizer::normalize(const CMaximumScoreScope& scope,
     if (lowerKnotPoint < m_NormalizedScoreKnotPoints.size()) {
         const TDoubleDoublePr& left = m_NormalizedScoreKnotPoints[lowerKnotPoint - 1];
         const TDoubleDoublePr& right = m_NormalizedScoreKnotPoints[lowerKnotPoint];
-        // Linearly interpolate between the two knot points.
-        normalizedScores[1] = left.second + (right.second - left.second) *
-                                                (lowerPercentile - left.first) /
-                                                (right.first - left.first);
+        normalizedScores[1] = maths::common::CTools::linearlyInterpolate(
+            left.first, right.first, left.second, right.second, lowerPercentile);
     } else {
         normalizedScores[1] = m_MaximumNormalizedScore;
     }
     if (upperKnotPoint < m_NormalizedScoreKnotPoints.size()) {
         const TDoubleDoublePr& left = m_NormalizedScoreKnotPoints[upperKnotPoint - 1];
         const TDoubleDoublePr& right = m_NormalizedScoreKnotPoints[upperKnotPoint];
-        // Linearly interpolate between the two knot points.
-        normalizedScores[1] = (normalizedScores[1] + left.second +
-                               (right.second - left.second) * (upperPercentile - left.first) /
-                                   (right.first - left.first)) /
-                              2.0;
+        normalizedScores[1] =
+            (normalizedScores[1] + maths::common::CTools::linearlyInterpolate(
+                                       left.first, right.first, left.second,
+                                       right.second, upperPercentile)) /
+            2.0;
     } else {
         normalizedScores[1] = (normalizedScores[1] + m_MaximumNormalizedScore) / 2.0;
     }
-    LOG_TRACE(<< "normalizedScores[1] = " << normalizedScores[1] << ", lowerBound = " << lowerBound
-              << ", upperBound = " << upperBound << ", lowerPercentile = " << lowerPercentile
-              << ", upperPercentile = " << upperPercentile);
+    LOG_TRACE(<< "normalizedScores[1] = " << normalizedScores[1] << ", lowerPercentile = "
+              << lowerPercentile << ", upperPercentile = " << upperPercentile);
 
     double maxScore{0.0};
     bool hasValidMaxScore = this->maxScore(scope, maxScore);
-    if (hasValidMaxScore == false) {
-        LOG_TRACE(<< "normalize: Not using maximum score for scope = " << scope.print());
-    } else {
-        LOG_TRACE(<< "normalize: Maximum score = " << maxScore
-                  << " for scope = " << scope.print());
-
+    LOG_TRACE(<< "hasValidMaxScore = " << hasValidMaxScore
+              << ", scope = " << scope.print());
+    if (hasValidMaxScore) {
         // Compute the maximum score ceiling
         double ratio = score / maxScore;
-        double curves[] = {0.0 + 1.5 * ratio, 0.5 + 0.5 * ratio};
         normalizedScores[2] = m_MaximumNormalizedScore *
-                              (*std::min_element(curves, curves + 2));
+                              std::min({0.0 + 1.5 * ratio, 0.5 + 0.5 * ratio});
         LOG_TRACE(<< "normalizedScores[2] = " << normalizedScores[2] << ", score = " << score
-                  << ", maxScore = " << maxScore << ", ratio = \"" << ratio << "\""
-                  << ", scope = " << scope.print());
+                  << ", maxScore = " << maxScore << ", ratio = " << ratio);
     }
 
     // Logarithmically interpolate the maximum score between the
@@ -451,6 +443,7 @@ void CAnomalyScore::CNormalizer::quantile(double score,
     double h = static_cast<double>(m_HighPercentileCount);
     double f = h / n;
     if (!(f >= 0.0 && f <= 1.0)) {
+        f = maths::common::CTools::truncate(f, 0.0, 1.0);
         LOG_ERROR(<< "h = " << h << ", n = " << n);
     }
     double fl = maths::common::CQDigest::cdfQuantile(n, f, lowerQuantile);
@@ -523,24 +516,25 @@ bool CAnomalyScore::CNormalizer::updateQuantiles(const CMaximumScoreScope& scope
     using TUInt32UInt64Pr = std::pair<uint32_t, uint64_t>;
     using TUInt32UInt64PrVec = std::vector<TUInt32UInt64Pr>;
 
-    bool bigChange(false);
-
     CMaxScore& maxScore = m_MaxScores[scope.key(m_IsForMembersOfPopulation, m_Dictionary)];
-
-    double oldMaxScore(maxScore.score());
-
+    double oldMaxScore{maxScore.score()};
     maxScore.add(score);
+    bool bigChange{maxScore.score() > BIG_CHANGE_FACTOR * oldMaxScore};
+    LOG_TRACE(<< "updateQuantiles: scope = " << scope.print()
+              << ", oldMaxScore = " << oldMaxScore << ", score = " << score
+              << ", newMaxScore = " << maxScore.score() << ", bigChange = " << bigChange);
 
-    LOG_TRACE(<< "updateQuantiles: scope = " << scope.print() << ", oldMaxScore = " << oldMaxScore
-              << ", score = " << score << ", maxScore[0] = " << maxScore.score());
-    if (maxScore.score() > BIG_CHANGE_FACTOR * oldMaxScore) {
-        bigChange = true;
-        LOG_TRACE(<< "Big change in normalizer - max score updated from "
-                  << oldMaxScore << " to " << maxScore.score());
+    m_Sample = std::max(m_Sample, score);
+    if (++m_CountSinceLastSample < m_CountPerSample) {
+        return bigChange;
     }
-    uint32_t discreteScore = this->discreteScore(score);
-    LOG_TRACE(<< "score = " << score << ", discreteScore = " << discreteScore
+
+    uint32_t discreteScore = this->discreteScore(m_Sample);
+    LOG_TRACE(<< "score = " << m_Sample << ", discreteScore = " << discreteScore
               << ", maxScore = " << maxScore.score() << ", scope = " << scope.print());
+
+    m_CountSinceLastSample = 0;
+    m_Sample = 0.0;
 
     uint64_t n = m_RawScoreQuantileSummary.n();
     uint64_t k = m_RawScoreQuantileSummary.k();
@@ -559,7 +553,7 @@ bool CAnomalyScore::CNormalizer::updateQuantiles(const CMaximumScoreScope& scope
             LOG_ERROR(<< "High quantile summary is empty: "
                       << m_RawScoreQuantileSummary.print());
         } else {
-            uint64_t highPercentileCount = static_cast<uint64_t>(
+            auto highPercentileCount = static_cast<uint64_t>(
                 (HIGH_PERCENTILE / 100.0) * static_cast<double>(n) + 0.5);
 
             // Estimate the high percentile score and update the count.
@@ -610,7 +604,7 @@ bool CAnomalyScore::CNormalizer::updateQuantiles(const CMaximumScoreScope& scope
     if ((n + 1) > k && (n + 1) % k == 0) {
         LOG_TRACE(<< "Refreshing high quantile summary");
 
-        uint64_t highPercentileCount = static_cast<uint64_t>(
+        auto highPercentileCount = static_cast<uint64_t>(
             (HIGH_PERCENTILE / 100.0) * static_cast<double>(n + 1) + 0.5);
 
         LOG_TRACE(<< "s(H) = " << m_HighPercentileScore << ", c(H) = " << m_HighPercentileCount
@@ -670,7 +664,8 @@ bool CAnomalyScore::CNormalizer::updateQuantiles(const CMaximumScoreScope& scope
                       << "%");
         } else {
             m_RawScoreQuantileSummary.quantile(HIGH_PERCENTILE / 100.0, m_HighPercentileScore);
-            double lowerBound, upperBound;
+            double lowerBound;
+            double upperBound;
             m_RawScoreQuantileSummary.cdf(m_HighPercentileScore, 0.0, lowerBound, upperBound);
             m_HighPercentileCount =
                 static_cast<uint64_t>(static_cast<double>(n + 1) * lowerBound + 0.5);
@@ -692,14 +687,13 @@ void CAnomalyScore::CNormalizer::propagateForwardByTime(double time) {
     double alpha = std::exp(-2.0 * m_DecayRate * time);
     for (auto i = m_MaxScores.begin(); i != m_MaxScores.end();
          i->second.forget(time) ? i = m_MaxScores.erase(i) : ++i) {
-
         i->second.age(alpha);
     }
 
     // Quantiles age at a much slower rate than everything else so that
     // we can accurately estimate high quantiles. We achieve this by only
     // aging them a certain fraction of the time.
-    m_TimeToQuantileDecay -= time;
+    m_TimeToQuantileDecay -= time / static_cast<double>(m_CountPerSample);
     if (m_TimeToQuantileDecay <= 0.0) {
         time = std::floor((QUANTILE_DECAY_TIME - m_TimeToQuantileDecay) / QUANTILE_DECAY_TIME);
 
@@ -748,7 +742,8 @@ bool CAnomalyScore::CNormalizer::upgrade(const std::string& loadedVersion,
     static const double Q_DIGEST_UPGRADE_FACTOR[][3] = {
         {1.0, 3.0, 30.0}, {1.0 / 3.0, 1.0, 10.0}, {1.0 / 30.0, 1.0 / 10.0, 1.0}};
 
-    std::size_t i, j;
+    std::size_t i;
+    std::size_t j;
     if (!core::CStringUtils::stringToType(loadedVersion, i) ||
         !core::CStringUtils::stringToType(currentVersion, j) ||
         i - 1 >= boost::size(HIGH_SCORE_UPGRADE_FACTOR) ||
@@ -785,9 +780,11 @@ bool CAnomalyScore::CNormalizer::upgrade(const std::string& loadedVersion,
 
 void CAnomalyScore::CNormalizer::clear() {
     m_HighPercentileScore = std::numeric_limits<uint32_t>::max();
-    m_HighPercentileCount = 0ull;
+    m_HighPercentileCount = 0ULL;
     m_IsForMembersOfPopulation.reset();
     m_MaxScores.clear();
+    m_CountSinceLastSample = 0;
+    m_Sample = 0.0;
     m_RawScoreQuantileSummary.clear();
     m_RawScoreHighQuantileSummary.clear();
     m_TimeToQuantileDecay = QUANTILE_DECAY_TIME;
@@ -796,12 +793,14 @@ void CAnomalyScore::CNormalizer::clear() {
 void CAnomalyScore::CNormalizer::acceptPersistInserter(core::CStatePersistInserter& inserter) const {
     inserter.insertValue(HIGH_PERCENTILE_SCORE_TAG, m_HighPercentileScore);
     inserter.insertValue(HIGH_PERCENTILE_COUNT_TAG, m_HighPercentileCount);
-    inserter.insertLevel(RAW_SCORE_QUANTILE_SUMMARY,
-                         std::bind(&maths::common::CQDigest::acceptPersistInserter,
-                                   &m_RawScoreQuantileSummary, std::placeholders::_1));
-    inserter.insertLevel(RAW_SCORE_HIGH_QUANTILE_SUMMARY,
-                         std::bind(&maths::common::CQDigest::acceptPersistInserter,
-                                   &m_RawScoreHighQuantileSummary, std::placeholders::_1));
+    inserter.insertValue(COUNT_SINCE_LAST_SAMPLE_TAG, m_CountSinceLastSample);
+    inserter.insertValue(SAMPLE_TAG, m_Sample, core::CIEEE754::E_DoublePrecision);
+    inserter.insertLevel(RAW_SCORE_QUANTILE_SUMMARY, [this](auto& inserter_) {
+        m_RawScoreQuantileSummary.acceptPersistInserter(inserter_);
+    });
+    inserter.insertLevel(RAW_SCORE_HIGH_QUANTILE_SUMMARY, [this](auto& inserter_) {
+        m_RawScoreHighQuantileSummary.acceptPersistInserter(inserter_);
+    });
     inserter.insertValue(TIME_TO_QUANTILE_DECAY_TAG, m_TimeToQuantileDecay);
     if (m_IsForMembersOfPopulation != boost::none) {
         inserter.insertValue(IS_FOR_MEMBERS_OF_POPULATION_TAG,
@@ -824,15 +823,15 @@ bool CAnomalyScore::CNormalizer::acceptRestoreTraverser(core::CStateRestoreTrave
                 static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()))));
         RESTORE(HIGH_PERCENTILE_COUNT_TAG,
                 core::CStringUtils::stringToType(traverser.value(), m_HighPercentileCount));
-
-        RESTORE(RAW_SCORE_QUANTILE_SUMMARY,
-                traverser.traverseSubLevel(
-                    std::bind(&maths::common::CQDigest::acceptRestoreTraverser,
-                              &m_RawScoreQuantileSummary, std::placeholders::_1)));
+        RESTORE_BUILT_IN(COUNT_SINCE_LAST_SAMPLE_TAG, m_CountSinceLastSample)
+        RESTORE_BUILT_IN(SAMPLE_TAG, m_Sample)
+        RESTORE(RAW_SCORE_QUANTILE_SUMMARY, traverser.traverseSubLevel([this](auto& traverser_) {
+            return m_RawScoreQuantileSummary.acceptRestoreTraverser(traverser_);
+        }))
         RESTORE(RAW_SCORE_HIGH_QUANTILE_SUMMARY,
-                traverser.traverseSubLevel(std::bind(
-                    &maths::common::CQDigest::acceptRestoreTraverser,
-                    &m_RawScoreHighQuantileSummary, std::placeholders::_1)));
+                traverser.traverseSubLevel([this](auto& traverser_) {
+                    return m_RawScoreHighQuantileSummary.acceptRestoreTraverser(traverser_);
+                }))
         RESTORE_SETUP_TEARDOWN(IS_FOR_MEMBERS_OF_POPULATION_TAG, int value,
                                core::CStringUtils::stringToType(traverser.value(), value),
                                m_IsForMembersOfPopulation.reset(value == 1))
@@ -844,15 +843,17 @@ bool CAnomalyScore::CNormalizer::acceptRestoreTraverser(core::CStateRestoreTrave
 }
 
 uint64_t CAnomalyScore::CNormalizer::checksum() const {
-    uint64_t seed = static_cast<uint64_t>(m_NoisePercentile);
+    auto seed = static_cast<uint64_t>(m_NoisePercentile);
     seed = maths::common::CChecksum::calculate(seed, m_NoiseMultiplier);
     seed = maths::common::CChecksum::calculate(seed, m_NormalizedScoreKnotPoints);
     seed = maths::common::CChecksum::calculate(seed, m_MaximumNormalizedScore);
     seed = maths::common::CChecksum::calculate(seed, m_HighPercentileScore);
     seed = maths::common::CChecksum::calculate(seed, m_HighPercentileCount);
     seed = maths::common::CChecksum::calculate(seed, m_IsForMembersOfPopulation);
+    seed = maths::common::CChecksum::calculate(seed, m_CountSinceLastSample);
+    seed = maths::common::CChecksum::calculate(seed, m_CountPerSample);
+    seed = maths::common::CChecksum::calculate(seed, m_Sample);
     seed = maths::common::CChecksum::calculate(seed, m_MaxScores);
-    seed = maths::common::CChecksum::calculate(seed, m_BucketNormalizationFactor);
     seed = maths::common::CChecksum::calculate(seed, m_RawScoreQuantileSummary);
     seed = maths::common::CChecksum::calculate(seed, m_RawScoreHighQuantileSummary);
     seed = maths::common::CChecksum::calculate(seed, m_DecayRate);
@@ -1007,9 +1008,9 @@ bool CAnomalyScore::normalizerFromJson(core::CStateRestoreTraverser& traverser,
                 }
             }
         } else if (name == NORMALIZER_TAG) {
-            restoredNormalizer = traverser.traverseSubLevel(
-                std::bind(&CAnomalyScore::CNormalizer::acceptRestoreTraverser,
-                          &normalizer, std::placeholders::_1));
+            restoredNormalizer = traverser.traverseSubLevel([&](auto& traverser_) {
+                return normalizer.acceptRestoreTraverser(traverser_);
+            });
             if (!restoredNormalizer) {
                 LOG_ERROR(<< "Unable to restore quantiles to the normaliser");
             }

--- a/lib/model/unittest/CAnomalyScoreTest.cc
+++ b/lib/model/unittest/CAnomalyScoreTest.cc
@@ -657,8 +657,8 @@ BOOST_AUTO_TEST_CASE(testNoiseForDifferentBucketLengths) {
     // Simulate noise in different bucket lengths and check that distribution
     // alert severities. Because there are multiple factors which affect the
     // score we don't necessarily get the same distribution for all bucket
-    // lengths. However, we do have an approximate rough upper bound on the
-    // count by severity based on the rate limiting we perform.
+    // lengths. However, we do have an approximate upper bound on the count
+    // by severity based on the rate limiting we perform.
 
     using TMeanAccumulator = maths::common::CBasicStatistics::SSampleMean<double>::TAccumulator;
     using TMeanAccumulatorVec = std::vector<TMeanAccumulator>;

--- a/lib/model/unittest/CHierarchicalResultsTest.cc
+++ b/lib/model/unittest/CHierarchicalResultsTest.cc
@@ -207,16 +207,16 @@ public:
 
 public:
     void visit(const model::CHierarchicalResults& /*results*/, const TNode& node, bool /*pivot*/) override {
-        if (this->isPartitioned(node)) {
+        if (isPartitioned(node)) {
             m_PartitionedNodes.push_back(&node);
         }
-        if (this->isPartition(node)) {
+        if (isPartition(node)) {
             m_PartitionNodes.push_back(&node);
         }
-        if (this->isPerson(node)) {
+        if (isPerson(node)) {
             m_PersonNodes.push_back(&node);
         }
-        if (this->isLeaf(node)) {
+        if (isLeaf(node)) {
             m_LeafNodes.push_back(&node);
         }
     }
@@ -1533,15 +1533,12 @@ BOOST_AUTO_TEST_CASE(testNormalizer) {
         {"1", FALSE_STR, PNF1, pn11, PF2, p21, EMPTY_STRING},
         {"1", FALSE_STR, PNF1, pn11, PF2, p22, EMPTY_STRING},
         {"1", FALSE_STR, PNF1, pn11, PF2, p23, EMPTY_STRING},
-        {"2", FALSE_STR, PNF1, pn12, PF1, p11, EMPTY_STRING},
-        {"2", FALSE_STR, PNF1, pn12, PF1, p12, EMPTY_STRING},
-        {"2", FALSE_STR, PNF1, pn12, PF1, p13, EMPTY_STRING},
-        {"3", TRUE_STR, PNF1, pn12, PF1, p11, EMPTY_STRING},
-        {"3", TRUE_STR, PNF1, pn12, PF1, p12, EMPTY_STRING},
-        {"3", TRUE_STR, PNF1, pn12, PF1, p13, EMPTY_STRING},
-        {"4", FALSE_STR, PNF2, pn21, PF1, p11, EMPTY_STRING},
-        {"4", FALSE_STR, PNF2, pn22, PF1, p12, EMPTY_STRING},
-        {"4", FALSE_STR, PNF2, pn23, PF1, p13, EMPTY_STRING}};
+        {"2", TRUE_STR, PNF1, pn12, PF1, p11, EMPTY_STRING},
+        {"2", TRUE_STR, PNF1, pn12, PF1, p12, EMPTY_STRING},
+        {"2", TRUE_STR, PNF1, pn12, PF1, p13, EMPTY_STRING},
+        {"3", FALSE_STR, PNF2, pn21, PF1, p11, EMPTY_STRING},
+        {"3", FALSE_STR, PNF2, pn22, PF1, p12, EMPTY_STRING},
+        {"3", FALSE_STR, PNF2, pn23, PF1, p13, EMPTY_STRING}};
     TStrNormalizerPtrMap expectedNormalizers;
     expectedNormalizers.emplace(
         "r", std::make_shared<model::CAnomalyScore::CNormalizer>(modelConfig));
@@ -1582,14 +1579,16 @@ BOOST_AUTO_TEST_CASE(testNormalizer) {
                 const std::string& partitionFieldName = *node->s_Spec.s_PartitionFieldName;
                 const std::string& personFieldName =
                     key == "n" ? EMPTY_STRING : *node->s_Spec.s_PersonFieldName;
-                key += ' ' + partitionFieldName + ' ' + personFieldName;
-                auto itr = expectedNormalizers.find(key);
-                if (itr != expectedNormalizers.end()) {
-                    return itr->second;
+                key += ' ' + partitionFieldName;
+                key += ' ' + personFieldName;
+                auto entry = expectedNormalizers.find(key);
+                if (entry != expectedNormalizers.end()) {
+                    return entry->second;
                 }
                 TNormalizerPtr& result = expectedNormalizers[key];
                 result = std::make_shared<model::CAnomalyScore::CNormalizer>(modelConfig);
-                result->isForMembersOfPopulation(partitionFieldName == PNF1);
+                result->isForMembersOfPopulation((partitionFieldName == PNF1) &&
+                                                 (personFieldName == PF1));
                 return result;
             };
         auto scope = [](const model::CHierarchicalResultsVisitor::TNode* node) {


### PR DESCRIPTION
This changes the way we normalise for short bucket lengths.

Previously, we tried to apply consistent rate limiting of alerts across different bucket lengths by accounting for the different number of results we receive per time interval. The approach we took proved to interact badly with uncertainty in the estimates of extreme quantiles. The upshot is we actually could get bias where our scores would be too low short bucket lengths. The problem was particularly severe if the time series had extended runs of unusual values.

This takes a different approach: we simply only update the quantiles with the high water mark in each fixed time interval. This achieves the same thing, but works reliably for shorter bucket lengths. I've added a test that rate limiting is working as expected across multiple bucket lengths.

This will potentially cause a non-trivial results change. One thing to consider is if we need special handling for upgrading existing jobs. First off we need to see differences on our QA suite.

Fixes #2276.