### PR TITLE
[8.3] [ML] Upgrade libxml2 to version 2.9.14

### DIFF
--- a/3rd_party/licenses/libxml2-INFO.csv
+++ b/3rd_party/licenses/libxml2-INFO.csv
@@ -1,2 +1,2 @@
 name,version,revision,url,license,copyright,sourceURL
-Libxml2,2.9.7,,http://xmlsoft.org/,MIT,Copyright (C) 1998-2012 Daniel Veillard,
+Libxml2,2.9.14,7846b0a677f8d3ce72486125fa281e92ac9970e8,http://xmlsoft.org/,MIT,Copyright (C) 1998-2012 Daniel Veillard,

--- a/build-setup/linux.md
+++ b/build-setup/linux.md
@@ -24,10 +24,10 @@ export CPP_SRC_HOME=$HOME/ml-cpp
 
 ### OS Packages
 
-You need the C++ compiler and the headers for the `zlib` library that comes with the OS.  You also need the archive utilities `unzip` and `bzip2`. `libffi-devel` and `openssl-devel` are dependencies for building PyTorch. Finally, the unit tests for date/time parsing require the `tzdata` package that contains the Linux timezone database.  On RHEL/CentOS these can be installed using:
+You need the C++ compiler and the headers for the `zlib` library that comes with the OS.  You also need the archive utilities `unzip`, `bzip2` and `xz`. `libffi-devel` and `openssl-devel` are dependencies for building PyTorch. Finally, the unit tests for date/time parsing require the `tzdata` package that contains the Linux timezone database.  On RHEL/CentOS these can be installed using:
 
 ```
-sudo yum install bzip2 gcc-c++ libffi-devel openssl-devel texinfo tzdata unzip zlib-devel
+sudo yum install bzip2 gcc-c++ libffi-devel openssl-devel texinfo tzdata unzip xz zlib-devel
 ```
 
 On other Linux distributions the package names are generally the same and you just need to use the correct package manager to install these packages.
@@ -154,7 +154,7 @@ Without the `prefix=/usr` bit, you'll end up with a personal Git build in `~/bin
 
 ### libxml2
 
-Anonymous FTP to ftp.xmlsoft.org, change directory to libxml2, switch to binary mode, and get `libxml2-2.9.7.tar.gz`.
+Download `libxml2-2.9.14.tar.xz` from <https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.14.tar.xz>.
 
 Uncompress and untar the resulting file. Then run:
 

--- a/build-setup/windows.md
+++ b/build-setup/windows.md
@@ -101,16 +101,16 @@ All the build output will end up in the top level `C:\tools\zlib-1.2.12` directo
 
 ### libxml2
 
-Download `libxml2-2.9.7.tar.bz2` from <ftp://xmlsoft.org/libxml2/> .
+Download `libxml2-2.9.14.tar.xz` from <https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.14.tar.xz>.
 
 Extract it in a Git bash shell using the GNU tar that comes with Git for Windows, e.g.:
 
 ```
 cd /c/tools
-tar jxvf /z/cpp_src/libxml2-2.9.7.tar.bz2
+tar Jxvf /z/cpp_src/libxml2-2.9.14.tar.xz
 ```
 
-Edit `C:\tools\libxml2-2.9.7\win32\Makefile.msvc` and change the following lines:
+Edit `C:\tools\libxml2-2.9.14\win32\Makefile.msvc` and change the following lines:
 
 ```
 CFLAGS = $(CFLAGS) /D "NDEBUG" /O2
@@ -127,7 +127,7 @@ CFLAGS = $(CFLAGS) /D "NDEBUG" /O2 /Zi /D_WIN32_WINNT=0x0601
 Start a command prompt using Start Menu -&gt; Apps -&gt; Visual Studio 2019 -&gt; x64 Native Tools Command Prompt for VS 2019, then in it type:
 
 ```
-cd \tools\libxml2-2.9.7\win32
+cd \tools\libxml2-2.9.14\win32
 cscript configure.js iconv=no prefix=C:\usr\local
 nmake
 nmake install

--- a/dev-tools/docker/build_linux_aarch64_cross_build_image.sh
+++ b/dev-tools/docker/build_linux_aarch64_cross_build_image.sh
@@ -22,7 +22,7 @@
 HOST=docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-linux-aarch64-cross-build
-VERSION=7
+VERSION=8
 
 set -e
 

--- a/dev-tools/docker/build_linux_aarch64_native_build_image.sh
+++ b/dev-tools/docker/build_linux_aarch64_native_build_image.sh
@@ -25,7 +25,7 @@ if [ `uname -m` != aarch64 ] ; then
     exit 1
 fi
 
-DOCKER_DIR=`docker info 2>/dev/null | grep '^Docker Root Dir' | awk -F: '{ print $2 }' | sed 's/^ *//'`
+DOCKER_DIR=`docker info 2>/dev/null | grep '^ *Docker Root Dir' | awk -F: '{ print $2 }' | sed 's/^ *//'`
 echo "Building this image may require up to 50GB of space for Docker"
 echo "Current space available in $DOCKER_DIR"
 df -h "$DOCKER_DIR"
@@ -34,7 +34,7 @@ sleep 5
 HOST=docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-linux-aarch64-native-build
-VERSION=7
+VERSION=8
 
 set -e
 

--- a/dev-tools/docker/build_linux_build_image.sh
+++ b/dev-tools/docker/build_linux_build_image.sh
@@ -25,7 +25,7 @@ if [ `uname -m` != x86_64 ] ; then
     exit 1
 fi
 
-DOCKER_DIR=`docker info 2>/dev/null | grep '^Docker Root Dir' | awk -F: '{ print $2 }' | sed 's/^ *//'`
+DOCKER_DIR=`docker info 2>/dev/null | grep '^ *Docker Root Dir' | awk -F: '{ print $2 }' | sed 's/^ *//'`
 echo "Building this image may require up to 50GB of space for Docker"
 echo "Current space available in $DOCKER_DIR"
 df -h "$DOCKER_DIR"
@@ -34,7 +34,7 @@ sleep 5
 HOST=docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-linux-build
-VERSION=22
+VERSION=23
 
 set -e
 

--- a/dev-tools/docker/linux_aarch64_cross_builder/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_cross_builder/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-aarch64-cross-build:7
+FROM docker.elastic.co/ml-dev/ml-linux-aarch64-cross-build:8
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_aarch64_cross_image/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_cross_image/Dockerfile
@@ -24,7 +24,7 @@ RUN \
 RUN \
   mkdir -p /usr/local/sysroot-aarch64-linux-gnu/usr && \
   cd /usr/local/sysroot-aarch64-linux-gnu/usr && \
-  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/usr-aarch64-linux-gnu-7.tar.bz2 | tar jxf - && \
+  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/usr-aarch64-linux-gnu-8.tar.bz2 | tar jxf - && \
   cd .. && \
   ln -s usr/lib lib && \
   ln -s usr/lib64 lib64

--- a/dev-tools/docker/linux_aarch64_native_builder/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_builder/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-aarch64-native-build:7
+FROM docker.elastic.co/ml-dev/ml-linux-aarch64-native-build:8
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_aarch64_native_image/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_image/Dockerfile
@@ -18,7 +18,7 @@ MAINTAINER David Roberts <dave.roberts@elastic.co>
 # Make sure OS packages are up to date and required packages are installed
 RUN \
   rm /var/lib/rpm/__db.* && \
-  yum install -y bzip2 gcc gcc-c++ git libffi-devel make openssl-devel texinfo unzip wget which zip zlib-devel
+  yum install -y bzip2 gcc gcc-c++ git libffi-devel make openssl-devel texinfo unzip wget which xz zip zlib-devel
 
 # For compiling with hardening and optimisation
 ENV CFLAGS "-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2 -march=armv8-a+crc+crypto"
@@ -63,13 +63,13 @@ RUN \
 # Build libxml2
 RUN \
   cd ${build_dir} && \
-  wget --quiet -O - ftp://anonymous@ftp.xmlsoft.org/libxml2/libxml2-2.9.7.tar.gz | tar zxf - && \
-  cd libxml2-2.9.7 && \
+  wget --quiet --no-check-certificate -O - https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.14.tar.xz | tar Jxf - && \
+  cd libxml2-2.9.14 && \
   ./configure --prefix=/usr/local/gcc103 --without-python --without-readline && \
   make -j`nproc` && \
   make install && \
   cd .. && \
-  rm -rf libxml2-2.9.7
+  rm -rf libxml2-2.9.14
 
 # Build Boost
 RUN \

--- a/dev-tools/docker/linux_aarch64_native_tester/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_tester/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-aarch64-native-build:7
+FROM docker.elastic.co/ml-dev/ml-linux-aarch64-native-build:8
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_builder/Dockerfile
+++ b/dev-tools/docker/linux_builder/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-build:22
+FROM docker.elastic.co/ml-dev/ml-linux-build:23
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -19,7 +19,7 @@ MAINTAINER David Roberts <dave.roberts@elastic.co>
 # libffi and openssl are required for building Python
 RUN \
   rm /var/lib/rpm/__db.* && \
-  yum install -y bzip2 gcc gcc-c++ git libffi-devel make openssl-devel texinfo unzip wget which zip zlib-devel
+  yum install -y bzip2 gcc gcc-c++ git libffi-devel make openssl-devel texinfo unzip wget which xz zip zlib-devel
 
 # For compiling with hardening and optimisation
 ENV CFLAGS "-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2 -msse4.2 -mfpmath=sse"
@@ -64,13 +64,13 @@ RUN \
 # Build libxml2
 RUN \
   cd ${build_dir} && \
-  wget --quiet -O - ftp://anonymous@ftp.xmlsoft.org/libxml2/libxml2-2.9.7.tar.gz | tar zxf - && \
-  cd libxml2-2.9.7 && \
+  wget --quiet --no-check-certificate -O - https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.14.tar.xz | tar Jxf - && \
+  cd libxml2-2.9.14 && \
   ./configure --prefix=/usr/local/gcc103 --without-python --without-readline && \
   make -j`nproc` && \
   make install && \
   cd .. && \
-  rm -rf libxml2-2.9.7
+  rm -rf libxml2-2.9.14
 
 # Build Boost
 RUN \

--- a/dev-tools/docker/linux_tester/Dockerfile
+++ b/dev-tools/docker/linux_tester/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-build:22
+FROM docker.elastic.co/ml-dev/ml-linux-build:23
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/download_windows_deps.ps1
+++ b/dev-tools/download_windows_deps.ps1
@@ -9,11 +9,11 @@
 # limitation.
 #
 $ErrorActionPreference="Stop"
-$Archive="usr-x86_64-windows-2016-7.zip"
+$Archive="usr-x86_64-windows-2016-8.zip"
 $Destination="C:\"
-# If zlib is not version 1.2.12 then we need the latest download
-if (!(Test-Path "$Destination\usr\local\include\zlib.h") -Or
-    !(Select-String -Path "$Destination\usr\local\include\zlib.h" -Pattern "0x12c0" -Quiet)) {
+# If libxml2 is not version 2.9.14 then we need the latest download
+if (!(Test-Path "$Destination\usr\local\include\libxml2\libxml\xmlversion.h") -Or
+    !(Select-String -Path "$Destination\usr\local\include\libxml2\libxml\xmlversion.h" -Pattern "2.9.14" -Quiet)) {
     Remove-Item "$Destination\usr" -Recurse -Force -ErrorAction Ignore
     $ZipSource="https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/$Archive"
     $ZipDestination="$Env:TEMP\$Archive"

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@
 * Upgrade PyTorch to version 1.11. (See {ml-pull}2233[#2233], {ml-pull}2235[#2235]
   and {ml-pull}2238[#2238].)
 * Upgrade zlib to version 1.2.12 on Windows. (See {ml-pull}2253[#2253].)
+* Upgrade libxml2 to version 2.9.14 on Linux and Windows. (See {ml-pull}2287[#2287].)
 * Improve time series model stability and anomaly scoring consistency for data
   for which many buckets are empty. (See {ml-pull}2267[#2267].)
 * Address root cause for actuals equals typical equals zero anomalies. (See {ml-pull}2270[#2270].)


### PR DESCRIPTION
Upgrades libxml2 to version 2.9.14 on Linux and Windows.

(On macOS, as before, we use the libxml2 that ships with the OS.)

Backport of #2287