### PR TITLE
[ML] Migrate to cstdint and std namespace versions of integer types

### DIFF
--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -272,7 +272,7 @@ int main(int argc, char** argv) {
     }
 
     ml::torch::CThreadSettings::validateThreadingParameters(
-        static_cast<int32_t>(std::thread::hardware_concurrency()),
+        static_cast<std::int32_t>(std::thread::hardware_concurrency()),
         numThreadsPerAllocation, numAllocations);
 
     ml::torch::CThreadSettings threadSettings{numThreadsPerAllocation, numAllocations};

--- a/include/api/CHierarchicalResultsWriter.h
+++ b/include/api/CHierarchicalResultsWriter.h
@@ -42,7 +42,7 @@ class API_EXPORT CHierarchicalResultsWriter : public model::CHierarchicalResults
 public:
     using TDouble1Vec = core::CSmallVector<double, 1>;
     using TOptionalDouble = boost::optional<double>;
-    using TOptionalUInt64 = boost::optional<uint64_t>;
+    using TOptionalUInt64 = boost::optional<std::uint64_t>;
 
     // Influencers
     using TStoredStringPtrVec = std::vector<core::CStoredStringPtr>;

--- a/include/api/CModelPlotDataJsonWriter.h
+++ b/include/api/CModelPlotDataJsonWriter.h
@@ -22,11 +22,10 @@
 
 #include <rapidjson/document.h>
 
+#include <cstdint>
 #include <iosfwd>
 #include <sstream>
 #include <string>
-
-#include <stdint.h>
 
 namespace ml {
 namespace api {

--- a/include/core/CCompressedDictionary.h
+++ b/include/core/CCompressedDictionary.h
@@ -21,11 +21,10 @@
 #include <boost/unordered/unordered_set_fwd.hpp>
 
 #include <array>
+#include <cstdint>
 #include <map>
 #include <set>
 #include <string>
-
-#include <stdint.h>
 
 namespace ml {
 namespace core {
@@ -47,7 +46,7 @@ namespace core {
 template<std::size_t N>
 class CCompressedDictionary {
 public:
-    using TUInt64Array = std::array<uint64_t, N>;
+    using TUInt64Array = std::array<std::uint64_t, N>;
     using TStrCPtr = const std::string*;
 
     //! \brief A hash representation of a string in the dictionary
@@ -121,7 +120,7 @@ public:
 
         std::size_t hash() const { return static_cast<std::size_t>(m_Hash[0]); }
 
-        uint64_t hash64() const { return m_Hash[0]; }
+        std::uint64_t hash64() const { return m_Hash[0]; }
 
         std::string print() const { return CContainerPrinter::print(m_Hash); }
 
@@ -201,7 +200,7 @@ private:
     CWord word(const TStrCPtr (&words)[NUMBER_OF_WORDS]) const {
         TUInt64Array hashes;
         for (std::size_t i = 0; i < N; ++i) {
-            uint64_t& hash = hashes[i];
+            std::uint64_t& hash = hashes[i];
             for (std::size_t wordIndex = 0; wordIndex < NUMBER_OF_WORDS; ++wordIndex) {
                 const std::string& word = *words[wordIndex];
                 hash = CHashing::safeMurmurHash64(word.c_str(),

--- a/include/core/CCondition.h
+++ b/include/core/CCondition.h
@@ -18,7 +18,7 @@
 #ifndef Windows
 #include <pthread.h>
 #endif
-#include <stdint.h>
+#include <cstdint>
 
 namespace ml {
 namespace core {
@@ -37,7 +37,7 @@ class CMutex;
 //!
 class CORE_EXPORT CCondition : private CNonCopyable {
 public:
-    CCondition(CMutex&);
+    explicit CCondition(CMutex&);
     ~CCondition();
 
     //! Wait in current thread for signal - blocks.  The wait may be
@@ -50,7 +50,7 @@ public:
     //! be spuriously interrupted by a signal, so the caller must check a
     //! condition that will detect spurious wakeups, and wait again if
     //! necessary.
-    bool wait(uint32_t t);
+    bool wait(std::uint32_t t);
 
     //! Wake up a single thread that is blocked in wait
     void signal();
@@ -61,7 +61,7 @@ public:
 private:
 #ifndef Windows
     //! Convert milliseconds to timespec
-    static bool convert(uint32_t, timespec&);
+    static bool convert(std::uint32_t, timespec&);
 #endif
 
 private:

--- a/include/core/CDataAdder.h
+++ b/include/core/CDataAdder.h
@@ -14,12 +14,11 @@
 #include <core/CNonCopyable.h>
 #include <core/ImportExport.h>
 
+#include <cstdint>
 #include <functional>
 #include <iosfwd>
 #include <memory>
 #include <string>
-
-#include <stdint.h>
 
 namespace ml {
 namespace core {

--- a/include/core/CFlatPrefixTree.h
+++ b/include/core/CFlatPrefixTree.h
@@ -14,10 +14,9 @@
 
 #include <core/ImportExport.h>
 
+#include <cstdint>
 #include <string>
 #include <vector>
-
-#include <stdint.h>
 
 namespace ml {
 namespace core {
@@ -45,7 +44,7 @@ namespace core {
 //! the associated char nodes. For the input of (ab, abd, bdf)
 //! the vector would look like:
 //! [($, $, 2) (a, b, 3) (b, b, 7) ($, $, 1) (b, *, 5) ($, $, 1) (d, l, -) ($, $, 1) (d, b, 9) ($, $, 1) (f, l, -) ]
-//! where '-' means no child and is actually represented by max(uint32_t).
+//! where '-' means no child and is actually represented by max(std::uint32_t).
 //! This representation allows for search by visiting the first node, applying
 //! binary search on the first character, moving on to the node indicated by
 //! the characters next index, applying binary search on the second character,
@@ -62,12 +61,12 @@ private:
         //! See CMemory.
         static bool dynamicSizeAlwaysZero() { return true; }
 
-        SNode(char c, char type, uint32_t next);
+        SNode(char c, char type, std::uint32_t next);
 
         bool operator<(char rhs) const;
         char s_Char;
         char s_Type;
-        uint32_t s_Next;
+        std::uint32_t s_Next;
     };
 
     struct SDistinctChar {

--- a/include/core/CHashing.h
+++ b/include/core/CHashing.h
@@ -19,11 +19,10 @@
 
 #include <boost/random/mersenne_twister.hpp>
 
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>
-
-#include <stdint.h>
 
 namespace ml {
 namespace core {
@@ -45,7 +44,7 @@ public:
     //! sufficient for our use cases!
     class CORE_EXPORT CUniversalHash {
     public:
-        using TUInt32Vec = std::vector<uint32_t>;
+        using TUInt32Vec = std::vector<std::uint32_t>;
 
     public:
         //! A member of the universal (2-independent) hash family on
@@ -64,33 +63,33 @@ public:
 
         public:
             CUInt32Hash();
-            CUInt32Hash(uint32_t m, uint32_t a, uint32_t b);
+            CUInt32Hash(std::uint32_t m, std::uint32_t a, std::uint32_t b);
 
             //! Get the range.
-            uint32_t m() const;
+            std::uint32_t m() const;
 
             //! Get the multiplier.
-            uint32_t a() const;
+            std::uint32_t a() const;
 
             //! Get the offset.
-            uint32_t b() const;
+            std::uint32_t b() const;
 
             //! \note This is implemented inline in contravention to
             //! the coding standards because we definitely don't want
             //! the cost of a function call here.
-            uint32_t operator()(uint32_t x) const {
+            std::uint32_t operator()(std::uint32_t x) const {
                 // Note by construction:
                 //   a * x + b < p^2 + p < 2^64
-                return static_cast<uint32_t>(
-                    ((static_cast<uint64_t>(m_A) * x + static_cast<uint64_t>(m_B)) % BIG_PRIME) %
-                    static_cast<uint64_t>(m_M));
+                return static_cast<std::uint32_t>(
+                    ((static_cast<std::uint64_t>(m_A) * x + static_cast<std::uint64_t>(m_B)) % BIG_PRIME) %
+                    static_cast<std::uint64_t>(m_M));
             }
 
             //! Print the hash function for debug.
             std::string print() const;
 
         private:
-            uint32_t m_M, m_A, m_B;
+            std::uint32_t m_M, m_A, m_B;
         };
 
         using TUInt32HashVec = std::vector<CUInt32Hash>;
@@ -106,29 +105,30 @@ public:
 
         public:
             CUInt32UnrestrictedHash();
-            CUInt32UnrestrictedHash(uint32_t a, uint32_t b);
+            CUInt32UnrestrictedHash(std::uint32_t a, std::uint32_t b);
 
             //! Get the multiplier.
-            uint32_t a() const;
+            std::uint32_t a() const;
 
             //! Get the offset.
-            uint32_t b() const;
+            std::uint32_t b() const;
 
             //! \note This is implemented inline in contravention to
             //! the coding standards because we definitely don't want
             //! the cost of a function call here.
-            uint32_t operator()(uint32_t x) const {
+            std::uint32_t operator()(std::uint32_t x) const {
                 // Note by construction:
                 //   a * x + b < p^2 + p < 2^64
-                return static_cast<uint32_t>(
-                    (static_cast<uint64_t>(m_A) * x + static_cast<uint64_t>(m_B)) % BIG_PRIME);
+                return static_cast<std::uint32_t>((static_cast<std::uint64_t>(m_A) * x +
+                                                   static_cast<std::uint64_t>(m_B)) %
+                                                  BIG_PRIME);
             }
 
             //! Print the hash function for debug.
             std::string print() const;
 
         private:
-            uint32_t m_A, m_B;
+            std::uint32_t m_A, m_B;
         };
 
         using TUInt32UnrestrictedHashVec = std::vector<CUInt32UnrestrictedHash>;
@@ -147,16 +147,16 @@ public:
         //! the implementation if this is a bottleneck in practice.
         class CORE_EXPORT CUInt32VecHash {
         public:
-            CUInt32VecHash(uint32_t m, const TUInt32Vec& a, uint32_t b);
+            CUInt32VecHash(std::uint32_t m, const TUInt32Vec& a, std::uint32_t b);
 
             //! Get the range.
-            uint32_t m() const;
+            std::uint32_t m() const;
 
             //! Get the multipliers.
             const TUInt32Vec& a() const;
 
             //! Get the offset.
-            uint32_t b() const;
+            std::uint32_t b() const;
 
             //! Overload for case our vector has two elements to
             //! avoid overhead of creating a vector to hash.
@@ -164,42 +164,44 @@ public:
             //! \note This is implemented inline in contravention to
             //! the coding standards because we definitely don't want
             //! the cost of a function call here.
-            uint32_t operator()(uint32_t x1, uint32_t x2) const {
+            std::uint32_t operator()(std::uint32_t x1, std::uint32_t x2) const {
                 // Note by construction:
                 //   (a(1) * x(1)) mod p + a(2) * x(2) + b
                 //     < p^2 + 2*p
                 //     < 2^64
-                uint64_t h = (static_cast<uint64_t>(m_A[0]) * x1) % BIG_PRIME +
-                             static_cast<uint64_t>(m_A[1]) * x2;
-                return static_cast<uint32_t>(((h + static_cast<uint64_t>(m_B)) % BIG_PRIME) %
-                                             static_cast<uint64_t>(m_M));
+                std::uint64_t h = (static_cast<std::uint64_t>(m_A[0]) * x1) % BIG_PRIME +
+                                  static_cast<std::uint64_t>(m_A[1]) * x2;
+                return static_cast<std::uint32_t>(
+                    ((h + static_cast<std::uint64_t>(m_B)) % BIG_PRIME) %
+                    static_cast<std::uint64_t>(m_M));
             }
 
             //! \note This is implemented inline in contravention to
             //! the coding standards because we definitely don't want
             //! the cost of a function call here.
-            uint32_t operator()(const TUInt32Vec& x) const {
+            std::uint32_t operator()(const TUInt32Vec& x) const {
                 // Note we variously use that:
                 //   a(1) * x(1)
                 //     < h mod p + a(i) * x(i)
                 //     < h mod p + a(n) * x(n) + b
                 //     < p^2 + 2*p
                 //     < 2^64
-                uint64_t h = static_cast<uint64_t>(m_A[0]) * x[0];
+                std::uint64_t h = static_cast<std::uint64_t>(m_A[0]) * x[0];
                 for (std::size_t i = 1; i < x.size(); ++i) {
-                    h = (h % BIG_PRIME + static_cast<uint64_t>(m_A[i]) * x[i]);
+                    h = (h % BIG_PRIME + static_cast<std::uint64_t>(m_A[i]) * x[i]);
                 }
-                return static_cast<uint32_t>(((h + static_cast<uint64_t>(m_B)) % BIG_PRIME) %
-                                             static_cast<uint64_t>(m_M));
+                return static_cast<std::uint32_t>(
+                    ((h + static_cast<std::uint64_t>(m_B)) % BIG_PRIME) %
+                    static_cast<std::uint64_t>(m_M));
             }
 
             //! Print the hash function for debug.
             std::string print() const;
 
         private:
-            uint32_t m_M;
+            std::uint32_t m_M;
             TUInt32Vec m_A;
-            uint32_t m_B;
+            std::uint32_t m_B;
         };
 
         using TUInt32VecHashVec = std::vector<CUInt32VecHash>;
@@ -254,7 +256,7 @@ public:
         //! applications we'll be mapping unique values (client ids, etc)
         //! to the first n integers so 4294967291 will be plenty big enough
         //! for our universes.
-        static const uint64_t BIG_PRIME;
+        static const std::uint64_t BIG_PRIME;
 
         //! Generate k independent samples of the 32 bit integer universal
         //! hash functions:
@@ -265,7 +267,7 @@ public:
         //! \param k The number of hash functions.
         //! \param m The range of the hash functions.
         //! \param result Filled in with the sampled hash functions.
-        static void generateHashes(std::size_t k, uint32_t m, TUInt32HashVec& result);
+        static void generateHashes(std::size_t k, std::uint32_t m, TUInt32HashVec& result);
 
         //! Generate k independent samples of the 32 bit integer universal
         //! hash functions:
@@ -287,7 +289,7 @@ public:
         //! \param n The size of vectors to hash.
         //! \param m The range of the hash functions.
         //! \param result Filled in with the sampled hash functions.
-        static void generateHashes(std::size_t k, std::size_t n, uint32_t m, TUInt32VecHashVec& result);
+        static void generateHashes(std::size_t k, std::size_t n, std::uint32_t m, TUInt32VecHashVec& result);
 
     private:
         //! Our random number generator for sampling hash function.
@@ -317,7 +319,7 @@ public:
     //! they will be different on machines with different endian
     //! conventions. If you aren't sure that you can safely use this
     //! version then use safeMurmurHash32.
-    static uint32_t murmurHash32(const void* key, int length, uint32_t seed);
+    static std::uint32_t murmurHash32(const void* key, int length, std::uint32_t seed);
 
     //! MurmurHash2: safe 32-bit hash.
     //!
@@ -328,7 +330,7 @@ public:
     //! don't want the result of hashing to depend on the address of
     //! the object which it would if we tried to mix the two approaches
     //! and check alignment.
-    static uint32_t safeMurmurHash32(const void* key, int length, uint32_t seed);
+    static std::uint32_t safeMurmurHash32(const void* key, int length, std::uint32_t seed);
 
     //! MurmurHash2: fast 64-bit hash.
     //!
@@ -349,7 +351,7 @@ public:
     //! they will be different on machines with different endian
     //! conventions. If you aren't sure that you can safely use this
     //! version then use safeMurmurHash64.
-    static uint64_t murmurHash64(const void* key, int length, uint64_t seed);
+    static std::uint64_t murmurHash64(const void* key, int length, std::uint64_t seed);
 
     //! MurmurHash2: safe 64-bit hash.
     //!
@@ -360,12 +362,12 @@ public:
     //! don't want the result of hashing to depend on the address of
     //! the object, which it would if we tried to mix the two approaches
     //! and check alignment.
-    static uint64_t safeMurmurHash64(const void* key, int length, uint64_t seed);
+    static std::uint64_t safeMurmurHash64(const void* key, int length, std::uint64_t seed);
 
     //! Wrapper for murmur hash to use with basic types.
     //!
     //! \warning This is slower than boost::hash for the types I tested
-    //! std::size_t, int, uint64_t, but does have better distributions.
+    //! std::size_t, int, std::uint64_t, but does have better distributions.
     template<typename T>
     class CMurmurHash2BT {
     public:
@@ -421,9 +423,10 @@ public:
         using TStrCRef = std::reference_wrapper<const std::string>;
 
     public:
-        CSafeMurmurHash2String64(uint64_t seed = 0x5bd1e995) : m_Seed(seed) {}
+        CSafeMurmurHash2String64(std::uint64_t seed = 0x5bd1e995)
+            : m_Seed(seed) {}
 
-        uint64_t operator()(const std::string& key) const;
+        std::uint64_t operator()(const std::string& key) const;
         std::size_t operator()(TStrCRef key) const {
             return this->operator()(key.get());
         }
@@ -435,14 +438,14 @@ public:
         }
 
     private:
-        uint64_t m_Seed;
+        std::uint64_t m_Seed;
     };
 
     //! 32 bit hash combine modeled on boost::hash_combine.
-    static uint32_t hashCombine(uint32_t seed, uint32_t h);
+    static std::uint32_t hashCombine(std::uint32_t seed, std::uint32_t h);
 
     //! 64 bit hash combine modeled on boost::hash_combine.
-    static uint64_t hashCombine(uint64_t seed, uint64_t h);
+    static std::uint64_t hashCombine(std::uint64_t seed, std::uint64_t h);
 };
 
 namespace hash_detail {
@@ -452,7 +455,7 @@ template<std::size_t>
 struct SMurmurHashForArchitecture {
     static std::size_t hash(const void* key, int length, std::size_t seed) {
         return static_cast<std::size_t>(
-            CHashing::murmurHash32(key, length, static_cast<uint32_t>(seed)));
+            CHashing::murmurHash32(key, length, static_cast<std::uint32_t>(seed)));
     }
 };
 
@@ -478,7 +481,8 @@ inline std::size_t CHashing::CMurmurHash2String::operator()(const std::string& k
         key.data(), static_cast<int>(key.size()), m_Seed);
 }
 
-inline uint64_t CHashing::CSafeMurmurHash2String64::operator()(const std::string& key) const {
+inline std::uint64_t CHashing::CSafeMurmurHash2String64::
+operator()(const std::string& key) const {
     return CHashing::safeMurmurHash64(key.data(), static_cast<int>(key.size()), m_Seed);
 }
 }

--- a/include/core/CIEEE754.h
+++ b/include/core/CIEEE754.h
@@ -56,7 +56,7 @@ public:
 #endif
     };
 
-    static const uint64_t IEEE754_MANTISSA_MASK = 0xFFFFFFFFFFFFF;
+    static const std::uint64_t IEEE754_MANTISSA_MASK = 0xFFFFFFFFFFFFF;
 
     //! Decompose a double in to its mantissa and exponent.
     //!

--- a/include/core/CJsonStateRestoreTraverser.h
+++ b/include/core/CJsonStateRestoreTraverser.h
@@ -116,8 +116,8 @@ private:
         bool Bool(bool b);
         bool Int(int i);
         bool Uint(unsigned u);
-        bool Int64(int64_t i);
-        bool Uint64(uint64_t u);
+        bool Int64(std::int64_t i);
+        bool Uint64(std::uint64_t u);
         bool Double(double d);
         bool RawNumber(const char*, rapidjson::SizeType, bool);
         bool String(const char* str, rapidjson::SizeType length, bool);

--- a/include/core/CMonotonicTime.h
+++ b/include/core/CMonotonicTime.h
@@ -13,7 +13,7 @@
 
 #include <core/ImportExport.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace ml {
 namespace core {
@@ -61,16 +61,16 @@ public:
     CMonotonicTime();
 
     //! Get the number of milliseconds since some fixed point in the past
-    uint64_t milliseconds() const;
+    std::uint64_t milliseconds() const;
 
     //! Get the number of nanoseconds since some fixed point in the past
-    uint64_t nanoseconds() const;
+    std::uint64_t nanoseconds() const;
 
 private:
     //! Operating system specific scaling factors
-    uint64_t m_ScalingFactor1;
-    uint64_t m_ScalingFactor2;
-    uint64_t m_ScalingFactor3;
+    std::uint64_t m_ScalingFactor1;
+    std::uint64_t m_ScalingFactor2;
+    std::uint64_t m_ScalingFactor3;
 };
 }
 }

--- a/include/core/CPackedBitVector.h
+++ b/include/core/CPackedBitVector.h
@@ -121,7 +121,7 @@ public:
     CPackedBitVector() = default;
     explicit CPackedBitVector(bool bit);
     CPackedBitVector(std::size_t dimension, bool bit);
-    CPackedBitVector(const TBoolVec& bits);
+    explicit CPackedBitVector(const TBoolVec& bits);
 
     //! Contract the vector by popping a component from the start.
     void contract();

--- a/include/core/CRapidJsonWriterBase.h
+++ b/include/core/CRapidJsonWriterBase.h
@@ -376,14 +376,14 @@ public:
 
     //! Adds a signed integer field with the name fieldname to an object.
     //! \p fieldName must outlive \p obj or memory corruption will occur.
-    void addIntFieldToObj(const std::string& fieldName, int64_t value, TValue& obj) const {
+    void addIntFieldToObj(const std::string& fieldName, std::int64_t value, TValue& obj) const {
         TValue v(value);
         this->addMember(fieldName, v, obj);
     }
 
     //! Adds an unsigned integer field with the name fieldname to an object.
     //! \p fieldName must outlive \p obj or memory corruption will occur.
-    void addUIntFieldToObj(const std::string& fieldName, uint64_t value, TValue& obj) const {
+    void addUIntFieldToObj(const std::string& fieldName, std::uint64_t value, TValue& obj) const {
         TValue v(value);
         this->addMember(fieldName, v, obj);
     }

--- a/include/core/CStateMachine.h
+++ b/include/core/CStateMachine.h
@@ -110,7 +110,7 @@ public:
     std::string printSymbol(std::size_t symbol) const;
 
     //! Get a checksum of this object.
-    uint64_t checksum() const;
+    std::uint64_t checksum() const;
 
     //! Print all the state machines.
     static std::size_t numberMachines();

--- a/include/core/CStopWatch.h
+++ b/include/core/CStopWatch.h
@@ -14,7 +14,7 @@
 #include <core/CMonotonicTime.h>
 #include <core/ImportExport.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace ml {
 namespace core {
@@ -43,12 +43,12 @@ public:
     void start();
 
     //! Stop the stop watch and retrieve the accumulated reading
-    uint64_t stop();
+    std::uint64_t stop();
 
     //! Retrieve the accumulated reading from the stop watch without
     //! stopping it.  (Not const because it may trigger a reset if the
     //! system clock has been adjusted.)
-    uint64_t lap();
+    std::uint64_t lap();
 
     //! Is the stop watch running?
     bool isRunning() const;
@@ -60,7 +60,7 @@ private:
     //! Calculate the difference between two monotonic times, with sanity
     //! checking just in case the timer does go backwards somehow, and
     //! return the answer in milliseconds
-    uint64_t calcDuration();
+    std::uint64_t calcDuration();
 
 private:
     //! Is the stop watch currently running?
@@ -71,11 +71,11 @@ private:
 
     //! Monotonic time (in milliseconds since some arbitrary time in the
     //! past) when the stop watch was last started
-    uint64_t m_Start;
+    std::uint64_t m_Start;
 
     //! Time (in milliseconds) accumulated over previous runs of the stop
     //! watch since the last reset
-    uint64_t m_AccumulatedTime;
+    std::uint64_t m_AccumulatedTime;
 };
 }
 }

--- a/include/core/CTimeUtils.h
+++ b/include/core/CTimeUtils.h
@@ -61,7 +61,7 @@ public:
     static std::string toTimeString(core_t::TTime t);
 
     //! Converts an epoch seconds timestamp to epoch millis
-    static int64_t toEpochMs(core_t::TTime t);
+    static std::int64_t toEpochMs(core_t::TTime t);
     //! strptime interface
     //! NOTE: the time returned here is a UTC value
     static bool strptime(const std::string& format,

--- a/include/core/CWindowsError.h
+++ b/include/core/CWindowsError.h
@@ -13,10 +13,9 @@
 
 #include <core/ImportExport.h>
 
+#include <cstdint>
 #include <iosfwd>
 #include <string>
-
-#include <stdint.h>
 
 namespace ml {
 namespace core {
@@ -44,17 +43,17 @@ public:
     CWindowsError();
 
     //! Initialise using a specific error number
-    CWindowsError(uint32_t errorCode);
+    CWindowsError(std::uint32_t errorCode);
 
     //! Access the raw error code number
-    uint32_t errorCode() const;
+    std::uint32_t errorCode() const;
 
     //! Textual representation of the error
     std::string errorString() const;
 
 private:
     //! The error code
-    uint32_t m_ErrorCode;
+    std::uint32_t m_ErrorCode;
 
     friend CORE_EXPORT std::ostream& operator<<(std::ostream&, const CWindowsError&);
 };

--- a/include/maths/analytics/COutliers.h
+++ b/include/maths/analytics/COutliers.h
@@ -165,7 +165,7 @@ public:
     using TPointVec = std::vector<POINT>;
     using TCoordinate = typename common::SCoordinate<POINT>::Type;
     using TCoordinateVec = std::vector<TCoordinate>;
-    using TUInt32CoordinatePr = std::pair<uint32_t, TCoordinate>;
+    using TUInt32CoordinatePr = std::pair<std::uint32_t, TCoordinate>;
     using TUInt32CoordinatePrVec = std::vector<TUInt32CoordinatePr>;
     static const TCoordinate UNSET_DISTANCE;
 

--- a/include/maths/common/CBasicStatisticsPersist.h
+++ b/include/maths/common/CBasicStatisticsPersist.h
@@ -314,7 +314,8 @@ CBasicStatistics::COrderStatisticsImpl<T, CONTAINER, LESS>::toDelimited(const TT
 }
 
 template<typename T, typename CONTAINER, typename LESS>
-std::uint64_t CBasicStatistics::COrderStatisticsImpl<T, CONTAINER, LESS>::checksum(std::uint64_t seed) const {
+std::uint64_t
+CBasicStatistics::COrderStatisticsImpl<T, CONTAINER, LESS>::checksum(std::uint64_t seed) const {
     if (this->count() == 0) {
         return seed;
     }

--- a/include/maths/common/CBasicStatisticsPersist.h
+++ b/include/maths/common/CBasicStatisticsPersist.h
@@ -162,7 +162,7 @@ std::string CBasicStatistics::SSampleCentralMoments<T, ORDER>::toDelimited() con
 }
 
 template<typename T, unsigned int ORDER>
-uint64_t CBasicStatistics::SSampleCentralMoments<T, ORDER>::checksum() const {
+std::uint64_t CBasicStatistics::SSampleCentralMoments<T, ORDER>::checksum() const {
     std::ostringstream raw;
     raw << basic_statistics_detail::typeToString(s_Count);
     for (std::size_t i = 0; i < ORDER; ++i) {
@@ -220,7 +220,7 @@ std::string CBasicStatistics::SSampleCovariances<POINT>::toDelimited() const {
 }
 
 template<typename POINT>
-uint64_t CBasicStatistics::SSampleCovariances<POINT>::checksum() const {
+std::uint64_t CBasicStatistics::SSampleCovariances<POINT>::checksum() const {
     std::ostringstream raw;
     raw << basic_statistics_detail::typeToString(s_Count);
     raw << ' ';
@@ -314,7 +314,7 @@ CBasicStatistics::COrderStatisticsImpl<T, CONTAINER, LESS>::toDelimited(const TT
 }
 
 template<typename T, typename CONTAINER, typename LESS>
-uint64_t CBasicStatistics::COrderStatisticsImpl<T, CONTAINER, LESS>::checksum(std::uint64_t seed) const {
+std::uint64_t CBasicStatistics::COrderStatisticsImpl<T, CONTAINER, LESS>::checksum(std::uint64_t seed) const {
     if (this->count() == 0) {
         return seed;
     }

--- a/include/maths/common/CBasicStatisticsPersist.h
+++ b/include/maths/common/CBasicStatisticsPersist.h
@@ -314,7 +314,7 @@ CBasicStatistics::COrderStatisticsImpl<T, CONTAINER, LESS>::toDelimited(const TT
 }
 
 template<typename T, typename CONTAINER, typename LESS>
-uint64_t CBasicStatistics::COrderStatisticsImpl<T, CONTAINER, LESS>::checksum(uint64_t seed) const {
+uint64_t CBasicStatistics::COrderStatisticsImpl<T, CONTAINER, LESS>::checksum(std::uint64_t seed) const {
     if (this->count() == 0) {
         return seed;
     }

--- a/include/maths/common/CBjkstUniqueValues.h
+++ b/include/maths/common/CBjkstUniqueValues.h
@@ -20,11 +20,10 @@
 #include <maths/common/ImportExport.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <utility>
 #include <variant>
 #include <vector>
-
-#include <stdint.h>
 
 namespace ml {
 namespace maths {
@@ -54,7 +53,7 @@ namespace common {
 //! IMPLEMENTATION DECISIONS:\n
 //! This implementation is reasonably space efficient but doesn't pack
 //! the hash map into a bit array for simplicity and better runtime
-//! constants. Also, since it uses an array of uint8_t to store the
+//! constants. Also, since it uses an array of std::uint8_t to store the
 //! hash map I've chosen to restrict the map hash function to 16 bits
 //! rather than the minimum value needed to get reasonable collision
 //! probability. This should be plenty big enough for all sizes of
@@ -78,7 +77,7 @@ public:
 
 public:
     //! Get the count of trailing zeros in value.
-    static uint8_t trailingZeros(uint32_t value);
+    static std::uint8_t trailingZeros(std::uint32_t value);
 
 public:
     //! \param numberHashes The number of independent hashes.
@@ -104,16 +103,16 @@ public:
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
     //! Add a new value.
-    void add(uint32_t value);
+    void add(std::uint32_t value);
 
     //! Remove a value.
-    void remove(uint32_t value);
+    void remove(std::uint32_t value);
 
     //! Get an estimate of the number of unique values added.
-    uint32_t number() const;
+    std::uint32_t number() const;
 
     //! Get a checksum for the sketch.
-    uint64_t checksum(uint64_t seed = 0) const;
+    std::uint64_t checksum(std::uint64_t seed = 0) const;
 
     //! Get the memory used by this sketch.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
@@ -122,9 +121,9 @@ public:
     std::size_t memoryUsage() const;
 
 private:
-    using TUInt8Vec = std::vector<uint8_t>;
+    using TUInt8Vec = std::vector<std::uint8_t>;
     using TUInt8VecVec = std::vector<TUInt8Vec>;
-    using TUInt32Vec = std::vector<uint32_t>;
+    using TUInt32Vec = std::vector<std::uint32_t>;
     using TUInt32VecItr = TUInt32Vec::iterator;
     using TUInt32VecCItr = TUInt32Vec::const_iterator;
 
@@ -144,13 +143,13 @@ private:
         void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 
         //! Add a new value.
-        void add(std::size_t maxSize, uint32_t value);
+        void add(std::size_t maxSize, std::uint32_t value);
 
         //! Remove a value.
-        void remove(uint32_t value);
+        void remove(std::uint32_t value);
 
         //! Get an estimate of the number of unique values added.
-        uint32_t number() const;
+        std::uint32_t number() const;
 
         //! The secondary hash function.
         TUInt32HashVec s_G;

--- a/include/maths/common/CClusterer.h
+++ b/include/maths/common/CClusterer.h
@@ -26,11 +26,10 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <vector>
-
-#include <stdint.h>
 
 namespace ml {
 namespace maths {

--- a/include/maths/common/CEntropySketch.h
+++ b/include/maths/common/CEntropySketch.h
@@ -15,7 +15,7 @@
 #include <maths/common/ImportExport.h>
 
 #include <cstddef>
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 namespace ml {
@@ -37,14 +37,14 @@ public:
     CEntropySketch(std::size_t k);
 
     //! Add \p category with count of \p count.
-    void add(std::size_t category, uint64_t count = 1);
+    void add(std::size_t category, std::uint64_t count = 1);
 
     //! Compute the entropy based on the values added so far.
     double calculate() const;
 
 private:
     using TDoubleVec = std::vector<double>;
-    using TUInt64Vec = std::vector<uint64_t>;
+    using TUInt64Vec = std::vector<std::uint64_t>;
 
 private:
     //! Generate the projection of the category counts.
@@ -52,7 +52,7 @@ private:
 
 private:
     //! The overall count.
-    uint64_t m_Y;
+    std::uint64_t m_Y;
 
     //! The sketch count.
     TDoubleVec m_Yi;

--- a/include/maths/common/CKMeansOnline1d.h
+++ b/include/maths/common/CKMeansOnline1d.h
@@ -122,7 +122,7 @@ public:
     double probability(std::size_t index) const override;
 
     //! Get a checksum for this object.
-    std::uint64_t checksum(uint64_t seed = 0) const override;
+    std::uint64_t checksum(std::uint64_t seed = 0) const override;
 
     //! Get the memory used by this component
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;

--- a/include/maths/common/CKMostCorrelated.h
+++ b/include/maths/common/CKMostCorrelated.h
@@ -21,10 +21,9 @@
 
 #include <boost/unordered_map.hpp>
 
+#include <cstdint>
 #include <utility>
 #include <vector>
-
-#include <stdint.h>
 
 namespace ml {
 namespace maths {
@@ -110,7 +109,7 @@ public:
     void capture();
 
     //! Get the checksum of this object.
-    uint64_t checksum(uint64_t seed = 0) const;
+    std::uint64_t checksum(std::uint64_t seed = 0) const;
 
     //! Debug the memory used by this object.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
@@ -180,7 +179,7 @@ protected:
                                   const core::CPackedBitVector& iy);
 
         //! Get the checksum of this object.
-        uint64_t checksum(uint64_t seed) const;
+        std::uint64_t checksum(std::uint64_t seed) const;
 
         //! Print for debug.
         std::string print() const;

--- a/include/maths/common/CModelWeight.h
+++ b/include/maths/common/CModelWeight.h
@@ -59,7 +59,7 @@ public:
     void age(double alpha);
 
     //! Get a checksum for this object.
-    uint64_t checksum(uint64_t seed) const;
+    std::uint64_t checksum(std::uint64_t seed) const;
 
     //! Restore state from part of a state document.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);

--- a/include/maths/common/CMultimodalPriorMode.h
+++ b/include/maths/common/CMultimodalPriorMode.h
@@ -49,7 +49,7 @@ struct SMultimodalPriorMode {
     double weight() const { return s_Prior->numberSamples(); }
 
     //! Get a checksum for this object.
-    uint64_t checksum(uint64_t seed) const {
+    std::uint64_t checksum(std::uint64_t seed) const {
         seed = CChecksum::calculate(seed, s_Index);
         return CChecksum::calculate(seed, s_Prior);
     }

--- a/include/maths/common/CMultivariateNormalConjugate.h
+++ b/include/maths/common/CMultivariateNormalConjugate.h
@@ -728,7 +728,7 @@ public:
     }
 
     //! Get a checksum for this object.
-    uint64_t checksum(uint64_t seed = 0) const override {
+    std::uint64_t checksum(std::uint64_t seed = 0) const override {
         seed = this->CMultivariatePrior::checksum(seed);
         seed = CChecksum::calculate(seed, m_GaussianMean);
         seed = CChecksum::calculate(seed, m_GaussianPrecision);

--- a/include/maths/common/CMultivariateOneOfNPrior.h
+++ b/include/maths/common/CMultivariateOneOfNPrior.h
@@ -261,7 +261,7 @@ public:
     void print(const std::string& separator, std::string& result) const override;
 
     //! Get a checksum for this object.
-    uint64_t checksum(uint64_t seed = 0) const override;
+    std::uint64_t checksum(std::uint64_t seed = 0) const override;
 
     //! Debug the memory used by this component.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;

--- a/include/maths/common/CMultivariatePrior.h
+++ b/include/maths/common/CMultivariatePrior.h
@@ -314,7 +314,7 @@ public:
     std::string printMarginalLikelihoodFunction(std::size_t x, std::size_t y) const;
 
     //! Get a checksum for this object.
-    virtual uint64_t checksum(uint64_t seed = 0) const = 0;
+    virtual std::uint64_t checksum(std::uint64_t seed = 0) const = 0;
 
     //! Get the memory used by this component
     virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const = 0;

--- a/include/maths/common/CNaturalBreaksClassifier.h
+++ b/include/maths/common/CNaturalBreaksClassifier.h
@@ -235,7 +235,7 @@ public:
     std::string print() const;
 
     //! Get a checksum for this object.
-    uint64_t checksum(uint64_t seed = 0) const;
+    std::uint64_t checksum(std::uint64_t seed = 0) const;
 
     //! Get the memory used by this component
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;

--- a/include/maths/common/CQDigest.h
+++ b/include/maths/common/CQDigest.h
@@ -16,12 +16,11 @@
 
 #include <maths/common/ImportExport.h>
 
+#include <cstdint>
 #include <functional>
 #include <list>
 #include <string>
 #include <vector>
-
-#include <stdint.h>
 
 namespace ml {
 namespace core {
@@ -82,7 +81,7 @@ namespace common {
 //! and to reserve sufficient memory up front for our node allocator.
 class MATHS_COMMON_EXPORT CQDigest : private core::CNonCopyable {
 public:
-    using TUInt32UInt64Pr = std::pair<uint32_t, uint64_t>;
+    using TUInt32UInt64Pr = std::pair<std::uint32_t, std::uint64_t>;
     using TUInt32UInt64PrVec = std::vector<TUInt32UInt64Pr>;
 
 public:
@@ -96,7 +95,7 @@ public:
     //@}
 
 public:
-    CQDigest(uint64_t k, double decayRate = 0.0);
+    CQDigest(std::uint64_t k, double decayRate = 0.0);
 
     //! \name Serialization
     //@{
@@ -108,7 +107,7 @@ public:
     //@}
 
     //! Add \p n values \p value to the q-digest.
-    void add(uint32_t value, uint64_t n = 1ull);
+    void add(std::uint32_t value, std::uint64_t n = 1ull);
 
     //! Merge this and \p digest.
     void merge(const CQDigest& digest);
@@ -135,7 +134,7 @@ public:
     //! digest isn't empty.
     //! \return True if the quantile could be computed and
     //! false otherwise.
-    bool quantile(double q, uint32_t& result) const;
+    bool quantile(double q, std::uint32_t& result) const;
 
     //! Find the largest value x such that upper bound of the
     //! c.d.f. is less than \p f, i.e. \f$\sup_y{\{y:F(y)<f\}}\f$.
@@ -144,7 +143,7 @@ public:
     //! only defined on the points where it changes, i.e. the
     //! q-digest node end points. So this returns the rightmost
     //! end point where the upper c.d.f. is less than \p f.
-    bool quantileSublevelSetSupremum(double f, uint32_t& result) const;
+    bool quantileSublevelSetSupremum(double f, std::uint32_t& result) const;
 
     //! Get the quantile corresponding to the c.d.f. value \p.
     //!
@@ -162,7 +161,7 @@ public:
     //! the c.d.f. at \p x.
     //! \param[out] upperBound Filled in with the upper bound for
     //! the c.d.f. at \p x.
-    bool cdf(uint32_t x, double confidence, double& lowerBound, double& upperBound) const;
+    bool cdf(std::uint32_t x, double confidence, double& lowerBound, double& upperBound) const;
 
     //! Compute the value of the p.d.f. at \p x.
     //!
@@ -173,13 +172,13 @@ public:
     //! the p.d.f. at \p x.
     //! \param[out] upperBound Filled in with the upper bound for
     //! the p.d.f. at \p x.
-    void pdf(uint32_t x, double confidence, double& lowerBound, double& upperBound) const;
+    void pdf(std::uint32_t x, double confidence, double& lowerBound, double& upperBound) const;
 
     //! Get the maximum knot point less than \p x.
-    void sublevelSetSupremum(uint32_t x, uint32_t& result) const;
+    void sublevelSetSupremum(std::uint32_t x, std::uint32_t& result) const;
 
     //! Get the minimum knot point greater than \p x.
-    void superlevelSetInfimum(uint32_t x, uint32_t& result) const;
+    void superlevelSetInfimum(std::uint32_t x, std::uint32_t& result) const;
 
     //! Get a summary of the q-digest. This is the counts less
     //! than or equal to each distinct integer in the quantile
@@ -189,13 +188,13 @@ public:
     void summary(TUInt32UInt64PrVec& result) const;
 
     //! Get the total number of values added to the q-digest.
-    uint64_t n() const;
+    std::uint64_t n() const;
 
     //! Get the size factor "k" for the q-digest.
-    uint64_t k() const;
+    std::uint64_t k() const;
 
     //! Get a checksum of this object.
-    uint64_t checksum(uint64_t seed) const;
+    std::uint64_t checksum(std::uint64_t seed) const;
 
     //! \name Test Methods
     //@{
@@ -248,36 +247,38 @@ private:
 
     public:
         CNode();
-        CNode(uint32_t min, uint32_t max, uint64_t count, uint64_t subtreeCount);
+        CNode(std::uint32_t min, std::uint32_t max, std::uint64_t count, std::uint64_t subtreeCount);
 
         //! Get the size of the q-digest rooted at this node.
         std::size_t size() const;
 
         //! Get the approximate quantile \p n.
-        uint32_t quantile(uint64_t leftCount, uint64_t n) const;
+        std::uint32_t quantile(std::uint64_t leftCount, std::uint64_t n) const;
 
         //! Get the largest value of x for which the upper count
         //! i.e. count of values definitely to the right of x, is
         //! less than \p n.
-        bool quantileSublevelSetSupremum(uint64_t n, uint64_t leftCount, uint32_t& result) const;
+        bool quantileSublevelSetSupremum(std::uint64_t n,
+                                         std::uint64_t leftCount,
+                                         std::uint32_t& result) const;
 
         //! Get the lower bound for the c.d.f. at \p x.
-        void cdfLowerBound(uint32_t x, uint64_t& result) const;
+        void cdfLowerBound(std::uint32_t x, std::uint64_t& result) const;
 
         //! Get the upper bound for the c.d.f. at \p x.
-        void cdfUpperBound(uint32_t x, uint64_t& result) const;
+        void cdfUpperBound(std::uint32_t x, std::uint64_t& result) const;
 
         //! Get the maximum knot point less than \p x.
-        void sublevelSetSupremum(const int64_t x, uint32_t& result) const;
+        void sublevelSetSupremum(const int64_t x, std::uint32_t& result) const;
 
         //! Get the minimum knot point greater than \p x.
-        void superlevelSetInfimum(uint32_t x, uint32_t& result) const;
+        void superlevelSetInfimum(std::uint32_t x, std::uint32_t& result) const;
 
         //! Fill in \p nodes with q-digest nodes in post-order.
         void postOrder(TNodePtrVec& nodes) const;
 
         //! Expand the node to fit \p value.
-        CNode* expand(CNodeAllocator& allocator, const uint32_t& value);
+        CNode* expand(CNodeAllocator& allocator, const std::uint32_t& value);
 
         //! Insert the specified node at its lowest ancestor
         //! in the q-digest.
@@ -286,21 +287,21 @@ private:
         //! Compress the digest at the triple comprising this node,
         //! its sibling and parent in the complete tree if they are
         //! in the q-digest.
-        CNode* compress(CNodeAllocator& allocator, uint64_t compressionFactor);
+        CNode* compress(CNodeAllocator& allocator, std::uint64_t compressionFactor);
 
         //! Age the counts by the specified factor.
-        uint64_t age(double factor);
+        std::uint64_t age(double factor);
 
         //! Get the span of universe values covered by the node.
-        uint32_t span() const;
+        std::uint32_t span() const;
         //! Get the minimum value covered by the node.
-        uint32_t min() const;
+        std::uint32_t min() const;
         //! Get the maximum value covered by the node.
-        uint32_t max() const;
+        std::uint32_t max() const;
         //! Get the count of entries in the node range.
-        const uint64_t& count() const;
+        const std::uint64_t& count() const;
         //! Get the count in the subtree rooted at this node.
-        const uint64_t& subtreeCount() const;
+        const std::uint64_t& subtreeCount() const;
 
         //! Persist this node and descendents
         void persistRecursive(const std::string& nodeTag,
@@ -310,7 +311,7 @@ private:
         bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
         //! Check the node invariants in the q-digest rooted at this node.
-        bool checkInvariants(uint64_t compressionFactor) const;
+        bool checkInvariants(std::uint64_t compressionFactor) const;
 
         //! Print for debug.
         std::string print() const;
@@ -363,16 +364,16 @@ private:
         TNodePtrVec m_Descendants;
 
         //! The minimum value covered by the node.
-        uint32_t m_Min;
+        std::uint32_t m_Min;
 
         //! The maximum value covered by the node.
-        uint32_t m_Max;
+        std::uint32_t m_Max;
 
         //! The count of the node.
-        uint64_t m_Count;
+        std::uint64_t m_Count;
 
         //! The count in the subtree root at this node.
-        uint64_t m_SubtreeCount;
+        std::uint64_t m_SubtreeCount;
     };
 
     //! Manages the creation and recycling of nodes.
@@ -415,9 +416,9 @@ private:
 private:
     //! Controls the maximum number of values stored. In particular,
     //! the number of nodes is less than \f$3k\f$.
-    uint64_t m_K;
+    std::uint64_t m_K;
     //! The number of values added to the q-digest.
-    uint64_t m_N;
+    std::uint64_t m_N;
     //! The root node.
     CNode* m_Root;
     //! The node allocator.

--- a/include/maths/common/CSpline.h
+++ b/include/maths/common/CSpline.h
@@ -611,7 +611,7 @@ public:
     }
 
     //! Get a checksum for this object.
-    uint64_t checksum(uint64_t seed = 0) const {
+    std::uint64_t checksum(std::uint64_t seed = 0) const {
         seed = CChecksum::calculate(seed, m_Type);
         seed = CChecksum::calculate(seed, m_Knots);
         seed = CChecksum::calculate(seed, m_Values);

--- a/include/maths/common/CXMeans.h
+++ b/include/maths/common/CXMeans.h
@@ -26,10 +26,9 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <numeric>
 #include <vector>
-
-#include <stdint.h>
 
 namespace ml {
 namespace maths {
@@ -55,7 +54,7 @@ public:
     using TDoubleVec = std::vector<double>;
     using TPointVec = std::vector<POINT>;
     using TPointVecVec = std::vector<TPointVec>;
-    using TUInt64USet = boost::unordered_set<uint64_t>;
+    using TUInt64USet = boost::unordered_set<std::uint64_t>;
     using TMeanAccumulator = typename CBasicStatistics::SSampleMean<POINT>::TAccumulator;
 
     //! A cluster.
@@ -105,7 +104,7 @@ public:
         const TPointVec& points() const { return m_Points; }
 
         //! Get the cluster checksum.
-        uint64_t checksum() const { return m_Checksum; }
+        std::uint64_t checksum() const { return m_Checksum; }
 
     private:
         //! The information criterion cost of this cluster.
@@ -115,7 +114,7 @@ public:
         //! The points in the cluster.
         TPointVec m_Points;
         //! A checksum for the points in the cluster.
-        uint64_t m_Checksum;
+        std::uint64_t m_Checksum;
     };
 
     using TClusterVec = std::vector<CCluster>;

--- a/include/maths/common/ProbabilityAggregators.h
+++ b/include/maths/common/ProbabilityAggregators.h
@@ -88,7 +88,7 @@ public:
     double numberSamples() const;
 
     //! Get a checksum for an object of this class.
-    uint64_t checksum(uint64_t seed) const;
+    std::uint64_t checksum(std::uint64_t seed) const;
 
     //! Print the joint probability for debugging.
     std::ostream& print(std::ostream& o) const;
@@ -212,7 +212,7 @@ public:
     bool calculate(double& result) const;
 
     //! Get a checksum for an object of this class.
-    uint64_t checksum(uint64_t seed) const;
+    std::uint64_t checksum(std::uint64_t seed) const;
 
     //! Print the extreme probability for debugging.
     std::ostream& print(std::ostream& o) const;
@@ -301,7 +301,7 @@ public:
     bool calibrated(double& result);
 
     //! Get a checksum for an object of this class.
-    uint64_t checksum(uint64_t seed) const;
+    std::uint64_t checksum(std::uint64_t seed) const;
 
 private:
     using TMinValueAccumulator = CBasicStatistics::COrderStatisticsHeap<double>;

--- a/include/maths/time_series/CAdaptiveBucketing.h
+++ b/include/maths/time_series/CAdaptiveBucketing.h
@@ -21,9 +21,8 @@
 #include <maths/time_series/ImportExport.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <vector>
-
-#include <stdint.h>
 
 namespace ml {
 namespace core {

--- a/include/maths/time_series/CCalendarComponentAdaptiveBucketing.h
+++ b/include/maths/time_series/CCalendarComponentAdaptiveBucketing.h
@@ -21,9 +21,8 @@
 #include <maths/time_series/ImportExport.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <vector>
-
-#include <stdint.h>
 
 namespace ml {
 namespace core {

--- a/include/maths/time_series/CCountMinSketch.h
+++ b/include/maths/time_series/CCountMinSketch.h
@@ -87,14 +87,14 @@ public:
     //!
     //! \note \p count can be negative in which case the count is
     //! removed from the sketch.
-    void add(uint32_t category, double count);
+    void add(std::uint32_t category, double count);
 
     //! Remove \p category from the sketch altogether.
     //!
     //! \note That one can decrement the counts by calling add with
     //! a negative count. However, if we have not sketched the counts
     //! this removes the map entry for \p category.
-    void removeFromMap(uint32_t category);
+    void removeFromMap(std::uint32_t category);
 
     //! Age the counts forwards \p time.
     void age(double alpha);
@@ -103,16 +103,16 @@ public:
     double totalCount() const;
 
     //! Get the count of category \p category.
-    double count(uint32_t category) const;
+    double count(std::uint32_t category) const;
 
     //! Get the fraction of category \p category.
-    double fraction(uint32_t category) const;
+    double fraction(std::uint32_t category) const;
 
     //! Check if the counts are sketched.
     bool sketched() const;
 
     //! Get a checksum for the sketch.
-    uint64_t checksum(uint64_t seed = 0) const;
+    std::uint64_t checksum(std::uint64_t seed = 0) const;
 
     //! Get the memory used by this sketch.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
@@ -145,7 +145,7 @@ private:
         TFloatVecVec s_Counts;
     };
 
-    using TUInt32FloatPr = std::pair<uint32_t, common::CFloatStorage>;
+    using TUInt32FloatPr = std::pair<std::uint32_t, common::CFloatStorage>;
     using TUInt32FloatPrVec = std::vector<TUInt32FloatPr>;
     using TUInt32FloatPrVecOrSketch = std::variant<TUInt32FloatPrVec, SSketch>;
 

--- a/include/model/CAnnotatedProbability.h
+++ b/include/model/CAnnotatedProbability.h
@@ -118,7 +118,7 @@ struct MODEL_EXPORT SAnnotatedProbability {
     using TDescriptiveDataDoublePr = SAttributeProbability::TDescriptiveDataDoublePr;
     using TDescriptiveDataDoublePr2Vec = SAttributeProbability::TDescriptiveDataDoublePr2Vec;
     using TOptionalDouble = boost::optional<double>;
-    using TOptionalUInt64 = boost::optional<uint64_t>;
+    using TOptionalUInt64 = boost::optional<std::uint64_t>;
 
     SAnnotatedProbability();
     SAnnotatedProbability(double p);

--- a/include/model/CAnomalyDetectorModel.h
+++ b/include/model/CAnomalyDetectorModel.h
@@ -31,6 +31,7 @@
 #include <boost/optional.hpp>
 #include <boost/unordered_map.hpp>
 
+#include <cstdint>
 #include <functional>
 #include <limits>
 #include <map>
@@ -38,8 +39,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <stdint.h>
 
 namespace ml {
 namespace core {
@@ -147,7 +146,7 @@ public:
     using TStr1Vec = core::CSmallVector<std::string, 1>;
     using TOptionalDouble = boost::optional<double>;
     using TOptionalDoubleVec = std::vector<TOptionalDouble>;
-    using TOptionalUInt64 = boost::optional<uint64_t>;
+    using TOptionalUInt64 = boost::optional<std::uint64_t>;
     using TOptionalSize = boost::optional<std::size_t>;
     using TAttributeProbability1Vec = core::CSmallVector<SAttributeProbability, 1>;
     using TInfluenceCalculatorCPtr = std::shared_ptr<const CInfluenceCalculator>;
@@ -446,7 +445,7 @@ public:
     //! the current bucket statistics. (This is designed to handle
     //! serialization, for which we don't serialize the current
     //! bucket statistics.)
-    virtual uint64_t checksum(bool includeCurrentBucketStats = true) const = 0;
+    virtual std::uint64_t checksum(bool includeCurrentBucketStats = true) const = 0;
 
     //! Get the memory used by this model
     virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const = 0;

--- a/include/model/CAnomalyScore.h
+++ b/include/model/CAnomalyScore.h
@@ -21,7 +21,6 @@
 #include <model/ImportExport.h>
 
 #include <boost/optional.hpp>
-#include <boost/unordered_map.hpp>
 
 #include <cstdint>
 #include <functional>
@@ -190,7 +189,7 @@ public:
         //@}
 
         //! Get a checksum of the object.
-        uint64_t checksum() const;
+        std::uint64_t checksum() const;
 
     private:
         using TDoubleDoublePr = std::pair<double, double>;
@@ -218,7 +217,7 @@ public:
             bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
             //! Get a checksum of the object.
-            uint64_t checksum() const;
+            std::uint64_t checksum() const;
 
         private:
             TMaxValueAccumulator m_Score;
@@ -252,10 +251,10 @@ public:
 
     private:
         //! Compute the discrete score from a raw score.
-        uint32_t discreteScore(double rawScore) const;
+        std::uint32_t discreteScore(double rawScore) const;
 
         //! Extract the raw score from a discrete score.
-        double rawScore(uint32_t discreteScore) const;
+        double rawScore(std::uint32_t discreteScore) const;
 
         //! Retrieve the maximum score for a partition
         bool maxScore(const CMaximumScoreScope& scope, double& maxScore) const;
@@ -271,10 +270,10 @@ public:
         double m_MaximumNormalizedScore{100.0};
 
         //! The approximate HIGH_PERCENTILE percentile raw score.
-        uint32_t m_HighPercentileScore;
+        std::uint32_t m_HighPercentileScore;
         //! The number of scores less than the approximate
         //! HIGH_PERCENTILE percentile raw score.
-        uint64_t m_HighPercentileCount{0};
+        std::uint64_t m_HighPercentileCount{0};
 
         //! True if this normalizer applies to results for individual
         //! members of a population analysis.

--- a/include/model/CBucketGatherer.h
+++ b/include/model/CBucketGatherer.h
@@ -32,12 +32,11 @@
 #include <boost/unordered_map.hpp>
 #include <boost/unordered_set.hpp>
 
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <stdint.h>
 
 namespace ml {
 namespace core {
@@ -71,18 +70,18 @@ public:
     using TStrVec = std::vector<std::string>;
     using TStrVecCItr = TStrVec::const_iterator;
     using TStrCPtrVec = std::vector<const std::string*>;
-    using TSizeUInt64Pr = std::pair<std::size_t, uint64_t>;
+    using TSizeUInt64Pr = std::pair<std::size_t, std::uint64_t>;
     using TSizeUInt64PrVec = std::vector<TSizeUInt64Pr>;
     using TFeatureVec = model_t::TFeatureVec;
     using TOptionalDouble = boost::optional<double>;
     using TSizeSizePr = std::pair<std::size_t, std::size_t>;
-    using TSizeSizePrUInt64Pr = std::pair<TSizeSizePr, uint64_t>;
+    using TSizeSizePrUInt64Pr = std::pair<TSizeSizePr, std::uint64_t>;
     using TSizeSizePrUInt64PrVec = std::vector<TSizeSizePrUInt64Pr>;
     using TDictionary = core::CCompressedDictionary<2>;
     using TWordSizeUMap = TDictionary::TWordTUMap<std::size_t>;
     using TWordSizeUMapItr = TWordSizeUMap::iterator;
     using TWordSizeUMapCItr = TWordSizeUMap::const_iterator;
-    using TSizeSizePrUInt64UMap = boost::unordered_map<TSizeSizePr, uint64_t>;
+    using TSizeSizePrUInt64UMap = boost::unordered_map<TSizeSizePr, std::uint64_t>;
     using TSizeSizePrUInt64UMapItr = TSizeSizePrUInt64UMap::iterator;
     using TSizeSizePrUInt64UMapCItr = TSizeSizePrUInt64UMap::const_iterator;
     using TSizeSizePrUInt64UMapQueue = CBucketQueue<TSizeSizePrUInt64UMap>;
@@ -101,9 +100,9 @@ public:
     //! \brief Hashes a ((size_t, size_t), string*) pair.
     struct MODEL_EXPORT SSizeSizePrStoredStringPtrPrHash {
         std::size_t operator()(const TSizeSizePrStoredStringPtrPr& key) const {
-            uint64_t seed = core::CHashing::hashCombine(
-                static_cast<uint64_t>(key.first.first),
-                static_cast<uint64_t>(key.first.second));
+            std::uint64_t seed = core::CHashing::hashCombine(
+                static_cast<std::uint64_t>(key.first.first),
+                static_cast<std::uint64_t>(key.first.second));
             return core::CHashing::hashCombine(seed, s_Hasher(*key.second));
         }
         core::CHashing::CMurmurHash2String s_Hasher;
@@ -118,7 +117,7 @@ public:
     };
 
     using TSizeSizePrStoredStringPtrPrUInt64UMap =
-        boost::unordered_map<TSizeSizePrStoredStringPtrPr, uint64_t, SSizeSizePrStoredStringPtrPrHash, SSizeSizePrStoredStringPtrPrEqual>;
+        boost::unordered_map<TSizeSizePrStoredStringPtrPr, std::uint64_t, SSizeSizePrStoredStringPtrPrHash, SSizeSizePrStoredStringPtrPrEqual>;
     using TSizeSizePrStoredStringPtrPrUInt64UMapCItr =
         TSizeSizePrStoredStringPtrPrUInt64UMap::const_iterator;
     using TSizeSizePrStoredStringPtrPrUInt64UMapItr =
@@ -315,7 +314,7 @@ public:
     //@}
 
     //! Get the checksum of this gatherer.
-    virtual uint64_t checksum() const = 0;
+    virtual std::uint64_t checksum() const = 0;
 
     //! Debug the memory used by this component.
     virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const = 0;

--- a/include/model/CCountingModel.h
+++ b/include/model/CCountingModel.h
@@ -210,7 +210,7 @@ public:
     //! the current bucket statistics. (This is designed to handle
     //! serialization, for which we don't serialize the current
     //! bucket statistics.)
-    uint64_t checksum(bool includeCurrentBucketStats = true) const override;
+    std::uint64_t checksum(bool includeCurrentBucketStats = true) const override;
 
     //! Get the memory used by this model
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
@@ -282,7 +282,7 @@ private:
     CMemoryUsageEstimator* memoryUsageEstimator() const override;
 
 private:
-    using TSizeUInt64Pr = std::pair<std::size_t, uint64_t>;
+    using TSizeUInt64Pr = std::pair<std::size_t, std::uint64_t>;
     using TSizeUInt64PrVec = std::vector<TSizeUInt64Pr>;
     using TMeanAccumulator = maths::common::CBasicStatistics::SSampleMean<double>::TAccumulator;
     using TMeanAccumulatorVec = std::vector<TMeanAccumulator>;

--- a/include/model/CDataGatherer.h
+++ b/include/model/CDataGatherer.h
@@ -27,15 +27,13 @@
 #include <model/SModelParams.h>
 
 #include <boost/any.hpp>
-#include <boost/optional.hpp>
 #include <boost/unordered_map.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <stdint.h>
 
 namespace ml {
 namespace core {
@@ -110,13 +108,13 @@ public:
     using TStrVec = std::vector<std::string>;
     using TStrVecCItr = TStrVec::const_iterator;
     using TStrCPtrVec = std::vector<const std::string*>;
-    using TSizeUInt64Pr = std::pair<std::size_t, uint64_t>;
+    using TSizeUInt64Pr = std::pair<std::size_t, std::uint64_t>;
     using TSizeUInt64PrVec = std::vector<TSizeUInt64Pr>;
     using TFeatureVec = model_t::TFeatureVec;
     using TSizeSizePr = std::pair<std::size_t, std::size_t>;
-    using TSizeSizePrUInt64Pr = std::pair<TSizeSizePr, uint64_t>;
+    using TSizeSizePrUInt64Pr = std::pair<TSizeSizePr, std::uint64_t>;
     using TSizeSizePrUInt64PrVec = std::vector<TSizeSizePrUInt64Pr>;
-    using TSizeSizePrUInt64UMap = boost::unordered_map<TSizeSizePr, uint64_t>;
+    using TSizeSizePrUInt64UMap = boost::unordered_map<TSizeSizePr, std::uint64_t>;
     using TSizeSizePrUInt64UMapQueue = CBucketQueue<TSizeSizePrUInt64UMap>;
     using TSizeSizePrStoredStringPtrPrUInt64UMap = CBucketGatherer::TSizeSizePrStoredStringPtrPrUInt64UMap;
     using TSizeSizePrStoredStringPtrPrUInt64UMapVec =
@@ -579,7 +577,7 @@ public:
     //@}
 
     //! Get the checksum of this gatherer.
-    uint64_t checksum() const;
+    std::uint64_t checksum() const;
 
     //! Debug the memory used by this component.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;

--- a/include/model/CDetectorEqualizer.h
+++ b/include/model/CDetectorEqualizer.h
@@ -17,9 +17,8 @@
 #include <model/ImportExport.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <vector>
-
-#include <stdint.h>
 
 namespace ml {
 namespace core {
@@ -62,7 +61,7 @@ public:
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
     //! Get a checksum for the equalizer.
-    uint64_t checksum() const;
+    std::uint64_t checksum() const;
 
     //! Get the largest probability that will be corrected.
     static double largestProbabilityToCorrect();

--- a/include/model/CDynamicStringIdRegistry.h
+++ b/include/model/CDynamicStringIdRegistry.h
@@ -134,7 +134,7 @@ public:
     void clear();
 
     //! Get the checksum of this registry.
-    uint64_t checksum() const;
+    std::uint64_t checksum() const;
 
     //! Debug the memory used by this registry.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;

--- a/include/model/CEventRateBucketGatherer.h
+++ b/include/model/CEventRateBucketGatherer.h
@@ -70,7 +70,7 @@ public:
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
 
     //! Get the checksum of this object.
-    uint64_t checksum() const;
+    std::uint64_t checksum() const;
 
     //! Get the memory usage of this object in a tree structure.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
@@ -244,7 +244,7 @@ public:
     //@}
 
     //! Get the checksum of this gatherer.
-    uint64_t checksum() const override;
+    std::uint64_t checksum() const override;
 
     //! Get the memory used by this object.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;

--- a/include/model/CEventRateModel.h
+++ b/include/model/CEventRateModel.h
@@ -24,11 +24,10 @@
 #include <model/ImportExport.h>
 #include <model/ModelTypes.h>
 
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <stdint.h>
 
 namespace {
 class CMockEventRateModel;

--- a/include/model/CForecastDataSink.h
+++ b/include/model/CForecastDataSink.h
@@ -28,11 +28,10 @@
 
 #include <boost/unordered_set.hpp>
 
+#include <cstdint>
 #include <iosfwd>
 #include <memory>
 #include <string>
-
-#include <stdint.h>
 
 namespace ml {
 namespace model {

--- a/include/model/CGathererTools.h
+++ b/include/model/CGathererTools.h
@@ -30,11 +30,10 @@
 #include <boost/optional.hpp>
 #include <boost/unordered_map.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <stdint.h>
 
 namespace ml {
 namespace core {

--- a/include/model/CHierarchicalResultsLevelSet.h
+++ b/include/model/CHierarchicalResultsLevelSet.h
@@ -19,7 +19,7 @@
 
 #include <model/CHierarchicalResults.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace ml {
 namespace model {

--- a/include/model/CIndividualModel.h
+++ b/include/model/CIndividualModel.h
@@ -23,10 +23,9 @@
 #include <boost/unordered_set.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <utility>
 #include <vector>
-
-#include <stdint.h>
 
 namespace ml {
 namespace model {

--- a/include/model/CMetricModel.h
+++ b/include/model/CMetricModel.h
@@ -21,11 +21,10 @@
 #include <model/ImportExport.h>
 #include <model/ModelTypes.h>
 
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <stdint.h>
 
 namespace CResourceLimitTest {
 class CMockMetricModel;

--- a/include/model/CSearchKey.h
+++ b/include/model/CSearchKey.h
@@ -16,16 +16,13 @@
 #include <core/CStoredStringPtr.h>
 #include <core/UnwrapRef.h>
 
-#include <maths/common/COrderings.h>
-
 #include <model/FunctionTypes.h>
 #include <model/ImportExport.h>
 
+#include <cstdint>
 #include <iosfwd>
 #include <string>
 #include <vector>
-
-#include <stdint.h>
 
 namespace ml {
 namespace core {

--- a/lib/api/unittest/CForecastRunnerTest.cc
+++ b/lib/api/unittest/CForecastRunnerTest.cc
@@ -69,7 +69,7 @@ void populateJob(TGenerateRecord generateRecord, CTestAnomalyJob& job, std::size
         BOOST_TEST_REQUIRE(job.handleRecord(dataRows));
     }
 
-    BOOST_REQUIRE_EQUAL(uint64_t(2 * buckets), job.numRecordsHandled());
+    BOOST_REQUIRE_EQUAL(std::uint64_t(2 * buckets), job.numRecordsHandled());
 }
 }
 

--- a/lib/api/unittest/CJsonOutputWriterTest.cc
+++ b/lib/api/unittest/CJsonOutputWriterTest.cc
@@ -280,7 +280,7 @@ void testBucketWriteHelper(bool isInterim) {
             BOOST_TEST_REQUIRE(!bucket.HasMember("is_interim"));
         }
 
-        BOOST_REQUIRE_EQUAL(uint64_t(10ll), bucket["processing_time_ms"].GetUint64());
+        BOOST_REQUIRE_EQUAL(std::uint64_t(10ll), bucket["processing_time_ms"].GetUint64());
     }
 
     for (rapidjson::SizeType i = 0; i < arrayDoc.Size(); i = i + 2) {

--- a/lib/api/unittest/CLengthEncodedInputParserTest.cc
+++ b/lib/api/unittest/CLengthEncodedInputParserTest.cc
@@ -90,7 +90,7 @@ public:
 private:
     template<typename NUM_TYPE>
     void appendNumber(NUM_TYPE num, std::string& str) {
-        uint32_t netNum(htonl(static_cast<uint32_t>(num)));
+        std::uint32_t netNum(htonl(static_cast<std::uint32_t>(num)));
         str.append(reinterpret_cast<char*>(&netNum), sizeof(netNum));
     }
 
@@ -283,11 +283,11 @@ BOOST_AUTO_TEST_CASE(testThroughput) {
 }
 
 BOOST_AUTO_TEST_CASE(testCorruptStreamDetection) {
-    uint32_t numFields(1);
-    uint32_t numFieldsNet(htonl(numFields));
-    std::string dodgyInput(reinterpret_cast<char*>(&numFieldsNet), sizeof(uint32_t));
+    std::uint32_t numFields(1);
+    std::uint32_t numFieldsNet(htonl(numFields));
+    std::string dodgyInput(reinterpret_cast<char*>(&numFieldsNet), sizeof(std::uint32_t));
     // This is going to create a length field consisting of four 'a' characters
-    // interpreted as a uint32_t
+    // interpreted as a std::uint32_t
     dodgyInput.append(1000, 'a');
 
     // Input must be binary otherwise Windows will stop at CTRL+Z

--- a/lib/api/unittest/CModelPlotDataJsonWriterTest.cc
+++ b/lib/api/unittest/CModelPlotDataJsonWriterTest.cc
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(testWriteFlat) {
     BOOST_REQUIRE_EQUAL(std::string("'count per bucket by person'"),
                         std::string(modelPlot["model_feature"].GetString()));
     BOOST_TEST_REQUIRE(modelPlot.HasMember("timestamp"));
-    BOOST_REQUIRE_EQUAL(int64_t(1000), modelPlot["timestamp"].GetInt64());
+    BOOST_REQUIRE_EQUAL(1000, modelPlot["timestamp"].GetInt64());
     BOOST_TEST_REQUIRE(modelPlot.HasMember("partition_field_name"));
     BOOST_REQUIRE_EQUAL(std::string("pName"),
                         std::string(modelPlot["partition_field_name"].GetString()));
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(testWriteFlat) {
     BOOST_TEST_REQUIRE(modelPlot.HasMember("model_median"));
     BOOST_REQUIRE_CLOSE_ABSOLUTE(3.0, modelPlot["model_median"].GetDouble(), 0.01);
     BOOST_TEST_REQUIRE(modelPlot.HasMember("bucket_span"));
-    BOOST_REQUIRE_EQUAL(int64_t(300), modelPlot["bucket_span"].GetInt64());
+    BOOST_REQUIRE_EQUAL(300, modelPlot["bucket_span"].GetInt64());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/core/CCondition.cc
+++ b/lib/core/CCondition.cc
@@ -46,7 +46,7 @@ bool CCondition::wait() {
     return true;
 }
 
-bool CCondition::wait(uint32_t t) {
+bool CCondition::wait(std::uint32_t t) {
     timespec tm;
 
     if (CCondition::convert(t, tm) == false) {
@@ -80,7 +80,7 @@ void CCondition::broadcast() {
     }
 }
 
-bool CCondition::convert(uint32_t t, timespec& tm) {
+bool CCondition::convert(std::uint32_t t, timespec& tm) {
     timeval now;
     if (::gettimeofday(&now, nullptr) < 0) {
         LOG_WARN(<< ::strerror(errno));
@@ -91,12 +91,12 @@ bool CCondition::convert(uint32_t t, timespec& tm) {
     // with overflows + convert timeval to timespec
     tm.tv_sec = now.tv_sec + (t / 1000);
 
-    uint32_t remainder(static_cast<uint32_t>(t % 1000));
+    std::uint32_t remainder(static_cast<std::uint32_t>(t % 1000));
     if (remainder == 0) {
         tm.tv_nsec = now.tv_usec * 1000;
     } else {
         // s is in microseconds
-        uint32_t s((remainder * 1000U) + static_cast<uint32_t>(now.tv_usec));
+        std::uint32_t s((remainder * 1000U) + static_cast<std::uint32_t>(now.tv_usec));
 
         tm.tv_sec = tm.tv_sec + (s / 1000000U);
         tm.tv_nsec = (s % 1000000U) * 1000;

--- a/lib/core/CCondition_Windows.cc
+++ b/lib/core/CCondition_Windows.cc
@@ -35,7 +35,7 @@ bool CCondition::wait() {
     return true;
 }
 
-bool CCondition::wait(uint32_t t) {
+bool CCondition::wait(std::uint32_t t) {
     BOOL success(SleepConditionVariableCS(&m_Condition, &m_Mutex.m_Mutex, t));
     if (success == FALSE) {
         DWORD errorCode(GetLastError());

--- a/lib/core/CFlatPrefixTree.cc
+++ b/lib/core/CFlatPrefixTree.cc
@@ -26,7 +26,7 @@ namespace ml {
 namespace core {
 
 namespace {
-const uint32_t NO_CHILD = std::numeric_limits<uint32_t>::max();
+const std::uint32_t NO_CHILD = std::numeric_limits<std::uint32_t>::max();
 const char PADDING_NODE = '$';
 const char LEAF_NODE = 'l';
 const char BRANCH_NODE = 'b';
@@ -43,7 +43,7 @@ struct SCharNotEqualTo {
 };
 }
 
-CFlatPrefixTree::SNode::SNode(char c, char type, uint32_t next)
+CFlatPrefixTree::SNode::SNode(char c, char type, std::uint32_t next)
     : s_Char(c), s_Type(type), s_Next(next) {
 }
 
@@ -107,7 +107,7 @@ void CFlatPrefixTree::buildRecursively(const TStrVec& prefixes,
     // Now, we create the nodes of the current level: the padding node, that contains
     // the number of distinct characters, and a node for each distinct character.
     m_FlatTree.push_back(SNode(PADDING_NODE, PADDING_NODE,
-                               static_cast<uint32_t>(distinctCharsWithRange.size())));
+                               static_cast<std::uint32_t>(distinctCharsWithRange.size())));
     std::size_t treeSizeBeforeNewChars = m_FlatTree.size();
     for (std::size_t i = 0; i < distinctCharsWithRange.size(); ++i) {
         SDistinctChar& distinctChar = distinctCharsWithRange[i];
@@ -120,7 +120,7 @@ void CFlatPrefixTree::buildRecursively(const TStrVec& prefixes,
         SDistinctChar& distinctChar = distinctCharsWithRange[i];
         if (distinctChar.s_Type != LEAF_NODE) {
             m_FlatTree[treeSizeBeforeNewChars + i].s_Next =
-                static_cast<uint32_t>(m_FlatTree.size());
+                static_cast<std::uint32_t>(m_FlatTree.size());
             this->buildRecursively(prefixes, distinctChar.s_Start,
                                    distinctChar.s_End, charPos + 1);
         }

--- a/lib/core/CHashing.cc
+++ b/lib/core/CHashing.cc
@@ -41,15 +41,15 @@ CHashing::CUniversalHash::CUInt32Hash::CUInt32Hash(std::uint32_t m, std::uint32_
     : m_M(m), m_A(a), m_B(b) {
 }
 
-uint32_t CHashing::CUniversalHash::CUInt32Hash::m() const {
+std::uint32_t CHashing::CUniversalHash::CUInt32Hash::m() const {
     return m_M;
 }
 
-uint32_t CHashing::CUniversalHash::CUInt32Hash::a() const {
+std::uint32_t CHashing::CUniversalHash::CUInt32Hash::a() const {
     return m_A;
 }
 
-uint32_t CHashing::CUniversalHash::CUInt32Hash::b() const {
+std::uint32_t CHashing::CUniversalHash::CUInt32Hash::b() const {
     return m_B;
 }
 
@@ -69,11 +69,11 @@ CHashing::CUniversalHash::CUInt32UnrestrictedHash::CUInt32UnrestrictedHash(std::
     : m_A(a), m_B(b) {
 }
 
-uint32_t CHashing::CUniversalHash::CUInt32UnrestrictedHash::a() const {
+std::uint32_t CHashing::CUniversalHash::CUInt32UnrestrictedHash::a() const {
     return m_A;
 }
 
-uint32_t CHashing::CUniversalHash::CUInt32UnrestrictedHash::b() const {
+std::uint32_t CHashing::CUniversalHash::CUInt32UnrestrictedHash::b() const {
     return m_B;
 }
 
@@ -89,7 +89,7 @@ CHashing::CUniversalHash::CUInt32VecHash::CUInt32VecHash(std::uint32_t m,
     : m_M(m), m_A(a), m_B(b) {
 }
 
-uint32_t CHashing::CUniversalHash::CUInt32VecHash::m() const {
+std::uint32_t CHashing::CUniversalHash::CUInt32VecHash::m() const {
     return m_M;
 }
 
@@ -98,7 +98,7 @@ CHashing::CUniversalHash::CUInt32VecHash::a() const {
     return m_A;
 }
 
-uint32_t CHashing::CUniversalHash::CUInt32VecHash::b() const {
+std::uint32_t CHashing::CUniversalHash::CUInt32VecHash::b() const {
     return m_B;
 }
 
@@ -292,7 +292,7 @@ void CHashing::CUniversalHash::generateHashes(std::size_t k,
     }
 }
 
-uint32_t CHashing::murmurHash32(const void* key, int length, std::uint32_t seed) {
+std::uint32_t CHashing::murmurHash32(const void* key, int length, std::uint32_t seed) {
     constexpr std::uint32_t m = 0x5bd1e995;
     constexpr int r = 24;
 
@@ -341,7 +341,7 @@ uint32_t CHashing::murmurHash32(const void* key, int length, std::uint32_t seed)
     return h;
 }
 
-uint32_t CHashing::safeMurmurHash32(const void* key, int length, std::uint32_t seed) {
+std::uint32_t CHashing::safeMurmurHash32(const void* key, int length, std::uint32_t seed) {
     constexpr std::uint32_t m = 0x5bd1e995;
     constexpr int r = 24;
 
@@ -391,7 +391,7 @@ uint32_t CHashing::safeMurmurHash32(const void* key, int length, std::uint32_t s
     return h;
 }
 
-uint64_t CHashing::murmurHash64(const void* key, int length, std::uint64_t seed) {
+std::uint64_t CHashing::murmurHash64(const void* key, int length, std::uint64_t seed) {
     constexpr std::uint64_t m = 0xc6a4a7935bd1e995ULL;
     constexpr int r = 47;
 
@@ -452,7 +452,7 @@ uint64_t CHashing::murmurHash64(const void* key, int length, std::uint64_t seed)
     return h;
 }
 
-uint64_t CHashing::safeMurmurHash64(const void* key, int length, std::uint64_t seed) {
+std::uint64_t CHashing::safeMurmurHash64(const void* key, int length, std::uint64_t seed) {
     constexpr std::uint64_t m = 0xc6a4a7935bd1e995ULL;
     constexpr int r = 47;
 
@@ -518,13 +518,13 @@ uint64_t CHashing::safeMurmurHash64(const void* key, int length, std::uint64_t s
     return h;
 }
 
-uint32_t CHashing::hashCombine(std::uint32_t seed, std::uint32_t h) {
+std::uint32_t CHashing::hashCombine(std::uint32_t seed, std::uint32_t h) {
     constexpr std::uint32_t C = 0x9e3779b9;
     seed ^= h + C + (seed << 6) + (seed >> 2);
     return seed;
 }
 
-uint64_t CHashing::hashCombine(std::uint64_t seed, std::uint64_t h) {
+std::uint64_t CHashing::hashCombine(std::uint64_t seed, std::uint64_t h) {
     // As with boost::hash_combine use the binary expansion of an irrational
     // number to generate 64 random independent bits, i.e.
     //   C = 2^64 / "golden ratio" = 2^65 / (1 + 5^(1/2))

--- a/lib/core/CHashing.cc
+++ b/lib/core/CHashing.cc
@@ -26,10 +26,10 @@ namespace core {
 
 namespace {
 
-using TUniform32 = boost::random::uniform_int_distribution<uint32_t>;
+using TUniform32 = boost::random::uniform_int_distribution<std::uint32_t>;
 }
 
-const uint64_t CHashing::CUniversalHash::BIG_PRIME = 4294967291ULL;
+const std::uint64_t CHashing::CUniversalHash::BIG_PRIME = 4294967291ULL;
 boost::random::mt11213b CHashing::CUniversalHash::ms_Generator;
 CFastMutex CHashing::CUniversalHash::ms_Mutex;
 
@@ -37,7 +37,7 @@ CHashing::CUniversalHash::CUInt32Hash::CUInt32Hash()
     : m_M(1000), m_A(1), m_B(0) {
 }
 
-CHashing::CUniversalHash::CUInt32Hash::CUInt32Hash(uint32_t m, uint32_t a, uint32_t b)
+CHashing::CUniversalHash::CUInt32Hash::CUInt32Hash(std::uint32_t m, std::uint32_t a, std::uint32_t b)
     : m_M(m), m_A(a), m_B(b) {
 }
 
@@ -64,7 +64,8 @@ CHashing::CUniversalHash::CUInt32UnrestrictedHash::CUInt32UnrestrictedHash()
     : m_A(1), m_B(0) {
 }
 
-CHashing::CUniversalHash::CUInt32UnrestrictedHash::CUInt32UnrestrictedHash(uint32_t a, uint32_t b)
+CHashing::CUniversalHash::CUInt32UnrestrictedHash::CUInt32UnrestrictedHash(std::uint32_t a,
+                                                                           std::uint32_t b)
     : m_A(a), m_B(b) {
 }
 
@@ -82,7 +83,9 @@ std::string CHashing::CUniversalHash::CUInt32UnrestrictedHash::print() const {
     return result.str();
 }
 
-CHashing::CUniversalHash::CUInt32VecHash::CUInt32VecHash(uint32_t m, const TUInt32Vec& a, uint32_t b)
+CHashing::CUniversalHash::CUInt32VecHash::CUInt32VecHash(std::uint32_t m,
+                                                         const TUInt32Vec& a,
+                                                         std::uint32_t b)
     : m_M(m), m_A(a), m_B(b) {
 }
 
@@ -137,8 +140,8 @@ operator()(const std::string& token, CUInt32UnrestrictedHash& hash) const {
         return false;
     }
 
-    uint32_t a;
-    uint32_t b;
+    std::uint32_t a;
+    std::uint32_t b;
     m_Token.assign(token, 0, delimPos);
     if (CStringUtils::stringToType(m_Token, a) == false) {
         LOG_ERROR(<< "Invalid multiplier in " << m_Token);
@@ -166,9 +169,9 @@ bool CHashing::CUniversalHash::CFromString::operator()(const std::string& token,
         return false;
     }
 
-    uint32_t m;
-    uint32_t a;
-    uint32_t b;
+    std::uint32_t m;
+    std::uint32_t a;
+    std::uint32_t b;
     m_Token.assign(token, 0, firstDelimPos);
     if (CStringUtils::stringToType(m_Token, m) == false) {
         LOG_ERROR(<< "Invalid range in " << m_Token);
@@ -189,7 +192,7 @@ bool CHashing::CUniversalHash::CFromString::operator()(const std::string& token,
     return true;
 }
 
-void CHashing::CUniversalHash::generateHashes(std::size_t k, uint32_t m, TUInt32HashVec& result) {
+void CHashing::CUniversalHash::generateHashes(std::size_t k, std::uint32_t m, TUInt32HashVec& result) {
     TUInt32Vec a;
     TUInt32Vec b;
     a.reserve(k);
@@ -198,11 +201,11 @@ void CHashing::CUniversalHash::generateHashes(std::size_t k, uint32_t m, TUInt32
     {
         CScopedFastLock scopedLock(ms_Mutex);
 
-        TUniform32 uniform1(1, static_cast<uint32_t>(BIG_PRIME - 1));
+        TUniform32 uniform1(1, static_cast<std::uint32_t>(BIG_PRIME - 1));
         std::generate_n(std::back_inserter(a), k,
                         [uniform1] { return uniform1(ms_Generator); });
 
-        TUniform32 uniform0(0, static_cast<uint32_t>(BIG_PRIME - 1));
+        TUniform32 uniform0(0, static_cast<std::uint32_t>(BIG_PRIME - 1));
         std::generate_n(std::back_inserter(b), k,
                         [uniform0] { return uniform0(ms_Generator); });
     }
@@ -229,11 +232,11 @@ void CHashing::CUniversalHash::generateHashes(std::size_t k,
     {
         CScopedFastLock scopedLock(ms_Mutex);
 
-        TUniform32 uniform1(1, static_cast<uint32_t>(BIG_PRIME - 1));
+        TUniform32 uniform1(1, static_cast<std::uint32_t>(BIG_PRIME - 1));
         std::generate_n(std::back_inserter(a), k,
                         [uniform1] { return uniform1(ms_Generator); });
 
-        TUniform32 uniform0(0, static_cast<uint32_t>(BIG_PRIME - 1));
+        TUniform32 uniform0(0, static_cast<std::uint32_t>(BIG_PRIME - 1));
         std::generate_n(std::back_inserter(b), k,
                         [uniform0] { return uniform0(ms_Generator); });
     }
@@ -252,7 +255,7 @@ void CHashing::CUniversalHash::generateHashes(std::size_t k,
 
 void CHashing::CUniversalHash::generateHashes(std::size_t k,
                                               std::size_t n,
-                                              uint32_t m,
+                                              std::uint32_t m,
                                               TUInt32VecHashVec& result) {
     using TUInt32VecVec = std::vector<TUInt32Vec>;
 
@@ -267,7 +270,7 @@ void CHashing::CUniversalHash::generateHashes(std::size_t k,
         for (std::size_t i = 0; i < k; ++i) {
             a.push_back(TUInt32Vec());
             a.back().reserve(n);
-            TUniform32 uniform1(1, static_cast<uint32_t>(BIG_PRIME - 1));
+            TUniform32 uniform1(1, static_cast<std::uint32_t>(BIG_PRIME - 1));
             std::generate_n(std::back_inserter(a.back()), n,
                             [uniform1] { return uniform1(ms_Generator); });
             for (unsigned int& aj : a.back()) {
@@ -278,7 +281,7 @@ void CHashing::CUniversalHash::generateHashes(std::size_t k,
             }
         }
 
-        TUniform32 uniform0(0, static_cast<uint32_t>(BIG_PRIME - 1));
+        TUniform32 uniform0(0, static_cast<std::uint32_t>(BIG_PRIME - 1));
         std::generate_n(std::back_inserter(b), k,
                         [uniform0] { return uniform0(ms_Generator); });
     }
@@ -289,20 +292,20 @@ void CHashing::CUniversalHash::generateHashes(std::size_t k,
     }
 }
 
-uint32_t CHashing::murmurHash32(const void* key, int length, uint32_t seed) {
-    constexpr uint32_t m = 0x5bd1e995;
+uint32_t CHashing::murmurHash32(const void* key, int length, std::uint32_t seed) {
+    constexpr std::uint32_t m = 0x5bd1e995;
     constexpr int r = 24;
 
-    uint32_t h = seed ^ length;
+    std::uint32_t h = seed ^ length;
 
     // Note, remainder = length % 4
     const int remainder = length & 0x3;
-    const auto* data = static_cast<const uint32_t*>(key);
+    const auto* data = static_cast<const std::uint32_t*>(key);
     // Note, shift = (length - remainder) / 4
-    const uint32_t* end = data + ((length - remainder) >> 2);
+    const std::uint32_t* end = data + ((length - remainder) >> 2);
 
     while (data != end) {
-        uint32_t k = *reinterpret_cast<const uint32_t*>(data);
+        std::uint32_t k = *reinterpret_cast<const std::uint32_t*>(data);
 
         k *= m;
         k ^= k >> r;
@@ -338,17 +341,17 @@ uint32_t CHashing::murmurHash32(const void* key, int length, uint32_t seed) {
     return h;
 }
 
-uint32_t CHashing::safeMurmurHash32(const void* key, int length, uint32_t seed) {
-    constexpr uint32_t m = 0x5bd1e995;
+uint32_t CHashing::safeMurmurHash32(const void* key, int length, std::uint32_t seed) {
+    constexpr std::uint32_t m = 0x5bd1e995;
     constexpr int r = 24;
 
-    uint32_t h = seed ^ length;
+    std::uint32_t h = seed ^ length;
 
     const auto* data = static_cast<const unsigned char*>(key);
 
     // Endian and alignment neutral implementation of the main loop.
     while (length >= 4) {
-        uint32_t k;
+        std::uint32_t k;
 
         k = data[0];
         k |= data[1] << 8;
@@ -388,20 +391,20 @@ uint32_t CHashing::safeMurmurHash32(const void* key, int length, uint32_t seed) 
     return h;
 }
 
-uint64_t CHashing::murmurHash64(const void* key, int length, uint64_t seed) {
-    constexpr uint64_t m = 0xc6a4a7935bd1e995ULL;
+uint64_t CHashing::murmurHash64(const void* key, int length, std::uint64_t seed) {
+    constexpr std::uint64_t m = 0xc6a4a7935bd1e995ULL;
     constexpr int r = 47;
 
-    uint64_t h = seed ^ (length * m);
+    std::uint64_t h = seed ^ (length * m);
 
     // Note, remainder = length % 8
     const int remainder = length & 0x7;
-    const auto* data = static_cast<const uint64_t*>(key);
+    const auto* data = static_cast<const std::uint64_t*>(key);
     // Note, shift = (length - remainder) / 8
-    const uint64_t* end = data + ((length - remainder) >> 3);
+    const std::uint64_t* end = data + ((length - remainder) >> 3);
 
     while (data != end) {
-        uint64_t k = *data;
+        std::uint64_t k = *data;
 
         k *= m;
         k ^= k >> r;
@@ -417,25 +420,25 @@ uint64_t CHashing::murmurHash64(const void* key, int length, uint64_t seed) {
 
     switch (remainder) {
     case 7:
-        h ^= uint64_t(remainingData[6]) << 48;
+        h ^= std::uint64_t(remainingData[6]) << 48;
         BOOST_FALLTHROUGH;
     case 6:
-        h ^= uint64_t(remainingData[5]) << 40;
+        h ^= std::uint64_t(remainingData[5]) << 40;
         BOOST_FALLTHROUGH;
     case 5:
-        h ^= uint64_t(remainingData[4]) << 32;
+        h ^= std::uint64_t(remainingData[4]) << 32;
         BOOST_FALLTHROUGH;
     case 4:
-        h ^= uint64_t(remainingData[3]) << 24;
+        h ^= std::uint64_t(remainingData[3]) << 24;
         BOOST_FALLTHROUGH;
     case 3:
-        h ^= uint64_t(remainingData[2]) << 16;
+        h ^= std::uint64_t(remainingData[2]) << 16;
         BOOST_FALLTHROUGH;
     case 2:
-        h ^= uint64_t(remainingData[1]) << 8;
+        h ^= std::uint64_t(remainingData[1]) << 8;
         BOOST_FALLTHROUGH;
     case 1:
-        h ^= uint64_t(remainingData[0]);
+        h ^= std::uint64_t(remainingData[0]);
         h *= m;
         BOOST_FALLTHROUGH;
     default:
@@ -449,26 +452,26 @@ uint64_t CHashing::murmurHash64(const void* key, int length, uint64_t seed) {
     return h;
 }
 
-uint64_t CHashing::safeMurmurHash64(const void* key, int length, uint64_t seed) {
-    constexpr uint64_t m = 0xc6a4a7935bd1e995ULL;
+uint64_t CHashing::safeMurmurHash64(const void* key, int length, std::uint64_t seed) {
+    constexpr std::uint64_t m = 0xc6a4a7935bd1e995ULL;
     constexpr int r = 47;
 
-    uint64_t h = seed ^ (length * m);
+    std::uint64_t h = seed ^ (length * m);
 
     const auto* data = static_cast<const unsigned char*>(key);
 
     // Endian and alignment neutral implementation.
     while (length >= 8) {
-        uint64_t k;
+        std::uint64_t k;
 
-        k = uint64_t(data[0]);
-        k |= uint64_t(data[1]) << 8;
-        k |= uint64_t(data[2]) << 16;
-        k |= uint64_t(data[3]) << 24;
-        k |= uint64_t(data[4]) << 32;
-        k |= uint64_t(data[5]) << 40;
-        k |= uint64_t(data[6]) << 48;
-        k |= uint64_t(data[7]) << 56;
+        k = std::uint64_t(data[0]);
+        k |= std::uint64_t(data[1]) << 8;
+        k |= std::uint64_t(data[2]) << 16;
+        k |= std::uint64_t(data[3]) << 24;
+        k |= std::uint64_t(data[4]) << 32;
+        k |= std::uint64_t(data[5]) << 40;
+        k |= std::uint64_t(data[6]) << 48;
+        k |= std::uint64_t(data[7]) << 56;
 
         k *= m;
         k ^= k >> r;
@@ -483,25 +486,25 @@ uint64_t CHashing::safeMurmurHash64(const void* key, int length, uint64_t seed) 
 
     switch (length) {
     case 7:
-        h ^= uint64_t(data[6]) << 48;
+        h ^= std::uint64_t(data[6]) << 48;
         BOOST_FALLTHROUGH;
     case 6:
-        h ^= uint64_t(data[5]) << 40;
+        h ^= std::uint64_t(data[5]) << 40;
         BOOST_FALLTHROUGH;
     case 5:
-        h ^= uint64_t(data[4]) << 32;
+        h ^= std::uint64_t(data[4]) << 32;
         BOOST_FALLTHROUGH;
     case 4:
-        h ^= uint64_t(data[3]) << 24;
+        h ^= std::uint64_t(data[3]) << 24;
         BOOST_FALLTHROUGH;
     case 3:
-        h ^= uint64_t(data[2]) << 16;
+        h ^= std::uint64_t(data[2]) << 16;
         BOOST_FALLTHROUGH;
     case 2:
-        h ^= uint64_t(data[1]) << 8;
+        h ^= std::uint64_t(data[1]) << 8;
         BOOST_FALLTHROUGH;
     case 1:
-        h ^= uint64_t(data[0]);
+        h ^= std::uint64_t(data[0]);
         h *= m;
         BOOST_FALLTHROUGH;
     default:
@@ -515,17 +518,17 @@ uint64_t CHashing::safeMurmurHash64(const void* key, int length, uint64_t seed) 
     return h;
 }
 
-uint32_t CHashing::hashCombine(uint32_t seed, uint32_t h) {
-    constexpr uint32_t C = 0x9e3779b9;
+uint32_t CHashing::hashCombine(std::uint32_t seed, std::uint32_t h) {
+    constexpr std::uint32_t C = 0x9e3779b9;
     seed ^= h + C + (seed << 6) + (seed >> 2);
     return seed;
 }
 
-uint64_t CHashing::hashCombine(uint64_t seed, uint64_t h) {
+uint64_t CHashing::hashCombine(std::uint64_t seed, std::uint64_t h) {
     // As with boost::hash_combine use the binary expansion of an irrational
     // number to generate 64 random independent bits, i.e.
     //   C = 2^64 / "golden ratio" = 2^65 / (1 + 5^(1/2))
-    constexpr uint64_t C = 0x9e3779b97f4A7c15ULL;
+    constexpr std::uint64_t C = 0x9e3779b97f4A7c15ULL;
     seed ^= h + C + (seed << 6) + (seed >> 2);
     return seed;
 }

--- a/lib/core/CJsonLogLayout.cc
+++ b/lib/core/CJsonLogLayout.cc
@@ -39,8 +39,8 @@ const std::string LOGGER{CProgName::progName()};
 const std::string TIMESTAMP_NAME{"timestamp"};
 const std::string LEVEL_NAME{"level"};
 const std::string PID_NAME{"pid"};
-// Cast this to int64_t as the type varies between int32_t and uint32_t on
-// different platforms and int64_t covers both
+// Cast this to std::int64_t as the type varies between std::int32_t and std::uint32_t on
+// different platforms and std::int64_t covers both
 const std::int64_t PID{static_cast<std::int64_t>(ml::core::CProcess::instance().id())};
 const std::string THREAD_NAME{"thread"};
 const std::string MESSAGE_NAME{"message"};

--- a/lib/core/CJsonStateRestoreTraverser.cc
+++ b/lib/core/CJsonStateRestoreTraverser.cc
@@ -366,7 +366,7 @@ bool CJsonStateRestoreTraverser::SRapidJsonHandler::Uint(unsigned u) {
     return true;
 }
 
-bool CJsonStateRestoreTraverser::SRapidJsonHandler::Int64(int64_t i) {
+bool CJsonStateRestoreTraverser::SRapidJsonHandler::Int64(std::int64_t i) {
     s_Type = E_TokenInt64;
     if (s_RememberValue) {
         s_Value[s_NextIndex].assign(CStringUtils::typeToString(i));
@@ -375,7 +375,7 @@ bool CJsonStateRestoreTraverser::SRapidJsonHandler::Int64(int64_t i) {
     return true;
 }
 
-bool CJsonStateRestoreTraverser::SRapidJsonHandler::Uint64(uint64_t u) {
+bool CJsonStateRestoreTraverser::SRapidJsonHandler::Uint64(std::uint64_t u) {
     s_Type = E_TokenUInt64;
     if (s_RememberValue) {
         s_Value[s_NextIndex].assign(CStringUtils::typeToString(u));

--- a/lib/core/CMonotonicTime.cc
+++ b/lib/core/CMonotonicTime.cc
@@ -22,7 +22,7 @@ CMonotonicTime::CMonotonicTime()
     : m_ScalingFactor1(0), m_ScalingFactor2(0), m_ScalingFactor3(0) {
 }
 
-uint64_t CMonotonicTime::milliseconds() const {
+std::uint64_t CMonotonicTime::milliseconds() const {
     struct timespec ts;
 
     int rc(-1);
@@ -54,7 +54,7 @@ uint64_t CMonotonicTime::milliseconds() const {
     return result;
 }
 
-uint64_t CMonotonicTime::nanoseconds() const {
+std::uint64_t CMonotonicTime::nanoseconds() const {
     struct timespec ts;
 
     int rc(-1);

--- a/lib/core/CMonotonicTime.cc
+++ b/lib/core/CMonotonicTime.cc
@@ -48,8 +48,8 @@ uint64_t CMonotonicTime::milliseconds() const {
         return ::time(0) * 1000ULL;
     }
 
-    uint64_t result(static_cast<uint64_t>(ts.tv_sec) * 1000ULL);
-    result += static_cast<uint64_t>(ts.tv_nsec) / 1000000ULL;
+    std::uint64_t result(static_cast<std::uint64_t>(ts.tv_sec) * 1000ULL);
+    result += static_cast<std::uint64_t>(ts.tv_nsec) / 1000000ULL;
 
     return result;
 }
@@ -75,8 +75,8 @@ uint64_t CMonotonicTime::nanoseconds() const {
         return ::time(0) * 1000000000ULL;
     }
 
-    uint64_t result(static_cast<uint64_t>(ts.tv_sec) * 1000000000ULL);
-    result += static_cast<uint64_t>(ts.tv_nsec);
+    std::uint64_t result(static_cast<std::uint64_t>(ts.tv_sec) * 1000000000ULL);
+    result += static_cast<std::uint64_t>(ts.tv_nsec);
 
     return result;
 }

--- a/lib/core/CMonotonicTime_MacOSX.cc
+++ b/lib/core/CMonotonicTime_MacOSX.cc
@@ -31,11 +31,11 @@ CMonotonicTime::CMonotonicTime()
     }
 }
 
-uint64_t CMonotonicTime::milliseconds() const {
+std::uint64_t CMonotonicTime::milliseconds() const {
     return ::mach_absolute_time() * m_ScalingFactor1 / m_ScalingFactor2;
 }
 
-uint64_t CMonotonicTime::nanoseconds() const {
+std::uint64_t CMonotonicTime::nanoseconds() const {
     return ::mach_absolute_time() * m_ScalingFactor1 / m_ScalingFactor3;
 }
 }

--- a/lib/core/CMonotonicTime_Windows.cc
+++ b/lib/core/CMonotonicTime_Windows.cc
@@ -25,7 +25,7 @@ CMonotonicTime::CMonotonicTime()
         LOG_WARN(<< "High frequency performance counters not available");
     } else {
         // The high frequency counter ticks this many times per second
-        m_ScalingFactor1 = static_cast<uint64_t>(largeInt.QuadPart);
+        m_ScalingFactor1 = static_cast<std::uint64_t>(largeInt.QuadPart);
     }
 }
 
@@ -59,17 +59,17 @@ uint64_t CMonotonicTime::nanoseconds() const {
 
     // Doing the division first here truncates the result to the number of
     // nanoseconds in a number of full seconds
-    uint64_t fullSecondNanoseconds(
-        (static_cast<uint64_t>(largeInt.QuadPart) / m_ScalingFactor1) * 1000000000ULL);
+    std::uint64_t fullSecondNanoseconds(
+        (static_cast<std::uint64_t>(largeInt.QuadPart) / m_ScalingFactor1) * 1000000000ULL);
 
     // This is the number of ticks over and above the last full second
-    uint64_t remainder(static_cast<uint64_t>(largeInt.QuadPart) % m_ScalingFactor1);
+    std::uint64_t remainder(static_cast<std::uint64_t>(largeInt.QuadPart) % m_ScalingFactor1);
 
     // Assuming the counter ticks less than 18.4 billion times per second, this
     // won't overflow when we do the multiplication first (and on Windows 2008
     // it ticks about 3.75 million times per second, so there's a fair amount
     // of leeway here)
-    uint64_t extraNanoseconds((remainder * 1000000000ULL) / m_ScalingFactor1);
+    std::uint64_t extraNanoseconds((remainder * 1000000000ULL) / m_ScalingFactor1);
 
     return fullSecondNanoseconds + extraNanoseconds;
 }

--- a/lib/core/CMonotonicTime_Windows.cc
+++ b/lib/core/CMonotonicTime_Windows.cc
@@ -29,12 +29,12 @@ CMonotonicTime::CMonotonicTime()
     }
 }
 
-uint64_t CMonotonicTime::milliseconds() const {
+std::uint64_t CMonotonicTime::milliseconds() const {
     // This is only accurate to about 15 milliseconds
     return GetTickCount64();
 }
 
-uint64_t CMonotonicTime::nanoseconds() const {
+std::uint64_t CMonotonicTime::nanoseconds() const {
     if (m_ScalingFactor1 == 0) {
         // High frequency performance counters are not available, so return an
         // approximation

--- a/lib/core/CProgName_MacOSX.cc
+++ b/lib/core/CProgName_MacOSX.cc
@@ -12,8 +12,9 @@
 
 #include <boost/filesystem.hpp>
 
+#include <cstdint>
+
 #include <mach-o/dyld.h>
-#include <stdint.h>
 #include <stdlib.h>
 
 namespace ml {
@@ -29,12 +30,12 @@ std::string CProgName::progName() {
 }
 
 std::string CProgName::progDir() {
-    uint32_t bufferSize(2048);
+    std::uint32_t bufferSize(2048);
     std::string path(bufferSize, '\0');
     if (_NSGetExecutablePath(&path[0], &bufferSize) != 0) {
         return std::string();
     }
-    size_t lastSlash(path.rfind('/'));
+    std::size_t lastSlash(path.rfind('/'));
     if (lastSlash == std::string::npos) {
         return std::string();
     }

--- a/lib/core/CStateMachine.cc
+++ b/lib/core/CStateMachine.cc
@@ -157,8 +157,8 @@ std::string CStateMachine::printSymbol(std::size_t symbol) const {
 }
 
 uint64_t CStateMachine::checksum() const {
-    return CHashing::hashCombine(static_cast<uint64_t>(m_Machine),
-                                 static_cast<uint64_t>(m_State));
+    return CHashing::hashCombine(static_cast<std::uint64_t>(m_Machine),
+                                 static_cast<std::uint64_t>(m_State));
 }
 
 std::size_t CStateMachine::numberMachines() {

--- a/lib/core/CStateMachine.cc
+++ b/lib/core/CStateMachine.cc
@@ -156,7 +156,7 @@ std::string CStateMachine::printSymbol(std::size_t symbol) const {
     return ms_Machines[m_Machine].s_Alphabet[symbol];
 }
 
-uint64_t CStateMachine::checksum() const {
+std::uint64_t CStateMachine::checksum() const {
     return CHashing::hashCombine(static_cast<std::uint64_t>(m_Machine),
                                  static_cast<std::uint64_t>(m_State));
 }

--- a/lib/core/CStopWatch.cc
+++ b/lib/core/CStopWatch.cc
@@ -70,7 +70,7 @@ void CStopWatch::reset(bool startRunning) {
 }
 
 uint64_t CStopWatch::calcDuration() {
-    uint64_t current(m_MonotonicTime.milliseconds());
+    std::uint64_t current(m_MonotonicTime.milliseconds());
     if (current < m_Start) {
         LOG_WARN(<< "Monotonic timer has gone backwards - "
                     "stop watch timings will be inaccurate");

--- a/lib/core/CStopWatch.cc
+++ b/lib/core/CStopWatch.cc
@@ -34,7 +34,7 @@ void CStopWatch::start() {
     m_Start = m_MonotonicTime.milliseconds();
 }
 
-uint64_t CStopWatch::stop() {
+std::uint64_t CStopWatch::stop() {
     if (!m_IsRunning) {
         LOG_ERROR(<< "Stop watch not running");
         return m_AccumulatedTime;
@@ -47,7 +47,7 @@ uint64_t CStopWatch::stop() {
     return m_AccumulatedTime;
 }
 
-uint64_t CStopWatch::lap() {
+std::uint64_t CStopWatch::lap() {
     if (!m_IsRunning) {
         LOG_ERROR(<< "Stop watch not running");
         return m_AccumulatedTime;
@@ -69,7 +69,7 @@ void CStopWatch::reset(bool startRunning) {
     }
 }
 
-uint64_t CStopWatch::calcDuration() {
+std::uint64_t CStopWatch::calcDuration() {
     std::uint64_t current(m_MonotonicTime.milliseconds());
     if (current < m_Start) {
         LOG_WARN(<< "Monotonic timer has gone backwards - "

--- a/lib/core/CTimeUtils.cc
+++ b/lib/core/CTimeUtils.cc
@@ -79,7 +79,7 @@ std::string CTimeUtils::toTimeString(core_t::TTime t) {
 }
 
 int64_t CTimeUtils::toEpochMs(core_t::TTime t) {
-    return static_cast<int64_t>(t) * 1000;
+    return static_cast<std::int64_t>(t) * 1000;
 }
 
 bool CTimeUtils::strptime(const std::string& format,

--- a/lib/core/CTimeUtils.cc
+++ b/lib/core/CTimeUtils.cc
@@ -78,7 +78,7 @@ std::string CTimeUtils::toTimeString(core_t::TTime t) {
     return result;
 }
 
-int64_t CTimeUtils::toEpochMs(core_t::TTime t) {
+std::int64_t CTimeUtils::toEpochMs(core_t::TTime t) {
     return static_cast<std::int64_t>(t) * 1000;
 }
 

--- a/lib/core/CWindowsError.cc
+++ b/lib/core/CWindowsError.cc
@@ -21,7 +21,7 @@ CWindowsError::CWindowsError() : m_ErrorCode(0) {
 CWindowsError::CWindowsError(std::uint32_t /* errorCode */) : m_ErrorCode(0) {
 }
 
-uint32_t CWindowsError::errorCode() const {
+std::uint32_t CWindowsError::errorCode() const {
     return m_ErrorCode;
 }
 

--- a/lib/core/CWindowsError.cc
+++ b/lib/core/CWindowsError.cc
@@ -18,7 +18,7 @@ namespace core {
 CWindowsError::CWindowsError() : m_ErrorCode(0) {
 }
 
-CWindowsError::CWindowsError(uint32_t /* errorCode */) : m_ErrorCode(0) {
+CWindowsError::CWindowsError(std::uint32_t /* errorCode */) : m_ErrorCode(0) {
 }
 
 uint32_t CWindowsError::errorCode() const {

--- a/lib/core/CWindowsError_Windows.cc
+++ b/lib/core/CWindowsError_Windows.cc
@@ -29,7 +29,7 @@ CWindowsError::CWindowsError() : m_ErrorCode(GetLastError()) {
 CWindowsError::CWindowsError(std::uint32_t errorCode) : m_ErrorCode(errorCode) {
 }
 
-uint32_t CWindowsError::errorCode() const {
+std::uint32_t CWindowsError::errorCode() const {
     return m_ErrorCode;
 }
 

--- a/lib/core/CWindowsError_Windows.cc
+++ b/lib/core/CWindowsError_Windows.cc
@@ -26,7 +26,7 @@ namespace core {
 CWindowsError::CWindowsError() : m_ErrorCode(GetLastError()) {
 }
 
-CWindowsError::CWindowsError(uint32_t errorCode) : m_ErrorCode(errorCode) {
+CWindowsError::CWindowsError(std::uint32_t errorCode) : m_ErrorCode(errorCode) {
 }
 
 uint32_t CWindowsError::errorCode() const {

--- a/lib/core/unittest/CFlatPrefixTreeTest.cc
+++ b/lib/core/unittest/CFlatPrefixTreeTest.cc
@@ -18,10 +18,9 @@
 #include <boost/unordered_set.hpp>
 
 #include <algorithm>
+#include <cstdint>
 #include <string>
 #include <vector>
-
-#include <stdint.h>
 
 BOOST_AUTO_TEST_SUITE(CFlatPrefixTreeTest)
 

--- a/lib/core/unittest/CHashingTest.cc
+++ b/lib/core/unittest/CHashingTest.cc
@@ -44,8 +44,8 @@ BOOST_AUTO_TEST_CASE(testUniversalHash) {
     // must hold for a randomly selected member of the family.
 
     double tolerances[] = {1.0, 1.6};
-    uint32_t m[] = {30, 300};
-    uint32_t u[] = {1000, 10000};
+    std::uint32_t m[] = {30, 300};
+    std::uint32_t u[] = {1000, 10000};
 
     for (size_t i = 0; i < boost::size(m); ++i) {
         CHashing::CUniversalHash::TUInt32HashVec hashes;
@@ -60,16 +60,16 @@ BOOST_AUTO_TEST_CASE(testUniversalHash) {
             CHashing::CUniversalHash::CUInt32Hash hash = hashes[h];
 
             for (size_t j = 0; j < boost::size(u); ++j) {
-                uint32_t n = u[j];
+                std::uint32_t n = u[j];
 
                 LOG_DEBUG(<< "m = " << m[i] << ", U = [" << n << "]");
 
-                uint32_t collisions = 0;
+                std::uint32_t collisions = 0;
 
-                for (uint32_t x = 0; x < n; ++x) {
-                    for (uint32_t y = x + 1; y < n; ++y) {
-                        uint32_t hx = hash(x);
-                        uint32_t hy = hash(y);
+                for (std::uint32_t x = 0; x < n; ++x) {
+                    for (std::uint32_t y = x + 1; y < n; ++y) {
+                        std::uint32_t hx = hash(x);
+                        std::uint32_t hy = hash(y);
                         if (hx == hy) {
                             ++collisions;
                         }
@@ -99,8 +99,8 @@ BOOST_AUTO_TEST_CASE(testUniversalHash) {
     // We test a large u and m non exhaustively by choosing sufficient
     // different numbers of pairs to hash.
 
-    using TUInt32Vec = std::vector<uint32_t>;
-    using TUInt32Pr = std::pair<uint32_t, uint32_t>;
+    using TUInt32Vec = std::vector<std::uint32_t>;
+    using TUInt32Pr = std::pair<std::uint32_t, std::uint32_t>;
     using TUInt32PrSet = std::set<TUInt32Pr>;
     using TUint32PrUIntMap = std::map<TUInt32Pr, unsigned int>;
     using TUint32PrUIntMapCItr = TUint32PrUIntMap::const_iterator;
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(testUniversalHash) {
         LOG_DEBUG(<< "**** m = " << 10000 << ", U = [" << 10000000 << "] ****");
 
         boost::random::mt11213b generator;
-        boost::random::uniform_int_distribution<uint32_t> uniform(0u, 10000000u);
+        boost::random::uniform_int_distribution<std::uint32_t> uniform(0u, 10000000u);
 
         TUInt32Vec samples;
         std::generate_n(std::back_inserter(samples), 1000u,
@@ -126,15 +126,15 @@ BOOST_AUTO_TEST_CASE(testUniversalHash) {
 
             CHashing::CUniversalHash::CUInt32Hash hash = hashes[h];
 
-            uint32_t collisions = 0;
+            std::uint32_t collisions = 0;
             TUInt32PrSet uniquePairs;
 
             for (std::size_t i = 0; i < samples.size(); ++i) {
                 for (std::size_t j = i + 1; j < samples.size(); ++j) {
                     if (samples[i] != samples[j] &&
                         uniquePairs.insert(TUInt32Pr(samples[i], samples[j])).second) {
-                        uint32_t hx = hash(samples[i]);
-                        uint32_t hy = hash(samples[j]);
+                        std::uint32_t hx = hash(samples[i]);
+                        std::uint32_t hy = hash(samples[j]);
                         if (hx == hy) {
                             ++collisions;
                         }
@@ -180,10 +180,10 @@ BOOST_AUTO_TEST_CASE(testUniversalHash) {
             LOG_DEBUG(<< "Testing hash = " << hashes[h].print());
 
             CHashing::CUniversalHash::CUInt32Hash hash = hashes[h];
-            for (uint32_t x = 0; x < 2000; ++x) {
-                for (uint32_t y = x + 1; y < 2000; ++y) {
-                    uint32_t hx = hash(x);
-                    uint32_t hy = hash(y);
+            for (std::uint32_t x = 0; x < 2000; ++x) {
+                for (std::uint32_t y = x + 1; y < 2000; ++y) {
+                    std::uint32_t hx = hash(x);
+                    std::uint32_t hy = hash(y);
                     ++uniqueHashedPairs[TUInt32Pr(hx, hy)];
                 }
             }
@@ -211,32 +211,32 @@ BOOST_AUTO_TEST_CASE(testUniversalHash) {
 BOOST_AUTO_TEST_CASE(testMurmurHash) {
     {
         std::string key("This is the voice of the Mysterons!");
-        uint32_t seed = 0xdead4321;
-        uint32_t result =
+        std::uint32_t seed = 0xdead4321;
+        std::uint32_t result =
             CHashing::murmurHash32(key.c_str(), static_cast<int>(key.size()), seed);
-        BOOST_REQUIRE_EQUAL(uint32_t(0xEE593473), result);
+        BOOST_REQUIRE_EQUAL(std::uint32_t(0xEE593473), result);
     }
     {
         std::string key("We know that you can hear us, Earthmen!");
-        uint32_t seed = 0xffeeeeff;
-        uint32_t result = CHashing::safeMurmurHash32(
+        std::uint32_t seed = 0xffeeeeff;
+        std::uint32_t result = CHashing::safeMurmurHash32(
             key.c_str(), static_cast<int>(key.size()), seed);
-        BOOST_REQUIRE_EQUAL(uint32_t(0x54837c96), result);
+        BOOST_REQUIRE_EQUAL(std::uint32_t(0x54837c96), result);
     }
     {
         std::string key("Your message has been analysed and it has been decided to allow one member of Spectrum to meet our representative.");
-        uint64_t seed = 0xaabbccddffeeeeffULL;
-        uint64_t result =
+        std::uint64_t seed = 0xaabbccddffeeeeffULL;
+        std::uint64_t result =
             CHashing::murmurHash64(key.c_str(), static_cast<int>(key.size()), seed);
-        BOOST_REQUIRE_EQUAL(uint64_t(14826751455157300659ull), result);
+        BOOST_REQUIRE_EQUAL(std::uint64_t(14826751455157300659ull), result);
     }
     {
         std::string key("Earthmen, we are peaceful beings and you have tried to destroy us, but you cannot succeed. You and your people "
                         "will pay for this act of aggression.");
-        uint64_t seed = 0x1324fedc9876abdeULL;
-        uint64_t result = CHashing::safeMurmurHash64(
+        std::uint64_t seed = 0x1324fedc9876abdeULL;
+        std::uint64_t result = CHashing::safeMurmurHash64(
             key.c_str(), static_cast<int>(key.size()), seed);
-        BOOST_REQUIRE_EQUAL(uint64_t(7291323361835448266ull), result);
+        BOOST_REQUIRE_EQUAL(std::uint64_t(7291323361835448266ull), result);
     }
 
     using TStrVec = std::vector<std::string>;
@@ -251,10 +251,10 @@ BOOST_AUTO_TEST_CASE(testMurmurHash) {
     rng.generateWords(stringSize, numberStrings, testStrings);
 
     core::CStopWatch stopWatch;
-    uint64_t defaultInsertTime = 0;
-    uint64_t defaultLookupTime = 0;
-    uint64_t murmurInsertTime = 0;
-    uint64_t murmurLookupTime = 0;
+    std::uint64_t defaultInsertTime = 0;
+    std::uint64_t defaultLookupTime = 0;
+    std::uint64_t murmurInsertTime = 0;
+    std::uint64_t murmurLookupTime = 0;
     for (int run = 0; run < 6; ++run) {
         LOG_DEBUG(<< "run = " << run);
 
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE(testHashCombine) {
     CHashing::CMurmurHash2String hasher;
 
     using TStrVec = std::vector<std::string>;
-    using TSizeSet = std::set<uint64_t>;
+    using TSizeSet = std::set<std::uint64_t>;
 
     const std::size_t stringSize = 32;
     const std::size_t numberStrings = 2000000;
@@ -366,8 +366,8 @@ BOOST_AUTO_TEST_CASE(testHashCombine) {
         for (std::size_t j = 0; j < numberStrings; j += 2) {
             uniqueHashes.insert(hasher(testStrings[j] + testStrings[j + 1]));
             uniqueHashCombines.insert(core::CHashing::hashCombine(
-                static_cast<uint64_t>(hasher(testStrings[j])),
-                static_cast<uint64_t>(hasher(testStrings[j + 1]))));
+                static_cast<std::uint64_t>(hasher(testStrings[j])),
+                static_cast<std::uint64_t>(hasher(testStrings[j + 1]))));
         }
 
         LOG_DEBUG(<< "# unique hashes          = " << uniqueHashes.size());
@@ -382,19 +382,19 @@ BOOST_AUTO_TEST_CASE(testHashCombine) {
 BOOST_AUTO_TEST_CASE(testConstructors) {
     {
         CHashing::CUniversalHash::CUInt32Hash hash(1, 2, 3);
-        BOOST_REQUIRE_EQUAL(uint32_t(1), hash.m());
-        BOOST_REQUIRE_EQUAL(uint32_t(2), hash.a());
-        BOOST_REQUIRE_EQUAL(uint32_t(3), hash.b());
+        BOOST_REQUIRE_EQUAL(std::uint32_t(1), hash.m());
+        BOOST_REQUIRE_EQUAL(std::uint32_t(2), hash.a());
+        BOOST_REQUIRE_EQUAL(std::uint32_t(3), hash.b());
     }
     {
         CHashing::CUniversalHash::CUInt32UnrestrictedHash hash;
-        BOOST_REQUIRE_EQUAL(uint32_t(1), hash.a());
-        BOOST_REQUIRE_EQUAL(uint32_t(0), hash.b());
+        BOOST_REQUIRE_EQUAL(std::uint32_t(1), hash.a());
+        BOOST_REQUIRE_EQUAL(std::uint32_t(0), hash.b());
     }
     {
         CHashing::CUniversalHash::CUInt32UnrestrictedHash hash(3, 4);
-        BOOST_REQUIRE_EQUAL(uint32_t(3), hash.a());
-        BOOST_REQUIRE_EQUAL(uint32_t(4), hash.b());
+        BOOST_REQUIRE_EQUAL(std::uint32_t(3), hash.a());
+        BOOST_REQUIRE_EQUAL(std::uint32_t(4), hash.b());
         LOG_DEBUG(<< hash.print());
     }
     {
@@ -405,8 +405,8 @@ BOOST_AUTO_TEST_CASE(testConstructors) {
         CHashing::CUniversalHash::CUInt32VecHash hash(5, a, 6);
         BOOST_REQUIRE_EQUAL(CContainerPrinter::print(a),
                             CContainerPrinter::print(hash.a()));
-        BOOST_REQUIRE_EQUAL(uint32_t(5), hash.m());
-        BOOST_REQUIRE_EQUAL(uint32_t(6), hash.b());
+        BOOST_REQUIRE_EQUAL(std::uint32_t(5), hash.m());
+        BOOST_REQUIRE_EQUAL(std::uint32_t(6), hash.b());
         LOG_DEBUG(<< hash.print());
     }
     {
@@ -425,15 +425,15 @@ BOOST_AUTO_TEST_CASE(testConstructors) {
         {
             CHashing::CUniversalHash::CUInt32UnrestrictedHash hash;
             BOOST_TEST_REQUIRE(c("2134,5432", hash));
-            BOOST_REQUIRE_EQUAL(uint32_t(2134), hash.a());
-            BOOST_REQUIRE_EQUAL(uint32_t(5432), hash.b());
+            BOOST_REQUIRE_EQUAL(std::uint32_t(2134), hash.a());
+            BOOST_REQUIRE_EQUAL(std::uint32_t(5432), hash.b());
         }
         {
             CHashing::CUniversalHash::CUInt32Hash hash;
             BOOST_TEST_REQUIRE(c("92134,54329,00000002", hash));
-            BOOST_REQUIRE_EQUAL(uint32_t(92134), hash.m());
-            BOOST_REQUIRE_EQUAL(uint32_t(54329), hash.a());
-            BOOST_REQUIRE_EQUAL(uint32_t(2), hash.b());
+            BOOST_REQUIRE_EQUAL(std::uint32_t(92134), hash.m());
+            BOOST_REQUIRE_EQUAL(std::uint32_t(54329), hash.a());
+            BOOST_REQUIRE_EQUAL(std::uint32_t(2), hash.b());
         }
     }
     {

--- a/lib/core/unittest/CMonotonicTimeTest.cc
+++ b/lib/core/unittest/CMonotonicTimeTest.cc
@@ -22,13 +22,13 @@ BOOST_AUTO_TEST_SUITE(CMonotonicTimeTest)
 BOOST_AUTO_TEST_CASE(testMilliseconds) {
     ml::core::CMonotonicTime monoTime;
 
-    uint64_t start(monoTime.milliseconds());
+    std::uint64_t start(monoTime.milliseconds());
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
-    uint64_t end(monoTime.milliseconds());
+    std::uint64_t end(monoTime.milliseconds());
 
-    uint64_t diff(end - start);
+    std::uint64_t diff(end - start);
     LOG_DEBUG(<< "During 1 second the monotonic millisecond timer advanced by "
               << diff << " milliseconds");
 
@@ -42,13 +42,13 @@ BOOST_AUTO_TEST_CASE(testMilliseconds) {
 BOOST_AUTO_TEST_CASE(testNanoseconds) {
     ml::core::CMonotonicTime monoTime;
 
-    uint64_t start(monoTime.nanoseconds());
+    std::uint64_t start(monoTime.nanoseconds());
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
-    uint64_t end(monoTime.nanoseconds());
+    std::uint64_t end(monoTime.nanoseconds());
 
-    uint64_t diff(end - start);
+    std::uint64_t diff(end - start);
     LOG_DEBUG(<< "During 1 second the monotonic nanosecond timer advanced by "
               << diff << " nanoseconds");
 

--- a/lib/core/unittest/CRapidJsonLineWriterTest.cc
+++ b/lib/core/unittest/CRapidJsonLineWriterTest.cc
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(testMicroBenchmark, *boost::unit_test::disabled()) {
         rapidjson::internal::dtoa(1.43e-35, buffer);
         rapidjson::internal::dtoa(42.0, buffer);
     }
-    uint64_t elapsed = stopWatch.stop();
+    std::uint64_t elapsed = stopWatch.stop();
     LOG_INFO(<< "Rapidjson dtoa " << runs << " runs took " << elapsed);
     stopWatch.reset();
     stopWatch.start();

--- a/lib/core/unittest/CStaticThreadPoolTest.cc
+++ b/lib/core/unittest/CStaticThreadPoolTest.cc
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(testScheduleDelayMinimisation) {
         // We should get here fast because the unblocked thread should keep
         // draining the instant tasks even though they're added to both queues.
 
-        uint64_t timeToSchedule{watch.stop()};
+        std::uint64_t timeToSchedule{watch.stop()};
         LOG_DEBUG(<< "Time to schedule " << timeToSchedule);
         //BOOST_TEST_REQUIRE(timeToSchedule <= 1);
     }
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(testThroughputStability) {
         // to process before we can finish scheduling. We give ourselves a little
         // head room.
 
-        uint64_t timeToSchedule{watch.stop()};
+        std::uint64_t timeToSchedule{watch.stop()};
         LOG_DEBUG(<< "Time to schedule " << timeToSchedule);
         //BOOST_TEST_REQUIRE(timeToSchedule >= 300);
         //BOOST_TEST_REQUIRE(timeToSchedule <= 350);

--- a/lib/core/unittest/CStringUtilsTest.cc
+++ b/lib/core/unittest/CStringUtilsTest.cc
@@ -19,10 +19,10 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include <cstdint>
 #include <set>
 #include <vector>
 
-#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -127,24 +127,24 @@ BOOST_AUTO_TEST_CASE(testReplaceFirst) {
 
 BOOST_AUTO_TEST_CASE(testTypeToString) {
     {
-        uint64_t i(18446744073709551615ULL);
+        std::uint64_t i(18446744073709551615ULL);
         std::string expected("18446744073709551615");
 
         std::string actual = ml::core::CStringUtils::typeToString(i);
         BOOST_REQUIRE_EQUAL(expected, actual);
 
-        uint64_t j(0);
+        std::uint64_t j(0);
         BOOST_TEST_REQUIRE(ml::core::CStringUtils::stringToType(actual, j));
         BOOST_REQUIRE_EQUAL(i, j);
     }
     {
-        uint32_t i(123456U);
+        std::uint32_t i(123456U);
         std::string expected("123456");
 
         std::string actual = ml::core::CStringUtils::typeToString(i);
         BOOST_REQUIRE_EQUAL(expected, actual);
 
-        uint32_t j(0);
+        std::uint32_t j(0);
         BOOST_TEST_REQUIRE(ml::core::CStringUtils::stringToType(actual, j));
         BOOST_REQUIRE_EQUAL(i, j);
     }
@@ -160,13 +160,13 @@ BOOST_AUTO_TEST_CASE(testTypeToString) {
         BOOST_REQUIRE_EQUAL(i, j);
     }
     {
-        int32_t i(123456);
+        std::int32_t i(123456);
         std::string expected("123456");
 
         std::string actual = ml::core::CStringUtils::typeToString(i);
         BOOST_REQUIRE_EQUAL(expected, actual);
 
-        int32_t j(0);
+        std::int32_t j(0);
         BOOST_TEST_REQUIRE(ml::core::CStringUtils::stringToType(actual, j));
         BOOST_REQUIRE_EQUAL(i, j);
     }
@@ -382,43 +382,43 @@ BOOST_AUTO_TEST_CASE(testStringToType) {
     }
     {
         // All good conversions
-        int32_t ret;
+        std::int32_t ret;
         BOOST_TEST_REQUIRE(ml::core::CStringUtils::stringToType("1000", ret));
-        BOOST_REQUIRE_EQUAL(int32_t(1000), ret);
+        BOOST_REQUIRE_EQUAL(1000, ret);
         BOOST_TEST_REQUIRE(ml::core::CStringUtils::stringToType("-1000", ret));
-        BOOST_REQUIRE_EQUAL(int32_t(-1000), ret);
+        BOOST_REQUIRE_EQUAL(-1000, ret);
         BOOST_TEST_REQUIRE(ml::core::CStringUtils::stringToType("0", ret));
-        BOOST_REQUIRE_EQUAL(int32_t(0), ret);
+        BOOST_REQUIRE_EQUAL(0, ret);
         BOOST_TEST_REQUIRE(ml::core::CStringUtils::stringToType("0x1000", ret));
-        BOOST_REQUIRE_EQUAL(int32_t(0x1000), ret);
+        BOOST_REQUIRE_EQUAL(0x1000, ret);
         BOOST_TEST_REQUIRE(ml::core::CStringUtils::stringToType("2147483647", ret));
-        BOOST_REQUIRE_EQUAL(int32_t(2147483647), ret);
+        BOOST_REQUIRE_EQUAL(2147483647, ret);
         BOOST_TEST_REQUIRE(ml::core::CStringUtils::stringToType("-2147483647", ret));
-        BOOST_REQUIRE_EQUAL(int32_t(-2147483647), ret);
+        BOOST_REQUIRE_EQUAL(-2147483647, ret);
     }
     {
         // All good conversions
-        uint64_t ret;
+        std::uint64_t ret;
         BOOST_TEST_REQUIRE(ml::core::CStringUtils::stringToType("1000", ret));
-        BOOST_REQUIRE_EQUAL(uint64_t(1000), ret);
+        BOOST_REQUIRE_EQUAL(1000, ret);
         BOOST_TEST_REQUIRE(ml::core::CStringUtils::stringToType("0", ret));
-        BOOST_REQUIRE_EQUAL(uint64_t(0), ret);
+        BOOST_REQUIRE_EQUAL(0, ret);
         BOOST_TEST_REQUIRE(ml::core::CStringUtils::stringToType("0x1000", ret));
-        BOOST_REQUIRE_EQUAL(uint64_t(0x1000), ret);
+        BOOST_REQUIRE_EQUAL(0x1000, ret);
         BOOST_TEST_REQUIRE(ml::core::CStringUtils::stringToType("18446744073709551615", ret));
-        BOOST_REQUIRE_EQUAL(uint64_t(18446744073709551615ULL), ret);
+        BOOST_REQUIRE_EQUAL(18446744073709551615ULL, ret);
     }
     {
         // All good conversions
-        uint32_t ret;
+        std::uint32_t ret;
         BOOST_TEST_REQUIRE(ml::core::CStringUtils::stringToType("1000", ret));
-        BOOST_REQUIRE_EQUAL(uint32_t(1000), ret);
+        BOOST_REQUIRE_EQUAL(std::uint32_t(1000), ret);
         BOOST_TEST_REQUIRE(ml::core::CStringUtils::stringToType("0", ret));
-        BOOST_REQUIRE_EQUAL(uint32_t(0), ret);
+        BOOST_REQUIRE_EQUAL(std::uint32_t(0), ret);
         BOOST_TEST_REQUIRE(ml::core::CStringUtils::stringToType("0x1000", ret));
-        BOOST_REQUIRE_EQUAL(uint32_t(0x1000), ret);
+        BOOST_REQUIRE_EQUAL(std::uint32_t(0x1000), ret);
         BOOST_TEST_REQUIRE(ml::core::CStringUtils::stringToType("2147483650", ret));
-        BOOST_REQUIRE_EQUAL(uint32_t(2147483650UL), ret);
+        BOOST_REQUIRE_EQUAL(std::uint32_t(2147483650UL), ret);
     }
     {
         // All good conversions
@@ -451,7 +451,7 @@ BOOST_AUTO_TEST_CASE(testStringToType) {
     }
     {
         // All bad conversions
-        int64_t ret;
+        std::int64_t ret;
         BOOST_TEST_REQUIRE(!ml::core::CStringUtils::stringToType("", ret));
         BOOST_TEST_REQUIRE(!ml::core::CStringUtils::stringToType("abc", ret));
         BOOST_TEST_REQUIRE(!ml::core::CStringUtils::stringToType("9223372036854775808", ret));
@@ -459,7 +459,7 @@ BOOST_AUTO_TEST_CASE(testStringToType) {
     }
     {
         // All bad conversions
-        int32_t ret;
+        std::int32_t ret;
         BOOST_TEST_REQUIRE(!ml::core::CStringUtils::stringToType("abc", ret));
         BOOST_TEST_REQUIRE(!ml::core::CStringUtils::stringToType("2147483648", ret));
         BOOST_TEST_REQUIRE(!ml::core::CStringUtils::stringToType("-2147483649", ret));
@@ -473,13 +473,13 @@ BOOST_AUTO_TEST_CASE(testStringToType) {
     }
     {
         // All bad conversions
-        uint64_t ret;
+        std::uint64_t ret;
         BOOST_TEST_REQUIRE(!ml::core::CStringUtils::stringToType("abc", ret));
         BOOST_TEST_REQUIRE(!ml::core::CStringUtils::stringToType("18446744073709551616", ret));
     }
     {
         // All bad conversions
-        uint32_t ret;
+        std::uint32_t ret;
         BOOST_TEST_REQUIRE(!ml::core::CStringUtils::stringToType("abc", ret));
         BOOST_TEST_REQUIRE(!ml::core::CStringUtils::stringToType("4294967296", ret));
     }
@@ -858,7 +858,7 @@ BOOST_AUTO_TEST_CASE(testPerformance, *boost::unit_test::disabled()) {
             std::string result(ml::core::CStringUtils::typeToString(count));
             ml::core::CStringUtils::stringToType(result, count);
         }
-        uint64_t timeMs(stopWatch.stop());
+        std::uint64_t timeMs(stopWatch.stop());
         LOG_DEBUG(<< "After CStringUtils::typeToString integer test");
         LOG_DEBUG(<< "CStringUtils::typeToString integer test took " << timeMs << "ms");
     }
@@ -872,7 +872,7 @@ BOOST_AUTO_TEST_CASE(testPerformance, *boost::unit_test::disabled()) {
             std::string result(boost::lexical_cast<std::string>(count));
             count = boost::lexical_cast<size_t>(result);
         }
-        uint64_t timeMs(stopWatch.stop());
+        std::uint64_t timeMs(stopWatch.stop());
         LOG_DEBUG(<< "After boost::lexical_cast integer test");
         LOG_DEBUG(<< "boost::lexical_cast integer test took " << timeMs << "ms");
     }
@@ -887,7 +887,7 @@ BOOST_AUTO_TEST_CASE(testPerformance, *boost::unit_test::disabled()) {
             std::string result(ml::core::CStringUtils::typeToString(count));
             ml::core::CStringUtils::stringToType(result, count);
         }
-        uint64_t timeMs(stopWatch.stop());
+        std::uint64_t timeMs(stopWatch.stop());
         LOG_DEBUG(<< "After CStringUtils::typeToString floating point test");
         LOG_DEBUG(<< "CStringUtils::typeToString floating point test took " << timeMs << "ms");
     }
@@ -901,7 +901,7 @@ BOOST_AUTO_TEST_CASE(testPerformance, *boost::unit_test::disabled()) {
             std::string result(boost::lexical_cast<std::string>(count));
             count = boost::lexical_cast<double>(result);
         }
-        uint64_t timeMs(stopWatch.stop());
+        std::uint64_t timeMs(stopWatch.stop());
         LOG_DEBUG(<< "After boost::lexical_cast floating point test");
         LOG_DEBUG(<< "boost::lexical_cast floating point test took " << timeMs << "ms");
     }

--- a/lib/core/unittest/CTimeUtilsTest.cc
+++ b/lib/core/unittest/CTimeUtilsTest.cc
@@ -88,13 +88,11 @@ BOOST_AUTO_TEST_CASE(testToLocal) {
 }
 
 BOOST_AUTO_TEST_CASE(testToEpochMs) {
-    BOOST_REQUIRE_EQUAL(int64_t(1000),
-                        ml::core::CTimeUtils::toEpochMs(ml::core_t::TTime(1)));
-    BOOST_REQUIRE_EQUAL(int64_t(-1000),
-                        ml::core::CTimeUtils::toEpochMs(ml::core_t::TTime(-1)));
-    BOOST_REQUIRE_EQUAL(int64_t(1521035866000),
+    BOOST_REQUIRE_EQUAL(1000, ml::core::CTimeUtils::toEpochMs(ml::core_t::TTime(1)));
+    BOOST_REQUIRE_EQUAL(-1000, ml::core::CTimeUtils::toEpochMs(ml::core_t::TTime(-1)));
+    BOOST_REQUIRE_EQUAL(1521035866000,
                         ml::core::CTimeUtils::toEpochMs(ml::core_t::TTime(1521035866)));
-    BOOST_REQUIRE_EQUAL(int64_t(-1521035866000),
+    BOOST_REQUIRE_EQUAL(-1521035866000,
                         ml::core::CTimeUtils::toEpochMs(ml::core_t::TTime(-1521035866)));
 }
 

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -1115,7 +1115,7 @@ std::size_t CBoostedTreeFactory::estimateExtraColumns(std::size_t numberColumns,
     //   1. The predicted values for the dependent variable
     //   2. The gradient of the loss function
     //   3. The upper triangle of the hessian of the loss function
-    //   4. The example's splits packed into uint8_t
+    //   4. The example's splits packed into std::uint8_t
     return numberLossParameters * (numberLossParameters + 5) / 2 + (numberColumns + 2) / 4;
 }
 

--- a/lib/maths/analytics/unittest/CTreeShapFeatureImportanceTest.cc
+++ b/lib/maths/analytics/unittest/CTreeShapFeatureImportanceTest.cc
@@ -240,7 +240,7 @@ struct SFixtureRandomTrees {
         s_Frame = core::makeMainStorageDataFrame(s_NumberFeatures, s_NumberRows).first;
         s_Frame->columnNames(columnNames(s_NumberFeatures));
         for (std::size_t i = 0; i < s_NumberRows; ++i) {
-            s_Frame->writeRow([&](core::CDataFrame::TFloatVecItr column, int32_t&) {
+            s_Frame->writeRow([&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
                 for (std::size_t j = 0; j < s_NumberFeatures; ++j, ++column) {
                     *column = values[i * s_NumberFeatures + j];
                 }

--- a/lib/maths/common/CBjkstUniqueValues.cc
+++ b/lib/maths/common/CBjkstUniqueValues.cc
@@ -229,7 +229,7 @@ public:
 };
 }
 
-uint8_t CBjkstUniqueValues::trailingZeros(std::uint32_t value) {
+std::uint8_t CBjkstUniqueValues::trailingZeros(std::uint32_t value) {
     if (value == 0) {
         return 32;
     }
@@ -409,7 +409,7 @@ void CBjkstUniqueValues::remove(std::uint32_t value) {
     }
 }
 
-uint32_t CBjkstUniqueValues::number() const {
+std::uint32_t CBjkstUniqueValues::number() const {
     const TUInt32Vec* values = std::get_if<TUInt32Vec>(&m_Sketch);
     if (values == nullptr) {
         try {
@@ -422,7 +422,7 @@ uint32_t CBjkstUniqueValues::number() const {
     return static_cast<std::uint32_t>(values->size());
 }
 
-uint64_t CBjkstUniqueValues::checksum(std::uint64_t seed) const {
+std::uint64_t CBjkstUniqueValues::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_MaxSize);
     seed = CChecksum::calculate(seed, m_NumberHashes);
     const TUInt32Vec* values = std::get_if<TUInt32Vec>(&m_Sketch);
@@ -628,7 +628,7 @@ void CBjkstUniqueValues::SSketch::remove(std::uint32_t value) {
     }
 }
 
-uint32_t CBjkstUniqueValues::SSketch::number() const {
+std::uint32_t CBjkstUniqueValues::SSketch::number() const {
     // This uses the median trick to reduce the error.
     TUInt32Vec estimates;
     estimates.reserve(s_Z.size());

--- a/lib/maths/common/CBjkstUniqueValues.cc
+++ b/lib/maths/common/CBjkstUniqueValues.cc
@@ -30,19 +30,19 @@ namespace common {
 namespace {
 namespace detail {
 
-using TUInt8Vec = std::vector<uint8_t>;
+using TUInt8Vec = std::vector<std::uint8_t>;
 using TUInt8VecItr = TUInt8Vec::iterator;
 using TUInt8VecCItr = TUInt8Vec::const_iterator;
 
 //! Convert the decomposition of the hash into two 8 bit integers
 //! bask into the original hash value.
-inline uint16_t from8Bit(uint8_t leading, uint8_t trailing) {
+inline uint16_t from8Bit(std::uint8_t leading, std::uint8_t trailing) {
     // The C++ standard says that arithmetic on types smaller than int may be
     // done by converting to int, so cast this way to avoid compiler warnings
     return static_cast<uint16_t>((static_cast<unsigned int>(leading) << 8) + trailing);
 }
 
-using TUInt8UInt8Pr = std::pair<uint8_t, uint8_t>;
+using TUInt8UInt8Pr = std::pair<std::uint8_t, std::uint8_t>;
 
 //! \brief Random access iterator wrapper for B set iterator.
 //!
@@ -58,13 +58,13 @@ using TUInt8UInt8Pr = std::pair<uint8_t, uint8_t>;
 // clang-format off
 class EMPTY_BASE_OPT CHashIterator final
     : private boost::less_than_comparable<CHashIterator,
-              boost::addable<CHashIterator, ptrdiff_t,
-              boost::subtractable<CHashIterator, ptrdiff_t>>> {
+              boost::addable<CHashIterator, std::ptrdiff_t,
+              boost::subtractable<CHashIterator, std::ptrdiff_t>>> {
     // clang-format on
 public:
     using iterator_category = std::random_access_iterator_tag;
     using value_type = uint16_t;
-    using difference_type = ptrdiff_t;
+    using difference_type = std::ptrdiff_t;
     using pointer = void;
     using reference = void;
 
@@ -97,19 +97,19 @@ public:
         m_Itr -= 3;
         return result;
     }
-    uint16_t operator[](ptrdiff_t n) const {
+    uint16_t operator[](std::ptrdiff_t n) const {
         auto itr = m_Itr + 3 * n;
         return from8Bit(*itr, *(itr + 1));
     }
-    const CHashIterator& operator+=(ptrdiff_t n) {
+    const CHashIterator& operator+=(std::ptrdiff_t n) {
         m_Itr += 3 * n;
         return *this;
     }
-    const CHashIterator& operator-=(ptrdiff_t n) {
+    const CHashIterator& operator-=(std::ptrdiff_t n) {
         m_Itr -= 3 * n;
         return *this;
     }
-    ptrdiff_t operator-(const CHashIterator& other) const {
+    std::ptrdiff_t operator-(const CHashIterator& other) const {
         return (m_Itr - other.m_Itr) / 3;
     }
 
@@ -117,7 +117,7 @@ private:
     TUInt8VecItr m_Itr;
 };
 
-bool insert(TUInt8Vec& b, uint16_t g, uint8_t zeros) {
+bool insert(TUInt8Vec& b, uint16_t g, std::uint8_t zeros) {
     // This uses the fact that the set "b" is laid out as follows:
     //  |<---8 bits--->|<---8 bits--->|<---8 bits--->|
     //  |(g >> 8) % 256|    g % 256   |    zeros     |
@@ -138,14 +138,14 @@ bool insert(TUInt8Vec& b, uint16_t g, uint8_t zeros) {
     // requires values after in b to be copied to their new
     // positions.
 
-    ptrdiff_t i = lb.base() - b.begin();
-    auto g1 = static_cast<uint8_t>(g >> 8);
-    auto g2 = static_cast<uint8_t>(g);
+    std::ptrdiff_t i = lb.base() - b.begin();
+    auto g1 = static_cast<std::uint8_t>(g >> 8);
+    auto g2 = static_cast<std::uint8_t>(g);
     LOG_TRACE(<< "Adding g = " << g << " at " << i
-              << " (g1 = " << static_cast<uint32_t>(g1)
-              << ", g2 = " << static_cast<uint32_t>(g2) << ")");
+              << " (g1 = " << static_cast<std::uint32_t>(g1)
+              << ", g2 = " << static_cast<std::uint32_t>(g2) << ")");
 
-    b.insert(lb.base(), 3u, uint8_t());
+    b.insert(lb.base(), 3u, std::uint8_t());
     b[i] = g1;
     b[i + 1] = g2;
     b[i + 2] = zeros;
@@ -165,7 +165,7 @@ void remove(TUInt8Vec& b, uint16_t g) {
     }
 }
 
-void prune(TUInt8Vec& b, uint8_t z) {
+void prune(TUInt8Vec& b, std::uint8_t z) {
     // This uses the fact that the set "b" is laid out as follows:
     //  |<---8 bits--->|<---8 bits--->|<---8 bits--->|
     //  |(g >> 8) % 256|    g % 256   |    zeros     |
@@ -179,8 +179,8 @@ void prune(TUInt8Vec& b, uint8_t z) {
             j += 3;
         } else {
             LOG_TRACE(<< "Removing " << from8Bit(b[i], b[i + 1])
-                      << ", zeros =  " << static_cast<uint32_t>(b[i + 2])
-                      << ", z = " << static_cast<uint32_t>(z));
+                      << ", zeros =  " << static_cast<std::uint32_t>(b[i + 2])
+                      << ", z = " << static_cast<std::uint32_t>(z));
         }
     }
     b.erase(b.begin() + j, b.end());
@@ -229,7 +229,7 @@ public:
 };
 }
 
-uint8_t CBjkstUniqueValues::trailingZeros(uint32_t value) {
+uint8_t CBjkstUniqueValues::trailingZeros(std::uint32_t value) {
     if (value == 0) {
         return 32;
     }
@@ -237,15 +237,15 @@ uint8_t CBjkstUniqueValues::trailingZeros(uint32_t value) {
     // This is just doing a binary search for the first
     // non-zero bit.
 
-    static const uint32_t MASKS[]{0xffff, 0xff, 0xf, 0x3, 0x1};
-    static const uint8_t SHIFTS[]{16, 8, 4, 2, 1};
+    static const std::uint32_t MASKS[]{0xffff, 0xff, 0xf, 0x3, 0x1};
+    static const std::uint8_t SHIFTS[]{16, 8, 4, 2, 1};
 
-    uint8_t result = 0;
+    std::uint8_t result = 0;
     for (std::size_t i = 0; i < 5; ++i) {
         switch (value & MASKS[i]) {
         case 0:
             value >>= SHIFTS[i];
-            result = static_cast<uint8_t>(result + SHIFTS[i]);
+            result = static_cast<std::uint8_t>(result + SHIFTS[i]);
             break;
         default:
             break;
@@ -374,7 +374,7 @@ void CBjkstUniqueValues::acceptPersistInserter(core::CStatePersistInserter& inse
     }
 }
 
-void CBjkstUniqueValues::add(uint32_t value) {
+void CBjkstUniqueValues::add(std::uint32_t value) {
     TUInt32Vec* values = std::get_if<TUInt32Vec>(&m_Sketch);
     if (values != nullptr) {
         auto i = std::lower_bound(values->begin(), values->end(), value);
@@ -392,7 +392,7 @@ void CBjkstUniqueValues::add(uint32_t value) {
     }
 }
 
-void CBjkstUniqueValues::remove(uint32_t value) {
+void CBjkstUniqueValues::remove(std::uint32_t value) {
     TUInt32Vec* values = std::get_if<TUInt32Vec>(&m_Sketch);
     if (values != nullptr) {
         auto i = std::lower_bound(values->begin(), values->end(), value);
@@ -419,10 +419,10 @@ uint32_t CBjkstUniqueValues::number() const {
             LOG_ABORT(<< "Unexpected exception: " << e.what());
         }
     }
-    return static_cast<uint32_t>(values->size());
+    return static_cast<std::uint32_t>(values->size());
 }
 
-uint64_t CBjkstUniqueValues::checksum(uint64_t seed) const {
+uint64_t CBjkstUniqueValues::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_MaxSize);
     seed = CChecksum::calculate(seed, m_NumberHashes);
     const TUInt32Vec* values = std::get_if<TUInt32Vec>(&m_Sketch);
@@ -480,8 +480,8 @@ std::size_t CBjkstUniqueValues::memoryUsage() const {
 }
 
 void CBjkstUniqueValues::sketch() {
-    static const std::size_t UINT8_SIZE = sizeof(uint8_t);
-    static const std::size_t UINT32_SIZE = sizeof(uint32_t);
+    static const std::size_t UINT8_SIZE = sizeof(std::uint8_t);
+    static const std::size_t UINT32_SIZE = sizeof(std::uint32_t);
     static const std::size_t HASH_SIZE =
         sizeof(core::CHashing::CUniversalHash::CUInt32UnrestrictedHash);
     static const std::size_t VEC8_SIZE = sizeof(TUInt8Vec);
@@ -590,14 +590,14 @@ void CBjkstUniqueValues::SSketch::acceptPersistInserter(core::CStatePersistInser
     }
 }
 
-void CBjkstUniqueValues::SSketch::add(std::size_t maxSize, uint32_t value) {
+void CBjkstUniqueValues::SSketch::add(std::size_t maxSize, std::uint32_t value) {
     LOG_TRACE(<< "Adding " << value);
     for (std::size_t i = 0; i < s_Z.size(); ++i) {
-        uint8_t zeros = trailingZeros((s_H[i])(value));
+        std::uint8_t zeros = trailingZeros((s_H[i])(value));
         if (zeros >= s_Z[i]) {
             TUInt8Vec& b = s_B[i];
             auto g = static_cast<uint16_t>((s_G[i])(value));
-            LOG_TRACE(<< "g = " << g << ", zeros = " << static_cast<uint32_t>(zeros));
+            LOG_TRACE(<< "g = " << g << ", zeros = " << static_cast<std::uint32_t>(zeros));
             if (detail::insert(b, g, zeros)) {
                 while (b.size() >= 3 * maxSize) {
                     ++s_Z[i];
@@ -610,19 +610,19 @@ void CBjkstUniqueValues::SSketch::add(std::size_t maxSize, uint32_t value) {
                     b.swap(shrunk);
                 }
                 LOG_TRACE(<< "|B| = " << b.size()
-                          << ", z = " << static_cast<uint32_t>(s_Z[i]));
+                          << ", z = " << static_cast<std::uint32_t>(s_Z[i]));
             }
         }
     }
 }
 
-void CBjkstUniqueValues::SSketch::remove(uint32_t value) {
+void CBjkstUniqueValues::SSketch::remove(std::uint32_t value) {
     for (std::size_t i = 0; i < s_Z.size(); ++i) {
-        uint8_t zeros = trailingZeros((s_H[i])(value));
+        std::uint8_t zeros = trailingZeros((s_H[i])(value));
         if (zeros >= s_Z[i]) {
             TUInt8Vec& b = s_B[i];
             auto g = static_cast<uint16_t>((s_G[i])(value));
-            LOG_TRACE(<< "g = " << g << ", zeros = " << static_cast<uint32_t>(zeros));
+            LOG_TRACE(<< "g = " << g << ", zeros = " << static_cast<std::uint32_t>(zeros));
             detail::remove(b, g);
         }
     }
@@ -634,8 +634,8 @@ uint32_t CBjkstUniqueValues::SSketch::number() const {
     estimates.reserve(s_Z.size());
     for (std::size_t i = 0; i < s_Z.size(); ++i) {
         LOG_TRACE(<< "|B| = " << s_B[i].size()
-                  << ", z = " << static_cast<uint32_t>(s_Z[i]));
-        estimates.push_back(static_cast<uint32_t>(s_B[i].size() / 3) * (1 << s_Z[i]));
+                  << ", z = " << static_cast<std::uint32_t>(s_Z[i]));
+        estimates.push_back(static_cast<std::uint32_t>(s_B[i].size() / 3) * (1 << s_Z[i]));
     }
 
     LOG_TRACE(<< "estimates = " << core::CContainerPrinter::print(estimates));

--- a/lib/maths/common/CEntropySketch.cc
+++ b/lib/maths/common/CEntropySketch.cc
@@ -27,7 +27,7 @@ namespace common {
 CEntropySketch::CEntropySketch(std::size_t k) : m_Y(0), m_Yi(k, 0.0) {
 }
 
-void CEntropySketch::add(std::size_t category, uint64_t count) {
+void CEntropySketch::add(std::size_t category, std::uint64_t count) {
     m_Y += count;
     TDoubleVec projection;
     this->generateProjection(category, projection);

--- a/lib/maths/common/CKMostCorrelated.cc
+++ b/lib/maths/common/CKMostCorrelated.cc
@@ -355,7 +355,7 @@ void CKMostCorrelated::capture() {
     }
 }
 
-uint64_t CKMostCorrelated::checksum(uint64_t seed) const {
+uint64_t CKMostCorrelated::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_K);
     seed = CChecksum::calculate(seed, m_DecayRate);
     seed = CChecksum::calculate(seed, m_Projections);
@@ -760,7 +760,7 @@ double CKMostCorrelated::SCorrelation::correlation(const TVector& px,
     return result;
 }
 
-uint64_t CKMostCorrelated::SCorrelation::checksum(uint64_t seed) const {
+uint64_t CKMostCorrelated::SCorrelation::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, s_Correlation);
     seed = CChecksum::calculate(seed, s_X);
     return CChecksum::calculate(seed, s_Y);

--- a/lib/maths/common/CKMostCorrelated.cc
+++ b/lib/maths/common/CKMostCorrelated.cc
@@ -355,7 +355,7 @@ void CKMostCorrelated::capture() {
     }
 }
 
-uint64_t CKMostCorrelated::checksum(std::uint64_t seed) const {
+std::uint64_t CKMostCorrelated::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_K);
     seed = CChecksum::calculate(seed, m_DecayRate);
     seed = CChecksum::calculate(seed, m_Projections);
@@ -760,7 +760,7 @@ double CKMostCorrelated::SCorrelation::correlation(const TVector& px,
     return result;
 }
 
-uint64_t CKMostCorrelated::SCorrelation::checksum(std::uint64_t seed) const {
+std::uint64_t CKMostCorrelated::SCorrelation::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, s_Correlation);
     seed = CChecksum::calculate(seed, s_X);
     return CChecksum::calculate(seed, s_Y);

--- a/lib/maths/common/CModelWeight.cc
+++ b/lib/maths/common/CModelWeight.cc
@@ -56,7 +56,7 @@ void CModelWeight::age(double alpha) {
     m_LogWeight = alpha * m_LogWeight + (1 - alpha) * m_LongTermLogWeight;
 }
 
-uint64_t CModelWeight::checksum(std::uint64_t seed) const {
+std::uint64_t CModelWeight::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_LogWeight);
     return CChecksum::calculate(seed, m_LongTermLogWeight);
 }

--- a/lib/maths/common/CModelWeight.cc
+++ b/lib/maths/common/CModelWeight.cc
@@ -56,7 +56,7 @@ void CModelWeight::age(double alpha) {
     m_LogWeight = alpha * m_LogWeight + (1 - alpha) * m_LongTermLogWeight;
 }
 
-uint64_t CModelWeight::checksum(uint64_t seed) const {
+uint64_t CModelWeight::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_LogWeight);
     return CChecksum::calculate(seed, m_LongTermLogWeight);
 }

--- a/lib/maths/common/CMultinomialConjugate.cc
+++ b/lib/maths/common/CMultinomialConjugate.cc
@@ -589,16 +589,16 @@ CMultinomialConjugate::marginalLikelihoodConfidenceInterval(double percentage,
         pU += 1.0 / static_cast<double>(m_Concentrations.size()) - p;
     }
     double q1 = (1.0 - percentage) / 2.0;
-    ptrdiff_t i1 = std::lower_bound(quantiles.begin(), quantiles.end(), q1 - pU) -
-                   quantiles.begin();
+    std::ptrdiff_t i1 = std::lower_bound(quantiles.begin(), quantiles.end(), q1 - pU) -
+                        quantiles.begin();
     double x1 = m_Categories[i1];
     double x2 = x1;
     if (percentage > 0.0) {
         double q2 = (1.0 + percentage) / 2.0;
-        ptrdiff_t i2 =
+        std::ptrdiff_t i2 =
             std::min(std::lower_bound(quantiles.begin(), quantiles.end(), q2 + pU) -
                          quantiles.begin(),
-                     static_cast<ptrdiff_t>(quantiles.size()) - 1);
+                     static_cast<std::ptrdiff_t>(quantiles.size()) - 1);
         x2 = m_Categories[i2];
     }
     LOG_TRACE(<< "x1 = " << x1 << ", x2 = " << x2);
@@ -1058,10 +1058,10 @@ bool CMultinomialConjugate::probabilityOfLessLikelySamples(maths_t::EProbability
                     TMeanAccumulator pAcc;
                     for (std::size_t k = 0; k < marginalSamples.size(); ++k) {
                         TDoubleDoubleSizeTr x(1.05 * marginalSamples[k], 0.0, 0);
-                        ptrdiff_t r = std::min(
+                        std::ptrdiff_t r = std::min(
                             std::upper_bound(pCategories.begin(), pCategories.end(), x) -
                                 pCategories.begin(),
-                            static_cast<ptrdiff_t>(pCategories.size()) - 1);
+                            static_cast<std::ptrdiff_t>(pCategories.size()) - 1);
 
                         double fl = r > 0 ? pCategories[r - 1].get<0>() : 0.0;
                         double fr = pCategories[r].get<0>();
@@ -1471,10 +1471,10 @@ void CMultinomialConjugate::probabilitiesOfLessLikelyCategories(maths_t::EProbab
                 TMeanAccumulator pAcc;
                 for (std::size_t k = 0; k < samples.size(); ++k) {
                     TDoubleDoubleSizeTr x(1.05 * samples[k], 0.0, 0);
-                    ptrdiff_t r = std::min(
+                    std::ptrdiff_t r = std::min(
                         std::upper_bound(pCategories.begin(), pCategories.end(), x) -
                             pCategories.begin(),
-                        static_cast<ptrdiff_t>(pCategories.size()) - 1);
+                        static_cast<std::ptrdiff_t>(pCategories.size()) - 1);
 
                     double fl = r > 0 ? pCategories[r - 1].get<0>() : 0.0;
                     double fr = pCategories[r].get<0>();

--- a/lib/maths/common/CMultivariateOneOfNPrior.cc
+++ b/lib/maths/common/CMultivariateOneOfNPrior.cc
@@ -746,7 +746,7 @@ void CMultivariateOneOfNPrior::print(const std::string& separator, std::string& 
     }
 }
 
-uint64_t CMultivariateOneOfNPrior::checksum(std::uint64_t seed) const {
+std::uint64_t CMultivariateOneOfNPrior::checksum(std::uint64_t seed) const {
     seed = this->CMultivariatePrior::checksum(seed);
     return CChecksum::calculate(seed, m_Models);
 }

--- a/lib/maths/common/CMultivariateOneOfNPrior.cc
+++ b/lib/maths/common/CMultivariateOneOfNPrior.cc
@@ -746,7 +746,7 @@ void CMultivariateOneOfNPrior::print(const std::string& separator, std::string& 
     }
 }
 
-uint64_t CMultivariateOneOfNPrior::checksum(uint64_t seed) const {
+uint64_t CMultivariateOneOfNPrior::checksum(std::uint64_t seed) const {
     seed = this->CMultivariatePrior::checksum(seed);
     return CChecksum::calculate(seed, m_Models);
 }

--- a/lib/maths/common/CNaturalBreaksClassifier.cc
+++ b/lib/maths/common/CNaturalBreaksClassifier.cc
@@ -476,7 +476,7 @@ std::string CNaturalBreaksClassifier::print() const {
     return core::CContainerPrinter::print(m_Categories);
 }
 
-uint64_t CNaturalBreaksClassifier::checksum(uint64_t seed) const {
+uint64_t CNaturalBreaksClassifier::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_Space);
     seed = CChecksum::calculate(seed, m_DecayRate);
     seed = CChecksum::calculate(seed, m_Categories);

--- a/lib/maths/common/CNaturalBreaksClassifier.cc
+++ b/lib/maths/common/CNaturalBreaksClassifier.cc
@@ -476,7 +476,7 @@ std::string CNaturalBreaksClassifier::print() const {
     return core::CContainerPrinter::print(m_Categories);
 }
 
-uint64_t CNaturalBreaksClassifier::checksum(std::uint64_t seed) const {
+std::uint64_t CNaturalBreaksClassifier::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_Space);
     seed = CChecksum::calculate(seed, m_DecayRate);
     seed = CChecksum::calculate(seed, m_Categories);

--- a/lib/maths/common/CPrior.cc
+++ b/lib/maths/common/CPrior.cc
@@ -182,7 +182,7 @@ CPrior::SPlot CPrior::marginalLikelihoodPlot(unsigned int numberPoints, double w
     return plot;
 }
 
-uint64_t CPrior::checksum(std::uint64_t seed) const {
+std::uint64_t CPrior::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_DataType);
     seed = CChecksum::calculate(seed, m_DecayRate);
     return CChecksum::calculate(seed, m_NumberSamples);

--- a/lib/maths/common/CPrior.cc
+++ b/lib/maths/common/CPrior.cc
@@ -182,7 +182,7 @@ CPrior::SPlot CPrior::marginalLikelihoodPlot(unsigned int numberPoints, double w
     return plot;
 }
 
-uint64_t CPrior::checksum(uint64_t seed) const {
+uint64_t CPrior::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_DataType);
     seed = CChecksum::calculate(seed, m_DecayRate);
     return CChecksum::calculate(seed, m_NumberSamples);

--- a/lib/maths/common/CQDigest.cc
+++ b/lib/maths/common/CQDigest.cc
@@ -405,15 +405,15 @@ void CQDigest::summary(TUInt32UInt64PrVec& result) const {
     }
 }
 
-uint64_t CQDigest::n() const {
+std::uint64_t CQDigest::n() const {
     return m_N;
 }
 
-uint64_t CQDigest::k() const {
+std::uint64_t CQDigest::k() const {
     return m_K;
 }
 
-uint64_t CQDigest::checksum(std::uint64_t seed) const {
+std::uint64_t CQDigest::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_K);
     seed = CChecksum::calculate(seed, m_N);
     seed = CChecksum::calculate(seed, m_DecayRate);
@@ -524,7 +524,7 @@ std::size_t CQDigest::CNode::size() const {
     return size;
 }
 
-uint32_t CQDigest::CNode::quantile(std::uint64_t leftCount, std::uint64_t n) const {
+std::uint32_t CQDigest::CNode::quantile(std::uint64_t leftCount, std::uint64_t n) const {
     // We need to find the smallest node in post-order where
     // the left count is greater than n. At each level we visit
     // the smallest, in post order, node in the q-digest for
@@ -725,7 +725,7 @@ CQDigest::CNode* CQDigest::CNode::compress(CNodeAllocator& allocator,
     return this;
 }
 
-uint64_t CQDigest::CNode::age(double factor) {
+std::uint64_t CQDigest::CNode::age(double factor) {
     m_SubtreeCount = 0;
 
     for (auto& descendant : m_Descendants) {
@@ -741,15 +741,15 @@ uint64_t CQDigest::CNode::age(double factor) {
     return m_SubtreeCount;
 }
 
-uint32_t CQDigest::CNode::span() const {
+std::uint32_t CQDigest::CNode::span() const {
     return m_Max - m_Min + 1;
 }
 
-uint32_t CQDigest::CNode::min() const {
+std::uint32_t CQDigest::CNode::min() const {
     return m_Min;
 }
 
-uint32_t CQDigest::CNode::max() const {
+std::uint32_t CQDigest::CNode::max() const {
     return m_Max;
 }
 

--- a/lib/maths/common/CQDigest.cc
+++ b/lib/maths/common/CQDigest.cc
@@ -42,7 +42,7 @@ const std::string CQDigest::K_TAG("a");
 const std::string CQDigest::N_TAG("b");
 const std::string CQDigest::NODE_TAG("c");
 
-CQDigest::CQDigest(uint64_t k, double decayRate)
+CQDigest::CQDigest(std::uint64_t k, double decayRate)
     : m_K(k), m_N(0), m_Root(nullptr),
       m_NodeAllocator(static_cast<std::size_t>(3 * m_K + 2)), m_DecayRate(decayRate) {
     m_Root = &m_NodeAllocator.create(CNode(0, 1, 0, 0));
@@ -96,7 +96,7 @@ void CQDigest::checkRestoredInvariants() const {
     //    }
 }
 
-void CQDigest::add(uint32_t value, uint64_t n) {
+void CQDigest::add(std::uint32_t value, std::uint64_t n) {
     LOG_TRACE(<< "Adding = " << value);
 
     m_N += n;
@@ -157,7 +157,7 @@ void CQDigest::propagateForwardsByTime(double time) {
 }
 
 bool CQDigest::scale(double factor) {
-    using TUInt32UInt32UInt64Tr = boost::tuple<uint32_t, uint32_t, uint64_t>;
+    using TUInt32UInt32UInt64Tr = boost::tuple<std::uint32_t, std::uint32_t, std::uint64_t>;
     using TUInt32UInt32UInt64TrVec = std::vector<TUInt32UInt32UInt64Tr>;
 
     if (factor <= 0.0) {
@@ -193,24 +193,25 @@ bool CQDigest::scale(double factor) {
     for (std::size_t i = 0; i < sketch.size(); ++i) {
         const TUInt32UInt32UInt64Tr& node = sketch[i];
 
-        uint32_t min = node.get<0>();
-        uint32_t max = node.get<1>();
-        uint32_t span = max - min + 1;
-        uint64_t count = node.get<2>() / span;
-        uint64_t remainder = node.get<2>() - count * span;
+        std::uint32_t min = node.get<0>();
+        std::uint32_t max = node.get<1>();
+        std::uint32_t span = max - min + 1;
+        std::uint64_t count = node.get<2>() / span;
+        std::uint64_t remainder = node.get<2>() - count * span;
         LOG_TRACE(<< "min = " << min << ", max = " << max
                   << ", count = " << count << ", remainder = " << remainder);
 
         if (count > 0) {
-            for (uint32_t j = 0; j < span; ++j) {
-                this->add(static_cast<uint32_t>(factor * static_cast<double>(min + j) + 0.5),
+            for (std::uint32_t j = 0; j < span; ++j) {
+                this->add(static_cast<std::uint32_t>(
+                              factor * static_cast<double>(min + j) + 0.5),
                           count);
             }
         }
         if (remainder > 0) {
-            boost::random::uniform_int_distribution<uint32_t> uniform(0, span - 1);
-            for (uint64_t j = 0; j < remainder; ++j) {
-                this->add(static_cast<uint32_t>(
+            boost::random::uniform_int_distribution<std::uint32_t> uniform(0, span - 1);
+            for (std::uint64_t j = 0; j < remainder; ++j) {
+                this->add(static_cast<std::uint32_t>(
                     factor * static_cast<double>(min + uniform(generator)) + 0.5));
             }
         }
@@ -235,7 +236,7 @@ void CQDigest::clear() {
     }
 }
 
-bool CQDigest::quantile(double q, uint32_t& result) const {
+bool CQDigest::quantile(double q, std::uint32_t& result) const {
     result = 0;
 
     if (m_N == 0) {
@@ -244,14 +245,14 @@ bool CQDigest::quantile(double q, uint32_t& result) const {
     }
 
     // Compute the count fraction we need to the left of the value.
-    auto n = static_cast<uint64_t>(q * static_cast<double>(m_N) + 0.5);
+    auto n = static_cast<std::uint64_t>(q * static_cast<double>(m_N) + 0.5);
 
     result = m_Root->quantile(0, n);
 
     return true;
 }
 
-bool CQDigest::quantileSublevelSetSupremum(double f, uint32_t& result) const {
+bool CQDigest::quantileSublevelSetSupremum(double f, std::uint32_t& result) const {
     result = 0;
     if (m_N == 0) {
         LOG_ERROR(<< "Can't compute level set for empty set");
@@ -266,7 +267,7 @@ bool CQDigest::quantileSublevelSetSupremum(double f, uint32_t& result) const {
         return true;
     }
 
-    auto n = static_cast<uint64_t>(f * static_cast<double>(m_N) + 0.5);
+    auto n = static_cast<std::uint64_t>(f * static_cast<double>(m_N) + 0.5);
     m_Root->quantileSublevelSetSupremum(n, 0, result);
     return true;
 }
@@ -301,7 +302,7 @@ double CQDigest::cdfQuantile(double n, double p, double q) {
     return p;
 }
 
-bool CQDigest::cdf(uint32_t x, double confidence, double& lowerBound, double& upperBound) const {
+bool CQDigest::cdf(std::uint32_t x, double confidence, double& lowerBound, double& upperBound) const {
     lowerBound = 0.0;
     upperBound = 0.0;
 
@@ -310,7 +311,7 @@ bool CQDigest::cdf(uint32_t x, double confidence, double& lowerBound, double& up
         return false;
     }
 
-    uint64_t l = 0;
+    std::uint64_t l = 0;
     m_Root->cdfLowerBound(x, l);
     lowerBound = static_cast<double>(l) / static_cast<double>(m_N);
     if (confidence > 0.0) {
@@ -318,7 +319,7 @@ bool CQDigest::cdf(uint32_t x, double confidence, double& lowerBound, double& up
                                  (100.0 - confidence) / 200.0);
     }
 
-    uint64_t u = 0;
+    std::uint64_t u = 0;
     m_Root->cdfUpperBound(x, u);
     upperBound = static_cast<double>(u) / static_cast<double>(m_N);
     if (confidence > 0.0) {
@@ -329,7 +330,7 @@ bool CQDigest::cdf(uint32_t x, double confidence, double& lowerBound, double& up
     return true;
 }
 
-void CQDigest::pdf(uint32_t x, double confidence, double& lowerBound, double& upperBound) const {
+void CQDigest::pdf(std::uint32_t x, double confidence, double& lowerBound, double& upperBound) const {
     lowerBound = 0.0;
     upperBound = 0.0;
 
@@ -337,11 +338,11 @@ void CQDigest::pdf(uint32_t x, double confidence, double& lowerBound, double& up
         return;
     }
 
-    uint32_t infimum = 0;
+    std::uint32_t infimum = 0;
     m_Root->superlevelSetInfimum(x, infimum);
 
-    uint32_t supremum = std::numeric_limits<uint32_t>::max();
-    m_Root->sublevelSetSupremum(static_cast<int64_t>(x), supremum);
+    std::uint32_t supremum = std::numeric_limits<std::uint32_t>::max();
+    m_Root->sublevelSetSupremum(static_cast<std::int64_t>(x), supremum);
 
     double infimumLowerBound;
     double infimumUpperBound;
@@ -363,11 +364,11 @@ void CQDigest::pdf(uint32_t x, double confidence, double& lowerBound, double& up
               << ", pdf = [" << lowerBound << "," << upperBound << "]");
 }
 
-void CQDigest::sublevelSetSupremum(uint32_t x, uint32_t& result) const {
-    m_Root->sublevelSetSupremum(static_cast<int64_t>(x), result);
+void CQDigest::sublevelSetSupremum(std::uint32_t x, std::uint32_t& result) const {
+    m_Root->sublevelSetSupremum(static_cast<std::int64_t>(x), result);
 }
 
-void CQDigest::superlevelSetInfimum(uint32_t x, uint32_t& result) const {
+void CQDigest::superlevelSetInfimum(std::uint32_t x, std::uint32_t& result) const {
     m_Root->superlevelSetInfimum(x, result);
 }
 
@@ -383,8 +384,8 @@ void CQDigest::summary(TUInt32UInt64PrVec& result) const {
 
     result.reserve(nodes.size());
 
-    uint32_t last = nodes[0]->max();
-    uint64_t count = nodes[0]->count();
+    std::uint32_t last = nodes[0]->max();
+    std::uint64_t count = nodes[0]->count();
     for (std::size_t i = 1; i < nodes.size(); ++i) {
         if (nodes[i]->max() != last) {
             result.emplace_back(last, count);
@@ -412,7 +413,7 @@ uint64_t CQDigest::k() const {
     return m_K;
 }
 
-uint64_t CQDigest::checksum(uint64_t seed) const {
+uint64_t CQDigest::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_K);
     seed = CChecksum::calculate(seed, m_N);
     seed = CChecksum::calculate(seed, m_DecayRate);
@@ -508,7 +509,7 @@ CQDigest::CNode::CNode()
       m_Max(0xDEADBEEF), m_Count(0xDEADBEEF), m_SubtreeCount(0xDEADBEEF) {
 }
 
-CQDigest::CNode::CNode(uint32_t min, uint32_t max, uint64_t count, uint64_t subtreeCount)
+CQDigest::CNode::CNode(std::uint32_t min, std::uint32_t max, std::uint64_t count, std::uint64_t subtreeCount)
     : m_Ancestor(nullptr), m_Descendants(), m_Min(min), m_Max(max),
       m_Count(count), m_SubtreeCount(subtreeCount) {
 }
@@ -523,7 +524,7 @@ std::size_t CQDigest::CNode::size() const {
     return size;
 }
 
-uint32_t CQDigest::CNode::quantile(uint64_t leftCount, uint64_t n) const {
+uint32_t CQDigest::CNode::quantile(std::uint64_t leftCount, std::uint64_t n) const {
     // We need to find the smallest node in post-order where
     // the left count is greater than n. At each level we visit
     // the smallest, in post order, node in the q-digest for
@@ -531,7 +532,7 @@ uint32_t CQDigest::CNode::quantile(uint64_t leftCount, uint64_t n) const {
     // this node doesn't have any descendants.
 
     for (const auto& descendant : m_Descendants) {
-        uint64_t count = descendant->subtreeCount();
+        std::uint64_t count = descendant->subtreeCount();
         if (leftCount + count >= n) {
             return descendant->quantile(leftCount, n);
         }
@@ -541,9 +542,9 @@ uint32_t CQDigest::CNode::quantile(uint64_t leftCount, uint64_t n) const {
     return m_Max;
 }
 
-bool CQDigest::CNode::quantileSublevelSetSupremum(uint64_t n,
-                                                  uint64_t leftCount,
-                                                  uint32_t& result) const {
+bool CQDigest::CNode::quantileSublevelSetSupremum(std::uint64_t n,
+                                                  std::uint64_t leftCount,
+                                                  std::uint32_t& result) const {
     // We are looking for the right end of the rightmost node
     // whose count together with those nodes to the left is
     // is less than n.
@@ -565,7 +566,7 @@ bool CQDigest::CNode::quantileSublevelSetSupremum(uint64_t n,
     return false;
 }
 
-void CQDigest::CNode::cdfLowerBound(uint32_t x, uint64_t& result) const {
+void CQDigest::CNode::cdfLowerBound(std::uint32_t x, std::uint64_t& result) const {
     // The lower bound is the sum of the counts at the nodes
     // for which the maximum value is less than or equal to x.
 
@@ -578,7 +579,7 @@ void CQDigest::CNode::cdfLowerBound(uint32_t x, uint64_t& result) const {
     }
 }
 
-void CQDigest::CNode::cdfUpperBound(uint32_t x, uint64_t& result) const {
+void CQDigest::CNode::cdfUpperBound(std::uint32_t x, std::uint64_t& result) const {
     // The upper bound is the sum of the counts at the nodes
     // for which the minimum value is less than or equal to x.
 
@@ -592,21 +593,21 @@ void CQDigest::CNode::cdfUpperBound(uint32_t x, uint64_t& result) const {
     }
 }
 
-void CQDigest::CNode::sublevelSetSupremum(const int64_t x, uint32_t& result) const {
+void CQDigest::CNode::sublevelSetSupremum(const std::int64_t x, std::uint32_t& result) const {
     for (auto i = m_Descendants.rbegin(); i != m_Descendants.rend(); ++i) {
-        if (static_cast<int64_t>((*i)->max()) > x) {
+        if (static_cast<std::int64_t>((*i)->max()) > x) {
             result = std::min(result, (*i)->max());
         } else {
             (*i)->sublevelSetSupremum(x, result);
             break;
         }
     }
-    if (static_cast<int64_t>(m_Max) > x && m_Count > 0) {
+    if (static_cast<std::int64_t>(m_Max) > x && m_Count > 0) {
         result = std::min(result, m_Max);
     }
 }
 
-void CQDigest::CNode::superlevelSetInfimum(uint32_t x, uint32_t& result) const {
+void CQDigest::CNode::superlevelSetInfimum(std::uint32_t x, std::uint32_t& result) const {
     for (const auto& descendant : m_Descendants) {
         if (descendant->max() < x) {
             result = std::max(result, descendant->max());
@@ -627,14 +628,15 @@ void CQDigest::CNode::postOrder(TNodePtrVec& nodes) const {
     nodes.push_back(const_cast<CNode*>(this));
 }
 
-CQDigest::CNode* CQDigest::CNode::expand(CNodeAllocator& allocator, const uint32_t& value) {
+CQDigest::CNode* CQDigest::CNode::expand(CNodeAllocator& allocator,
+                                         const std::uint32_t& value) {
     if (m_Max >= value) {
         // No expansion necessary.
         return nullptr;
     }
 
     CNode* result = m_Count == 0 ? this : &allocator.create(CNode(m_Min, m_Max, 0, 0));
-    uint32_t levelSpan = result->span();
+    std::uint32_t levelSpan = result->span();
     do {
         result->m_Max += levelSpan;
         levelSpan <<= 1;
@@ -681,7 +683,8 @@ CQDigest::CNode& CQDigest::CNode::insert(CNodeAllocator& allocator, const CNode&
     return newNode;
 }
 
-CQDigest::CNode* CQDigest::CNode::compress(CNodeAllocator& allocator, uint64_t compressionFactor) {
+CQDigest::CNode* CQDigest::CNode::compress(CNodeAllocator& allocator,
+                                           std::uint64_t compressionFactor) {
     if (m_Ancestor == nullptr) {
         // The node is no longer in the q-digest.
         return nullptr;
@@ -693,8 +696,8 @@ CQDigest::CNode* CQDigest::CNode::compress(CNodeAllocator& allocator, uint64_t c
     // Get the sibling of this node if it exists.
     CNode* sibling = ancestor->sibling(*this);
 
-    uint64_t count = (ancestor->isParent(*this) ? ancestor->count() : 0) +
-                     this->count() + (sibling != nullptr ? sibling->count() : 0);
+    std::uint64_t count = (ancestor->isParent(*this) ? ancestor->count() : 0) +
+                          this->count() + (sibling != nullptr ? sibling->count() : 0);
 
     // Check if we should compress this node.
     if (count >= compressionFactor) {
@@ -730,7 +733,7 @@ uint64_t CQDigest::CNode::age(double factor) {
     }
 
     if (m_Count > 0) {
-        m_Count = static_cast<uint64_t>(
+        m_Count = static_cast<std::uint64_t>(
             std::max(static_cast<double>(m_Count) * factor + 0.5, 1.0));
     }
     m_SubtreeCount += m_Count;
@@ -750,11 +753,11 @@ uint32_t CQDigest::CNode::max() const {
     return m_Max;
 }
 
-const uint64_t& CQDigest::CNode::count() const {
+const std::uint64_t& CQDigest::CNode::count() const {
     return m_Count;
 }
 
-const uint64_t& CQDigest::CNode::subtreeCount() const {
+const std::uint64_t& CQDigest::CNode::subtreeCount() const {
     return m_SubtreeCount;
 }
 
@@ -803,7 +806,7 @@ bool CQDigest::CNode::acceptRestoreTraverser(core::CStateRestoreTraverser& trave
     return true;
 }
 
-bool CQDigest::CNode::checkInvariants(uint64_t compressionFactor) const {
+bool CQDigest::CNode::checkInvariants(std::uint64_t compressionFactor) const {
     // 1) span is a power of 2
     // 2) q-digest connectivity is consistent.
     // 3) subtree counts are consistent.
@@ -817,15 +820,15 @@ bool CQDigest::CNode::checkInvariants(uint64_t compressionFactor) const {
     // minus 1 will be identical.  If span is not a power of 2 then subtracting
     // 1 will leave some set bits set, meaning the OR and XOR give different
     // results.
-    uint32_t span(this->span());
-    uint32_t spanMinusOne(span - 1);
+    std::uint32_t span(this->span());
+    std::uint32_t spanMinusOne(span - 1);
     if ((span | spanMinusOne) != (span ^ spanMinusOne)) {
         LOG_ERROR(<< "Bad span: " << this->print());
         return false;
     }
 
     SPostLess postLess;
-    uint64_t subtreeCount = m_Count;
+    std::uint64_t subtreeCount = m_Count;
 
     for (std::size_t i = 0; i < m_Descendants.size(); ++i) {
         if (m_Descendants[i]->m_Ancestor != this) {
@@ -862,8 +865,8 @@ bool CQDigest::CNode::checkInvariants(uint64_t compressionFactor) const {
 
     if (!this->isRoot()) {
         const CNode* sibling = m_Ancestor->sibling(*this);
-        uint64_t count = m_Count + (sibling != nullptr ? sibling->count() : 0) +
-                         (m_Ancestor->isParent(*this) ? m_Ancestor->count() : 0);
+        std::uint64_t count = m_Count + (sibling != nullptr ? sibling->count() : 0) +
+                              (m_Ancestor->isParent(*this) ? m_Ancestor->count() : 0);
         if (count < compressionFactor) {
             LOG_ERROR(<< "Bad triple count: " << count << ", floor(n/k) = " << compressionFactor);
             return false;
@@ -896,9 +899,9 @@ CQDigest::TNodePtrVecCItr CQDigest::CNode::endDescendants() const {
 }
 
 CQDigest::CNode* CQDigest::CNode::sibling(const CNode& node) const {
-    uint32_t min = node.min();
+    std::uint32_t min = node.min();
     node.isLeftChild() ? min += node.span() : min -= node.span();
-    uint32_t max = node.max();
+    std::uint32_t max = node.max();
     node.isLeftChild() ? max += node.span() : max -= node.span();
     CNode sibling(min, max, 0, 0);
 

--- a/lib/maths/common/CQuantileSketch.cc
+++ b/lib/maths/common/CQuantileSketch.cc
@@ -37,8 +37,8 @@ using TFloatFloatPrVec = CQuantileSketch::TFloatFloatPrVec;
 
 //! \brief An iterator over just the unique knot values.
 // clang-format off
-class CUniqueIterator : private boost::addable2<CUniqueIterator, ptrdiff_t,
-                                boost::subtractable2<CUniqueIterator, ptrdiff_t,
+class CUniqueIterator : private boost::addable2<CUniqueIterator, std::ptrdiff_t,
+                                boost::subtractable2<CUniqueIterator, std::ptrdiff_t,
                                 boost::equality_comparable<CUniqueIterator>>> {
     // clang-format on
 public:
@@ -67,14 +67,14 @@ public:
         return *this;
     }
 
-    const CUniqueIterator& operator+=(ptrdiff_t i) {
+    const CUniqueIterator& operator+=(std::ptrdiff_t i) {
         while (--i >= 0) {
             this->operator++();
         }
         return *this;
     }
 
-    const CUniqueIterator& operator-=(ptrdiff_t i) {
+    const CUniqueIterator& operator-=(std::ptrdiff_t i) {
         while (--i >= 0) {
             this->operator--();
         }
@@ -172,15 +172,15 @@ bool CQuantileSketch::cdf(double x_, double& result) const {
     }
 
     CFloatStorage x = x_;
-    ptrdiff_t n = m_Knots.size();
+    std::ptrdiff_t n = m_Knots.size();
     if (n == 1) {
         result = x < m_Knots[0].first ? 0.0 : (x > m_Knots[0].first ? 1.0 : 0.5);
         return true;
     }
 
-    ptrdiff_t k = std::lower_bound(m_Knots.begin(), m_Knots.end(), x,
-                                   COrderings::SFirstLess()) -
-                  m_Knots.begin();
+    std::ptrdiff_t k = std::lower_bound(m_Knots.begin(), m_Knots.end(), x,
+                                        COrderings::SFirstLess()) -
+                       m_Knots.begin();
     LOG_TRACE(<< "k = " << k);
 
     switch (m_Interpolation) {
@@ -203,8 +203,8 @@ bool CQuantileSketch::cdf(double x_, double& result) const {
             bool left = (2 * k < n);
             bool loc = (2.0 * x < xl + xr);
             double partial = 0.0;
-            for (ptrdiff_t i = left ? 0 : (loc ? k : k + 1),
-                           m = left ? (loc ? k - 1 : k) : n;
+            for (std::ptrdiff_t i = left ? 0 : (loc ? k : k + 1),
+                                m = left ? (loc ? k - 1 : k) : n;
                  i < m; ++i) {
                 partial += m_Knots[i].second;
             }
@@ -240,7 +240,7 @@ bool CQuantileSketch::cdf(double x_, double& result) const {
         } else {
             bool left = (2 * k < n);
             double partial = x < m_Knots[0].first ? 0.0 : 0.5 * m_Knots[0].second;
-            for (ptrdiff_t i = left ? 0 : k + 1, m = left ? k : n; i < m; ++i) {
+            for (std::ptrdiff_t i = left ? 0 : k + 1, m = left ? k : n; i < m; ++i) {
                 partial += m_Knots[i].second;
             }
             partial /= m_Count;

--- a/lib/maths/common/CStatisticalTests.cc
+++ b/lib/maths/common/CStatisticalTests.cc
@@ -246,9 +246,9 @@ double CStatisticalTests::CCramerVonMises::pValue() const {
     // Linearly interpolate between the rows of the T statistic
     // values.
     double tt[16];
-    ptrdiff_t row =
+    std::ptrdiff_t row =
         CTools::truncate(std::lower_bound(std::begin(N), std::end(N), m_Size + 1) - N,
-                         ptrdiff_t(1), ptrdiff_t(12));
+                         std::ptrdiff_t(1), std::ptrdiff_t(12));
     double alpha = static_cast<double>(m_Size + 1 - N[row - 1]) /
                    static_cast<double>(N[row] - N[row - 1]);
     double beta = 1.0 - alpha;
@@ -264,8 +264,9 @@ double CStatisticalTests::CCramerVonMises::pValue() const {
         return 1.0;
     }
 
-    ptrdiff_t col = CTools::truncate(std::lower_bound(std::begin(tt), std::end(tt), t) - tt,
-                                     ptrdiff_t(1), ptrdiff_t(15));
+    std::ptrdiff_t col =
+        CTools::truncate(std::lower_bound(std::begin(tt), std::end(tt), t) - tt,
+                         std::ptrdiff_t(1), std::ptrdiff_t(15));
     double a = tt[col - 1];
     double b = tt[col];
     double fa = P_VALUES[col - 1];

--- a/lib/maths/common/ProbabilityAggregators.cc
+++ b/lib/maths/common/ProbabilityAggregators.cc
@@ -314,7 +314,7 @@ double CJointProbabilityOfLessLikelySamples::numberSamples() const {
     return m_NumberSamples;
 }
 
-uint64_t CJointProbabilityOfLessLikelySamples::checksum(uint64_t seed) const {
+uint64_t CJointProbabilityOfLessLikelySamples::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_OnlyProbability);
     seed = CChecksum::calculate(seed, m_SumZScores);
     seed = CChecksum::calculate(seed, m_SumZScoresSquared);
@@ -675,7 +675,7 @@ bool CProbabilityOfExtremeSample::calculate(double& result) const {
     return true;
 }
 
-uint64_t CProbabilityOfExtremeSample::checksum(uint64_t seed) const {
+uint64_t CProbabilityOfExtremeSample::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_MinValue);
     return CChecksum::calculate(seed, m_NumberSamples);
 }
@@ -966,7 +966,7 @@ bool CLogProbabilityOfMFromNExtremeSamples::calibrated(double& result) {
     return false;
 }
 
-uint64_t CLogProbabilityOfMFromNExtremeSamples::checksum(uint64_t seed) const {
+uint64_t CLogProbabilityOfMFromNExtremeSamples::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_MinValues);
     return CChecksum::calculate(seed, m_NumberSamples);
 }

--- a/lib/maths/common/ProbabilityAggregators.cc
+++ b/lib/maths/common/ProbabilityAggregators.cc
@@ -314,7 +314,7 @@ double CJointProbabilityOfLessLikelySamples::numberSamples() const {
     return m_NumberSamples;
 }
 
-uint64_t CJointProbabilityOfLessLikelySamples::checksum(std::uint64_t seed) const {
+std::uint64_t CJointProbabilityOfLessLikelySamples::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_OnlyProbability);
     seed = CChecksum::calculate(seed, m_SumZScores);
     seed = CChecksum::calculate(seed, m_SumZScoresSquared);
@@ -675,7 +675,7 @@ bool CProbabilityOfExtremeSample::calculate(double& result) const {
     return true;
 }
 
-uint64_t CProbabilityOfExtremeSample::checksum(std::uint64_t seed) const {
+std::uint64_t CProbabilityOfExtremeSample::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_MinValue);
     return CChecksum::calculate(seed, m_NumberSamples);
 }
@@ -966,7 +966,7 @@ bool CLogProbabilityOfMFromNExtremeSamples::calibrated(double& result) {
     return false;
 }
 
-uint64_t CLogProbabilityOfMFromNExtremeSamples::checksum(std::uint64_t seed) const {
+std::uint64_t CLogProbabilityOfMFromNExtremeSamples::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_MinValues);
     return CChecksum::calculate(seed, m_NumberSamples);
 }

--- a/lib/maths/common/unittest/CBjkstUniqueValuesTest.cc
+++ b/lib/maths/common/unittest/CBjkstUniqueValuesTest.cc
@@ -32,11 +32,11 @@ namespace {
 
 using TDoubleVec = std::vector<double>;
 using TSizeVec = std::vector<std::size_t>;
-using TUInt32Set = std::set<uint32_t>;
+using TUInt32Set = std::set<std::uint32_t>;
 using TMeanAccumulator = maths::common::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
-uint8_t trailingZeros(uint32_t x) {
-    uint8_t result = 0;
+uint8_t trailingZeros(std::uint32_t x) {
+    std::uint8_t result = 0;
     for (/**/; (x & 0x1) == 0; x >>= 1) {
         ++result;
     }
@@ -45,18 +45,18 @@ uint8_t trailingZeros(uint32_t x) {
 }
 
 BOOST_AUTO_TEST_CASE(testTrailingZeros) {
-    uint32_t n = 1;
-    for (uint8_t i = 0; i < 32; n <<= 1, ++i) {
+    std::uint32_t n = 1;
+    for (std::uint8_t i = 0; i < 32; n <<= 1, ++i) {
         BOOST_REQUIRE_EQUAL(i, CBjkstUniqueValues::trailingZeros(n));
     }
 
     TDoubleVec samples;
 
     CRandomNumbers rng;
-    rng.generateUniformSamples(0.0, std::numeric_limits<uint32_t>::max(), 10000, samples);
+    rng.generateUniformSamples(0.0, std::numeric_limits<std::uint32_t>::max(), 10000, samples);
 
     for (std::size_t i = 0; i < samples.size(); ++i) {
-        uint32_t sample = static_cast<uint32_t>(samples[i]);
+        std::uint32_t sample = static_cast<std::uint32_t>(samples[i]);
         BOOST_REQUIRE_EQUAL(trailingZeros(sample),
                             CBjkstUniqueValues::trailingZeros(sample));
     }
@@ -83,7 +83,8 @@ BOOST_AUTO_TEST_CASE(testNumber) {
         rng.generateUniformSamples(0.0, 20000.0, 500u + i, samples);
 
         for (std::size_t j = 0; j < 2 * samples.size(); ++j) {
-            uint32_t sample = static_cast<uint32_t>(samples[j % samples.size()]);
+            std::uint32_t sample =
+                static_cast<std::uint32_t>(samples[j % samples.size()]);
             approxUniqueValues5.add(sample);
             approxUniqueValues6.add(sample);
             uniqueValues.insert(sample);
@@ -152,7 +153,7 @@ BOOST_AUTO_TEST_CASE(testRemove) {
         maths::common::CBjkstUniqueValues sketch(2, 150);
         TUInt32Set unique;
         for (std::size_t i = 0; i < categories.size(); ++i) {
-            uint32_t category = static_cast<uint32_t>(categories[i]);
+            std::uint32_t category = static_cast<std::uint32_t>(categories[i]);
             sketch.add(category);
             unique.insert(category);
         }
@@ -169,7 +170,7 @@ BOOST_AUTO_TEST_CASE(testRemove) {
 
         rng.random_shuffle(categories.begin(), categories.end());
         for (std::size_t i = 0; i < toRemove[t]; ++i) {
-            uint32_t category = static_cast<uint32_t>(categories[i]);
+            std::uint32_t category = static_cast<std::uint32_t>(categories[i]);
             sketch.remove(category);
             unique.erase(category);
         }
@@ -213,22 +214,22 @@ BOOST_AUTO_TEST_CASE(testSwap) {
     maths::common::CBjkstUniqueValues sketch3(3, 120);
     maths::common::CBjkstUniqueValues sketch4(2, 180);
     for (std::size_t i = 0; i < categories1.size(); ++i) {
-        sketch1.add(static_cast<uint32_t>(categories1[i]));
+        sketch1.add(static_cast<std::uint32_t>(categories1[i]));
     }
     for (std::size_t i = 0; i < categories2.size(); ++i) {
-        sketch2.add(static_cast<uint32_t>(categories2[i]));
+        sketch2.add(static_cast<std::uint32_t>(categories2[i]));
     }
     for (std::size_t i = 0; i < categories3.size(); ++i) {
-        sketch3.add(static_cast<uint32_t>(categories3[i]));
+        sketch3.add(static_cast<std::uint32_t>(categories3[i]));
     }
     for (std::size_t i = 0; i < categories4.size(); ++i) {
-        sketch4.add(static_cast<uint32_t>(categories4[i]));
+        sketch4.add(static_cast<std::uint32_t>(categories4[i]));
     }
 
-    uint64_t checksum1 = sketch1.checksum();
-    uint64_t checksum2 = sketch2.checksum();
-    uint64_t checksum3 = sketch3.checksum();
-    uint64_t checksum4 = sketch4.checksum();
+    std::uint64_t checksum1 = sketch1.checksum();
+    std::uint64_t checksum2 = sketch2.checksum();
+    std::uint64_t checksum3 = sketch3.checksum();
+    std::uint64_t checksum4 = sketch4.checksum();
     LOG_DEBUG(<< "checksum1 = " << checksum1);
     LOG_DEBUG(<< "checksum2 = " << checksum2);
     LOG_DEBUG(<< "checksum3 = " << checksum3);
@@ -270,7 +271,7 @@ BOOST_AUTO_TEST_CASE(testSmall) {
     maths::common::CBjkstUniqueValues sketch(3, 100);
     TUInt32Set unique;
     for (std::size_t i = 0; i < 100; ++i) {
-        uint32_t category = static_cast<uint32_t>(categories[i]);
+        std::uint32_t category = static_cast<std::uint32_t>(categories[i]);
         sketch.add(category);
         unique.insert(category);
         BOOST_REQUIRE_EQUAL(unique.size(), std::size_t(sketch.number()));
@@ -279,7 +280,7 @@ BOOST_AUTO_TEST_CASE(testSmall) {
 
     LOG_DEBUG(<< "# categories = " << sketch.number());
     for (std::size_t i = 100; i < categories.size(); ++i) {
-        uint32_t category = static_cast<uint32_t>(categories[i]);
+        std::uint32_t category = static_cast<std::uint32_t>(categories[i]);
         sketch.add(category);
         unique.insert(category);
         if (i % 20 == 0) {
@@ -307,7 +308,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
 
     maths::common::CBjkstUniqueValues origSketch(2, 100);
     for (std::size_t i = 0; i < 100; ++i) {
-        origSketch.add(static_cast<uint32_t>(categories[i]));
+        origSketch.add(static_cast<std::uint32_t>(categories[i]));
     }
 
     std::string origXml;
@@ -338,7 +339,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
     }
 
     for (std::size_t i = 100; i < categories.size(); ++i) {
-        origSketch.add(static_cast<uint32_t>(categories[i]));
+        origSketch.add(static_cast<std::uint32_t>(categories[i]));
     }
 
     origXml.clear();

--- a/lib/maths/common/unittest/CBjkstUniqueValuesTest.cc
+++ b/lib/maths/common/unittest/CBjkstUniqueValuesTest.cc
@@ -35,7 +35,7 @@ using TSizeVec = std::vector<std::size_t>;
 using TUInt32Set = std::set<std::uint32_t>;
 using TMeanAccumulator = maths::common::CBasicStatistics::SSampleMean<double>::TAccumulator;
 
-uint8_t trailingZeros(std::uint32_t x) {
+std::uint8_t trailingZeros(std::uint32_t x) {
     std::uint8_t result = 0;
     for (/**/; (x & 0x1) == 0; x >>= 1) {
         ++result;

--- a/lib/maths/common/unittest/CChecksumTest.cc
+++ b/lib/maths/common/unittest/CChecksumTest.cc
@@ -40,17 +40,17 @@ namespace {
 enum EAnEnum { E_1, E_2, E_3 };
 
 struct SFoo {
-    SFoo(uint64_t key) : s_Key(key) {}
-    uint64_t checksum() const { return s_Key; }
-    uint64_t s_Key;
+    SFoo(std::uint64_t key) : s_Key(key) {}
+    std::uint64_t checksum() const { return s_Key; }
+    std::uint64_t s_Key;
 };
 
 struct SBar {
-    SBar(uint64_t key) : s_Key(key) {}
-    uint64_t checksum(uint64_t seed) const {
+    SBar(std::uint64_t key) : s_Key(key) {}
+    std::uint64_t checksum(std::uint64_t seed) const {
         return core::CHashing::hashCombine(seed, s_Key);
     }
-    uint64_t s_Key;
+    std::uint64_t s_Key;
 };
 
 using TIntVec = std::vector<int>;
@@ -69,7 +69,7 @@ using TBarVec = std::vector<SBar>;
 }
 
 BOOST_AUTO_TEST_CASE(testMemberChecksum) {
-    uint64_t seed = 1679023009937ull;
+    std::uint64_t seed = 1679023009937ull;
 
     LOG_DEBUG(<< "");
     LOG_DEBUG(<< "*** test member functions ***");
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(testMemberChecksum) {
 }
 
 BOOST_AUTO_TEST_CASE(testContainers) {
-    uint64_t seed = 1679023009937ull;
+    std::uint64_t seed = 1679023009937ull;
 
     test::CRandomNumbers rng;
 
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(testContainers) {
     {
         std::string values[] = {"rain", "in", "spain"};
         TStrSet a(std::begin(values), std::end(values));
-        uint64_t expected = seed;
+        std::uint64_t expected = seed;
         core::CHashing::CSafeMurmurHash2String64 hasher;
         for (TStrSetCItr itr = a.begin(); itr != a.end(); ++itr) {
             expected = core::CHashing::safeMurmurHash64(
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(testContainers) {
 }
 
 BOOST_AUTO_TEST_CASE(testNullable) {
-    uint64_t seed = 1679023009937ull;
+    std::uint64_t seed = 1679023009937ull;
 
     // Test optional and pointers.
     //
@@ -232,7 +232,7 @@ BOOST_AUTO_TEST_CASE(testNullable) {
 }
 
 BOOST_AUTO_TEST_CASE(testAccumulators) {
-    uint64_t seed = 1679023009937ull;
+    std::uint64_t seed = 1679023009937ull;
 
     // Test accumulators.
     {
@@ -250,7 +250,7 @@ BOOST_AUTO_TEST_CASE(testAccumulators) {
 }
 
 BOOST_AUTO_TEST_CASE(testPair) {
-    uint64_t seed = 1679023009937ull;
+    std::uint64_t seed = 1679023009937ull;
 
     // Test pair.
     {
@@ -276,7 +276,7 @@ BOOST_AUTO_TEST_CASE(testPair) {
         TDoubleMeanVarAccumulatorPrList collection;
         collection.push_back(a);
         collection.push_back(b);
-        uint64_t expected = maths::common::CChecksum::calculate(seed, a);
+        std::uint64_t expected = maths::common::CChecksum::calculate(seed, a);
         expected = maths::common::CChecksum::calculate(expected, b);
         LOG_DEBUG(<< "expected checksum = " << expected);
         LOG_DEBUG(<< "actual checksum   = "
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(testPair) {
 }
 
 BOOST_AUTO_TEST_CASE(testArray) {
-    uint64_t seed = 1679023009937ull;
+    std::uint64_t seed = 1679023009937ull;
 
     double a[] = {1.0, 23.8, 15.2, 14.7};
     double b[] = {1.0, 23.8, 15.2, 14.7};
@@ -304,7 +304,7 @@ BOOST_AUTO_TEST_CASE(testArray) {
 }
 
 BOOST_AUTO_TEST_CASE(testCombinations) {
-    uint64_t seed = 1679023009937ull;
+    std::uint64_t seed = 1679023009937ull;
 
     test::CRandomNumbers rng;
 
@@ -318,7 +318,7 @@ BOOST_AUTO_TEST_CASE(testCombinations) {
     // etc.
     {
         SFoo values[] = {
-            SFoo(static_cast<uint64_t>(-1)), SFoo(20), SFoo(10), SFoo(15), SFoo(2), SFoo(2)};
+            SFoo(static_cast<std::uint64_t>(-1)), SFoo(20), SFoo(10), SFoo(15), SFoo(2), SFoo(2)};
         TFooDeque a(std::begin(values), std::end(values));
         TFooDeque b(std::begin(values), std::end(values));
         LOG_DEBUG(<< "checksum a = " << maths::common::CChecksum::calculate(seed, a));
@@ -345,7 +345,7 @@ BOOST_AUTO_TEST_CASE(testCombinations) {
     }
     {
         SBar values[] = {
-            SBar(static_cast<uint64_t>(-1)), SBar(20), SBar(10), SBar(15), SBar(2), SBar(2)};
+            SBar(static_cast<std::uint64_t>(-1)), SBar(20), SBar(10), SBar(15), SBar(2), SBar(2)};
         TBarVec a(std::begin(values), std::end(values));
         TBarVec b(std::begin(values), std::end(values));
         LOG_DEBUG(<< "checksum a = " << maths::common::CChecksum::calculate(seed, a));

--- a/lib/maths/common/unittest/CGammaRateConjugateTest.cc
+++ b/lib/maths/common/unittest/CGammaRateConjugateTest.cc
@@ -1234,7 +1234,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
         maths::common::MINIMUM_CLUSTER_SPLIT_COUNT, maths::common::MINIMUM_CATEGORY_COUNT);
     maths::common::CGammaRateConjugate restoredFilter(params, traverser);
 
-    uint64_t checksum = origFilter.checksum();
+    std::uint64_t checksum = origFilter.checksum();
     LOG_DEBUG(<< "orig checksum = " << checksum
               << " restored checksum = " << restoredFilter.checksum());
     BOOST_REQUIRE_EQUAL(checksum, restoredFilter.checksum());

--- a/lib/maths/common/unittest/CKMostCorrelatedTest.cc
+++ b/lib/maths/common/unittest/CKMostCorrelatedTest.cc
@@ -691,7 +691,7 @@ BOOST_AUTO_TEST_CASE(testScale) {
     test::CRandomNumbers rng;
 
     std::size_t n[] = {200, 400, 800, 1600, 3200};
-    uint64_t elapsed[5];
+    std::uint64_t elapsed[5];
 
     for (std::size_t s = 0; s < boost::size(n); ++s) {
         double proportions[] = {0.2, 0.3, 0.5};

--- a/lib/maths/common/unittest/CLogNormalMeanPrecConjugateTest.cc
+++ b/lib/maths/common/unittest/CLogNormalMeanPrecConjugateTest.cc
@@ -1274,7 +1274,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
         origFilter.addSamples({samples[i]}, maths_t::CUnitWeights::SINGLE_UNIT);
     }
     double decayRate = origFilter.decayRate();
-    uint64_t checksum = origFilter.checksum();
+    std::uint64_t checksum = origFilter.checksum();
 
     std::string origXml;
     {

--- a/lib/maths/common/unittest/CMultimodalPriorTest.cc
+++ b/lib/maths/common/unittest/CMultimodalPriorTest.cc
@@ -1865,7 +1865,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
         origFilter.addSamples({samples[i]}, maths_t::CUnitWeights::SINGLE_UNIT);
     }
     double decayRate = origFilter.decayRate();
-    uint64_t checksum = origFilter.checksum();
+    std::uint64_t checksum = origFilter.checksum();
 
     std::string origXml;
     {

--- a/lib/maths/common/unittest/CMultinomialConjugateTest.cc
+++ b/lib/maths/common/unittest/CMultinomialConjugateTest.cc
@@ -668,12 +668,12 @@ BOOST_AUTO_TEST_CASE(testProbabilityOfLessLikelySamples) {
 
                 maths::common::CJointProbabilityOfLessLikelySamples expectedProbabilityCalculator;
                 {
-                    ptrdiff_t i = std::lower_bound(categories.begin(),
-                                                   categories.end(), itr->first[0]) -
-                                  categories.begin();
-                    ptrdiff_t j = std::lower_bound(categories.begin(),
-                                                   categories.end(), itr->first[1]) -
-                                  categories.begin();
+                    std::ptrdiff_t i = std::lower_bound(categories.begin(),
+                                                        categories.end(), itr->first[0]) -
+                                       categories.begin();
+                    std::ptrdiff_t j = std::lower_bound(categories.begin(),
+                                                        categories.end(), itr->first[1]) -
+                                       categories.begin();
                     expectedProbabilityCalculator.add(expectedProbabilities[i]);
                     expectedProbabilityCalculator.add(expectedProbabilities[j]);
                 }
@@ -879,7 +879,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
         origFilter.addSamples({samples[i]}, maths_t::CUnitWeights::SINGLE_UNIT);
     }
     double decayRate = origFilter.decayRate();
-    uint64_t checksum = origFilter.checksum();
+    std::uint64_t checksum = origFilter.checksum();
 
     std::string origXml;
     {

--- a/lib/maths/common/unittest/CMultivariateConstantPriorTest.cc
+++ b/lib/maths/common/unittest/CMultivariateConstantPriorTest.cc
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
     LOG_DEBUG(<< "*** Non-informative ***");
     {
         maths::common::CMultivariateConstantPrior origFilter(3);
-        uint64_t checksum = origFilter.checksum();
+        std::uint64_t checksum = origFilter.checksum();
 
         std::string origXml;
         {
@@ -274,7 +274,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
 
         maths::common::CMultivariateConstantPrior origFilter(
             3, TDouble10Vec(std::begin(constant), std::end(constant)));
-        uint64_t checksum = origFilter.checksum();
+        std::uint64_t checksum = origFilter.checksum();
 
         std::string origXml;
         {

--- a/lib/maths/common/unittest/CMultivariateMultimodalPriorTest.cc
+++ b/lib/maths/common/unittest/CMultivariateMultimodalPriorTest.cc
@@ -1036,7 +1036,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
         origFilter.addSamples({samples[i]},
                               maths_t::CUnitWeights::singleUnit<TDouble10Vec>(2));
     }
-    uint64_t checksum = origFilter.checksum();
+    std::uint64_t checksum = origFilter.checksum();
 
     std::string origXml;
     {

--- a/lib/maths/common/unittest/CMultivariateNormalConjugateTest.cc
+++ b/lib/maths/common/unittest/CMultivariateNormalConjugateTest.cc
@@ -1057,7 +1057,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
                               maths_t::CUnitWeights::singleUnit<TDouble10Vec>(2));
     }
     double decayRate = origFilter.decayRate();
-    uint64_t checksum = origFilter.checksum();
+    std::uint64_t checksum = origFilter.checksum();
 
     std::string origXml;
     {

--- a/lib/maths/common/unittest/CMultivariateOneOfNPriorTest.cc
+++ b/lib/maths/common/unittest/CMultivariateOneOfNPriorTest.cc
@@ -973,7 +973,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
     }
     std::size_t dimension = origFilter.dimension();
     double decayRate = origFilter.decayRate();
-    uint64_t checksum = origFilter.checksum();
+    std::uint64_t checksum = origFilter.checksum();
 
     std::string origXml;
     {

--- a/lib/maths/common/unittest/CNaturalBreaksClassifierTest.cc
+++ b/lib/maths/common/unittest/CNaturalBreaksClassifierTest.cc
@@ -631,7 +631,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
         origClassifier.add(samples[i]);
     }
 
-    uint64_t checksum = origClassifier.checksum();
+    std::uint64_t checksum = origClassifier.checksum();
 
     std::string origXml;
     {

--- a/lib/maths/common/unittest/CNormalMeanPrecConjugateTest.cc
+++ b/lib/maths/common/unittest/CNormalMeanPrecConjugateTest.cc
@@ -1143,7 +1143,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
         origFilter.addSamples({samples[i]}, maths_t::CUnitWeights::SINGLE_UNIT);
     }
     double decayRate = origFilter.decayRate();
-    uint64_t checksum = origFilter.checksum();
+    std::uint64_t checksum = origFilter.checksum();
 
     std::string origXml;
     {

--- a/lib/maths/common/unittest/COneOfNPriorTest.cc
+++ b/lib/maths/common/unittest/COneOfNPriorTest.cc
@@ -1205,7 +1205,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
         origFilter.addSamples({samples[i]}, maths_t::CUnitWeights::SINGLE_UNIT);
     }
     double decayRate = origFilter.decayRate();
-    uint64_t checksum = origFilter.checksum();
+    std::uint64_t checksum = origFilter.checksum();
 
     std::string origXml;
     {

--- a/lib/maths/common/unittest/CPRNGTest.cc
+++ b/lib/maths/common/unittest/CPRNGTest.cc
@@ -32,10 +32,10 @@ BOOST_AUTO_TEST_CASE(testSplitMix64) {
     boost::normal_distribution<> norm(4.0, 10.0);
 
     // Test min and max.
-    maths::common::CBasicStatistics::COrderStatisticsStack<uint64_t, 1> min;
-    maths::common::CBasicStatistics::COrderStatisticsStack<uint64_t, 1, std::greater<uint64_t>> max;
+    maths::common::CBasicStatistics::COrderStatisticsStack<std::uint64_t, 1> min;
+    maths::common::CBasicStatistics::COrderStatisticsStack<std::uint64_t, 1, std::greater<std::uint64_t>> max;
     for (std::size_t i = 0; i < 10000; ++i) {
-        uint64_t x = rng1();
+        std::uint64_t x = rng1();
         min.add(x);
         max.add(x);
     }
@@ -50,9 +50,9 @@ BOOST_AUTO_TEST_CASE(testSplitMix64) {
 
     // Test generate.
     maths::common::CPRNG::CSplitMix64 rng2 = rng1;
-    uint64_t samples1[50] = {0u};
+    std::uint64_t samples1[50] = {0u};
     rng1.generate(&samples1[0], &samples1[50]);
-    uint64_t samples2[50] = {0u};
+    std::uint64_t samples2[50] = {0u};
     for (std::size_t i = 0; i < 50; ++i) {
         samples2[i] = rng2();
     }
@@ -138,10 +138,10 @@ BOOST_AUTO_TEST_CASE(testXorOShiro128Plus) {
     boost::normal_distribution<> norm(-4.0, 4.0);
 
     // Test min and max.
-    maths::common::CBasicStatistics::COrderStatisticsStack<uint64_t, 1> min;
-    maths::common::CBasicStatistics::COrderStatisticsStack<uint64_t, 1, std::greater<uint64_t>> max;
+    maths::common::CBasicStatistics::COrderStatisticsStack<std::uint64_t, 1> min;
+    maths::common::CBasicStatistics::COrderStatisticsStack<std::uint64_t, 1, std::greater<std::uint64_t>> max;
     for (std::size_t i = 0; i < 10000; ++i) {
-        uint64_t x = rng1();
+        std::uint64_t x = rng1();
         min.add(x);
         max.add(x);
     }
@@ -156,9 +156,9 @@ BOOST_AUTO_TEST_CASE(testXorOShiro128Plus) {
 
     // Test generate.
     maths::common::CPRNG::CXorOShiro128Plus rng2 = rng1;
-    uint64_t samples1[50] = {0u};
+    std::uint64_t samples1[50] = {0u};
     rng1.generate(&samples1[0], &samples1[50]);
-    uint64_t samples2[50] = {0u};
+    std::uint64_t samples2[50] = {0u};
     for (std::size_t i = 0; i < 50; ++i) {
         samples2[i] = rng2();
     }
@@ -260,10 +260,10 @@ BOOST_AUTO_TEST_CASE(testXorShift1024Mult) {
     boost::normal_distribution<> norm(100.0, 8000.0);
 
     // Test min and max.
-    maths::common::CBasicStatistics::COrderStatisticsStack<uint64_t, 1> min;
-    maths::common::CBasicStatistics::COrderStatisticsStack<uint64_t, 1, std::greater<uint64_t>> max;
+    maths::common::CBasicStatistics::COrderStatisticsStack<std::uint64_t, 1> min;
+    maths::common::CBasicStatistics::COrderStatisticsStack<std::uint64_t, 1, std::greater<std::uint64_t>> max;
     for (std::size_t i = 0; i < 10000; ++i) {
-        uint64_t x = rng1();
+        std::uint64_t x = rng1();
         min.add(x);
         max.add(x);
     }
@@ -278,9 +278,9 @@ BOOST_AUTO_TEST_CASE(testXorShift1024Mult) {
 
     // Test generate.
     maths::common::CPRNG::CXorShift1024Mult rng2 = rng1;
-    uint64_t samples1[50] = {0u};
+    std::uint64_t samples1[50] = {0u};
     rng1.generate(&samples1[0], &samples1[50]);
-    uint64_t samples2[50] = {0u};
+    std::uint64_t samples2[50] = {0u};
     for (std::size_t i = 0; i < 50; ++i) {
         samples2[i] = rng2();
     }

--- a/lib/maths/common/unittest/CPoissonMeanConjugateTest.cc
+++ b/lib/maths/common/unittest/CPoissonMeanConjugateTest.cc
@@ -921,7 +921,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
         origFilter.addSamples({samples[i]}, maths_t::CUnitWeights::SINGLE_UNIT);
     }
     double decayRate = origFilter.decayRate();
-    uint64_t checksum = origFilter.checksum();
+    std::uint64_t checksum = origFilter.checksum();
 
     std::string origXml;
     {

--- a/lib/maths/common/unittest/CQDigestTest.cc
+++ b/lib/maths/common/unittest/CQDigestTest.cc
@@ -35,7 +35,7 @@ using namespace common;
 using namespace test;
 
 using TDoubleVec = std::vector<double>;
-using TUInt32UInt64Pr = std::pair<uint32_t, uint64_t>;
+using TUInt32UInt64Pr = std::pair<std::uint32_t, std::uint64_t>;
 using TUInt32UInt64PrVec = std::vector<TUInt32UInt64Pr>;
 
 BOOST_AUTO_TEST_CASE(testAdd) {
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(testAdd) {
         };
 
         for (std::size_t i = 0; i < 5; ++i) {
-            qDigest.add(static_cast<uint32_t>(i));
+            qDigest.add(static_cast<std::uint32_t>(i));
 
             LOG_DEBUG(<< qDigest.print());
 
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(testAdd) {
 
     // Large n uniform random.
     {
-        using TUInt64Set = std::multiset<uint64_t>;
+        using TUInt64Set = std::multiset<std::uint64_t>;
 
         const double expectedMaxErrors[] = {0.007, 0.01,  0.12,  0.011, 0.016,
                                             0.018, 0.023, 0.025, 0.02};
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(testAdd) {
 
         TUInt64Set orderedSamples;
         for (std::size_t i = 0; i < samples.size(); ++i) {
-            uint32_t sample = static_cast<uint32_t>(std::floor(samples[i]));
+            std::uint32_t sample = static_cast<std::uint32_t>(std::floor(samples[i]));
 
             qDigest.add(sample);
             orderedSamples.insert(sample);
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(testAdd) {
                 for (unsigned int j = 1; j < 10; ++j) {
                     double q = static_cast<double>(j) / 10.0;
 
-                    uint32_t quantile;
+                    std::uint32_t quantile;
                     qDigest.quantile(q, quantile);
 
                     std::size_t rank = std::distance(
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(testCdf) {
 
     std::size_t s = 0;
     for (/**/; s < std::min(k, samples.size()); ++s) {
-        uint32_t sample = static_cast<uint32_t>(std::floor(samples[s]));
+        std::uint32_t sample = static_cast<std::uint32_t>(std::floor(samples[s]));
         qDigest.add(sample);
     }
 
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE(testCdf) {
     }
 
     for (/**/; s < samples.size(); ++s) {
-        uint32_t sample = static_cast<uint32_t>(std::floor(samples[s]));
+        std::uint32_t sample = static_cast<std::uint32_t>(std::floor(samples[s]));
         qDigest.add(sample);
     }
 
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE(testSummary) {
         generator.generateUniformSamples(0.0, 500.0, 100u, samples);
 
         for (std::size_t i = 0; i < samples.size(); ++i) {
-            uint32_t sample = static_cast<uint32_t>(std::floor(samples[i]));
+            std::uint32_t sample = static_cast<std::uint32_t>(std::floor(samples[i]));
             qDigest.add(sample);
         }
 
@@ -238,7 +238,7 @@ BOOST_AUTO_TEST_CASE(testSummary) {
         for (std::size_t i = 0; i < summary.size(); ++i) {
             double q = static_cast<double>(summary[i].second) / 100.0;
 
-            uint32_t xq;
+            std::uint32_t xq;
             qDigest.quantile(q, xq);
 
             LOG_DEBUG(<< "q = " << q << ", x(q) = " << summary[i].first
@@ -325,10 +325,10 @@ BOOST_AUTO_TEST_CASE(testPropagateForwardByTime) {
         TDoubleVec samples;
         rng.generateNormalSamples(mean, std * std, 200000, samples);
         for (std::size_t i = 0; i < samples.size(); ++i) {
-            qDigest.add(static_cast<uint32_t>(samples[i] + 0.5));
+            qDigest.add(static_cast<std::uint32_t>(samples[i] + 0.5));
         }
 
-        uint64_t n = qDigest.n();
+        std::uint64_t n = qDigest.n();
         LOG_DEBUG(<< "n = " << n);
 
         TDoubleVec cdfLower;
@@ -338,7 +338,7 @@ BOOST_AUTO_TEST_CASE(testPropagateForwardByTime) {
         boost::math::normal_distribution<> normal(mean, std);
         for (double x = mean - 5.0 * std; x <= mean + 5 * std; x += 5.0) {
             double lb, ub;
-            BOOST_TEST_REQUIRE(qDigest.cdf(static_cast<uint32_t>(x), 0.0, lb, ub));
+            BOOST_TEST_REQUIRE(qDigest.cdf(static_cast<std::uint32_t>(x), 0.0, lb, ub));
             cdfLower.push_back(lb);
             double f = boost::math::cdf(normal, x);
             cdfUpper.push_back(ub);
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE(testPropagateForwardByTime) {
         qDigest.propagateForwardsByTime(1.0);
         BOOST_TEST_REQUIRE(qDigest.checkInvariants());
 
-        uint64_t nAged = qDigest.n();
+        std::uint64_t nAged = qDigest.n();
         LOG_DEBUG(<< "nAged = " << nAged);
 
         BOOST_REQUIRE_CLOSE_ABSOLUTE(0.001, double(n - nAged) / double(n), 5e-4);
@@ -359,7 +359,7 @@ BOOST_AUTO_TEST_CASE(testPropagateForwardByTime) {
         TDoubleVec cdfUpperAged;
         for (double x = mean - 5.0 * std; x <= mean + 5 * std; x += 5.0) {
             double lb, ub;
-            BOOST_TEST_REQUIRE(qDigest.cdf(static_cast<uint32_t>(x), 0.0, lb, ub));
+            BOOST_TEST_REQUIRE(qDigest.cdf(static_cast<std::uint32_t>(x), 0.0, lb, ub));
             cdfLowerAged.push_back(lb);
             cdfUpperAged.push_back(ub);
         }
@@ -392,7 +392,7 @@ BOOST_AUTO_TEST_CASE(testPropagateForwardByTime) {
         for (std::size_t i = 0; i < 500; ++i) {
             rng.generateNormalSamples(mean, std * std, 2000, samples);
             for (std::size_t j = 0; j < samples.size(); ++j) {
-                qDigest.add(static_cast<uint32_t>(samples[j] + 0.5));
+                qDigest.add(static_cast<std::uint32_t>(samples[j] + 0.5));
             }
             if (i % 10 == 0) {
                 LOG_DEBUG(<< "iteration = " << i);
@@ -405,7 +405,7 @@ BOOST_AUTO_TEST_CASE(testPropagateForwardByTime) {
         boost::math::normal_distribution<> normal(mean, std);
         for (double x = mean - 5.0 * std; x <= mean + 5 * std; x += 5.0) {
             double lb, ub;
-            BOOST_TEST_REQUIRE(qDigest.cdf(static_cast<uint32_t>(x), 0.0, lb, ub));
+            BOOST_TEST_REQUIRE(qDigest.cdf(static_cast<std::uint32_t>(x), 0.0, lb, ub));
             double f = boost::math::cdf(normal, x);
             BOOST_TEST_REQUIRE(lb <= f);
             BOOST_TEST_REQUIRE(ub >= f);
@@ -487,8 +487,8 @@ BOOST_AUTO_TEST_CASE(testScale) {
             CQDigest qDigestScaled(20u);
 
             for (std::size_t j = 0; j < samples.size(); ++j) {
-                qDigest.add(static_cast<uint32_t>(samples[j]));
-                qDigestScaled.add(static_cast<uint32_t>(scales[i] * samples[j]));
+                qDigest.add(static_cast<std::uint32_t>(samples[j]));
+                qDigestScaled.add(static_cast<std::uint32_t>(scales[i] * samples[j]));
             }
 
             qDigest.scale(scales[i]);
@@ -499,11 +499,11 @@ BOOST_AUTO_TEST_CASE(testScale) {
             double maxType2 = 0.0;
             double totalType2 = 0.0;
 
-            uint32_t end =
-                static_cast<uint32_t>(
+            std::uint32_t end =
+                static_cast<std::uint32_t>(
                     scales[i] * *std::max_element(samples.begin(), samples.end())) +
                 1;
-            for (uint32_t j = 0; j < end; ++j) {
+            for (std::uint32_t j = 0; j < end; ++j) {
                 double expectedLowerBound;
                 double expectedUpperBound;
                 qDigestScaled.cdf(j, 0.0, expectedLowerBound, expectedUpperBound);
@@ -542,7 +542,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
     generator.generateUniformSamples(0.0, 5000.0, 1000u, samples);
 
     for (std::size_t i = 0; i < samples.size(); ++i) {
-        uint32_t sample = static_cast<uint32_t>(std::floor(samples[i]));
+        std::uint32_t sample = static_cast<std::uint32_t>(std::floor(samples[i]));
 
         origQDigest.add(sample);
     }

--- a/lib/maths/common/unittest/CXMeansOnline1dTest.cc
+++ b/lib/maths/common/unittest/CXMeansOnline1dTest.cc
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(testCluster) {
             cluster.logLikelihoodFromCluster(maths_t::E_ClustersFractionWeight, 1.5),
         1e-10);
 
-    uint64_t origChecksum = cluster.checksum(0);
+    std::uint64_t origChecksum = cluster.checksum(0);
     std::string origXml;
     {
         core::CRapidXmlStatePersistInserter inserter("root");
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(testCluster) {
         maths_t::E_ContinuousData, 0.1, maths::common::MINIMUM_CLUSTER_SPLIT_FRACTION,
         maths::common::MINIMUM_CLUSTER_SPLIT_COUNT, maths::common::MINIMUM_CATEGORY_COUNT);
     restore(params, traverser, restoredCluster);
-    uint64_t restoredChecksum = restoredCluster.checksum(0);
+    std::uint64_t restoredChecksum = restoredCluster.checksum(0);
     BOOST_REQUIRE_EQUAL(origChecksum, restoredChecksum);
 
     double x2[] = {10.3, 10.6, 10.7, 9.8, 11.2, 11.0};

--- a/lib/maths/common/unittest/CXMeansOnlineTest.cc
+++ b/lib/maths/common/unittest/CXMeansOnlineTest.cc
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(testCluster) {
             cluster.logLikelihoodFromCluster(maths_t::E_ClustersFractionWeight, TPoint(1.5)),
         1e-10);
 
-    uint64_t origChecksum = cluster.checksum(0);
+    std::uint64_t origChecksum = cluster.checksum(0);
     std::string origXml;
     {
         core::CRapidXmlStatePersistInserter inserter("root");
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(testCluster) {
         maths_t::E_ContinuousData, 0.1, maths::common::MINIMUM_CLUSTER_SPLIT_FRACTION,
         maths::common::MINIMUM_CLUSTER_SPLIT_COUNT, maths::common::MINIMUM_CATEGORY_COUNT);
     restore(params, traverser, restoredCluster);
-    uint64_t restoredChecksum = restoredCluster.checksum(0);
+    std::uint64_t restoredChecksum = restoredCluster.checksum(0);
     BOOST_REQUIRE_EQUAL(origChecksum, restoredChecksum);
 
     double x2[][2]{{10.3, 10.4}, {10.6, 10.5}, {10.7, 11.0}, {9.8, 10.2},

--- a/lib/maths/common/unittest/CXMeansTest.cc
+++ b/lib/maths/common/unittest/CXMeansTest.cc
@@ -22,10 +22,9 @@
 #include <test/CRandomNumbersDetail.h>
 
 #include <boost/math/constants/constants.hpp>
-#include <boost/range.hpp>
 #include <boost/test/unit_test.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 
 using TVector2 = ml::maths::common::CVectorNx1<double, 2>;
 using TVector4 = ml::maths::common::CVectorNx1<double, 4>;
@@ -663,7 +662,7 @@ BOOST_AUTO_TEST_CASE(testPoorlyConditioned) {
     }
     std::sort(cluster2.begin(), cluster2.end());
     TVector2Vec cluster3;
-    for (std::size_t i = 20; i < boost::size(points_); ++i) {
+    for (std::size_t i = 20; i < std::size(points_); ++i) {
         cluster3.push_back(TVector2(&points_[i][0], &points_[i][2]));
     }
     std::sort(cluster3.begin(), cluster3.end());
@@ -674,7 +673,7 @@ BOOST_AUTO_TEST_CASE(testPoorlyConditioned) {
         LOG_DEBUG(<< "*** test = " << t << " ***");
 
         TVector2Vec points;
-        for (std::size_t i = 0; i < boost::size(points_); ++i) {
+        for (std::size_t i = 0; i < std::size(points_); ++i) {
             points.push_back(TVector2(&points_[i][0], &points_[i][2]));
         }
 

--- a/lib/maths/time_series/CCountMinSketch.cc
+++ b/lib/maths/time_series/CCountMinSketch.cc
@@ -190,7 +190,7 @@ double CCountMinSketch::oneMinusDeltaError() const {
            m_TotalCount;
 }
 
-void CCountMinSketch::add(uint32_t category, double count) {
+void CCountMinSketch::add(std::uint32_t category, double count) {
     LOG_TRACE(<< "Adding category = " << category << ", count = " << count);
 
     m_TotalCount += count;
@@ -215,7 +215,7 @@ void CCountMinSketch::add(uint32_t category, double count) {
         try {
             auto& sketch = std::get<SSketch>(m_Sketch);
             for (std::size_t i = 0; i < sketch.s_Hashes.size(); ++i) {
-                uint32_t hash = (sketch.s_Hashes[i])(category);
+                std::uint32_t hash = (sketch.s_Hashes[i])(category);
                 std::size_t j = static_cast<std::size_t>(hash) % m_Columns;
                 sketch.s_Counts[i][j] += count;
                 LOG_TRACE(<< "count (i,j) = (" << i << "," << j << ")"
@@ -227,7 +227,7 @@ void CCountMinSketch::add(uint32_t category, double count) {
     }
 }
 
-void CCountMinSketch::removeFromMap(uint32_t category) {
+void CCountMinSketch::removeFromMap(std::uint32_t category) {
     auto* counts = std::get_if<TUInt32FloatPrVec>(&m_Sketch);
     if (counts != nullptr) {
         auto itr = std::lower_bound(counts->begin(), counts->end(), category,
@@ -262,7 +262,7 @@ double CCountMinSketch::totalCount() const {
     return m_TotalCount;
 }
 
-double CCountMinSketch::count(uint32_t category) const {
+double CCountMinSketch::count(std::uint32_t category) const {
     using TMinAccumulator = common::CBasicStatistics::COrderStatisticsStack<double, 1>;
 
     const auto* counts = std::get_if<TUInt32FloatPrVec>(&m_Sketch);
@@ -279,7 +279,7 @@ double CCountMinSketch::count(uint32_t category) const {
     try {
         const auto& sketch = std::get<SSketch>(m_Sketch);
         for (std::size_t i = 0; i < sketch.s_Hashes.size(); ++i) {
-            uint32_t hash = (sketch.s_Hashes[i])(category);
+            std::uint32_t hash = (sketch.s_Hashes[i])(category);
             std::size_t j = static_cast<std::size_t>(hash) % m_Columns;
             LOG_TRACE(<< "count (i,j) = (" << i << "," << j << ")"
                       << " <- " << sketch.s_Counts[i][j]);
@@ -291,7 +291,7 @@ double CCountMinSketch::count(uint32_t category) const {
     return result.count() > 0 ? result[0] : 0.0;
 }
 
-double CCountMinSketch::fraction(uint32_t category) const {
+double CCountMinSketch::fraction(std::uint32_t category) const {
     return this->count(category) / m_TotalCount;
 }
 
@@ -299,7 +299,7 @@ bool CCountMinSketch::sketched() const {
     return std::get_if<SSketch>(&m_Sketch) != nullptr;
 }
 
-uint64_t CCountMinSketch::checksum(uint64_t seed) const {
+uint64_t CCountMinSketch::checksum(std::uint64_t seed) const {
     seed = common::CChecksum::calculate(seed, m_Rows);
     seed = common::CChecksum::calculate(seed, m_Columns);
     seed = common::CChecksum::calculate(seed, m_TotalCount);

--- a/lib/maths/time_series/CCountMinSketch.cc
+++ b/lib/maths/time_series/CCountMinSketch.cc
@@ -299,7 +299,7 @@ bool CCountMinSketch::sketched() const {
     return std::get_if<SSketch>(&m_Sketch) != nullptr;
 }
 
-uint64_t CCountMinSketch::checksum(std::uint64_t seed) const {
+std::uint64_t CCountMinSketch::checksum(std::uint64_t seed) const {
     seed = common::CChecksum::calculate(seed, m_Rows);
     seed = common::CChecksum::calculate(seed, m_Columns);
     seed = common::CChecksum::calculate(seed, m_TotalCount);

--- a/lib/maths/time_series/CTimeSeriesModel.cc
+++ b/lib/maths/time_series/CTimeSeriesModel.cc
@@ -1818,12 +1818,13 @@ void CTimeSeriesCorrelations::refresh(const CTimeSeriesCorrelateModelAllocator& 
         LOG_TRACE(<< "correlationCoeffs = "
                   << core::CContainerPrinter::print(correlationCoeffs));
 
-        ptrdiff_t cutoff{std::upper_bound(correlationCoeffs.begin(),
-                                          correlationCoeffs.end(), 0.5 * m_MinimumSignificantCorrelation,
-                                          [](double lhs, double rhs) {
-                                              return std::fabs(lhs) > std::fabs(rhs);
-                                          }) -
-                         correlationCoeffs.begin()};
+        std::ptrdiff_t cutoff{
+            std::upper_bound(correlationCoeffs.begin(), correlationCoeffs.end(),
+                             0.5 * m_MinimumSignificantCorrelation,
+                             [](double lhs, double rhs) {
+                                 return std::fabs(lhs) > std::fabs(rhs);
+                             }) -
+            correlationCoeffs.begin()};
         LOG_TRACE(<< "cutoff = " << cutoff);
 
         correlated.erase(correlated.begin() + cutoff, correlated.end());

--- a/lib/maths/time_series/unittest/CCalendarComponentAdaptiveBucketingTest.cc
+++ b/lib/maths/time_series/unittest/CCalendarComponentAdaptiveBucketingTest.cc
@@ -115,8 +115,8 @@ BOOST_FIXTURE_TEST_CASE(testSwap, CTestFixture) {
         now - core::constants::WEEK};
     maths::time_series::CCalendarComponentAdaptiveBucketing bucketing2{feature2, 0, 0.1};
 
-    uint64_t checksum1{bucketing1.checksum()};
-    uint64_t checksum2{bucketing2.checksum()};
+    std::uint64_t checksum1{bucketing1.checksum()};
+    std::uint64_t checksum2{bucketing2.checksum()};
 
     bucketing1.swap(bucketing2);
 
@@ -150,8 +150,8 @@ BOOST_FIXTURE_TEST_CASE(testRefine, CTestFixture) {
         bool inWindow{bucketing1.feature().inWindow(t)};
         if (inWindow) {
             core_t::TTime x{bucketing1.feature().offset(t)};
-            ptrdiff_t i{std::lower_bound(std::begin(times), std::end(times), x) -
-                        std::begin(times)};
+            std::ptrdiff_t i{std::lower_bound(std::begin(times), std::end(times), x) -
+                             std::begin(times)};
             double x0{static_cast<double>(times[i - 1])};
             double x1{static_cast<double>(times[i])};
             double y0{function[i - 1]};
@@ -174,8 +174,8 @@ BOOST_FIXTURE_TEST_CASE(testRefine, CTestFixture) {
     for (std::size_t i = 1; i < endpoints1.size(); ++i) {
         core_t::TTime t{static_cast<core_t::TTime>(
             0.5 * (endpoints1[i] + endpoints1[i - 1] + 1.0))};
-        ptrdiff_t j{std::lower_bound(std::begin(times), std::end(times), t) -
-                    std::begin(times)};
+        std::ptrdiff_t j{std::lower_bound(std::begin(times), std::end(times), t) -
+                         std::begin(times)};
         double x0{static_cast<double>(times[j - 1])};
         double x1{static_cast<double>(times[j])};
         double y0{function[j - 1]};
@@ -192,8 +192,8 @@ BOOST_FIXTURE_TEST_CASE(testRefine, CTestFixture) {
     for (std::size_t i = 1; i < endpoints1.size(); ++i) {
         core_t::TTime t{static_cast<core_t::TTime>(
             0.5 * (endpoints2[i] + endpoints2[i - 1] + 1.0))};
-        ptrdiff_t j{std::lower_bound(std::begin(times), std::end(times), t) -
-                    std::begin(times)};
+        std::ptrdiff_t j{std::lower_bound(std::begin(times), std::end(times), t) -
+                         std::begin(times)};
         double x0{static_cast<double>(times[j - 1])};
         double x1{static_cast<double>(times[j])};
         double y0{function[j - 1]};
@@ -494,7 +494,7 @@ BOOST_FIXTURE_TEST_CASE(testPersist, CTestFixture) {
         bucketing.refine(static_cast<core_t::TTime>(86400 * (p + 1)));
     }
 
-    uint64_t checksum{bucketing.checksum()};
+    std::uint64_t checksum{bucketing.checksum()};
 
     std::string origXml;
     {

--- a/lib/maths/time_series/unittest/CCalendarCyclicTestTest.cc
+++ b/lib/maths/time_series/unittest/CCalendarCyclicTestTest.cc
@@ -73,10 +73,10 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
 
         TDoubleVec error;
         for (core_t::TTime time = 0; time <= end; time += HALF_HOUR) {
-            ptrdiff_t i = maths::common::CTools::truncate(
+            std::ptrdiff_t i = maths::common::CTools::truncate(
                 std::lower_bound(std::begin(months), std::end(months), time) -
                     std::begin(months),
-                ptrdiff_t(1), ptrdiff_t(boost::size(months)));
+                std::ptrdiff_t(1), std::ptrdiff_t(boost::size(months)));
 
             rng.generateNormalSamples(0.0, 9.0, 1, error);
             if (time >= months[i - 1] + 30000 && time < months[i - 1] + 50000) {
@@ -120,10 +120,10 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
 
         TDoubleVec error;
         for (core_t::TTime time = 0; time <= end; time += HALF_HOUR) {
-            ptrdiff_t i = maths::common::CTools::truncate(
+            std::ptrdiff_t i = maths::common::CTools::truncate(
                 std::lower_bound(std::begin(months), std::end(months), time) -
                     std::begin(months),
-                ptrdiff_t(1), ptrdiff_t(boost::size(months)));
+                std::ptrdiff_t(1), std::ptrdiff_t(boost::size(months)));
 
             rng.generateNormalSamples(0.0, 9.0, 1, error);
             if (time >= months[i - 1] + 10000 && time < months[i - 1] + 20000) {
@@ -164,10 +164,10 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
 
         TDoubleVec error;
         for (core_t::TTime time = 0; time <= end; time += HALF_HOUR) {
-            ptrdiff_t i = maths::common::CTools::truncate(
+            std::ptrdiff_t i = maths::common::CTools::truncate(
                 std::lower_bound(std::begin(months), std::end(months), time) -
                     std::begin(months),
-                ptrdiff_t(1), ptrdiff_t(boost::size(months)));
+                std::ptrdiff_t(1), std::ptrdiff_t(boost::size(months)));
 
             rng.generateNormalSamples(0.0, 9.0, 1, error);
             if (time >= months[i - 1] + 45000 && time < months[i - 1] + 60000) {
@@ -208,10 +208,10 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
 
         TDoubleVec error;
         for (core_t::TTime time = 0; time <= end; time += HALF_HOUR) {
-            ptrdiff_t i = maths::common::CTools::truncate(
+            std::ptrdiff_t i = maths::common::CTools::truncate(
                 std::lower_bound(std::begin(months), std::end(months), time) -
                     std::begin(months),
-                ptrdiff_t(1), ptrdiff_t(boost::size(months)));
+                std::ptrdiff_t(1), std::ptrdiff_t(boost::size(months)));
 
             rng.generateNormalSamples(0.0, 9.0, 1, error);
             if (time >= months[i - 1] + 45000 && time < months[i - 1] + 60000) {
@@ -266,10 +266,10 @@ BOOST_AUTO_TEST_CASE(testTimeZones) {
 
         TDoubleVec error;
         for (core_t::TTime time = 0; time <= end; time += HALF_HOUR) {
-            ptrdiff_t i = maths::common::CTools::truncate(
+            std::ptrdiff_t i = maths::common::CTools::truncate(
                 std::lower_bound(std::begin(months), std::end(months), time + timeZoneOffset) -
                     std::begin(months),
-                ptrdiff_t(1), ptrdiff_t(boost::size(months)));
+                std::ptrdiff_t(1), std::ptrdiff_t(boost::size(months)));
 
             rng.generateNormalSamples(0.0, 9.0, 1, error);
             if (time + timeZoneOffset >= months[i - 1] + 25000 &&
@@ -313,10 +313,10 @@ BOOST_AUTO_TEST_CASE(testTimeZones) {
 
         TDoubleVec error;
         for (core_t::TTime time = 0; time <= end; time += HALF_HOUR) {
-            ptrdiff_t i = maths::common::CTools::truncate(
+            std::ptrdiff_t i = maths::common::CTools::truncate(
                 std::lower_bound(std::begin(months), std::end(months), time + timeZoneOffset) -
                     std::begin(months),
-                ptrdiff_t(1), ptrdiff_t(boost::size(months)));
+                std::ptrdiff_t(1), std::ptrdiff_t(boost::size(months)));
 
             rng.generateNormalSamples(0.0, 9.0, 1, error);
             if (time + timeZoneOffset >= months[i - 1] + 45000 &&
@@ -376,10 +376,10 @@ BOOST_AUTO_TEST_CASE(testVeryLargeCyclicSpikes) {
 
         TDoubleVec error;
         for (core_t::TTime time = 0; time <= end; time += HOUR) {
-            ptrdiff_t i = maths::common::CTools::truncate(
+            std::ptrdiff_t i = maths::common::CTools::truncate(
                 std::lower_bound(std::begin(months), std::end(months), time) -
                     std::begin(months),
-                ptrdiff_t(1), ptrdiff_t(boost::size(months)));
+                std::ptrdiff_t(1), std::ptrdiff_t(boost::size(months)));
 
             rng.generateNormalSamples(0.0, 9.0, 1, error);
             if (time >= months[i - 1] + 36000 && time < months[i - 1] + 39600) {

--- a/lib/maths/time_series/unittest/CCountMinSketchTest.cc
+++ b/lib/maths/time_series/unittest/CCountMinSketchTest.cc
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(testCounts) {
 
         for (std::size_t i = 0; i < counts.size(); ++i) {
             counts[i] = std::floor(counts[i]);
-            sketch.add(static_cast<uint32_t>(i), counts[i]);
+            sketch.add(static_cast<std::uint32_t>(i), counts[i]);
         }
         LOG_DEBUG(<< "error = " << sketch.oneMinusDeltaError());
 
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(testCounts) {
         double errorCount = 0.0;
         for (std::size_t i = 0; i < counts.size(); ++i) {
             double count = counts[i];
-            double estimated = sketch.count(static_cast<uint32_t>(i));
+            double estimated = sketch.count(static_cast<std::uint32_t>(i));
             if (i % 50 == 0) {
                 LOG_DEBUG(<< "category = " << i << ", true count = " << count
                           << ", estimated count = " << estimated);
@@ -95,18 +95,18 @@ BOOST_AUTO_TEST_CASE(testCounts) {
 
         for (std::size_t i = 0; i < heavyHitters.size(); ++i) {
             heavyHitters[i] = std::floor(heavyHitters[i]);
-            sketch.add(static_cast<uint32_t>(i), heavyHitters[i]);
+            sketch.add(static_cast<std::uint32_t>(i), heavyHitters[i]);
         }
         for (std::size_t i = 0; i < counts.size(); ++i) {
             counts[i] = std::floor(counts[i]);
-            sketch.add(static_cast<uint32_t>(i + heavyHitters.size()), counts[i]);
+            sketch.add(static_cast<std::uint32_t>(i + heavyHitters.size()), counts[i]);
         }
         LOG_DEBUG(<< "error = " << sketch.oneMinusDeltaError());
 
         TMeanAccumulator meanRelativeError;
         for (std::size_t i = 0; i < heavyHitters.size(); ++i) {
             double count = heavyHitters[i];
-            double estimated = sketch.count(static_cast<uint32_t>(i));
+            double estimated = sketch.count(static_cast<std::uint32_t>(i));
             LOG_DEBUG(<< "category = " << i << ", true count = " << count
                       << ", estimated count = " << estimated);
 
@@ -139,22 +139,22 @@ BOOST_AUTO_TEST_CASE(testSwap) {
     maths::time_series::CCountMinSketch sketch3(3, 300);
     maths::time_series::CCountMinSketch sketch4(2, 400);
     for (std::size_t i = 0; i < counts1.size(); ++i) {
-        sketch1.add(static_cast<uint32_t>(i), counts1[i]);
+        sketch1.add(static_cast<std::uint32_t>(i), counts1[i]);
     }
     for (std::size_t i = 0; i < counts2.size(); ++i) {
-        sketch2.add(static_cast<uint32_t>(i), counts2[i]);
+        sketch2.add(static_cast<std::uint32_t>(i), counts2[i]);
     }
     for (std::size_t i = 0; i < counts3.size(); ++i) {
-        sketch3.add(static_cast<uint32_t>(i), counts3[i]);
+        sketch3.add(static_cast<std::uint32_t>(i), counts3[i]);
     }
     for (std::size_t i = 0; i < counts4.size(); ++i) {
-        sketch4.add(static_cast<uint32_t>(i), counts4[i]);
+        sketch4.add(static_cast<std::uint32_t>(i), counts4[i]);
     }
 
-    uint64_t checksum1 = sketch1.checksum();
-    uint64_t checksum2 = sketch2.checksum();
-    uint64_t checksum3 = sketch3.checksum();
-    uint64_t checksum4 = sketch4.checksum();
+    std::uint64_t checksum1 = sketch1.checksum();
+    std::uint64_t checksum2 = sketch2.checksum();
+    std::uint64_t checksum3 = sketch3.checksum();
+    std::uint64_t checksum4 = sketch4.checksum();
     LOG_DEBUG(<< "checksum1 = " << checksum1);
     LOG_DEBUG(<< "checksum2 = " << checksum2);
     LOG_DEBUG(<< "checksum3 = " << checksum3);
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
 
     maths::time_series::CCountMinSketch origSketch(2, 600);
     for (std::size_t i = 0; i < counts.size(); ++i) {
-        origSketch.add(static_cast<uint32_t>(i), counts[i]);
+        origSketch.add(static_cast<std::uint32_t>(i), counts[i]);
     }
 
     std::string origXml;
@@ -223,7 +223,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
     TDoubleVec moreCounts;
     rng.generateUniformSamples(2.0, 301.0, 500, moreCounts);
     for (std::size_t i = 0; i < moreCounts.size(); ++i) {
-        origSketch.add(static_cast<uint32_t>(counts.size() + i), moreCounts[i]);
+        origSketch.add(static_cast<std::uint32_t>(counts.size() + i), moreCounts[i]);
     }
 
     origXml.clear();

--- a/lib/maths/time_series/unittest/CSeasonalComponentAdaptiveBucketingTest.cc
+++ b/lib/maths/time_series/unittest/CSeasonalComponentAdaptiveBucketingTest.cc
@@ -94,8 +94,8 @@ BOOST_AUTO_TEST_CASE(testSwap) {
     maths::time_series::CGeneralPeriodTime time2(120);
     maths::time_series::CSeasonalComponentAdaptiveBucketing bucketing2(time2, 0.1);
 
-    uint64_t checksum1 = bucketing1.checksum();
-    uint64_t checksum2 = bucketing2.checksum();
+    std::uint64_t checksum1 = bucketing1.checksum();
+    std::uint64_t checksum2 = bucketing2.checksum();
 
     bucketing1.swap(bucketing2);
 
@@ -134,8 +134,8 @@ BOOST_AUTO_TEST_CASE(testRefine) {
             for (core_t::TTime t = 0; t < 86400; t += 1800) {
                 core_t::TTime x = start + t;
 
-                ptrdiff_t i = std::lower_bound(std::begin(times), std::end(times), t) -
-                              std::begin(times);
+                std::ptrdiff_t i = std::lower_bound(std::begin(times), std::end(times), t) -
+                                   std::begin(times);
 
                 double x0 = static_cast<double>(times[i - 1]);
                 double x1 = static_cast<double>(times[i]);
@@ -156,8 +156,8 @@ BOOST_AUTO_TEST_CASE(testRefine) {
         for (std::size_t i = 1; i < endpoints1.size(); ++i) {
             core_t::TTime t = static_cast<core_t::TTime>(
                 0.5 * (endpoints1[i] + endpoints1[i - 1] + 1.0));
-            ptrdiff_t j = std::lower_bound(std::begin(times), std::end(times), t) -
-                          std::begin(times);
+            std::ptrdiff_t j = std::lower_bound(std::begin(times), std::end(times), t) -
+                               std::begin(times);
             double x0 = static_cast<double>(times[j - 1]);
             double x1 = static_cast<double>(times[j]);
             double y0 = function[j - 1];
@@ -174,8 +174,8 @@ BOOST_AUTO_TEST_CASE(testRefine) {
         for (std::size_t i = 1; i < endpoints1.size(); ++i) {
             core_t::TTime t = static_cast<core_t::TTime>(
                 0.5 * (endpoints2[i] + endpoints2[i - 1] + 1.0));
-            ptrdiff_t j = std::lower_bound(std::begin(times), std::end(times), t) -
-                          std::begin(times);
+            std::ptrdiff_t j = std::lower_bound(std::begin(times), std::end(times), t) -
+                               std::begin(times);
             double x0 = static_cast<double>(times[j - 1]);
             double x1 = static_cast<double>(times[j]);
             double y0 = function[j - 1];
@@ -736,7 +736,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
         origBucketing.refine(static_cast<core_t::TTime>(86400 * (p + 1)));
     }
 
-    uint64_t checksum = origBucketing.checksum();
+    std::uint64_t checksum = origBucketing.checksum();
 
     std::string origXml;
     {

--- a/lib/maths/time_series/unittest/CTimeSeriesModelTest.cc
+++ b/lib/maths/time_series/unittest/CTimeSeriesModelTest.cc
@@ -382,10 +382,10 @@ BOOST_AUTO_TEST_CASE(testClone) {
             time += bucketLength;
         }
 
-        uint64_t checksum1 = model.checksum();
+        std::uint64_t checksum1 = model.checksum();
         std::unique_ptr<maths::time_series::CUnivariateTimeSeriesModel> clone1{
             model.clone(1)};
-        uint64_t checksum2 = clone1->checksum();
+        std::uint64_t checksum2 = clone1->checksum();
         BOOST_REQUIRE_EQUAL(checksum1, checksum2);
         std::unique_ptr<maths::time_series::CUnivariateTimeSeriesModel> clone2{
             model.clone(2)};
@@ -410,14 +410,14 @@ BOOST_AUTO_TEST_CASE(testClone) {
             time += bucketLength;
         }
 
-        uint64_t checksum1 = model.checksum();
+        std::uint64_t checksum1 = model.checksum();
         std::unique_ptr<maths::time_series::CMultivariateTimeSeriesModel> clone1{
             model.clone(1)};
-        uint64_t checksum2 = clone1->checksum();
+        std::uint64_t checksum2 = clone1->checksum();
         BOOST_REQUIRE_EQUAL(checksum1, checksum2);
         std::unique_ptr<maths::time_series::CMultivariateTimeSeriesModel> clone2{
             model.clone(2)};
-        uint64_t checksum3 = clone2->checksum();
+        std::uint64_t checksum3 = clone2->checksum();
         BOOST_REQUIRE_EQUAL(checksum1, checksum3);
         BOOST_REQUIRE_EQUAL(std::size_t(0), clone2->identifier());
     }
@@ -754,8 +754,8 @@ BOOST_AUTO_TEST_CASE(testAddMultipleSamples) {
         prior.propagateForwardsByTime(1.0);
 
         for (std::size_t i = 0; i < trends.size(); ++i) {
-            uint64_t checksum1{trends[i]->checksum()};
-            uint64_t checksum2{model.trendModel()[i]->checksum()};
+            std::uint64_t checksum1{trends[i]->checksum()};
+            std::uint64_t checksum2{model.trendModel()[i]->checksum()};
             LOG_DEBUG(<< "checksum1 = " << checksum1 << " checksum2 = " << checksum2);
             BOOST_REQUIRE_EQUAL(checksum1, checksum2);
         }

--- a/lib/model/CAnnotatedProbability.cc
+++ b/lib/model/CAnnotatedProbability.cc
@@ -238,7 +238,7 @@ bool SAnnotatedProbability::acceptRestoreTraverser(core::CStateRestoreTraverser&
             s_Influences.emplace_back(
                 TStoredStringPtrStoredStringPtrPr(influencerName, influencerValue), d);
         } else if (name == CURRENT_BUCKET_COUNT_TAG) {
-            uint64_t i{0};
+            std::uint64_t i{0};
             if (!core::CPersistUtils::restore(CURRENT_BUCKET_COUNT_TAG, i, traverser)) {
                 LOG_ERROR(<< "Restore error for " << traverser.name() << " / "
                           << traverser.value());

--- a/lib/model/CAnomalyDetectorModel.cc
+++ b/lib/model/CAnomalyDetectorModel.cc
@@ -291,7 +291,7 @@ void CAnomalyDetectorModel::prune() {
     this->prune(this->defaultPruneWindow());
 }
 
-uint64_t CAnomalyDetectorModel::checksum(bool /*includeCurrentBucketStats*/) const {
+std::uint64_t CAnomalyDetectorModel::checksum(bool /*includeCurrentBucketStats*/) const {
     using TStrCRefUInt64Map =
         std::map<TStrCRef, std::uint64_t, maths::common::COrderings::SLess>;
     std::uint64_t seed{m_DataGatherer->checksum()};

--- a/lib/model/CAnomalyDetectorModel.cc
+++ b/lib/model/CAnomalyDetectorModel.cc
@@ -292,14 +292,15 @@ void CAnomalyDetectorModel::prune() {
 }
 
 uint64_t CAnomalyDetectorModel::checksum(bool /*includeCurrentBucketStats*/) const {
-    using TStrCRefUInt64Map = std::map<TStrCRef, uint64_t, maths::common::COrderings::SLess>;
-    uint64_t seed{m_DataGatherer->checksum()};
+    using TStrCRefUInt64Map =
+        std::map<TStrCRef, std::uint64_t, maths::common::COrderings::SLess>;
+    std::uint64_t seed{m_DataGatherer->checksum()};
     seed = maths::common::CChecksum::calculate(seed, m_Params);
     seed = maths::common::CChecksum::calculate(seed, m_BucketCount);
     TStrCRefUInt64Map hashes;
     for (std::size_t pid = 0; pid < m_PersonBucketCounts.size(); ++pid) {
         if (m_DataGatherer->isPersonActive(pid)) {
-            uint64_t& hash{hashes[std::cref(m_DataGatherer->personName(pid))]};
+            std::uint64_t& hash{hashes[std::cref(m_DataGatherer->personName(pid))]};
             hash = maths::common::CChecksum::calculate(hash, m_PersonBucketCounts[pid]);
         }
     }

--- a/lib/model/CAnomalyScore.cc
+++ b/lib/model/CAnomalyScore.cc
@@ -842,7 +842,7 @@ bool CAnomalyScore::CNormalizer::acceptRestoreTraverser(core::CStateRestoreTrave
     return true;
 }
 
-uint64_t CAnomalyScore::CNormalizer::checksum() const {
+std::uint64_t CAnomalyScore::CNormalizer::checksum() const {
     auto seed = static_cast<std::uint64_t>(m_NoisePercentile);
     seed = maths::common::CChecksum::calculate(seed, m_NoiseMultiplier);
     seed = maths::common::CChecksum::calculate(seed, m_NormalizedScoreKnotPoints);
@@ -860,7 +860,7 @@ uint64_t CAnomalyScore::CNormalizer::checksum() const {
     return maths::common::CChecksum::calculate(seed, m_TimeToQuantileDecay);
 }
 
-uint32_t CAnomalyScore::CNormalizer::discreteScore(double rawScore) const {
+std::uint32_t CAnomalyScore::CNormalizer::discreteScore(double rawScore) const {
     return static_cast<std::uint32_t>(DISCRETIZATION_FACTOR * rawScore + 0.5);
 }
 
@@ -946,7 +946,7 @@ bool CAnomalyScore::CNormalizer::CMaxScore::acceptRestoreTraverser(core::CStateR
     return true;
 }
 
-uint64_t CAnomalyScore::CNormalizer::CMaxScore::checksum() const {
+std::uint64_t CAnomalyScore::CNormalizer::CMaxScore::checksum() const {
     std::uint64_t seed = maths::common::CChecksum::calculate(0, m_Score);
     return maths::common::CChecksum::calculate(seed, m_TimeSinceLastScore);
 }

--- a/lib/model/CAnomalyScore.cc
+++ b/lib/model/CAnomalyScore.cc
@@ -259,7 +259,7 @@ CAnomalyScore::CNormalizer::CNormalizer(const CAnomalyDetectorModelConfig& confi
     : m_NoisePercentile(config.noisePercentile()),
       m_NoiseMultiplier(config.noiseMultiplier()),
       m_NormalizedScoreKnotPoints(config.normalizedScoreKnotPoints()),
-      m_HighPercentileScore(std::numeric_limits<uint32_t>::max()),
+      m_HighPercentileScore(std::numeric_limits<std::uint32_t>::max()),
       m_CountPerSample(core::constants::HOUR /
                        maths::common::CTools::truncate(2 * config.bucketLength(),
                                                        5 * core::constants::MINUTE,
@@ -293,7 +293,7 @@ bool CAnomalyScore::CNormalizer::normalize(const CMaximumScoreScope& scope,
     double normalizedScores[]{m_MaximumNormalizedScore, m_MaximumNormalizedScore,
                               m_MaximumNormalizedScore, m_MaximumNormalizedScore};
 
-    uint32_t discreteScore = this->discreteScore(score);
+    std::uint32_t discreteScore = this->discreteScore(score);
 
     // Our normalized score is the minimum of a set of different
     // score ceilings. The idea is that we have a number of factors
@@ -332,7 +332,7 @@ bool CAnomalyScore::CNormalizer::normalize(const CMaximumScoreScope& scope,
     // c.d.f. of the score and pn the noise percentile. We achieve
     // this by adding "max score" * min(F(0) / "noise percentile",
     // to the score.
-    uint32_t noiseScore;
+    std::uint32_t noiseScore;
     m_RawScoreQuantileSummary.quantile(m_NoisePercentile / 100.0, noiseScore);
     auto knotPoint = std::lower_bound(m_NormalizedScoreKnotPoints.begin(),
                                       m_NormalizedScoreKnotPoints.end(),
@@ -369,13 +369,13 @@ bool CAnomalyScore::CNormalizer::normalize(const CMaximumScoreScope& scope,
                                   m_NormalizedScoreKnotPoints.end(), lowerPercentile,
                                   maths::common::COrderings::SFirstLess()) -
                      m_NormalizedScoreKnotPoints.begin(),
-                 ptrdiff_t(1));
+                 std::ptrdiff_t(1));
     std::size_t upperKnotPoint =
         std::max(std::lower_bound(m_NormalizedScoreKnotPoints.begin(),
                                   m_NormalizedScoreKnotPoints.end(), upperPercentile,
                                   maths::common::COrderings::SFirstLess()) -
                      m_NormalizedScoreKnotPoints.begin(),
-                 ptrdiff_t(1));
+                 std::ptrdiff_t(1));
     if (lowerKnotPoint < m_NormalizedScoreKnotPoints.size()) {
         const TDoubleDoublePr& left = m_NormalizedScoreKnotPoints[lowerKnotPoint - 1];
         const TDoubleDoublePr& right = m_NormalizedScoreKnotPoints[lowerKnotPoint];
@@ -435,7 +435,7 @@ void CAnomalyScore::CNormalizer::quantile(double score,
                                           double confidence,
                                           double& lowerBound,
                                           double& upperBound) const {
-    uint32_t discreteScore = this->discreteScore(score);
+    std::uint32_t discreteScore = this->discreteScore(score);
     double n = static_cast<double>(m_RawScoreQuantileSummary.n());
     double lowerQuantile = (100.0 - confidence) / 200.0;
     double upperQuantile = (100.0 + confidence) / 200.0;
@@ -513,7 +513,7 @@ void CAnomalyScore::CNormalizer::quantile(double score,
 }
 
 bool CAnomalyScore::CNormalizer::updateQuantiles(const CMaximumScoreScope& scope, double score) {
-    using TUInt32UInt64Pr = std::pair<uint32_t, uint64_t>;
+    using TUInt32UInt64Pr = std::pair<std::uint32_t, std::uint64_t>;
     using TUInt32UInt64PrVec = std::vector<TUInt32UInt64Pr>;
 
     CMaxScore& maxScore = m_MaxScores[scope.key(m_IsForMembersOfPopulation, m_Dictionary)];
@@ -529,15 +529,15 @@ bool CAnomalyScore::CNormalizer::updateQuantiles(const CMaximumScoreScope& scope
         return bigChange;
     }
 
-    uint32_t discreteScore = this->discreteScore(m_Sample);
+    std::uint32_t discreteScore = this->discreteScore(m_Sample);
     LOG_TRACE(<< "score = " << m_Sample << ", discreteScore = " << discreteScore
               << ", maxScore = " << maxScore.score() << ", scope = " << scope.print());
 
     m_CountSinceLastSample = 0;
     m_Sample = 0.0;
 
-    uint64_t n = m_RawScoreQuantileSummary.n();
-    uint64_t k = m_RawScoreQuantileSummary.k();
+    std::uint64_t n = m_RawScoreQuantileSummary.n();
+    std::uint64_t k = m_RawScoreQuantileSummary.k();
     LOG_TRACE(<< "n = " << n << ", k = " << k);
 
     // We are about to compress the q-digest, at the moment it comprises
@@ -553,7 +553,7 @@ bool CAnomalyScore::CNormalizer::updateQuantiles(const CMaximumScoreScope& scope
             LOG_ERROR(<< "High quantile summary is empty: "
                       << m_RawScoreQuantileSummary.print());
         } else {
-            auto highPercentileCount = static_cast<uint64_t>(
+            auto highPercentileCount = static_cast<std::uint64_t>(
                 (HIGH_PERCENTILE / 100.0) * static_cast<double>(n) + 0.5);
 
             // Estimate the high percentile score and update the count.
@@ -581,8 +581,8 @@ bool CAnomalyScore::CNormalizer::updateQuantiles(const CMaximumScoreScope& scope
 
             // Populate the high quantile summary.
             for (/**/; i < L.size(); ++i) {
-                uint32_t x = L[i].first;
-                uint64_t m = L[i].second - L[i - 1].second;
+                std::uint32_t x = L[i].first;
+                std::uint64_t m = L[i].second - L[i - 1].second;
 
                 LOG_TRACE(<< "Adding (" << x << ", " << m << ") to H");
                 m_RawScoreHighQuantileSummary.add(x, m);
@@ -604,7 +604,7 @@ bool CAnomalyScore::CNormalizer::updateQuantiles(const CMaximumScoreScope& scope
     if ((n + 1) > k && (n + 1) % k == 0) {
         LOG_TRACE(<< "Refreshing high quantile summary");
 
-        auto highPercentileCount = static_cast<uint64_t>(
+        auto highPercentileCount = static_cast<std::uint64_t>(
             (HIGH_PERCENTILE / 100.0) * static_cast<double>(n + 1) + 0.5);
 
         LOG_TRACE(<< "s(H) = " << m_HighPercentileScore << ", c(H) = " << m_HighPercentileCount
@@ -629,18 +629,18 @@ bool CAnomalyScore::CNormalizer::updateQuantiles(const CMaximumScoreScope& scope
                     H.begin()),
                 H.size() - 1);
 
-            uint64_t r = L[i0].second;
+            std::uint64_t r = L[i0].second;
             for (std::size_t i = i0 + 1;
                  i < L.size() && L[i0].second + m_RawScoreHighQuantileSummary.n() < n + 1;
                  ++i) {
                 for (/**/; j < H.size() && H[j].first <= L[i].first; ++j) {
-                    r += (H[j].second -
-                          (j == 0 ? static_cast<uint64_t>(0) : H[j - 1].second));
+                    r += (H[j].second - (j == 0 ? static_cast<std::uint64_t>(0)
+                                                : H[j - 1].second));
                 }
 
-                uint32_t x = L[i].first;
-                uint64_t m = r < L[i].second ? L[i].second - r
-                                             : static_cast<uint64_t>(0);
+                std::uint32_t x = L[i].first;
+                std::uint64_t m = r < L[i].second ? L[i].second - r
+                                                  : static_cast<std::uint64_t>(0);
                 r += m;
                 if (m > 0) {
                     LOG_TRACE(<< "Adding (" << x << ',' << m << ") to H");
@@ -667,8 +667,8 @@ bool CAnomalyScore::CNormalizer::updateQuantiles(const CMaximumScoreScope& scope
             double lowerBound;
             double upperBound;
             m_RawScoreQuantileSummary.cdf(m_HighPercentileScore, 0.0, lowerBound, upperBound);
-            m_HighPercentileCount =
-                static_cast<uint64_t>(static_cast<double>(n + 1) * lowerBound + 0.5);
+            m_HighPercentileCount = static_cast<std::uint64_t>(
+                static_cast<double>(n + 1) * lowerBound + 0.5);
 
             LOG_TRACE(<< "s(H) = " << m_HighPercentileScore << ", c(H) = " << m_HighPercentileCount
                       << ", percentile = " << 100.0 * lowerBound << "%");
@@ -697,11 +697,11 @@ void CAnomalyScore::CNormalizer::propagateForwardByTime(double time) {
     if (m_TimeToQuantileDecay <= 0.0) {
         time = std::floor((QUANTILE_DECAY_TIME - m_TimeToQuantileDecay) / QUANTILE_DECAY_TIME);
 
-        uint64_t n = m_RawScoreQuantileSummary.n();
+        std::uint64_t n = m_RawScoreQuantileSummary.n();
         m_RawScoreQuantileSummary.propagateForwardsByTime(time);
         m_RawScoreHighQuantileSummary.propagateForwardsByTime(time);
         if (n > 0) {
-            m_HighPercentileCount = static_cast<uint64_t>(
+            m_HighPercentileCount = static_cast<std::uint64_t>(
                 static_cast<double>(m_RawScoreQuantileSummary.n()) /
                     static_cast<double>(n) * static_cast<double>(m_HighPercentileCount) +
                 0.5);
@@ -779,7 +779,7 @@ bool CAnomalyScore::CNormalizer::upgrade(const std::string& loadedVersion,
 }
 
 void CAnomalyScore::CNormalizer::clear() {
-    m_HighPercentileScore = std::numeric_limits<uint32_t>::max();
+    m_HighPercentileScore = std::numeric_limits<std::uint32_t>::max();
     m_HighPercentileCount = 0ULL;
     m_IsForMembersOfPopulation.reset();
     m_MaxScores.clear();
@@ -816,11 +816,11 @@ bool CAnomalyScore::CNormalizer::acceptRestoreTraverser(core::CStateRestoreTrave
         // This used to be 64 bit but is now 32 bit, so may need adjusting
         // on restoration
         RESTORE_SETUP_TEARDOWN(
-            HIGH_PERCENTILE_SCORE_TAG, uint64_t highPercentileScore64(0),
+            HIGH_PERCENTILE_SCORE_TAG, std::uint64_t highPercentileScore64(0),
             core::CStringUtils::stringToType(traverser.value(), highPercentileScore64),
-            m_HighPercentileScore = static_cast<uint32_t>(std::min(
+            m_HighPercentileScore = static_cast<std::uint32_t>(std::min(
                 highPercentileScore64,
-                static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()))));
+                static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()))));
         RESTORE(HIGH_PERCENTILE_COUNT_TAG,
                 core::CStringUtils::stringToType(traverser.value(), m_HighPercentileCount));
         RESTORE_BUILT_IN(COUNT_SINCE_LAST_SAMPLE_TAG, m_CountSinceLastSample)
@@ -843,7 +843,7 @@ bool CAnomalyScore::CNormalizer::acceptRestoreTraverser(core::CStateRestoreTrave
 }
 
 uint64_t CAnomalyScore::CNormalizer::checksum() const {
-    auto seed = static_cast<uint64_t>(m_NoisePercentile);
+    auto seed = static_cast<std::uint64_t>(m_NoisePercentile);
     seed = maths::common::CChecksum::calculate(seed, m_NoiseMultiplier);
     seed = maths::common::CChecksum::calculate(seed, m_NormalizedScoreKnotPoints);
     seed = maths::common::CChecksum::calculate(seed, m_MaximumNormalizedScore);
@@ -861,10 +861,10 @@ uint64_t CAnomalyScore::CNormalizer::checksum() const {
 }
 
 uint32_t CAnomalyScore::CNormalizer::discreteScore(double rawScore) const {
-    return static_cast<uint32_t>(DISCRETIZATION_FACTOR * rawScore + 0.5);
+    return static_cast<std::uint32_t>(DISCRETIZATION_FACTOR * rawScore + 0.5);
 }
 
-double CAnomalyScore::CNormalizer::rawScore(uint32_t discreteScore) const {
+double CAnomalyScore::CNormalizer::rawScore(std::uint32_t discreteScore) const {
     return static_cast<double>(discreteScore) / DISCRETIZATION_FACTOR;
 }
 
@@ -947,7 +947,7 @@ bool CAnomalyScore::CNormalizer::CMaxScore::acceptRestoreTraverser(core::CStateR
 }
 
 uint64_t CAnomalyScore::CNormalizer::CMaxScore::checksum() const {
-    uint64_t seed = maths::common::CChecksum::calculate(0, m_Score);
+    std::uint64_t seed = maths::common::CChecksum::calculate(0, m_Score);
     return maths::common::CChecksum::calculate(seed, m_TimeSinceLastScore);
 }
 

--- a/lib/model/CBucketGatherer.cc
+++ b/lib/model/CBucketGatherer.cc
@@ -41,7 +41,7 @@ const std::string BUCKET_EXPLICIT_NULLS_TAG("m");
 namespace detail {
 
 using TSizeSizePr = std::pair<std::size_t, std::size_t>;
-using TSizeSizePrUInt64Pr = std::pair<TSizeSizePr, uint64_t>;
+using TSizeSizePrUInt64Pr = std::pair<TSizeSizePr, std::uint64_t>;
 using TSizeSizePrStoredStringPtrPrUInt64UMap = CBucketGatherer::TSizeSizePrStoredStringPtrPrUInt64UMap;
 using TSizeSizePrStoredStringPtrPrUInt64UMapCItr =
     CBucketGatherer::TSizeSizePrStoredStringPtrPrUInt64UMapCItr;
@@ -66,7 +66,7 @@ void insertPersonAttributeCounts(const TSizeSizePrUInt64Pr& tuple,
 //! Restore a person, attribute and count.
 bool restorePersonAttributeCounts(core::CStateRestoreTraverser& traverser,
                                   TSizeSizePr& key,
-                                  uint64_t& count) {
+                                  std::uint64_t& count) {
     do {
         const std::string& name = traverser.name();
         RESTORE_BUILT_IN(PERSON_UID_TAG, key.first)
@@ -110,7 +110,7 @@ bool restoreInfluencerPersonAttributeCounts(core::CStateRestoreTraverser& traver
     std::size_t person = 0;
     std::size_t attribute = 0;
     std::string influence = "";
-    uint64_t count = 0;
+    std::uint64_t count = 0;
     do {
         const std::string name = traverser.name();
         RESTORE_BUILT_IN(PERSON_UID_TAG, person)
@@ -149,7 +149,7 @@ struct SBucketCountsPersister {
                     core::CStateRestoreTraverser& traverser) {
         do {
             TSizeSizePr key;
-            uint64_t count{0u};
+            std::uint64_t count{0u};
             if (!traverser.hasSubLevel()) {
                 continue;
             }
@@ -300,7 +300,7 @@ bool CBucketGatherer::addEventData(CEventData& data) {
                     influencerCounts[i]
                         .emplace(boost::unordered::piecewise_construct,
                                  boost::make_tuple(pidCid, inf),
-                                 boost::make_tuple(uint64_t(0)))
+                                 boost::make_tuple(std::uint64_t(0)))
                         .first->second += count;
                 }
             }
@@ -353,7 +353,7 @@ void CBucketGatherer::skipSampleNow(core_t::TTime sampleBucketStart) {
 }
 
 void CBucketGatherer::personNonZeroCounts(core_t::TTime time, TSizeUInt64PrVec& result) const {
-    using TSizeUInt64Map = std::map<std::size_t, uint64_t>;
+    using TSizeUInt64Map = std::map<std::size_t, std::uint64_t>;
 
     result.clear();
 
@@ -505,10 +505,10 @@ uint64_t CBucketGatherer::checksum() const {
     using TStrCRef = std::reference_wrapper<const std::string>;
     using TStrCRefStrCRefPr = std::pair<TStrCRef, TStrCRef>;
     using TStrCRefStrCRefPrVec = std::vector<TStrCRefStrCRefPr>;
-    using TStrCRefStrCRefPrUInt64Pr = std::pair<TStrCRefStrCRefPr, uint64_t>;
+    using TStrCRefStrCRefPrUInt64Pr = std::pair<TStrCRefStrCRefPr, std::uint64_t>;
     using TStrCRefStrCRefPrUInt64PrVec = std::vector<TStrCRefStrCRefPrUInt64Pr>;
 
-    uint64_t result = maths::common::CChecksum::calculate(0, m_BucketStart);
+    std::uint64_t result = maths::common::CChecksum::calculate(0, m_BucketStart);
 
     result = maths::common::CChecksum::calculate(
         result, m_PersonAttributeCounts.latestBucketEnd());

--- a/lib/model/CBucketGatherer.cc
+++ b/lib/model/CBucketGatherer.cc
@@ -501,7 +501,7 @@ bool CBucketGatherer::hasExplicitNullsOnly(core_t::TTime time, std::size_t pid, 
            bucketCounts.find(pidCid) == bucketCounts.end();
 }
 
-uint64_t CBucketGatherer::checksum() const {
+std::uint64_t CBucketGatherer::checksum() const {
     using TStrCRef = std::reference_wrapper<const std::string>;
     using TStrCRefStrCRefPr = std::pair<TStrCRef, TStrCRef>;
     using TStrCRefStrCRefPrVec = std::vector<TStrCRefStrCRefPr>;

--- a/lib/model/CCountingModel.cc
+++ b/lib/model/CCountingModel.cc
@@ -304,7 +304,7 @@ bool CCountingModel::computeTotalProbability(const std::string& /*person*/,
 }
 
 uint64_t CCountingModel::checksum(bool includeCurrentBucketStats) const {
-    uint64_t result = this->CAnomalyDetectorModel::checksum(includeCurrentBucketStats);
+    std::uint64_t result = this->CAnomalyDetectorModel::checksum(includeCurrentBucketStats);
     result = maths::common::CChecksum::calculate(result, m_MeanCounts);
     if (includeCurrentBucketStats) {
         result = maths::common::CChecksum::calculate(result, m_StartTime);

--- a/lib/model/CCountingModel.cc
+++ b/lib/model/CCountingModel.cc
@@ -303,7 +303,7 @@ bool CCountingModel::computeTotalProbability(const std::string& /*person*/,
     return true;
 }
 
-uint64_t CCountingModel::checksum(bool includeCurrentBucketStats) const {
+std::uint64_t CCountingModel::checksum(bool includeCurrentBucketStats) const {
     std::uint64_t result = this->CAnomalyDetectorModel::checksum(includeCurrentBucketStats);
     result = maths::common::CChecksum::calculate(result, m_MeanCounts);
     if (includeCurrentBucketStats) {

--- a/lib/model/CDataGatherer.cc
+++ b/lib/model/CDataGatherer.cc
@@ -555,7 +555,7 @@ CDataGatherer::influencerCounts(core_t::TTime time) const {
     return m_BucketGatherer->influencerCounts(time);
 }
 
-uint64_t CDataGatherer::checksum() const {
+std::uint64_t CDataGatherer::checksum() const {
     std::uint64_t result = m_PeopleRegistry.checksum();
     result = maths::common::CChecksum::calculate(result, m_AttributesRegistry);
     result = maths::common::CChecksum::calculate(result, m_SummaryMode);

--- a/lib/model/CDataGatherer.cc
+++ b/lib/model/CDataGatherer.cc
@@ -556,7 +556,7 @@ CDataGatherer::influencerCounts(core_t::TTime time) const {
 }
 
 uint64_t CDataGatherer::checksum() const {
-    uint64_t result = m_PeopleRegistry.checksum();
+    std::uint64_t result = m_PeopleRegistry.checksum();
     result = maths::common::CChecksum::calculate(result, m_AttributesRegistry);
     result = maths::common::CChecksum::calculate(result, m_SummaryMode);
     result = maths::common::CChecksum::calculate(result, m_Features);

--- a/lib/model/CDetectorEqualizer.cc
+++ b/lib/model/CDetectorEqualizer.cc
@@ -131,7 +131,7 @@ void CDetectorEqualizer::age(double factor) {
     }
 }
 
-uint64_t CDetectorEqualizer::checksum() const {
+std::uint64_t CDetectorEqualizer::checksum() const {
     return maths::common::CChecksum::calculate(0, m_Sketches);
 }
 

--- a/lib/model/CDynamicStringIdRegistry.cc
+++ b/lib/model/CDynamicStringIdRegistry.cc
@@ -206,7 +206,7 @@ void CDynamicStringIdRegistry::clear() {
     m_RecycledUids.clear();
 }
 
-uint64_t CDynamicStringIdRegistry::checksum() const {
+std::uint64_t CDynamicStringIdRegistry::checksum() const {
     using TStrCRef = std::reference_wrapper<const std::string>;
     using TStrCRefVec = std::vector<TStrCRef>;
 

--- a/lib/model/CEventRateBucketGatherer.cc
+++ b/lib/model/CEventRateBucketGatherer.cc
@@ -49,16 +49,16 @@ namespace {
 
 using TSizeVec = std::vector<std::size_t>;
 using TStrVec = std::vector<std::string>;
-using TStrUInt64Map = std::map<std::string, uint64_t>;
+using TStrUInt64Map = std::map<std::string, std::uint64_t>;
 using TSizeSizePr = std::pair<std::size_t, std::size_t>;
 using TSizeSizePrVec = std::vector<TSizeSizePr>;
-using TUInt64Vec = std::vector<uint64_t>;
+using TUInt64Vec = std::vector<std::uint64_t>;
 using TSizeUSet = boost::unordered_set<std::size_t>;
 using TSizeUSetCItr = TSizeUSet::const_iterator;
 using TSizeUSetVec = std::vector<TSizeUSet>;
 using TMeanAccumulator = maths::common::CBasicStatistics::SSampleMean<double>::TAccumulator;
 using TSizeSizePrMeanAccumulatorUMap = boost::unordered_map<TSizeSizePr, TMeanAccumulator>;
-using TSizeSizePrUInt64Map = std::map<TSizeSizePr, uint64_t>;
+using TSizeSizePrUInt64Map = std::map<TSizeSizePr, std::uint64_t>;
 using TSizeSizePrMeanAccumulatorUMapQueue = CBucketQueue<TSizeSizePrMeanAccumulatorUMap>;
 using TCategoryAnyMap = CEventRateBucketGatherer::TCategoryAnyMap;
 using TSizeSizePrStrDataUMap = boost::unordered_map<TSizeSizePr, CUniqueStringFeatureData>;
@@ -483,7 +483,7 @@ struct SChecksum {
                 }
                 std::sort(people.begin(), people.end(),
                           maths::common::COrderings::SReferenceLess());
-                uint64_t& hash = hashes[gatherer.attributeName(cid)];
+                std::uint64_t& hash = hashes[gatherer.attributeName(cid)];
                 hash = maths::common::CChecksum::calculate(hash, people);
             }
         }
@@ -521,7 +521,7 @@ struct SChecksum {
 
         for (auto& hash_ : attributeHashes) {
             std::sort(hash_.second.begin(), hash_.second.end());
-            uint64_t& hash = hashes[gatherer.attributeName(hash_.first)];
+            std::uint64_t& hash = hashes[gatherer.attributeName(hash_.first)];
             hash = maths::common::CChecksum::calculate(hash, hash_.second);
         }
     }
@@ -1001,7 +1001,7 @@ void CEventRateBucketGatherer::removeAttributes(std::size_t lowestAttributeToRem
 }
 
 uint64_t CEventRateBucketGatherer::checksum() const {
-    uint64_t seed = this->CBucketGatherer::checksum();
+    std::uint64_t seed = this->CBucketGatherer::checksum();
     TStrUInt64Map hashes;
     applyFunc(m_FeatureData, [&, checksum = SChecksum{} ](const auto& data) {
         checksum(data, m_DataGatherer, hashes);
@@ -1167,10 +1167,10 @@ void CEventRateBucketGatherer::personCounts(model_t::EFeature feature,
     }
 
     for (const auto& count_ : this->bucketCounts(time)) {
-        uint64_t& count = std::lower_bound(result.begin(), result.end(),
-                                           CDataGatherer::extractPersonId(count_),
-                                           maths::common::COrderings::SFirstLess())
-                              ->second.s_Count;
+        std::uint64_t& count = std::lower_bound(result.begin(), result.end(),
+                                                CDataGatherer::extractPersonId(count_),
+                                                maths::common::COrderings::SFirstLess())
+                                   ->second.s_Count;
         count += CDataGatherer::extractData(count_);
     }
 
@@ -1427,7 +1427,7 @@ void CEventRateBucketGatherer::bucketMeanTimesPerPerson(model_t::EFeature featur
         result.reserve(arrivalTimes.size());
         for (const auto& time_ : arrivalTimes) {
             result.emplace_back(CDataGatherer::extractPersonId(time_),
-                                static_cast<uint64_t>(maths::common::CBasicStatistics::mean(
+                                static_cast<std::uint64_t>(maths::common::CBasicStatistics::mean(
                                     CDataGatherer::extractData(time_))));
         }
         std::sort(result.begin(), result.end(), maths::common::COrderings::SFirstLess());
@@ -1470,7 +1470,7 @@ void CEventRateBucketGatherer::bucketMeanTimesPerPersonAttribute(model_t::EFeatu
         result.reserve(arrivalTimes.size());
         for (const auto& time_ : arrivalTimes) {
             result.emplace_back(time_.first,
-                                static_cast<uint64_t>(maths::common::CBasicStatistics::mean(
+                                static_cast<std::uint64_t>(maths::common::CBasicStatistics::mean(
                                     CDataGatherer::extractData(time_))));
         }
         std::sort(result.begin(), result.end(), maths::common::COrderings::SFirstLess());
@@ -1806,7 +1806,7 @@ bool CUniqueStringFeatureData::acceptRestoreTraverser(core::CStateRestoreTravers
 }
 
 uint64_t CUniqueStringFeatureData::checksum() const {
-    uint64_t seed = maths::common::CChecksum::calculate(0, m_UniqueStrings);
+    std::uint64_t seed = maths::common::CChecksum::calculate(0, m_UniqueStrings);
     return maths::common::CChecksum::calculate(seed, m_InfluencerUniqueStrings);
 }
 

--- a/lib/model/CEventRateBucketGatherer.cc
+++ b/lib/model/CEventRateBucketGatherer.cc
@@ -1000,7 +1000,7 @@ void CEventRateBucketGatherer::removeAttributes(std::size_t lowestAttributeToRem
     this->CBucketGatherer::removeAttributes(lowestAttributeToRemove);
 }
 
-uint64_t CEventRateBucketGatherer::checksum() const {
+std::uint64_t CEventRateBucketGatherer::checksum() const {
     std::uint64_t seed = this->CBucketGatherer::checksum();
     TStrUInt64Map hashes;
     applyFunc(m_FeatureData, [&, checksum = SChecksum{} ](const auto& data) {
@@ -1805,7 +1805,7 @@ bool CUniqueStringFeatureData::acceptRestoreTraverser(core::CStateRestoreTravers
     return true;
 }
 
-uint64_t CUniqueStringFeatureData::checksum() const {
+std::uint64_t CUniqueStringFeatureData::checksum() const {
     std::uint64_t seed = maths::common::CChecksum::calculate(0, m_UniqueStrings);
     return maths::common::CChecksum::calculate(seed, m_InfluencerUniqueStrings);
 }

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -494,22 +494,23 @@ bool CEventRateModel::computeProbability(std::size_t pid,
 }
 
 uint64_t CEventRateModel::checksum(bool includeCurrentBucketStats) const {
-    using TStrCRefUInt64Map = std::map<TStrCRef, uint64_t, maths::common::COrderings::SLess>;
+    using TStrCRefUInt64Map =
+        std::map<TStrCRef, std::uint64_t, maths::common::COrderings::SLess>;
 
-    uint64_t seed = this->CIndividualModel::checksum(includeCurrentBucketStats);
+    std::uint64_t seed = this->CIndividualModel::checksum(includeCurrentBucketStats);
 
     TStrCRefUInt64Map hashes;
     const TDoubleVec& categories = m_ProbabilityPrior.categories();
     const TDoubleVec& concentrations = m_ProbabilityPrior.concentrations();
     for (std::size_t i = 0; i < categories.size(); ++i) {
-        uint64_t& hash =
+        std::uint64_t& hash =
             hashes[std::cref(this->personName(static_cast<std::size_t>(categories[i])))];
         hash = maths::common::CChecksum::calculate(hash, concentrations[i]);
     }
     if (includeCurrentBucketStats) {
         for (const auto& featureData_ : m_CurrentBucketStats.s_FeatureData) {
             for (const auto& data : featureData_.second) {
-                uint64_t& hash = hashes[std::cref(this->personName(data.first))];
+                std::uint64_t& hash = hashes[std::cref(this->personName(data.first))];
                 hash = maths::common::CChecksum::calculate(hash, data.second.s_Count);
             }
         }

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -493,7 +493,7 @@ bool CEventRateModel::computeProbability(std::size_t pid,
     return true;
 }
 
-uint64_t CEventRateModel::checksum(bool includeCurrentBucketStats) const {
+std::uint64_t CEventRateModel::checksum(bool includeCurrentBucketStats) const {
     using TStrCRefUInt64Map =
         std::map<TStrCRef, std::uint64_t, maths::common::COrderings::SLess>;
 

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -419,7 +419,7 @@ void CEventRatePopulationModel::sample(core_t::TTime startTime,
                 // Set up fuzzy de-duplication.
                 for (const auto& data_ : data) {
                     std::size_t cid = CDataGatherer::extractAttributeId(data_);
-                    uint64_t count = CDataGatherer::extractData(data_).s_Count;
+                    std::uint64_t count = CDataGatherer::extractData(data_).s_Count;
                     duplicates[cid].add({static_cast<double>(count)});
                 }
                 for (auto& attribute : duplicates) {
@@ -790,7 +790,7 @@ bool CEventRatePopulationModel::computeTotalProbability(
 }
 
 uint64_t CEventRatePopulationModel::checksum(bool includeCurrentBucketStats) const {
-    uint64_t seed = this->CPopulationModel::checksum(includeCurrentBucketStats);
+    std::uint64_t seed = this->CPopulationModel::checksum(includeCurrentBucketStats);
     seed = maths::common::CChecksum::calculate(seed, m_NewAttributeProbabilityPrior);
     if (includeCurrentBucketStats) {
         seed = maths::common::CChecksum::calculate(seed, m_CurrentBucketStats.s_StartTime);
@@ -798,7 +798,7 @@ uint64_t CEventRatePopulationModel::checksum(bool includeCurrentBucketStats) con
 
     using TStrCRefStrCRefPr = std::pair<TStrCRef, TStrCRef>;
     using TStrCRefStrCRefPrUInt64Map =
-        std::map<TStrCRefStrCRefPr, uint64_t, maths::common::COrderings::SLess>;
+        std::map<TStrCRefStrCRefPr, std::uint64_t, maths::common::COrderings::SLess>;
 
     const CDataGatherer& gatherer = this->dataGatherer();
 
@@ -808,7 +808,7 @@ uint64_t CEventRatePopulationModel::checksum(bool includeCurrentBucketStats) con
     const TDoubleVec& concentrations = m_AttributeProbabilityPrior.concentrations();
     for (std::size_t i = 0; i < categories.size(); ++i) {
         std::size_t cid = static_cast<std::size_t>(categories[i]);
-        uint64_t& hash =
+        std::uint64_t& hash =
             hashes[{std::cref(EMPTY_STRING), std::cref(this->attributeName(cid))}];
         hash = maths::common::CChecksum::calculate(hash, concentrations[i]);
     }
@@ -816,7 +816,7 @@ uint64_t CEventRatePopulationModel::checksum(bool includeCurrentBucketStats) con
     for (const auto& feature : m_FeatureModels) {
         for (std::size_t cid = 0; cid < feature.s_Models.size(); ++cid) {
             if (gatherer.isAttributeActive(cid)) {
-                uint64_t& hash =
+                std::uint64_t& hash =
                     hashes[{std::cref(EMPTY_STRING), std::cref(gatherer.attributeName(cid))}];
                 hash = maths::common::CChecksum::calculate(hash, feature.s_Models[cid]);
             }
@@ -828,8 +828,9 @@ uint64_t CEventRatePopulationModel::checksum(bool includeCurrentBucketStats) con
             std::size_t cids[]{model.first.first, model.first.second};
             if (gatherer.isAttributeActive(cids[0]) &&
                 gatherer.isAttributeActive(cids[1])) {
-                uint64_t& hash = hashes[{std::cref(gatherer.attributeName(cids[0])),
-                                         std::cref(gatherer.attributeName(cids[1]))}];
+                std::uint64_t& hash =
+                    hashes[{std::cref(gatherer.attributeName(cids[0])),
+                            std::cref(gatherer.attributeName(cids[1]))}];
                 hash = maths::common::CChecksum::calculate(hash, model.second);
             }
         }
@@ -837,7 +838,7 @@ uint64_t CEventRatePopulationModel::checksum(bool includeCurrentBucketStats) con
 
     if (includeCurrentBucketStats) {
         for (const auto& personCount : this->personCounts()) {
-            uint64_t& hash =
+            std::uint64_t& hash =
                 hashes[{std::cref(gatherer.personName(personCount.first)), std::cref(EMPTY_STRING)}];
             hash = maths::common::CChecksum::calculate(hash, personCount.second);
         }
@@ -845,7 +846,7 @@ uint64_t CEventRatePopulationModel::checksum(bool includeCurrentBucketStats) con
             for (const auto& data : feature.second) {
                 std::size_t pid = CDataGatherer::extractPersonId(data);
                 std::size_t cid = CDataGatherer::extractAttributeId(data);
-                uint64_t& hash =
+                std::uint64_t& hash =
                     hashes[{std::cref(this->personName(pid)), std::cref(this->attributeName(cid))}];
                 hash = maths::common::CChecksum::calculate(
                     hash, CDataGatherer::extractData(data).s_Count);

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -789,7 +789,7 @@ bool CEventRatePopulationModel::computeTotalProbability(
     return true;
 }
 
-uint64_t CEventRatePopulationModel::checksum(bool includeCurrentBucketStats) const {
+std::uint64_t CEventRatePopulationModel::checksum(bool includeCurrentBucketStats) const {
     std::uint64_t seed = this->CPopulationModel::checksum(includeCurrentBucketStats);
     seed = maths::common::CChecksum::calculate(seed, m_NewAttributeProbabilityPrior);
     if (includeCurrentBucketStats) {

--- a/lib/model/CFeatureData.cc
+++ b/lib/model/CFeatureData.cc
@@ -68,7 +68,8 @@ const TSizeVec& CFeatureDataIndexing::valueIndices(std::size_t dimension) {
 
 ////// SEventRateFeatureData //////
 
-SEventRateFeatureData::SEventRateFeatureData(uint64_t count) : s_Count(count) {
+SEventRateFeatureData::SEventRateFeatureData(std::uint64_t count)
+    : s_Count(count) {
 }
 
 void SEventRateFeatureData::swap(SEventRateFeatureData& other) {

--- a/lib/model/CForecastDataSink.cc
+++ b/lib/model/CForecastDataSink.cc
@@ -115,7 +115,7 @@ CForecastDataSink::CForecastDataSink(const std::string& jobId,
 }
 
 void CForecastDataSink::writeStats(const double progress,
-                                   uint64_t runtime,
+                                   std::uint64_t runtime,
                                    const TStrUMap& messages,
                                    bool successful) {
     TScopedAllocator scopedAllocator("CForecastDataSink", m_Writer);

--- a/lib/model/CForecastDataSink.cc
+++ b/lib/model/CForecastDataSink.cc
@@ -203,7 +203,7 @@ void CForecastDataSink::push(bool flush, rapidjson::Value& doc) {
     }
 }
 
-uint64_t CForecastDataSink::numRecordsWritten() const {
+std::uint64_t CForecastDataSink::numRecordsWritten() const {
     return m_NumRecordsWritten;
 }
 

--- a/lib/model/CGathererTools.cc
+++ b/lib/model/CGathererTools.cc
@@ -141,7 +141,7 @@ bool CGathererTools::CArrivalTimeGatherer::acceptRestoreTraverser(core::CStateRe
     return true;
 }
 
-uint64_t CGathererTools::CArrivalTimeGatherer::checksum() const {
+std::uint64_t CGathererTools::CArrivalTimeGatherer::checksum() const {
     return maths::common::CChecksum::calculate(static_cast<std::uint64_t>(m_LastTime), m_Value);
 }
 
@@ -291,7 +291,7 @@ bool CGathererTools::CSumGatherer::acceptRestoreTraverser(core::CStateRestoreTra
     return true;
 }
 
-uint64_t CGathererTools::CSumGatherer::checksum() const {
+std::uint64_t CGathererTools::CSumGatherer::checksum() const {
     std::uint64_t seed = static_cast<std::uint64_t>(m_Classifier.isInteger());
     seed = maths::common::CChecksum::calculate(seed, m_Classifier.isNonNegative());
     seed = maths::common::CChecksum::calculate(seed, m_BucketSums);

--- a/lib/model/CGathererTools.cc
+++ b/lib/model/CGathererTools.cc
@@ -142,7 +142,7 @@ bool CGathererTools::CArrivalTimeGatherer::acceptRestoreTraverser(core::CStateRe
 }
 
 uint64_t CGathererTools::CArrivalTimeGatherer::checksum() const {
-    return maths::common::CChecksum::calculate(static_cast<uint64_t>(m_LastTime), m_Value);
+    return maths::common::CChecksum::calculate(static_cast<std::uint64_t>(m_LastTime), m_Value);
 }
 
 std::string CGathererTools::CArrivalTimeGatherer::print() const {
@@ -292,7 +292,7 @@ bool CGathererTools::CSumGatherer::acceptRestoreTraverser(core::CStateRestoreTra
 }
 
 uint64_t CGathererTools::CSumGatherer::checksum() const {
-    uint64_t seed = static_cast<uint64_t>(m_Classifier.isInteger());
+    std::uint64_t seed = static_cast<std::uint64_t>(m_Classifier.isInteger());
     seed = maths::common::CChecksum::calculate(seed, m_Classifier.isNonNegative());
     seed = maths::common::CChecksum::calculate(seed, m_BucketSums);
     return maths::common::CChecksum::calculate(seed, m_InfluencerBucketSums);

--- a/lib/model/CHierarchicalResultsAggregator.cc
+++ b/lib/model/CHierarchicalResultsAggregator.cc
@@ -173,7 +173,7 @@ bool CHierarchicalResultsAggregator::acceptRestoreTraverser(core::CStateRestoreT
 }
 
 uint64_t CHierarchicalResultsAggregator::checksum() const {
-    uint64_t seed = static_cast<uint64_t>(m_DecayRate);
+    std::uint64_t seed = static_cast<std::uint64_t>(m_DecayRate);
     seed = maths::common::CChecksum::calculate(seed, m_Parameters);
     seed = maths::common::CChecksum::calculate(seed, m_MaximumAnomalousProbability);
     return this->TBase::checksum(seed);

--- a/lib/model/CHierarchicalResultsAggregator.cc
+++ b/lib/model/CHierarchicalResultsAggregator.cc
@@ -172,7 +172,7 @@ bool CHierarchicalResultsAggregator::acceptRestoreTraverser(core::CStateRestoreT
     return true;
 }
 
-uint64_t CHierarchicalResultsAggregator::checksum() const {
+std::uint64_t CHierarchicalResultsAggregator::checksum() const {
     std::uint64_t seed = static_cast<std::uint64_t>(m_DecayRate);
     seed = maths::common::CChecksum::calculate(seed, m_Parameters);
     seed = maths::common::CChecksum::calculate(seed, m_MaximumAnomalousProbability);

--- a/lib/model/CHierarchicalResultsNormalizer.cc
+++ b/lib/model/CHierarchicalResultsNormalizer.cc
@@ -60,7 +60,7 @@ void SNormalizer::propagateForwardByTime(double time) {
 }
 
 uint64_t SNormalizer::checksum() const {
-    uint64_t seed = maths::common::CChecksum::calculate(0, s_Description);
+    std::uint64_t seed = maths::common::CChecksum::calculate(0, s_Description);
     return maths::common::CChecksum::calculate(seed, s_Normalizer);
 }
 }

--- a/lib/model/CHierarchicalResultsNormalizer.cc
+++ b/lib/model/CHierarchicalResultsNormalizer.cc
@@ -59,7 +59,7 @@ void SNormalizer::propagateForwardByTime(double time) {
     s_Normalizer->propagateForwardByTime(time);
 }
 
-uint64_t SNormalizer::checksum() const {
+std::uint64_t SNormalizer::checksum() const {
     std::uint64_t seed = maths::common::CChecksum::calculate(0, s_Description);
     return maths::common::CChecksum::calculate(seed, s_Normalizer);
 }

--- a/lib/model/CIndividualModel.cc
+++ b/lib/model/CIndividualModel.cc
@@ -244,7 +244,7 @@ bool CIndividualModel::computeTotalProbability(const std::string& /*person*/,
     return true;
 }
 
-uint64_t CIndividualModel::checksum(bool includeCurrentBucketStats) const {
+std::uint64_t CIndividualModel::checksum(bool includeCurrentBucketStats) const {
     std::uint64_t seed = this->CAnomalyDetectorModel::checksum(includeCurrentBucketStats);
 
     TStrCRefUInt64Map hashes1;

--- a/lib/model/CIndividualModel.cc
+++ b/lib/model/CIndividualModel.cc
@@ -43,10 +43,10 @@ namespace {
 
 using TDouble2Vec = core::CSmallVector<double, 2>;
 using TStrCRef = std::reference_wrapper<const std::string>;
-using TStrCRefUInt64Map = std::map<TStrCRef, uint64_t, maths::common::COrderings::SLess>;
+using TStrCRefUInt64Map = std::map<TStrCRef, std::uint64_t, maths::common::COrderings::SLess>;
 using TStrCRefStrCRefPr = std::pair<TStrCRef, TStrCRef>;
 using TStrCRefStrCRefPrUInt64Map =
-    std::map<TStrCRefStrCRefPr, uint64_t, maths::common::COrderings::SLess>;
+    std::map<TStrCRefStrCRefPr, std::uint64_t, maths::common::COrderings::SLess>;
 
 //! Update \p hashes with the hashes of the active people in \p values.
 template<typename T>
@@ -55,7 +55,7 @@ void hashActive(const CDataGatherer& gatherer,
                 TStrCRefUInt64Map& hashes) {
     for (std::size_t pid = 0; pid < values.size(); ++pid) {
         if (gatherer.isPersonActive(pid)) {
-            uint64_t& hash = hashes[std::cref(gatherer.personName(pid))];
+            std::uint64_t& hash = hashes[std::cref(gatherer.personName(pid))];
             hash = maths::common::CChecksum::calculate(hash, values[pid]);
         }
     }
@@ -150,7 +150,7 @@ CIndividualModel::currentBucketCount(std::size_t pid, core_t::TTime time) const 
 
     return result != this->currentBucketPersonCounts().end() && result->first == pid
                ? result->second
-               : static_cast<uint64_t>(0);
+               : static_cast<std::uint64_t>(0);
 }
 
 bool CIndividualModel::bucketStatsAvailable(core_t::TTime time) const {
@@ -245,7 +245,7 @@ bool CIndividualModel::computeTotalProbability(const std::string& /*person*/,
 }
 
 uint64_t CIndividualModel::checksum(bool includeCurrentBucketStats) const {
-    uint64_t seed = this->CAnomalyDetectorModel::checksum(includeCurrentBucketStats);
+    std::uint64_t seed = this->CAnomalyDetectorModel::checksum(includeCurrentBucketStats);
 
     TStrCRefUInt64Map hashes1;
 
@@ -262,8 +262,8 @@ uint64_t CIndividualModel::checksum(bool includeCurrentBucketStats) const {
         for (const auto& model : feature.s_Models->correlationModels()) {
             std::size_t pids[]{model.first.first, model.first.second};
             if (gatherer.isPersonActive(pids[0]) && gatherer.isPersonActive(pids[1])) {
-                uint64_t& hash = hashes2[{std::cref(this->personName(pids[0])),
-                                          std::cref(this->personName(pids[1]))}];
+                std::uint64_t& hash =
+                    hashes2[{std::cref(this->personName(pids[0])), std::cref(this->personName(pids[1]))}];
                 hash = maths::common::CChecksum::calculate(hash, model.second);
             }
         }
@@ -273,7 +273,7 @@ uint64_t CIndividualModel::checksum(bool includeCurrentBucketStats) const {
         seed = maths::common::CChecksum::calculate(seed, this->currentBucketStartTime());
         const TSizeUInt64PrVec& personCounts = this->currentBucketPersonCounts();
         for (const auto& count : personCounts) {
-            uint64_t& hash = hashes1[std::cref(this->personName(count.first))];
+            std::uint64_t& hash = hashes1[std::cref(this->personName(count.first))];
             hash = maths::common::CChecksum::calculate(hash, count.second);
         }
     }

--- a/lib/model/CInterimBucketCorrector.cc
+++ b/lib/model/CInterimBucketCorrector.cc
@@ -46,11 +46,11 @@ CInterimBucketCorrector::CInterimBucketCorrector(core_t::TTime bucketLength)
       m_FinalCountTrend(trendDecayRate(bucketLength), bucketLength, COMPONENT_SIZE) {
 }
 
-void CInterimBucketCorrector::currentBucketCount(core_t::TTime time, uint64_t count) {
+void CInterimBucketCorrector::currentBucketCount(core_t::TTime time, std::uint64_t count) {
     m_Completeness = this->estimateBucketCompleteness(time, count);
 }
 
-void CInterimBucketCorrector::finalBucketCount(core_t::TTime time, uint64_t count) {
+void CInterimBucketCorrector::finalBucketCount(core_t::TTime time, std::uint64_t count) {
     core_t::TTime bucketMidPoint{this->calcBucketMidPoint(time)};
     m_Completeness = 1.0;
     m_FinalCountTrend.addPoint(bucketMidPoint, static_cast<double>(count));

--- a/lib/model/CMetricBucketGatherer.cc
+++ b/lib/model/CMetricBucketGatherer.cc
@@ -1321,7 +1321,7 @@ void CMetricBucketGatherer::removeAttributes(std::size_t lowestAttributeToRemove
     this->CBucketGatherer::removeAttributes(lowestAttributeToRemove);
 }
 
-uint64_t CMetricBucketGatherer::checksum() const {
+std::uint64_t CMetricBucketGatherer::checksum() const {
     std::uint64_t seed = this->CBucketGatherer::checksum();
     seed = maths::common::CChecksum::calculate(seed, m_DataGatherer.params().s_DecayRate);
     TStrCRefStrCRefPrUInt64Map hashes;

--- a/lib/model/CMetricBucketGatherer.cc
+++ b/lib/model/CMetricBucketGatherer.cc
@@ -48,7 +48,7 @@ using TStrVec = std::vector<std::string>;
 using TStrCRef = std::reference_wrapper<const std::string>;
 using TStrCRefStrCRefPr = std::pair<TStrCRef, TStrCRef>;
 using TStrCRefStrCRefPrUInt64Map =
-    std::map<TStrCRefStrCRefPr, uint64_t, maths::common::COrderings::SLexicographicalCompare>;
+    std::map<TStrCRefStrCRefPr, std::uint64_t, maths::common::COrderings::SLexicographicalCompare>;
 using TSampleVec = std::vector<CSample>;
 using TSizeMeanGathererUMap = boost::unordered_map<std::size_t, CGathererTools::TMeanGatherer>;
 using TSizeSizeMeanGathererUMapUMap = boost::unordered_map<std::size_t, TSizeMeanGathererUMap>;
@@ -1322,7 +1322,7 @@ void CMetricBucketGatherer::removeAttributes(std::size_t lowestAttributeToRemove
 }
 
 uint64_t CMetricBucketGatherer::checksum() const {
-    uint64_t seed = this->CBucketGatherer::checksum();
+    std::uint64_t seed = this->CBucketGatherer::checksum();
     seed = maths::common::CChecksum::calculate(seed, m_DataGatherer.params().s_DecayRate);
     TStrCRefStrCRefPrUInt64Map hashes;
     applyFunc(m_FeatureData, [&, hash = SHash{} ](const auto& category, const auto& data) {
@@ -1463,7 +1463,7 @@ void CMetricBucketGatherer::addValue(std::size_t pid,
 
 void CMetricBucketGatherer::startNewBucket(core_t::TTime time, bool skipUpdates) {
     LOG_TRACE(<< "StartNewBucket, " << time << " @ " << this);
-    using TUInt64Vec = std::vector<uint64_t>;
+    using TUInt64Vec = std::vector<std::uint64_t>;
     using TSizeUInt64VecUMap = boost::unordered_map<std::size_t, TUInt64Vec>;
 
     // Only update the sampleCounts if we are the primary bucket gatherer.

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -449,9 +449,10 @@ bool CMetricModel::computeProbability(const std::size_t pid,
 }
 
 uint64_t CMetricModel::checksum(bool includeCurrentBucketStats) const {
-    using TStrCRefUInt64Map = std::map<TStrCRef, uint64_t, maths::common::COrderings::SLess>;
+    using TStrCRefUInt64Map =
+        std::map<TStrCRef, std::uint64_t, maths::common::COrderings::SLess>;
 
-    uint64_t seed = this->CIndividualModel::checksum(includeCurrentBucketStats);
+    std::uint64_t seed = this->CIndividualModel::checksum(includeCurrentBucketStats);
 
 #define KEY(pid) std::cref(this->personName(pid))
 
@@ -461,11 +462,11 @@ uint64_t CMetricModel::checksum(bool includeCurrentBucketStats) const {
             m_CurrentBucketStats.s_FeatureData;
         for (std::size_t i = 0; i < featureData.size(); ++i) {
             for (std::size_t j = 0; j < featureData[i].second.size(); ++j) {
-                uint64_t& hash = hashes[KEY(featureData[i].second[j].first)];
+                std::uint64_t& hash = hashes[KEY(featureData[i].second[j].first)];
                 const TFeatureData& data = featureData[i].second[j].second;
                 hash = maths::common::CChecksum::calculate(hash, data.s_BucketValue);
                 hash = core::CHashing::hashCombine(
-                    hash, static_cast<uint64_t>(data.s_IsInteger));
+                    hash, static_cast<std::uint64_t>(data.s_IsInteger));
                 hash = maths::common::CChecksum::calculate(hash, data.s_Samples);
             }
         }

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -448,7 +448,7 @@ bool CMetricModel::computeProbability(const std::size_t pid,
     return true;
 }
 
-uint64_t CMetricModel::checksum(bool includeCurrentBucketStats) const {
+std::uint64_t CMetricModel::checksum(bool includeCurrentBucketStats) const {
     using TStrCRefUInt64Map =
         std::map<TStrCRef, std::uint64_t, maths::common::COrderings::SLess>;
 

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -703,7 +703,7 @@ bool CMetricPopulationModel::computeTotalProbability(const std::string& /*person
     return true;
 }
 
-uint64_t CMetricPopulationModel::checksum(bool includeCurrentBucketStats) const {
+std::uint64_t CMetricPopulationModel::checksum(bool includeCurrentBucketStats) const {
     std::uint64_t seed = this->CPopulationModel::checksum(includeCurrentBucketStats);
     if (includeCurrentBucketStats) {
         seed = maths::common::CChecksum::calculate(seed, m_CurrentBucketStats.s_StartTime);

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -704,14 +704,14 @@ bool CMetricPopulationModel::computeTotalProbability(const std::string& /*person
 }
 
 uint64_t CMetricPopulationModel::checksum(bool includeCurrentBucketStats) const {
-    uint64_t seed = this->CPopulationModel::checksum(includeCurrentBucketStats);
+    std::uint64_t seed = this->CPopulationModel::checksum(includeCurrentBucketStats);
     if (includeCurrentBucketStats) {
         seed = maths::common::CChecksum::calculate(seed, m_CurrentBucketStats.s_StartTime);
     }
 
     using TStrCRefStrCRefPr = std::pair<TStrCRef, TStrCRef>;
     using TStrCRefStrCRefPrUInt64Map =
-        std::map<TStrCRefStrCRefPr, uint64_t, maths::common::COrderings::SLess>;
+        std::map<TStrCRefStrCRefPr, std::uint64_t, maths::common::COrderings::SLess>;
 
     const CDataGatherer& gatherer = this->dataGatherer();
 
@@ -720,7 +720,7 @@ uint64_t CMetricPopulationModel::checksum(bool includeCurrentBucketStats) const 
     for (const auto& feature : m_FeatureModels) {
         for (std::size_t cid = 0; cid < feature.s_Models.size(); ++cid) {
             if (gatherer.isAttributeActive(cid)) {
-                uint64_t& hash =
+                std::uint64_t& hash =
                     hashes[{std::cref(EMPTY_STRING), std::cref(gatherer.attributeName(cid))}];
                 hash = maths::common::CChecksum::calculate(hash, feature.s_Models[cid]);
             }
@@ -732,8 +732,9 @@ uint64_t CMetricPopulationModel::checksum(bool includeCurrentBucketStats) const 
             std::size_t cids[]{model.first.first, model.first.second};
             if (gatherer.isAttributeActive(cids[0]) &&
                 gatherer.isAttributeActive(cids[1])) {
-                uint64_t& hash = hashes[{std::cref(gatherer.attributeName(cids[0])),
-                                         std::cref(gatherer.attributeName(cids[1]))}];
+                std::uint64_t& hash =
+                    hashes[{std::cref(gatherer.attributeName(cids[0])),
+                            std::cref(gatherer.attributeName(cids[1]))}];
                 hash = maths::common::CChecksum::calculate(hash, model.second);
             }
         }
@@ -741,7 +742,7 @@ uint64_t CMetricPopulationModel::checksum(bool includeCurrentBucketStats) const 
 
     if (includeCurrentBucketStats) {
         for (const auto& personCount : this->personCounts()) {
-            uint64_t& hash =
+            std::uint64_t& hash =
                 hashes[{std::cref(gatherer.personName(personCount.first)), std::cref(EMPTY_STRING)}];
             hash = maths::common::CChecksum::calculate(hash, personCount.second);
         }
@@ -750,7 +751,7 @@ uint64_t CMetricPopulationModel::checksum(bool includeCurrentBucketStats) const 
                 std::size_t pid = CDataGatherer::extractPersonId(data_);
                 std::size_t cid = CDataGatherer::extractAttributeId(data_);
                 const TFeatureData& data = CDataGatherer::extractData(data_);
-                uint64_t& hash =
+                std::uint64_t& hash =
                     hashes[{std::cref(this->personName(pid)), std::cref(this->attributeName(cid))}];
                 hash = maths::common::CChecksum::calculate(hash, data.s_BucketValue);
                 hash = maths::common::CChecksum::calculate(hash, data.s_IsInteger);

--- a/lib/model/CModelTools.cc
+++ b/lib/model/CModelTools.cc
@@ -174,8 +174,8 @@ std::size_t CModelTools::CFuzzyDeduplicate::SDuplicateValueHash::
 operator()(const TTimeDouble2VecPr& value) const {
     return static_cast<std::size_t>(std::accumulate(
         value.second.begin(), value.second.end(),
-        static_cast<uint64_t>(value.first), [](uint64_t seed, double v) {
-            return core::CHashing::hashCombine(seed, static_cast<uint64_t>(v));
+        static_cast<std::uint64_t>(value.first), [](std::uint64_t seed, double v) {
+            return core::CHashing::hashCombine(seed, static_cast<std::uint64_t>(v));
         }));
 }
 

--- a/lib/model/CPopulationModel.cc
+++ b/lib/model/CPopulationModel.cc
@@ -39,7 +39,7 @@ namespace model {
 namespace {
 
 using TStrCRef = std::reference_wrapper<const std::string>;
-using TStrCRefUInt64Map = std::map<TStrCRef, uint64_t, maths::common::COrderings::SLess>;
+using TStrCRefUInt64Map = std::map<TStrCRef, std::uint64_t, maths::common::COrderings::SLess>;
 
 enum EEntity { E_Person, E_Attribute };
 
@@ -75,7 +75,7 @@ void hashActive(EEntity entity,
                 TStrCRefUInt64Map& hashes) {
     for (std::size_t id = 0; id < values.size(); ++id) {
         if (isActive(entity, gatherer, id)) {
-            uint64_t& hash = hashes[std::cref(name(entity, gatherer, id))];
+            std::uint64_t& hash = hashes[std::cref(name(entity, gatherer, id))];
             hash = maths::common::CChecksum::calculate(hash, values[id]);
         }
     }
@@ -180,9 +180,9 @@ void CPopulationModel::sample(core_t::TTime startTime,
             m_AttributeFirstBucketTimes[cid] = startTime;
         }
         m_AttributeLastBucketTimes[cid] = startTime;
-        m_DistinctPersonCounts[cid].add(static_cast<int32_t>(pid));
+        m_DistinctPersonCounts[cid].add(static_cast<std::int32_t>(pid));
         if (cid < m_PersonAttributeBucketCounts.size()) {
-            m_PersonAttributeBucketCounts[cid].add(static_cast<int32_t>(pid), 1.0);
+            m_PersonAttributeBucketCounts[cid].add(static_cast<std::int32_t>(pid), 1.0);
         }
     }
 
@@ -193,7 +193,7 @@ void CPopulationModel::sample(core_t::TTime startTime,
 }
 
 uint64_t CPopulationModel::checksum(bool includeCurrentBucketStats) const {
-    uint64_t seed = this->CAnomalyDetectorModel::checksum(includeCurrentBucketStats);
+    std::uint64_t seed = this->CAnomalyDetectorModel::checksum(includeCurrentBucketStats);
 
     const CDataGatherer& gatherer = this->dataGatherer();
     TStrCRefUInt64Map hashes;
@@ -259,7 +259,7 @@ double CPopulationModel::sampleRateWeight(std::size_t pid, std::size_t cid) cons
     const maths::time_series::CCountMinSketch& counts = m_PersonAttributeBucketCounts[cid];
     const maths::common::CBjkstUniqueValues& distinctPeople = m_DistinctPersonCounts[cid];
 
-    double personCount = counts.count(static_cast<uint32_t>(pid)) -
+    double personCount = counts.count(static_cast<std::uint32_t>(pid)) -
                          counts.oneMinusDeltaError();
     if (personCount <= 0.0) {
         return 1.0;
@@ -540,7 +540,7 @@ void CPopulationModel::peopleAndAttributesToRemove(core_t::TTime time,
 
 void CPopulationModel::removePeople(const TSizeVec& peopleToRemove) {
     for (std::size_t i = 0; i < peopleToRemove.size(); ++i) {
-        uint32_t pid = static_cast<uint32_t>(peopleToRemove[i]);
+        std::uint32_t pid = static_cast<std::uint32_t>(peopleToRemove[i]);
         for (std::size_t cid = 0; cid < m_PersonAttributeBucketCounts.size(); ++cid) {
             m_PersonAttributeBucketCounts[cid].removeFromMap(pid);
         }
@@ -582,7 +582,8 @@ bool CPopulationModel::CCorrectionKey::operator==(const CCorrectionKey& rhs) con
 }
 
 std::size_t CPopulationModel::CCorrectionKey::hash() const {
-    uint64_t seed = core::CHashing::hashCombine(static_cast<uint64_t>(m_Feature), m_Pid);
+    std::uint64_t seed =
+        core::CHashing::hashCombine(static_cast<std::uint64_t>(m_Feature), m_Pid);
     seed = core::CHashing::hashCombine(seed, m_Cid);
     return static_cast<std::size_t>(core::CHashing::hashCombine(seed, m_Correlate));
 }

--- a/lib/model/CPopulationModel.cc
+++ b/lib/model/CPopulationModel.cc
@@ -192,7 +192,7 @@ void CPopulationModel::sample(core_t::TTime startTime,
     }
 }
 
-uint64_t CPopulationModel::checksum(bool includeCurrentBucketStats) const {
+std::uint64_t CPopulationModel::checksum(bool includeCurrentBucketStats) const {
     std::uint64_t seed = this->CAnomalyDetectorModel::checksum(includeCurrentBucketStats);
 
     const CDataGatherer& gatherer = this->dataGatherer();

--- a/lib/model/CSample.cc
+++ b/lib/model/CSample.cc
@@ -91,7 +91,7 @@ CSample::TDouble1Vec CSample::value(std::size_t dimension) const {
 }
 
 uint64_t CSample::checksum() const {
-    uint64_t seed = static_cast<uint64_t>(m_Time);
+    std::uint64_t seed = static_cast<std::uint64_t>(m_Time);
     seed = maths::common::CChecksum::calculate(seed, m_Value);
     seed = maths::common::CChecksum::calculate(seed, m_VarianceScale);
     return maths::common::CChecksum::calculate(seed, m_Count);

--- a/lib/model/CSample.cc
+++ b/lib/model/CSample.cc
@@ -90,7 +90,7 @@ CSample::TDouble1Vec CSample::value(std::size_t dimension) const {
     return result;
 }
 
-uint64_t CSample::checksum() const {
+std::uint64_t CSample::checksum() const {
     std::uint64_t seed = static_cast<std::uint64_t>(m_Time);
     seed = maths::common::CChecksum::calculate(seed, m_Value);
     seed = maths::common::CChecksum::calculate(seed, m_VarianceScale);

--- a/lib/model/CSampleCounts.cc
+++ b/lib/model/CSampleCounts.cc
@@ -220,7 +220,7 @@ void CSampleCounts::resize(std::size_t id) {
     }
 }
 
-uint64_t CSampleCounts::checksum(const CDataGatherer& gatherer) const {
+std::uint64_t CSampleCounts::checksum(const CDataGatherer& gatherer) const {
     TStrCRefUInt64Map hashes;
     for (std::size_t id = 0; id < m_SampleCounts.size(); ++id) {
         if (gatherer.isPopulation() ? gatherer.isAttributeActive(id)

--- a/lib/model/CSampleCounts.cc
+++ b/lib/model/CSampleCounts.cc
@@ -36,7 +36,8 @@ const double NUMBER_BUCKETS_TO_ESTIMATE_SAMPLE_COUNT(3.0);
 const double NUMBER_BUCKETS_TO_REFRESH_SAMPLE_COUNT(30.0);
 
 using TStrCRef = std::reference_wrapper<const std::string>;
-using TStrCRefUInt64Map = std::map<TStrCRef, uint64_t, maths::common::COrderings::SReferenceLess>;
+using TStrCRefUInt64Map =
+    std::map<TStrCRef, std::uint64_t, maths::common::COrderings::SReferenceLess>;
 }
 
 CSampleCounts::CSampleCounts(unsigned int sampleCountOverride)
@@ -224,7 +225,7 @@ uint64_t CSampleCounts::checksum(const CDataGatherer& gatherer) const {
     for (std::size_t id = 0; id < m_SampleCounts.size(); ++id) {
         if (gatherer.isPopulation() ? gatherer.isAttributeActive(id)
                                     : gatherer.isPersonActive(id)) {
-            uint64_t& hash = hashes[TStrCRef(this->name(gatherer, id))];
+            std::uint64_t& hash = hashes[TStrCRef(this->name(gatherer, id))];
             hash = maths::common::CChecksum::calculate(hash, m_SampleCounts[id]);
             hash = maths::common::CChecksum::calculate(hash, m_MeanNonZeroBucketCounts[id]);
             hash = maths::common::CChecksum::calculate(hash, m_EffectiveSampleVariances[id]);

--- a/lib/model/CSearchKey.cc
+++ b/lib/model/CSearchKey.cc
@@ -351,7 +351,7 @@ const CSearchKey::TStoredStringPtrVec& CSearchKey::influenceFieldNames() const {
     return m_InfluenceFieldNames;
 }
 
-uint64_t CSearchKey::hash() const {
+std::uint64_t CSearchKey::hash() const {
     if (m_Hash != 0) {
         return m_Hash;
     }

--- a/lib/model/CSearchKey.cc
+++ b/lib/model/CSearchKey.cc
@@ -356,15 +356,15 @@ uint64_t CSearchKey::hash() const {
         return m_Hash;
     }
     m_Hash = m_UseNull ? 1 : 0;
-    m_Hash = 4 * m_Hash + static_cast<uint64_t>(m_ExcludeFrequent);
-    m_Hash = core::CHashing::hashCombine(m_Hash, static_cast<uint64_t>(m_DetectorIndex));
-    m_Hash = core::CHashing::hashCombine(m_Hash, static_cast<uint64_t>(m_Function));
+    m_Hash = 4 * m_Hash + static_cast<std::uint64_t>(m_ExcludeFrequent);
+    m_Hash = core::CHashing::hashCombine(m_Hash, static_cast<std::uint64_t>(m_DetectorIndex));
+    m_Hash = core::CHashing::hashCombine(m_Hash, static_cast<std::uint64_t>(m_Function));
     m_Hash = maths::common::CChecksum::calculate(m_Hash, *m_FieldName);
     m_Hash = maths::common::CChecksum::calculate(m_Hash, *m_ByFieldName);
     m_Hash = maths::common::CChecksum::calculate(m_Hash, *m_OverFieldName);
     m_Hash = maths::common::CChecksum::calculate(m_Hash, *m_PartitionFieldName);
     m_Hash = maths::common::CChecksum::calculate(m_Hash, m_InfluenceFieldNames);
-    m_Hash = std::max(m_Hash, uint64_t(1));
+    m_Hash = std::max(m_Hash, std::uint64_t(1));
     return m_Hash;
 }
 

--- a/lib/model/SModelParams.cc
+++ b/lib/model/SModelParams.cc
@@ -89,7 +89,7 @@ SModelParams::distributionRestoreParams(maths_t::EDataType dataType) const {
             this->minimumCategoryCount()};
 }
 
-uint64_t SModelParams::checksum(uint64_t seed) const {
+uint64_t SModelParams::checksum(std::uint64_t seed) const {
     seed = maths::common::CChecksum::calculate(seed, s_LearnRate);
     seed = maths::common::CChecksum::calculate(seed, s_DecayRate);
     seed = maths::common::CChecksum::calculate(seed, s_InitialDecayRateMultiplier);

--- a/lib/model/SModelParams.cc
+++ b/lib/model/SModelParams.cc
@@ -89,7 +89,7 @@ SModelParams::distributionRestoreParams(maths_t::EDataType dataType) const {
             this->minimumCategoryCount()};
 }
 
-uint64_t SModelParams::checksum(std::uint64_t seed) const {
+std::uint64_t SModelParams::checksum(std::uint64_t seed) const {
     seed = maths::common::CChecksum::calculate(seed, s_LearnRate);
     seed = maths::common::CChecksum::calculate(seed, s_DecayRate);
     seed = maths::common::CChecksum::calculate(seed, s_InitialDecayRateMultiplier);

--- a/lib/model/unittest/CAnomalyScoreTest.cc
+++ b/lib/model/unittest/CAnomalyScoreTest.cc
@@ -16,6 +16,7 @@
 #include <core/CStringUtils.h>
 
 #include <maths/common/CBasicStatistics.h>
+#include <maths/common/COrderings.h>
 #include <maths/common/CTools.h>
 #include <maths/common/ProbabilityAggregators.h>
 

--- a/lib/model/unittest/CBucketQueueTest.cc
+++ b/lib/model/unittest/CBucketQueueTest.cc
@@ -25,9 +25,9 @@ using namespace ml;
 using namespace model;
 
 using TSizeSizePr = std::pair<std::size_t, std::size_t>;
-using TSizeSizePrUInt64Pr = std::pair<TSizeSizePr, uint64_t>;
+using TSizeSizePrUInt64Pr = std::pair<TSizeSizePr, std::uint64_t>;
 using TSizeSizePrUInt64PrVec = std::vector<TSizeSizePrUInt64Pr>;
-using TSizeSizePrUInt64UMap = boost::unordered_map<TSizeSizePr, uint64_t>;
+using TSizeSizePrUInt64UMap = boost::unordered_map<TSizeSizePr, std::uint64_t>;
 using TSizeSizePrUInt64UMapQueue = model::CBucketQueue<TSizeSizePrUInt64UMap>;
 using TSizeSizePrUInt64UMapQueueCItr = TSizeSizePrUInt64UMapQueue::const_iterator;
 

--- a/lib/model/unittest/CEventRateDataGathererTest.cc
+++ b/lib/model/unittest/CEventRateDataGathererTest.cc
@@ -42,7 +42,7 @@ using namespace model;
 
 using TSizeVec = std::vector<std::size_t>;
 using TFeatureVec = std::vector<model_t::EFeature>;
-using TSizeUInt64Pr = std::pair<std::size_t, uint64_t>;
+using TSizeUInt64Pr = std::pair<std::size_t, std::uint64_t>;
 using TSizeUInt64PrVec = std::vector<TSizeUInt64Pr>;
 using TStrVec = std::vector<std::string>;
 using TStrVecCItr = TStrVec::const_iterator;
@@ -1560,7 +1560,8 @@ BOOST_FIXTURE_TEST_CASE(testDistinctStrings, CTestFixture) {
             data.insert(ss.str(), influencers);
             SEventRateFeatureData featureData(0);
             data.populateDistinctCountFeatureData(featureData);
-            BOOST_REQUIRE_EQUAL(std::max(uint64_t(3), uint64_t(i)), featureData.s_Count);
+            BOOST_REQUIRE_EQUAL(std::max(std::uint64_t(3), std::uint64_t(i)),
+                                featureData.s_Count);
         }
     }
     {
@@ -1687,9 +1688,9 @@ BOOST_FIXTURE_TEST_CASE(testDistinctStrings, CTestFixture) {
             SEventRateFeatureData featureData(0);
             data.populateInfoContentFeatureData(featureData);
             BOOST_TEST_REQUIRE((featureData.s_Count - 12) >=
-                               std::max(uint64_t(3), uint64_t(i)));
+                               std::max(std::uint64_t(3), std::uint64_t(i)));
             BOOST_TEST_REQUIRE((featureData.s_Count - 12) <=
-                               std::max(uint64_t(3), uint64_t(i)) * 3);
+                               std::max(std::uint64_t(3), std::uint64_t(i)) * 3);
         }
     }
     {
@@ -1869,7 +1870,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t(time % 86400),
+            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 86400),
                                 featureData[0].second[0].second.s_Count);
         }
         {
@@ -1879,7 +1880,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 86400) + 50),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 50),
                                 featureData[0].second[0].second.s_Count);
         }
         time += bucketLength;
@@ -1890,7 +1891,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t(time % 86400),
+            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 86400),
                                 featureData[0].second[0].second.s_Count);
         }
         {
@@ -1900,7 +1901,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 86400) + 100),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 100),
                                 featureData[0].second[0].second.s_Count);
         }
         time += bucketLength;
@@ -1911,7 +1912,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t(time % 86400),
+            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 86400),
                                 featureData[0].second[0].second.s_Count);
         }
         {
@@ -1921,7 +1922,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 86400) + 150),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 150),
                                 featureData[0].second[0].second.s_Count);
         }
 
@@ -1934,7 +1935,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 86400) + 100),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 100),
                                 featureData[0].second[0].second.s_Count);
         }
         time += bucketLength;
@@ -1945,7 +1946,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 86400) + 200),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 200),
                                 featureData[0].second[0].second.s_Count);
         }
 
@@ -1991,7 +1992,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t(time % 604800),
+            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 604800),
                                 featureData[0].second[0].second.s_Count);
         }
         {
@@ -2001,7 +2002,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 604800) + 50),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 50),
                                 featureData[0].second[0].second.s_Count);
         }
         time += bucketLength;
@@ -2012,7 +2013,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t(time % 604800),
+            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 604800),
                                 featureData[0].second[0].second.s_Count);
         }
         {
@@ -2022,7 +2023,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 604800) + 100),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 100),
                                 featureData[0].second[0].second.s_Count);
         }
         time += bucketLength;
@@ -2033,7 +2034,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t(time % 604800),
+            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 604800),
                                 featureData[0].second[0].second.s_Count);
         }
         {
@@ -2043,7 +2044,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 604800) + 150),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 150),
                                 featureData[0].second[0].second.s_Count);
         }
 
@@ -2056,7 +2057,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 604800) + 100),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 100),
                                 featureData[0].second[0].second.s_Count);
         }
         time += bucketLength;
@@ -2067,7 +2068,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 604800) + 200),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 200),
                                 featureData[0].second[0].second.s_Count);
         }
 
@@ -2114,7 +2115,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t(time % 604800),
+            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 604800),
                                 featureData[0].second[0].second.s_Count);
         }
         {
@@ -2124,7 +2125,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 604800) + 50),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 50),
                                 featureData[0].second[0].second.s_Count);
         }
         time += bucketLength;
@@ -2135,7 +2136,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t(time % 604800),
+            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 604800),
                                 featureData[0].second[0].second.s_Count);
         }
         {
@@ -2145,7 +2146,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 604800) + 100),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 100),
                                 featureData[0].second[0].second.s_Count);
         }
         time += bucketLength;
@@ -2156,7 +2157,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t(time % 604800),
+            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 604800),
                                 featureData[0].second[0].second.s_Count);
         }
         {
@@ -2166,7 +2167,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 604800) + 150),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 150),
                                 featureData[0].second[0].second.s_Count);
         }
 
@@ -2179,7 +2180,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 604800) + 100),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 100),
                                 featureData[0].second[0].second.s_Count);
         }
         time += bucketLength;
@@ -2190,7 +2191,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 604800) + 200),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 200),
                                 featureData[0].second[0].second.s_Count);
         }
 
@@ -2238,7 +2239,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t(time % 86400),
+            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 86400),
                                 featureData[0].second[0].second.s_Count);
         }
         {
@@ -2248,7 +2249,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 86400) + 50),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 50),
                                 featureData[0].second[0].second.s_Count);
         }
         time += bucketLength;
@@ -2259,7 +2260,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t(time % 86400),
+            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 86400),
                                 featureData[0].second[0].second.s_Count);
         }
         {
@@ -2269,7 +2270,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 86400) + 100),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 100),
                                 featureData[0].second[0].second.s_Count);
         }
         time += bucketLength;
@@ -2280,7 +2281,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t(time % 86400),
+            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 86400),
                                 featureData[0].second[0].second.s_Count);
         }
         {
@@ -2290,7 +2291,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 86400) + 150),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 150),
                                 featureData[0].second[0].second.s_Count);
         }
 
@@ -2303,7 +2304,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 86400) + 100),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 100),
                                 featureData[0].second[0].second.s_Count);
         }
         time += bucketLength;
@@ -2314,7 +2315,7 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
             gatherer.featureData(time, bucketLength, featureData);
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData.size());
             BOOST_REQUIRE_EQUAL(std::size_t(1), featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(uint64_t((time % 86400) + 200),
+            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 200),
                                 featureData[0].second[0].second.s_Count);
         }
 

--- a/lib/model/unittest/CEventRateModelTest.cc
+++ b/lib/model/unittest/CEventRateModelTest.cc
@@ -43,11 +43,10 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <stdint.h>
 
 BOOST_TEST_DONT_PRINT_LOG_VALUE(CModelTestFixtureBase::TStrVec::iterator)
 
@@ -64,8 +63,8 @@ const CModelTestFixtureBase::TSizeDoublePr1Vec NO_CORRELATES;
 class CTestFixture : public CModelTestFixtureBase {
 public:
     TUInt64Vec rawEventCounts(std::size_t copies = 1) {
-        uint64_t counts[] = {54, 67, 39, 58, 46, 50, 42,
-                             48, 53, 51, 50, 57, 53, 49};
+        std::uint64_t counts[] = {54, 67, 39, 58, 46, 50, 42,
+                                  48, 53, 51, 50, 57, 53, 49};
         TUInt64Vec result;
         for (std::size_t i = 0; i < copies; ++i) {
             result.insert(result.end(), std::begin(counts), std::end(counts));
@@ -261,7 +260,7 @@ BOOST_FIXTURE_TEST_CASE(testCountSample, CTestFixture) {
 
         // Test we sample the data correctly.
         BOOST_REQUIRE_EQUAL(expectedEventCounts[j],
-                            static_cast<uint64_t>(model->currentBucketValue(
+                            static_cast<std::uint64_t>(model->currentBucketValue(
                                 model_t::E_IndividualCountByBucketAndPerson, 0,
                                 0, bucketStartTime)[0]));
         BOOST_REQUIRE_EQUAL(timeseriesModel->checksum(),
@@ -358,7 +357,7 @@ BOOST_FIXTURE_TEST_CASE(testNonZeroCountSample, CTestFixture) {
 
             // Test we sample the data correctly.
             BOOST_REQUIRE_EQUAL(expectedEventCounts[j],
-                                static_cast<uint64_t>(model->currentBucketValue(
+                                static_cast<std::uint64_t>(model->currentBucketValue(
                                     model_t::E_IndividualNonZeroCountByBucketAndPerson,
                                     0, 0, bucketStartTime)[0]));
             BOOST_REQUIRE_EQUAL(timeseriesModel->checksum(),

--- a/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
+++ b/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
@@ -59,7 +59,7 @@ using TSizeVec = std::vector<std::size_t>;
 using TStrVec = std::vector<std::string>;
 using TEventRateDataGathererPtr = std::shared_ptr<CDataGatherer>;
 using TSizeSizePr = std::pair<std::size_t, std::size_t>;
-using TSizeSizePrUInt64Map = std::map<TSizeSizePr, uint64_t>;
+using TSizeSizePrUInt64Map = std::map<TSizeSizePr, std::uint64_t>;
 using TSizeSizePrUInt64MapCItr = TSizeSizePrUInt64Map::iterator;
 using TSizeSet = std::set<std::size_t>;
 using TSizeSizeSetMap = std::map<std::size_t, TSizeSet>;
@@ -556,7 +556,7 @@ BOOST_FIXTURE_TEST_CASE(testCompressedLength, CTestFixture) {
 
 BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
     using TStrSizeMap = std::map<std::string, std::size_t>;
-    using TSizeUInt64Pr = std::pair<std::size_t, uint64_t>;
+    using TSizeUInt64Pr = std::pair<std::size_t, std::uint64_t>;
     using TSizeUInt64PrVec = std::vector<TSizeUInt64Pr>;
 
     const core_t::TTime startTime = 1367280000;

--- a/lib/model/unittest/CEventRatePopulationModelTest.cc
+++ b/lib/model/unittest/CEventRatePopulationModelTest.cc
@@ -161,7 +161,7 @@ BOOST_FIXTURE_TEST_CASE(testBasicAccessors, CTestFixture) {
     // Check that the correct data is read retrieved by the
     // basic model accessors.
 
-    using TSizeUInt64Map = std::map<std::size_t, uint64_t>;
+    using TSizeUInt64Map = std::map<std::size_t, std::uint64_t>;
 
     core_t::TTime startTime = 1367280000;
     const core_t::TTime bucketLength = 3600;

--- a/lib/model/unittest/CMetricAnomalyDetectorTest.cc
+++ b/lib/model/unittest/CMetricAnomalyDetectorTest.cc
@@ -102,7 +102,7 @@ public:
             m_HighAnomalyFactors.push_back(anomalyFactor);
         } else if (anomalyFactor > 0.0) {
             m_AnomalyFactors.push_back(anomalyFactor);
-            uint64_t currentRate(0);
+            std::uint64_t currentRate(0);
             if (node.s_AnnotatedProbability.s_CurrentBucketCount) {
                 currentRate = *node.s_AnnotatedProbability.s_CurrentBucketCount;
             }
@@ -375,7 +375,8 @@ BOOST_AUTO_TEST_CASE(testPersist) {
 
     LOG_TRACE(<< "Event rate detector XML representation:\n" << origXml);
 
-    uint64_t peakMemoryUsageBeforeRestoring = counters.counter(counter_t::E_TSADPeakMemoryUsage);
+    std::uint64_t peakMemoryUsageBeforeRestoring =
+        counters.counter(counter_t::E_TSADPeakMemoryUsage);
 
     // Clear the counter to verify that restoring detector also restores counter's value.
     counters.counter(counter_t::E_TSADPeakMemoryUsage) = 0;
@@ -401,7 +402,8 @@ BOOST_AUTO_TEST_CASE(testPersist) {
             &core::CProgramCounters::staticsAcceptRestoreTraverser));
     }
 
-    uint64_t peakMemoryUsageAfterRestoring = counters.counter(counter_t::E_TSADPeakMemoryUsage);
+    std::uint64_t peakMemoryUsageAfterRestoring =
+        counters.counter(counter_t::E_TSADPeakMemoryUsage);
     BOOST_REQUIRE_EQUAL(peakMemoryUsageBeforeRestoring, peakMemoryUsageAfterRestoring);
 
     // The XML representation of the new detector should be the same as the original

--- a/lib/model/unittest/CMetricDataGathererTest.cc
+++ b/lib/model/unittest/CMetricDataGathererTest.cc
@@ -43,7 +43,7 @@ using TDoubleVec = std::vector<double>;
 using TSizeVec = std::vector<std::size_t>;
 using TSizeSizePr = std::pair<std::size_t, std::size_t>;
 using TFeatureVec = std::vector<model_t::EFeature>;
-using TSizeUInt64Pr = std::pair<std::size_t, uint64_t>;
+using TSizeUInt64Pr = std::pair<std::size_t, std::uint64_t>;
 using TSizeUInt64PrVec = std::vector<TSizeUInt64Pr>;
 using TStrVec = std::vector<std::string>;
 using TSizeFeatureDataPr = std::pair<std::size_t, SMetricFeatureData>;
@@ -1090,21 +1090,24 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenSingleSeries, CTestFixture) {
     BOOST_REQUIRE_EQUAL(1.0, featureData[1].second[0].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(2.0, featureData[2].second[0].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(3.0, featureData[3].second[0].second.s_BucketValue->value()[0]);
-    BOOST_REQUIRE_EQUAL(uint64_t(2), gatherer.bucketCounts(0).find(pidCidPr)->second);
+    BOOST_REQUIRE_EQUAL(std::uint64_t(2),
+                        gatherer.bucketCounts(0).find(pidCidPr)->second);
 
     gatherer.featureData(600, bucketLength, featureData);
     BOOST_REQUIRE_EQUAL(4.0, featureData[0].second[0].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(3.0, featureData[1].second[0].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(5.0, featureData[2].second[0].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(12.0, featureData[3].second[0].second.s_BucketValue->value()[0]);
-    BOOST_REQUIRE_EQUAL(uint64_t(3), gatherer.bucketCounts(600).find(pidCidPr)->second);
+    BOOST_REQUIRE_EQUAL(std::uint64_t(3),
+                        gatherer.bucketCounts(600).find(pidCidPr)->second);
 
     gatherer.featureData(1200, bucketLength, featureData);
     BOOST_REQUIRE_EQUAL(6.0, featureData[0].second[0].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(6.0, featureData[1].second[0].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(6.0, featureData[2].second[0].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(6.0, featureData[3].second[0].second.s_BucketValue->value()[0]);
-    BOOST_REQUIRE_EQUAL(uint64_t(1), gatherer.bucketCounts(1200).find(pidCidPr)->second);
+    BOOST_REQUIRE_EQUAL(std::uint64_t(1),
+                        gatherer.bucketCounts(1200).find(pidCidPr)->second);
 
     gatherer.resetBucket(600);
     addArrival(gatherer, m_ResourceMonitor, 610, "p", 2.0);
@@ -1115,21 +1118,24 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenSingleSeries, CTestFixture) {
     BOOST_REQUIRE_EQUAL(1.0, featureData[1].second[0].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(2.0, featureData[2].second[0].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(3.0, featureData[3].second[0].second.s_BucketValue->value()[0]);
-    BOOST_REQUIRE_EQUAL(uint64_t(2), gatherer.bucketCounts(0).find(pidCidPr)->second);
+    BOOST_REQUIRE_EQUAL(std::uint64_t(2),
+                        gatherer.bucketCounts(0).find(pidCidPr)->second);
 
     gatherer.featureData(600, bucketLength, featureData);
     BOOST_REQUIRE_EQUAL(2.5, featureData[0].second[0].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(2.0, featureData[1].second[0].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(3.0, featureData[2].second[0].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(5.0, featureData[3].second[0].second.s_BucketValue->value()[0]);
-    BOOST_REQUIRE_EQUAL(uint64_t(2), gatherer.bucketCounts(0).find(pidCidPr)->second);
+    BOOST_REQUIRE_EQUAL(std::uint64_t(2),
+                        gatherer.bucketCounts(0).find(pidCidPr)->second);
 
     gatherer.featureData(1200, bucketLength, featureData);
     BOOST_REQUIRE_EQUAL(6.0, featureData[0].second[0].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(6.0, featureData[1].second[0].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(6.0, featureData[2].second[0].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(6.0, featureData[3].second[0].second.s_BucketValue->value()[0]);
-    BOOST_REQUIRE_EQUAL(uint64_t(1), gatherer.bucketCounts(1200).find(pidCidPr)->second);
+    BOOST_REQUIRE_EQUAL(std::uint64_t(1),
+                        gatherer.bucketCounts(1200).find(pidCidPr)->second);
 
     gatherer.sampleNow(0);
     gatherer.featureData(0, bucketLength, featureData);
@@ -1213,9 +1219,12 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenMultipleSeries, CTestFixture) {
     BOOST_REQUIRE_EQUAL(3.0, featureData[3].second[2].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(3.0, featureData[3].second[2].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(3.0, featureData[3].second[2].second.s_BucketValue->value()[0]);
-    BOOST_REQUIRE_EQUAL(uint64_t(2), gatherer.bucketCounts(0).find(pidCidPr0)->second);
-    BOOST_REQUIRE_EQUAL(uint64_t(2), gatherer.bucketCounts(0).find(pidCidPr1)->second);
-    BOOST_REQUIRE_EQUAL(uint64_t(2), gatherer.bucketCounts(0).find(pidCidPr2)->second);
+    BOOST_REQUIRE_EQUAL(std::uint64_t(2),
+                        gatherer.bucketCounts(0).find(pidCidPr0)->second);
+    BOOST_REQUIRE_EQUAL(std::uint64_t(2),
+                        gatherer.bucketCounts(0).find(pidCidPr1)->second);
+    BOOST_REQUIRE_EQUAL(std::uint64_t(2),
+                        gatherer.bucketCounts(0).find(pidCidPr2)->second);
 
     gatherer.featureData(600, bucketLength, featureData);
     BOOST_REQUIRE_EQUAL(4.0, featureData[0].second[0].second.s_BucketValue->value()[0]);
@@ -1230,9 +1239,12 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenMultipleSeries, CTestFixture) {
     BOOST_REQUIRE_EQUAL(12.0, featureData[3].second[2].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(12.0, featureData[3].second[2].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(12.0, featureData[3].second[2].second.s_BucketValue->value()[0]);
-    BOOST_REQUIRE_EQUAL(uint64_t(3), gatherer.bucketCounts(600).find(pidCidPr0)->second);
-    BOOST_REQUIRE_EQUAL(uint64_t(3), gatherer.bucketCounts(600).find(pidCidPr1)->second);
-    BOOST_REQUIRE_EQUAL(uint64_t(3), gatherer.bucketCounts(600).find(pidCidPr2)->second);
+    BOOST_REQUIRE_EQUAL(std::uint64_t(3),
+                        gatherer.bucketCounts(600).find(pidCidPr0)->second);
+    BOOST_REQUIRE_EQUAL(std::uint64_t(3),
+                        gatherer.bucketCounts(600).find(pidCidPr1)->second);
+    BOOST_REQUIRE_EQUAL(std::uint64_t(3),
+                        gatherer.bucketCounts(600).find(pidCidPr2)->second);
 
     gatherer.featureData(1200, bucketLength, featureData);
     BOOST_REQUIRE_EQUAL(6.0, featureData[0].second[0].second.s_BucketValue->value()[0]);
@@ -1247,11 +1259,11 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenMultipleSeries, CTestFixture) {
     BOOST_REQUIRE_EQUAL(6.0, featureData[3].second[2].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(6.0, featureData[3].second[2].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(6.0, featureData[3].second[2].second.s_BucketValue->value()[0]);
-    BOOST_REQUIRE_EQUAL(uint64_t(1),
+    BOOST_REQUIRE_EQUAL(std::uint64_t(1),
                         gatherer.bucketCounts(1200).find(pidCidPr0)->second);
-    BOOST_REQUIRE_EQUAL(uint64_t(1),
+    BOOST_REQUIRE_EQUAL(std::uint64_t(1),
                         gatherer.bucketCounts(1200).find(pidCidPr1)->second);
-    BOOST_REQUIRE_EQUAL(uint64_t(1),
+    BOOST_REQUIRE_EQUAL(std::uint64_t(1),
                         gatherer.bucketCounts(1200).find(pidCidPr2)->second);
 
     gatherer.resetBucket(600);
@@ -1273,9 +1285,12 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenMultipleSeries, CTestFixture) {
     BOOST_REQUIRE_EQUAL(3.0, featureData[3].second[2].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(3.0, featureData[3].second[2].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(3.0, featureData[3].second[2].second.s_BucketValue->value()[0]);
-    BOOST_REQUIRE_EQUAL(uint64_t(2), gatherer.bucketCounts(0).find(pidCidPr0)->second);
-    BOOST_REQUIRE_EQUAL(uint64_t(2), gatherer.bucketCounts(0).find(pidCidPr1)->second);
-    BOOST_REQUIRE_EQUAL(uint64_t(2), gatherer.bucketCounts(0).find(pidCidPr2)->second);
+    BOOST_REQUIRE_EQUAL(std::uint64_t(2),
+                        gatherer.bucketCounts(0).find(pidCidPr0)->second);
+    BOOST_REQUIRE_EQUAL(std::uint64_t(2),
+                        gatherer.bucketCounts(0).find(pidCidPr1)->second);
+    BOOST_REQUIRE_EQUAL(std::uint64_t(2),
+                        gatherer.bucketCounts(0).find(pidCidPr2)->second);
 
     gatherer.featureData(600, bucketLength, featureData);
     BOOST_REQUIRE_EQUAL(2.5, featureData[0].second[0].second.s_BucketValue->value()[0]);
@@ -1290,9 +1305,12 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenMultipleSeries, CTestFixture) {
     BOOST_REQUIRE_EQUAL(5.0, featureData[3].second[2].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(5.0, featureData[3].second[2].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(5.0, featureData[3].second[2].second.s_BucketValue->value()[0]);
-    BOOST_REQUIRE_EQUAL(uint64_t(2), gatherer.bucketCounts(600).find(pidCidPr0)->second);
-    BOOST_REQUIRE_EQUAL(uint64_t(2), gatherer.bucketCounts(600).find(pidCidPr1)->second);
-    BOOST_REQUIRE_EQUAL(uint64_t(2), gatherer.bucketCounts(600).find(pidCidPr2)->second);
+    BOOST_REQUIRE_EQUAL(std::uint64_t(2),
+                        gatherer.bucketCounts(600).find(pidCidPr0)->second);
+    BOOST_REQUIRE_EQUAL(std::uint64_t(2),
+                        gatherer.bucketCounts(600).find(pidCidPr1)->second);
+    BOOST_REQUIRE_EQUAL(std::uint64_t(2),
+                        gatherer.bucketCounts(600).find(pidCidPr2)->second);
 
     gatherer.featureData(1200, bucketLength, featureData);
     BOOST_REQUIRE_EQUAL(6.0, featureData[0].second[0].second.s_BucketValue->value()[0]);
@@ -1307,11 +1325,11 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenMultipleSeries, CTestFixture) {
     BOOST_REQUIRE_EQUAL(6.0, featureData[3].second[2].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(6.0, featureData[3].second[2].second.s_BucketValue->value()[0]);
     BOOST_REQUIRE_EQUAL(6.0, featureData[3].second[2].second.s_BucketValue->value()[0]);
-    BOOST_REQUIRE_EQUAL(uint64_t(1),
+    BOOST_REQUIRE_EQUAL(std::uint64_t(1),
                         gatherer.bucketCounts(1200).find(pidCidPr0)->second);
-    BOOST_REQUIRE_EQUAL(uint64_t(1),
+    BOOST_REQUIRE_EQUAL(std::uint64_t(1),
                         gatherer.bucketCounts(1200).find(pidCidPr1)->second);
-    BOOST_REQUIRE_EQUAL(uint64_t(1),
+    BOOST_REQUIRE_EQUAL(std::uint64_t(1),
                         gatherer.bucketCounts(1200).find(pidCidPr2)->second);
 
     gatherer.sampleNow(0);

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -365,7 +365,7 @@ BOOST_FIXTURE_TEST_CASE(testMultivariateSample, CTestFixture) {
         BOOST_REQUIRE_EQUAL(0, this->addPerson("p", m_Gatherer));
 
         // Bucket values.
-        uint64_t expectedCount{0};
+        std::uint64_t expectedCount{0};
         TMean2Accumulator baselineLatLongError;
         TMean2Accumulator expectedLatLong;
         TMean2Accumulator expectedBaselineLatLong;
@@ -490,9 +490,9 @@ BOOST_FIXTURE_TEST_CASE(testMultivariateSample, CTestFixture) {
                     inserter.toXml(newXml);
                 }
 
-                uint64_t origChecksum = model.checksum(false);
+                std::uint64_t origChecksum = model.checksum(false);
                 LOG_DEBUG(<< "original checksum = " << origChecksum);
-                uint64_t restoredChecksum = restoredModel->checksum(false);
+                std::uint64_t restoredChecksum = restoredModel->checksum(false);
                 LOG_DEBUG(<< "restored checksum = " << restoredChecksum);
                 BOOST_REQUIRE_EQUAL(origChecksum, restoredChecksum);
                 BOOST_REQUIRE_EQUAL(origXml, newXml);
@@ -1861,9 +1861,9 @@ BOOST_FIXTURE_TEST_CASE(testCorrelatePersist, CTestFixture) {
                 inserter.toXml(newXml);
             }
 
-            uint64_t origChecksum = m_Model->checksum(false);
+            std::uint64_t origChecksum = m_Model->checksum(false);
             LOG_DEBUG(<< "original checksum = " << origChecksum);
-            uint64_t restoredChecksum = restoredModel->checksum(false);
+            std::uint64_t restoredChecksum = restoredModel->checksum(false);
             LOG_DEBUG(<< "restored checksum = " << restoredChecksum);
             BOOST_REQUIRE_EQUAL(origChecksum, restoredChecksum);
             BOOST_REQUIRE_EQUAL(origXml, newXml);
@@ -2341,11 +2341,11 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
     const maths::common::CModel* mathsModelWithSkip =
         modelWithSkipView->model(model_t::E_IndividualMeanByPerson, 0);
     BOOST_TEST_REQUIRE(mathsModelWithSkip != nullptr);
-    uint64_t withSkipChecksum = mathsModelWithSkip->checksum();
+    std::uint64_t withSkipChecksum = mathsModelWithSkip->checksum();
     const maths::common::CModel* mathsModelNoSkip =
         modelNoSkipView->model(model_t::E_IndividualMeanByPerson, 0);
     BOOST_TEST_REQUIRE(mathsModelNoSkip != nullptr);
-    uint64_t noSkipChecksum = mathsModelNoSkip->checksum();
+    std::uint64_t noSkipChecksum = mathsModelNoSkip->checksum();
     BOOST_TEST_REQUIRE(withSkipChecksum != noSkipChecksum);
 
     // Check the last value times of the underlying models are the same

--- a/lib/model/unittest/CMetricPopulationDataGathererTest.cc
+++ b/lib/model/unittest/CMetricPopulationDataGathererTest.cc
@@ -655,11 +655,11 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
     // people are removed.
 
     using TSizeVec = std::vector<std::size_t>;
-    using TSizeUInt64Pr = std::pair<std::size_t, uint64_t>;
+    using TSizeUInt64Pr = std::pair<std::size_t, std::uint64_t>;
     using TSizeUInt64PrVec = std::vector<TSizeUInt64Pr>;
     using TStrFeatureDataPr = std::pair<std::string, SMetricFeatureData>;
     using TStrFeatureDataPrVec = std::vector<TStrFeatureDataPr>;
-    using TStrSizeMap = std::map<std::string, uint64_t>;
+    using TStrSizeMap = std::map<std::string, std::uint64_t>;
 
     const core_t::TTime startTime = 1367280000;
     const core_t::TTime bucketLength = 3600;

--- a/lib/model/unittest/CMetricPopulationModelTest.cc
+++ b/lib/model/unittest/CMetricPopulationModelTest.cc
@@ -1275,8 +1275,8 @@ BOOST_FIXTURE_TEST_CASE(testIgnoreSamplingGivenDetectionRules, CTestFixture) {
 
     // This time we expect the model checksums to differ because of the
     // different weightings applied to the samples for attribute c4
-    uint64_t withSkipChecksum = modelWithSkip->checksum();
-    uint64_t noSkipChecksum = modelNoSkip->checksum();
+    std::uint64_t withSkipChecksum = modelWithSkip->checksum();
+    std::uint64_t noSkipChecksum = modelNoSkip->checksum();
     BOOST_TEST_REQUIRE(withSkipChecksum != noSkipChecksum);
 
     // expect models for attributes c0 - c4

--- a/lib/model/unittest/CModelTestFixtureBase.h
+++ b/lib/model/unittest/CModelTestFixtureBase.h
@@ -63,7 +63,7 @@ public:
     using TOptionalDoubleVec = std::vector<TOptionalDouble>;
     using TOptionalStr = boost::optional<std::string>;
     using TOptionalUInt = boost::optional<unsigned int>;
-    using TOptionalUInt64 = boost::optional<uint64_t>;
+    using TOptionalUInt64 = boost::optional<std::uint64_t>;
 
     using TPriorPtr = std::shared_ptr<ml::maths::common::CPrior>;
 
@@ -72,7 +72,7 @@ public:
     using TSizeSizePr = std::pair<std::size_t, std::size_t>;
     using TSizeSizePrVec = std::vector<TSizeSizePr>;
     using TSizeSizePrVecVec = std::vector<TSizeSizePrVec>;
-    using TSizeSizePrUInt64Map = std::map<TSizeSizePr, uint64_t>;
+    using TSizeSizePrUInt64Map = std::map<TSizeSizePr, std::uint64_t>;
     using TSizeVec = std::vector<std::size_t>;
     using TSizeVecVec = std::vector<TSizeVec>;
     using TSizeVecVecVec = std::vector<TSizeVecVec>;
@@ -80,7 +80,7 @@ public:
     using TStrSizePrVec = std::vector<TStrSizePr>;
     using TStrSizePrVecVec = std::vector<TStrSizePrVec>;
     using TStrSizePrVecVecVec = std::vector<TStrSizePrVecVec>;
-    using TStrUInt64Map = std::map<std::string, uint64_t>;
+    using TStrUInt64Map = std::map<std::string, std::uint64_t>;
 
     using TStrVec = std::vector<std::string>;
     using TStrVecVec = std::vector<TStrVec>;
@@ -92,7 +92,7 @@ public:
     using TTimeStrVecPrVec = std::vector<TTimeStrVecPr>;
     using TTimeVec = std::vector<ml::core_t::TTime>;
 
-    using TUInt64Vec = std::vector<uint64_t>;
+    using TUInt64Vec = std::vector<std::uint64_t>;
     using TUIntVec = std::vector<unsigned int>;
 
 protected:

--- a/lib/model/unittest/Mocks.cc
+++ b/lib/model/unittest/Mocks.cc
@@ -122,7 +122,7 @@ bool CMockModel::computeTotalProbability(const std::string& /*person*/,
     return false;
 }
 
-uint64_t CMockModel::checksum(bool /*includeCurrentBucketStats*/) const {
+std::uint64_t CMockModel::checksum(bool /*includeCurrentBucketStats*/) const {
     return 0;
 }
 

--- a/lib/model/unittest/Mocks.h
+++ b/lib/model/unittest/Mocks.h
@@ -91,7 +91,7 @@ public:
                                  TOptionalDouble& probability,
                                  TAttributeProbability1Vec& attributeProbabilities) const override;
 
-    uint64_t checksum(bool includeCurrentBucketStats = true) const override;
+    std::uint64_t checksum(bool includeCurrentBucketStats = true) const override;
 
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override;
 

--- a/lib/seccomp/CSystemCallFilter_Windows.cc
+++ b/lib/seccomp/CSystemCallFilter_Windows.cc
@@ -49,7 +49,7 @@ void CSystemCallFilter::installSystemCallFilter() {
 
     // Limit the number of active processes to 1 and
     // flag that the limit is set
-    limits.ActiveProcessLimit = uint32_t{1};
+    limits.ActiveProcessLimit = std::uint32_t{1};
     limits.LimitFlags = limits.LimitFlags | JOB_OBJECT_LIMIT_ACTIVE_PROCESS;
     if (SetInformationJobObject(job, JobObjectBasicLimitInformation, &limits,
                                 sizeof(limits)) == 0) {


### PR DESCRIPTION
Now we're running clang tidy on the codebase we plan to gradually address its suggestions. One is to migrate our uses of `stdint.h` to `cstdint`, which is more idiomatic C++. In conjunction with this change we are only guaranteed that types are defined in the `std::` namespace.