### PR TITLE
[ML] More efficient predictions and fix flaky test

### DIFF
--- a/include/maths/analytics/CBoostedTreeFactory.h
+++ b/include/maths/analytics/CBoostedTreeFactory.h
@@ -264,6 +264,9 @@ private:
     //! Resize the data frame with the extra columns used by incremental train.
     void prepareDataFrameForIncrementalTrain(core::CDataFrame& frame) const;
 
+    //! Resize the data frame with the extra columns used by prediction.
+    void prepareDataFrameForPredict(core::CDataFrame& frame) const;
+
     //! Set up cross validation.
     void initializeCrossValidation(core::CDataFrame& frame) const;
 

--- a/include/maths/analytics/CBoostedTreeUtils.h
+++ b/include/maths/analytics/CBoostedTreeUtils.h
@@ -126,6 +126,16 @@ inline TSizeAlignmentPrVec extraColumnsForIncrementalTrain(std::size_t numberLos
     return {{numberLossParameters, core::CAlignment::E_Unaligned}};
 }
 
+//! Get the extra columns needed for prediction.
+inline TSizeAlignmentPrVec extraColumnsForPredict(std::size_t numberLossParameters) {
+    return {{numberLossParameters, core::CAlignment::E_Unaligned}}; // prediction
+}
+
+//! Get the tags for extra columns needed for prediction.
+inline TSizeVec extraColumnTagsForPredict() {
+    return {E_Prediction};
+}
+
 //! Read the prediction from \p row.
 inline TMemoryMappedFloatVector readPrediction(const TRowRef& row,
                                                const TSizeVec& extraColumns,

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -155,6 +155,7 @@ CBoostedTreeFactory::buildForTrain(core::CDataFrame& frame, std::size_t dependen
     skipIfAfter(CBoostedTreeImpl::E_EncodingInitialized, [&] {
         this->initializeMissingFeatureMasks(frame);
         this->initializeNumberFolds(frame);
+        // There are only "old" training examples for the initial train.
         if (frame.numberRows() > m_TreeImpl->m_NewTrainingRowMask.size()) {
             m_TreeImpl->m_NewTrainingRowMask.extend(
                 false, frame.numberRows() - m_TreeImpl->m_NewTrainingRowMask.size());
@@ -256,16 +257,7 @@ CBoostedTreeFactory::buildForPredict(core::CDataFrame& frame, std::size_t depend
 
     m_TreeImpl->m_DependentVariable = dependentVariable;
 
-    skipIfAfter(CBoostedTreeImpl::E_NotInitialized, [&] {
-        this->initializeMissingFeatureMasks(frame);
-        if (frame.numberRows() > m_TreeImpl->m_NewTrainingRowMask.size()) {
-            // We assume any additional rows are new examples.
-            m_TreeImpl->m_NewTrainingRowMask.extend(
-                true, frame.numberRows() - m_TreeImpl->m_NewTrainingRowMask.size());
-        }
-    });
-
-    this->prepareDataFrameForTrain(frame);
+    this->prepareDataFrameForPredict(frame);
 
     skipIfAfter(CBoostedTreeImpl::E_NotInitialized, [&] {
         this->determineFeatureDataTypes(frame);
@@ -425,8 +417,8 @@ void CBoostedTreeFactory::initializeNumberFolds(core::CDataFrame& frame) const {
 void CBoostedTreeFactory::prepareDataFrameForEncode(core::CDataFrame& frame) const {
 
     std::size_t rowWeightColumn{UNIT_ROW_WEIGHT_COLUMN};
-    const auto& columnNames = frame.columnNames();
     if (m_RowWeightColumnName.empty() == false) {
+        const auto& columnNames = frame.columnNames();
         auto column = std::find(columnNames.begin(), columnNames.end(), m_RowWeightColumnName);
         if (column == columnNames.end()) {
             HANDLE_FATAL(<< "Input error: unrecognised row weight field name '"
@@ -443,8 +435,8 @@ void CBoostedTreeFactory::prepareDataFrameForEncode(core::CDataFrame& frame) con
 void CBoostedTreeFactory::prepareDataFrameForTrain(core::CDataFrame& frame) const {
 
     std::size_t rowWeightColumn{UNIT_ROW_WEIGHT_COLUMN};
-    const auto& columnNames = frame.columnNames();
     if (m_RowWeightColumnName.empty() == false) {
+        const auto& columnNames = frame.columnNames();
         auto column = std::find(columnNames.begin(), columnNames.end(), m_RowWeightColumnName);
         if (column == columnNames.end()) {
             HANDLE_FATAL(<< "Input error: unrecognised row weight field name '"
@@ -461,6 +453,30 @@ void CBoostedTreeFactory::prepareDataFrameForTrain(core::CDataFrame& frame) cons
     std::tie(extraColumns, paddedExtraColumns) = frame.resizeColumns(
         m_TreeImpl->m_NumberThreads, extraColumnsForTrain(numberLossParameters));
     auto extraColumnTags = extraColumnTagsForTrain();
+    m_TreeImpl->m_ExtraColumns.resize(NUMBER_EXTRA_COLUMNS);
+    for (std::size_t i = 0; i < extraColumns.size(); ++i) {
+        m_TreeImpl->m_ExtraColumns[extraColumnTags[i]] = extraColumns[i];
+    }
+    m_TreeImpl->m_ExtraColumns[E_Weight] = rowWeightColumn;
+    m_PaddedExtraColumns += paddedExtraColumns;
+
+    std::size_t newFrameMemory{core::CMemory::dynamicSize(frame)};
+    m_TreeImpl->m_Instrumentation->updateMemoryUsage(newFrameMemory - oldFrameMemory);
+    m_TreeImpl->m_Instrumentation->flush();
+}
+
+void CBoostedTreeFactory::prepareDataFrameForPredict(core::CDataFrame& frame) const {
+
+    std::size_t rowWeightColumn{UNIT_ROW_WEIGHT_COLUMN};
+
+    // Extend the frame with the bookkeeping columns used in train.
+    std::size_t oldFrameMemory{core::CMemory::dynamicSize(frame)};
+    TSizeVec extraColumns;
+    std::size_t paddedExtraColumns;
+    std::size_t numberLossParameters{m_TreeImpl->m_Loss->numberParameters()};
+    std::tie(extraColumns, paddedExtraColumns) = frame.resizeColumns(
+        m_TreeImpl->m_NumberThreads, extraColumnsForPredict(numberLossParameters));
+    auto extraColumnTags = extraColumnTagsForPredict();
     m_TreeImpl->m_ExtraColumns.resize(NUMBER_EXTRA_COLUMNS);
     for (std::size_t i = 0; i < extraColumns.size(); ++i) {
         m_TreeImpl->m_ExtraColumns[extraColumnTags[i]] = extraColumns[i];


### PR DESCRIPTION
This changes the way we set up the data frame for prediction since it doesn't need to cache loss derivatives. It also reworks the test for adding trees in incremental training. In particular, it corrects measuring the accuracy on the hold out set using the corrected loss used for selecting the best model and prepares the hold data set more carefully to mix in out of domain data.

Closes #2271.