### PR TITLE
[ML] Fix a source of "Discarding sample = nan, weights = ..." log errors

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -51,6 +51,8 @@
   classification and regression models. (See {ml-pull}2259[#2259].)
 * Fix cause of "Must provide points at which to evaluate function" log error training
   classification and regression models. (See {ml-pull}2268[#2268].)
+* Fix a source of "Discarding sample = nan, weights = ..." log errors for time series
+  anomaly detection. (See {ml-pull}2286[#2286].)
 
 == {es} version 8.2.2
 

--- a/lib/maths/common/CGammaRateConjugate.cc
+++ b/lib/maths/common/CGammaRateConjugate.cc
@@ -913,7 +913,7 @@ void CGammaRateConjugate::addSamples(const TDouble1Vec& samples,
             if (x <= 0.0 || !CMathsFuncs::isFinite(x) ||
                 !CMathsFuncs::isFinite(weights[i])) {
                 LOG_ERROR(<< "Discarding sample = " << x << ", weights = "
-                          << core::CContainerPrinter::print(weights));
+                          << core::CContainerPrinter::print(weights[i]));
                 continue;
             }
             double n = maths_t::countForUpdate(weights[i]);

--- a/lib/maths/common/CNaturalBreaksClassifier.cc
+++ b/lib/maths/common/CNaturalBreaksClassifier.cc
@@ -25,6 +25,7 @@
 #include <maths/common/CMathsFuncs.h>
 #include <maths/common/CRestoreParams.h>
 #include <maths/common/CSampling.h>
+#include <maths/common/CTools.h>
 
 #include <boost/algorithm/cxx11/is_sorted.hpp>
 #include <boost/math/distributions/normal.hpp>
@@ -38,33 +39,12 @@ namespace ml {
 namespace maths {
 namespace common {
 namespace {
-
-//! Orders two tuples by their mean.
-struct SMeanLess {
-    bool operator()(const CNaturalBreaksClassifier::TTuple& lhs,
-                    const CNaturalBreaksClassifier::TTuple& rhs) const {
-        return CBasicStatistics::mean(lhs) < CBasicStatistics::mean(rhs);
-    }
-};
-
-//! Checks if a tuple count is less than a specified value.
-class CCountLessThan {
-public:
-    CCountLessThan(double count) : m_Count(count) {}
-
-    bool operator()(const CNaturalBreaksClassifier::TTuple& tuple) const {
-        return CBasicStatistics::count(tuple) < m_Count;
-    }
-
-private:
-    double m_Count;
-};
 const core::TPersistenceTag SPACE_TAG("a", "space");
 const core::TPersistenceTag CATEGORY_TAG("b", "category");
 const core::TPersistenceTag POINTS_TAG("c", "points");
 const core::TPersistenceTag DECAY_RATE_TAG("d", "decay_rate");
-
 const std::string EMPTY_STRING;
+const double ALMOST_ONE = 0.99999;
 }
 
 CNaturalBreaksClassifier::CNaturalBreaksClassifier(std::size_t space,
@@ -72,7 +52,7 @@ CNaturalBreaksClassifier::CNaturalBreaksClassifier(std::size_t space,
                                                    double minimumCategoryCount)
     : m_Space(std::max(space, MINIMUM_SPACE)), m_DecayRate(decayRate),
       m_MinimumCategoryCount(minimumCategoryCount) {
-    m_Categories.reserve(m_Space + MAXIMUM_BUFFER_SIZE + 1u);
+    m_Categories.reserve(m_Space + MAXIMUM_BUFFER_SIZE + 1);
     m_PointsBuffer.reserve(MAXIMUM_BUFFER_SIZE);
 }
 
@@ -189,7 +169,7 @@ bool CNaturalBreaksClassifier::split(std::size_t n, std::size_t p, TClassifierVe
     LOG_TRACE(<< "raw categories = " << this->print());
 
     if (n >= m_Categories.size()) {
-        double p_ = static_cast<double>(p);
+        auto p_ = static_cast<double>(p);
         for (std::size_t i = 0; p_ > 0.0 && i < m_Categories.size(); ++i) {
             if (CBasicStatistics::count(m_Categories[i]) < p_) {
                 return false;
@@ -203,8 +183,9 @@ bool CNaturalBreaksClassifier::split(std::size_t n, std::size_t p, TClassifierVe
                 m_Space, m_DecayRate, m_MinimumCategoryCount, category));
         }
         return true;
-    } else if (n == 1) {
-        double p_ = static_cast<double>(p);
+    }
+    if (n == 1) {
+        auto p_ = static_cast<double>(p);
         double count = 0.0;
         for (std::size_t i = 0; p_ > 0.0 && i < m_Categories.size(); ++i) {
             count += CBasicStatistics::count(m_Categories[i]);
@@ -281,7 +262,7 @@ bool CNaturalBreaksClassifier::categories(std::size_t n, std::size_t p, TTupleVe
     LOG_TRACE(<< "raw categories = " << this->print());
 
     if (n >= m_Categories.size()) {
-        double p_ = static_cast<double>(p);
+        auto p_ = static_cast<double>(p);
         for (std::size_t i = 0; p_ > 0.0 && i < m_Categories.size(); ++i) {
             if (CBasicStatistics::count(m_Categories[i]) < p_) {
                 return false;
@@ -293,8 +274,9 @@ bool CNaturalBreaksClassifier::categories(std::size_t n, std::size_t p, TTupleVe
             result.insert(result.end(), m_Categories.begin(), m_Categories.end());
         }
         return true;
-    } else if (n == 1) {
-        double p_ = static_cast<double>(p);
+    }
+    if (n == 1) {
+        auto p_ = static_cast<double>(p);
         TTuple category =
             std::accumulate(m_Categories.begin(), m_Categories.end(), TTuple());
         if (CBasicStatistics::count(category) < p_) {
@@ -395,14 +377,17 @@ void CNaturalBreaksClassifier::propagateForwardsByTime(double time) {
     // Prune any dead categories: we're not interested in maintaining
     // categories with low counts.
     m_Categories.erase(std::remove_if(m_Categories.begin(), m_Categories.end(),
-                                      CCountLessThan(m_MinimumCategoryCount)),
+                                      [this](const auto& category) {
+                                          return CBasicStatistics::count(category) <
+                                                 m_MinimumCategoryCount;
+                                      }),
                        m_Categories.end());
 
     LOG_TRACE(<< "categories = " << core::CContainerPrinter::print(m_Categories));
 }
 
 bool CNaturalBreaksClassifier::buffering() const {
-    return m_PointsBuffer.size() > 0;
+    return m_PointsBuffer.empty() == false;
 }
 
 void CNaturalBreaksClassifier::sample(std::size_t numberSamples,
@@ -416,8 +401,6 @@ void CNaturalBreaksClassifier::sample(std::size_t numberSamples,
 
     using TMeanAccumulator = CBasicStatistics::SSampleMean<double>::TAccumulator;
 
-    static const double ALMOST_ONE = 0.99999;
-
     // See, for example, Effective C++ item 3.
     const_cast<CNaturalBreaksClassifier*>(this)->reduce();
     LOG_TRACE(<< "categories = " << core::CContainerPrinter::print(m_Categories));
@@ -425,14 +408,17 @@ void CNaturalBreaksClassifier::sample(std::size_t numberSamples,
     TDoubleVec weights;
     weights.reserve(m_Categories.size());
     double weightSum = 0.0;
-
-    for (std::size_t i = 0; i < m_Categories.size(); ++i) {
-        double nCategory = CBasicStatistics::count(m_Categories[i]);
-        weights.push_back(nCategory);
-        weightSum += nCategory;
+    for (const auto& category : m_Categories) {
+        double count = CBasicStatistics::count(category);
+        weights.push_back(count);
+        weightSum += count;
     }
-    for (std::size_t i = 0; i < weights.size(); ++i) {
-        weights[i] /= weightSum;
+    if (weightSum == 0.0) {
+        return;
+    }
+
+    for (auto& weight : weights) {
+        weight /= weightSum;
     }
 
     numberSamples = std::min(numberSamples, static_cast<std::size_t>(weightSum));
@@ -445,38 +431,38 @@ void CNaturalBreaksClassifier::sample(std::size_t numberSamples,
     TDoubleVec categorySamples;
     for (std::size_t i = 0; i < m_Categories.size(); ++i) {
         double ni = static_cast<double>(numberSamples) * weights[i];
-        std::size_t ni_ = static_cast<std::size_t>(std::ceil(ni));
-
+        auto ni_ = static_cast<std::size_t>(std::ceil(ni));
         double m = CBasicStatistics::mean(m_Categories[i]);
         double v = CBasicStatistics::maximumLikelihoodVariance(m_Categories[i]);
 
         CSampling::normalSampleQuantiles(m, v, ni_, categorySamples);
+
         for (std::size_t j = 0; j < categorySamples.size(); ++j) {
             if (categorySamples[j] < smallest) {
-                if (v == 0.0) {
+                // Fallback to range restricted sampling.
+                if (m < smallest || v == 0.0) {
                     categorySamples.assign(ni_, smallest);
                 } else {
                     m -= std::min(smallest, 0.0);
                     double shape = m * m / v;
                     double rate = m / v;
                     CSampling::gammaSampleQuantiles(shape, rate, ni_, categorySamples);
-                    for (std::size_t k = 0; k < categorySamples.size(); ++k) {
-                        categorySamples[k] += std::min(smallest, 0.0);
+                    for (auto& categorySample : categorySamples) {
+                        categorySample += std::min(smallest, 0.0);
                     }
                 }
                 break;
             }
         }
 
-        if (categorySamples.size() > 0) {
+        if (categorySamples.empty() == false) {
             ni /= static_cast<double>(categorySamples.size());
-            for (std::size_t j = 0; j < categorySamples.size(); ++j) {
-                double nij = std::min(1.0 - CBasicStatistics::count(sample), ni);
-                sample.add(categorySamples[j], nij);
+            for (auto& categorySample : categorySamples) {
+                double nij = CTools::truncate(1.0 - CBasicStatistics::count(sample), 0.0, ni);
+                sample.add(categorySample, nij);
                 if (CBasicStatistics::count(sample) > ALMOST_ONE) {
                     result.push_back(CBasicStatistics::mean(sample));
-                    sample = nij < ni ? CBasicStatistics::momentsAccumulator(
-                                            ni - nij, categorySamples[j])
+                    sample = nij < ni ? CBasicStatistics::momentsAccumulator(ni - nij, categorySample)
                                       : TMeanAccumulator{};
                 }
             }
@@ -668,7 +654,9 @@ void CNaturalBreaksClassifier::reduce() {
     }
     m_PointsBuffer.clear();
 
-    std::sort(m_Categories.begin(), m_Categories.end(), SMeanLess());
+    std::sort(m_Categories.begin(), m_Categories.end(), [](const auto& lhs, const auto& rhs) {
+        return CBasicStatistics::mean(lhs) < CBasicStatistics::mean(rhs);
+    });
     LOG_TRACE(<< "categories = " << core::CContainerPrinter::print(m_Categories));
 
     while (m_Categories.size() > m_Space) {

--- a/lib/maths/common/CSampling.cc
+++ b/lib/maths/common/CSampling.cc
@@ -803,8 +803,7 @@ void CSampling::normalSampleQuantiles(double mean, double variance, std::size_t 
     if (n == 0) {
         return;
     }
-
-    if (variance == 0.0) {
+    if (variance <= 0.0) {
         result.resize(n, mean);
         return;
     }

--- a/lib/maths/common/CTools.cc
+++ b/lib/maths/common/CTools.cc
@@ -1390,8 +1390,9 @@ double CTools::SIntervalExpectation::operator()(const normal& normal_, double a,
         return expa == expb ? (a + b) / 2.0 : (a * expa + b * expb) / (expa + expb);
     }
 
-    return mean + 2.0 * sd * (expa - expb) /
-                      boost::math::double_constants::root_two_pi / (erfb - erfa);
+    return truncate(mean + 2.0 * sd * (expa - expb) /
+                               boost::math::double_constants::root_two_pi / (erfb - erfa),
+                    -POS_INF, POS_INF);
 }
 
 double CTools::SIntervalExpectation::

--- a/lib/maths/common/CTools.cc
+++ b/lib/maths/common/CTools.cc
@@ -1442,7 +1442,9 @@ operator()(const lognormal& logNormal, double a, double b) const {
 
     double erfa_ = std::erf(a_);
     double erfb_ = std::erf(b_);
-    return (erfb - erfa) == (erfb_ - erfa_) ? mean : mean * (erfb - erfa) / (erfb_ - erfa_);
+    return truncate(
+        (erfb - erfa) == (erfb_ - erfa_) ? mean : mean * (erfb - erfa) / (erfb_ - erfa_),
+        -POS_INF, POS_INF);
 }
 
 double CTools::SIntervalExpectation::operator()(const gamma& gamma_, double a, double b) const {
@@ -1480,7 +1482,9 @@ double CTools::SIntervalExpectation::operator()(const gamma& gamma_, double a, d
 
     double gama_ = boost::math::gamma_p(shape, rate * a);
     double gamb_ = boost::math::gamma_p(shape, rate * b);
-    return (gamb - gama) == (gamb_ - gama_) ? mean : mean * (gamb - gama) / (gamb_ - gama_);
+    return truncate(
+        (gamb - gama) == (gamb_ - gama_) ? mean : mean * (gamb - gama) / (gamb_ - gama_),
+        -POS_INF, POS_INF);
 }
 
 //////// smallestProbability Implementation ////////


### PR DESCRIPTION
Recent changes to anomaly detection code exposed a pre-existing bug in sampling code for one of our distribution models. In particular, we were computing `E[X 1{[a, b]}] / E[1{[a, b]}]` for log-normal and gamma distributions and not properly handling the case `a -> 0`. As `a` gets close to 0 one can simply snap it to 0 and use an alternative form for `E[X 1{[0, b]}]` which is more numerically pleasant. Even then we can run into `E[X 1{[a, b]}] / E[1{[a, b]}] = 0/0` for finite precision. In this case, we need to compute an asymptotic approximation.

The upshot is previously we would generate NaN samples. These were subsequently discarded, so as far as I can tell the actual impact isn't too severe. However, it would generate log errors when we trapped and discarded the bad values.