### PR TITLE
[ML] Memory management for incremental training

### DIFF
--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -61,6 +61,7 @@ public:
     static const std::string FEATURE_BAG_FRACTION;
     static const std::string PREDICTION_CHANGE_COST;
     static const std::string TREE_TOPOLOGY_CHANGE_PENALTY;
+    static const std::string TRAINED_MODEL_MEMORY_USAGE;
     static const std::string NUM_FOLDS;
     static const std::string TRAIN_FRACTION_PER_FOLD;
     static const std::string NUM_HOLDOUT_ROWS;
@@ -174,6 +175,7 @@ private:
     std::string m_PredictionFieldName;
     double m_TrainingPercent;
     std::size_t m_NumberLossParameters{0};
+    std::size_t m_TrainedModelMemoryUsage{0};
     TBoostedTreeFactoryUPtr m_BoostedTreeFactory;
     TBoostedTreeUPtr m_BoostedTree;
     CDataFrameTrainBoostedTreeInstrumentation m_Instrumentation;

--- a/include/api/CInferenceModelMetadata.h
+++ b/include/api/CInferenceModelMetadata.h
@@ -56,6 +56,7 @@ public:
     static const std::string JSON_RELATIVE_IMPORTANCE_TAG;
     static const std::string JSON_TOTAL_FEATURE_IMPORTANCE_TAG;
     static const std::string JSON_TRAIN_PROPERTIES_TAG;
+    static const std::string JSON_TRAINED_MODEL_MEMORY_USAGE_TAG;
 
 public:
     using TVector = maths::common::CDenseVector<double>;
@@ -86,6 +87,8 @@ public:
     void lossGap(double lossGap);
     //! Set the number of rows in the training data summarization.
     void numDataSummarizationRows(std::size_t numRows);
+    //! Set the trained model memory usage.
+    void trainedModelMemoryUsage(std::size_t memoryUsage);
 
 private:
     struct SHyperparameterImportance {
@@ -127,6 +130,7 @@ private:
     std::size_t m_NumTrainRows{0};
     double m_LossGap{0.0};
     std::size_t m_NumDataSummarizationRows{0};
+    std::size_t m_TrainedModelMemoryUsage{0};
 };
 }
 }

--- a/include/core/CDataFrame.h
+++ b/include/core/CDataFrame.h
@@ -628,7 +628,7 @@ private:
     //! True if the data frame resides in main memory.
     bool m_InMainMemory;
     //! The number of rows in the data frame.
-    std::size_t m_NumberRows = 0;
+    std::size_t m_NumberRows{0};
     //! The number of columns in the data frame.
     std::size_t m_NumberColumns;
     //! The number of columns a row could contain. This is greater than or
@@ -661,9 +661,9 @@ private:
 
     //! \name Parse Counters
     //@{
-    std::uint64_t m_MissingValueCount = 0;
-    std::uint64_t m_BadValueCount = 0;
-    std::uint64_t m_BadDocHashCount = 0;
+    std::uint64_t m_MissingValueCount{0};
+    std::uint64_t m_BadValueCount{0};
+    std::uint64_t m_BadDocHashCount{0};
     //@}
 
     //! The stored slices.

--- a/include/maths/analytics/CBoostedTreeFactory.h
+++ b/include/maths/analytics/CBoostedTreeFactory.h
@@ -202,18 +202,32 @@ public:
     //! Set the callback function for training state recording.
     CBoostedTreeFactory& trainingStateCallback(TTrainingStateCallback callback);
 
-    //! Estimate the maximum booking memory that training a boosted tree on a data
-    //! frame with \p numberRows row and \p numberColumns columns will use.
+    //! Estimate the maximum booking memory used computing encodings for a
+    //! frame with \p numberRows, \p numberColumns and \p numberCategoricalColumns.
+    std::size_t estimateMemoryUsageForEncode(std::size_t numberRows,
+                                             std::size_t numberColumns,
+                                             std::size_t numberCategoricalColumns) const;
+    //! Estimate the maximum booking memory used training a model on a data frame
+    //! with \p numberRows and \p numberColumns.
     std::size_t estimateMemoryUsageForTrain(std::size_t numberRows,
                                             std::size_t numberColumns) const;
-    //! Estimate the maximum booking memory that incrementally training a boosted
-    //! tree on a data frame with \p numberRows row and \p numberColumns columns
-    //! will use.
+    //! Estimate the maximum booking memory used incrementally training a model
+    //! on a data frame with \p numberRows and \p numberColumns.
     std::size_t estimateMemoryUsageForTrainIncremental(std::size_t numberRows,
                                                        std::size_t numberColumns) const;
+    //! Estimate the maximum booking memory that predicting values from a model
+    //! will use.
+    std::size_t estimateMemoryUsageForPredict() const;
+    //! Estimate the number of columns computing encodings will add to the data frame.
+    static std::size_t estimateExtraColumnsForEncode();
     //! Estimate the number of columns training the model will add to the data frame.
     static std::size_t estimateExtraColumnsForTrain(std::size_t numberColumns,
                                                     std::size_t numberLossParameters);
+    //! Estimate the number of columns updating the model will add to the data frame.
+    static std::size_t estimateExtraColumnsForTrainIncremental(std::size_t numberColumns,
+                                                               std::size_t numberLossParameters);
+    //! Estimate the number of columns predicting the model will add to the data frame.
+    static std::size_t estimateExtraColumnsForPredict(std::size_t numberLossParameters);
 
     //! Build a boosted tree object for encoding on \p frame.
     TBoostedTreeUPtr buildForEncode(core::CDataFrame& frame, std::size_t dependentVariable);

--- a/include/maths/analytics/CBoostedTreeFactory.h
+++ b/include/maths/analytics/CBoostedTreeFactory.h
@@ -215,9 +215,10 @@ public:
     //! on a data frame with \p numberRows and \p numberColumns.
     std::size_t estimateMemoryUsageForTrainIncremental(std::size_t numberRows,
                                                        std::size_t numberColumns) const;
-    //! Estimate the maximum booking memory that predicting values from a model
-    //! will use.
-    std::size_t estimateMemoryUsageForPredict() const;
+    //! Estimate the maximum booking memory used when predicting a model on a data
+    //! frame with \p numberRows and \p numberColumns.
+    std::size_t estimateMemoryUsageForPredict(std::size_t numberRows,
+                                              std::size_t numberColumns) const;
     //! Estimate the number of columns computing encodings will add to the data frame.
     static std::size_t estimateExtraColumnsForEncode();
     //! Estimate the number of columns training the model will add to the data frame.

--- a/include/maths/analytics/CBoostedTreeImpl.h
+++ b/include/maths/analytics/CBoostedTreeImpl.h
@@ -41,10 +41,11 @@
 #include <utility>
 #include <vector>
 
+class CBoostedTreeImplForTest;
+
 namespace ml {
 namespace maths {
 namespace analytics {
-class CBoostedTreeImplForTest;
 class CTreeShapFeatureImportance;
 namespace boosted_tree {
 class CArgMinLoss;
@@ -144,18 +145,15 @@ public:
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;
 
-    //! Estimate the maximum booking memory that training a boosted tree on a data
-    //! frame with \p numberRows row and \p numberColumns columns will use.
-    std::size_t estimateMemoryUsageTrain(std::size_t numberRows, std::size_t numberColumns) const;
+    //! Estimate the maximum booking memory that train on a data frame with
+    //! \p numberRows rows and \p numberColumns columns will use.
+    std::size_t estimateMemoryUsageForTrain(std::size_t numberRows,
+                                            std::size_t numberColumns) const;
 
-    //! Estimate the maximum booking memory that incrementally training a boosted
-    //! tree on a data frame with \p numberRows row and \p numberColumns columns
-    //! will use.
-    std::size_t estimateMemoryUsageTrainIncremental(std::size_t numberRows,
-                                                    std::size_t numberColumns) const;
-
-    //! Correct from worst case memory usage to a more realistic estimate.
-    static std::size_t correctedMemoryUsage(double memoryUsageBytes);
+    //! Estimate the maximum booking memory that trainIncremental on a data frame
+    //! with \p numberRows rows and \p numberColumns columns will use.
+    std::size_t estimateMemoryUsageForTrainIncremental(std::size_t numberRows,
+                                                       std::size_t numberColumns) const;
 
     //! Persist by passing information to \p inserter.
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
@@ -459,6 +457,14 @@ private:
     //! Record hyperparameters for instrumentation.
     void recordHyperparameters();
 
+    //! Estimate the memory usage for training (either from scratch or incremental).
+    std::size_t estimateMemoryUsageForTraining(std::size_t numberRows,
+                                               std::size_t numberColumns,
+                                               std::size_t numberTrees) const;
+
+    //! Correct from worst case memory usage to a more realistic estimate.
+    static std::size_t correctedMemoryUsageForTraining(double memoryUsageBytes);
+
 private:
     //! \name Parameters
     //@{
@@ -534,7 +540,7 @@ private:
 private:
     friend class CBoostedTreeFactory;
     friend class CBoostedTreeHyperparameters;
-    friend class CBoostedTreeImplForTest;
+    friend class ::CBoostedTreeImplForTest;
 };
 }
 }

--- a/include/maths/analytics/CBoostedTreeImpl.h
+++ b/include/maths/analytics/CBoostedTreeImpl.h
@@ -155,6 +155,11 @@ public:
     std::size_t estimateMemoryUsageForTrainIncremental(std::size_t numberRows,
                                                        std::size_t numberColumns) const;
 
+    //! Estimate the maximum booking memory that predict on a data frame with
+    //! \p numberRows rows and \p numberColumns columns will use.
+    std::size_t estimateMemoryUsageForPredict(std::size_t numberRows,
+                                              std::size_t numberColumns) const;
+
     //! Persist by passing information to \p inserter.
     void acceptPersistInserter(core::CStatePersistInserter& inserter) const;
 

--- a/include/maths/analytics/CBoostedTreeUtils.h
+++ b/include/maths/analytics/CBoostedTreeUtils.h
@@ -123,7 +123,7 @@ inline TSizeVec extraColumnTagsForIncrementalTrain() {
 
 //! Get the extra columns needed by incremental training.
 inline TSizeAlignmentPrVec extraColumnsForIncrementalTrain(std::size_t numberLossParameters) {
-    return {{numberLossParameters, core::CAlignment::E_Unaligned}};
+    return {{numberLossParameters, core::CAlignment::E_Unaligned}}; // previous prediction
 }
 
 //! Get the extra columns needed for prediction.

--- a/include/maths/analytics/CDataFrameCategoryEncoder.h
+++ b/include/maths/analytics/CDataFrameCategoryEncoder.h
@@ -344,6 +344,14 @@ public:
     //! Make the encoding.
     virtual TEncodingUPtrVec makeEncodings();
 
+    //! Get the memory used by this object.
+    std::size_t memoryUsage() const;
+
+    //! Estimate the memory that selecting encoding will require.
+    static std::size_t estimateMemoryUsage(std::size_t numberRows,
+                                           std::size_t numberColumns,
+                                           std::size_t numberCategoricalColumns);
+
     //! \name Test Methods
     //@{
     //! Get the encoding offset in feature vector of \p index.
@@ -369,6 +377,7 @@ private:
     using TSizeUSetVec = std::vector<TSizeUSet>;
 
 private:
+    CMakeDataFrameCategoryEncoder() = default;
     TEncodingUPtrVec readEncodings() const;
     TSizeDoublePrVecVec mics(const CDataFrameUtils::CColumnValue& target,
                              const TSizeVec& metricColumnMask,
@@ -384,12 +393,12 @@ private:
 
 private:
     // Begin parameters
-    std::size_t m_MinimumRowsPerFeature = MINIMUM_ROWS_PER_FEATURE;
-    double m_MinimumFrequencyToOneHotEncode = MINIMUM_FREQUENCY_TO_ONE_HOT_ENCODE;
-    double m_MinimumRelativeMicToSelectFeature = MINIMUM_RELATIVE_MIC_TO_SELECT_FEATURE;
-    double m_RedundancyWeight = REDUNDANCY_WEIGHT;
-    std::size_t m_NumberThreads;
-    const core::CDataFrame* m_Frame;
+    std::size_t m_MinimumRowsPerFeature{MINIMUM_ROWS_PER_FEATURE};
+    double m_MinimumFrequencyToOneHotEncode{MINIMUM_FREQUENCY_TO_ONE_HOT_ENCODE};
+    double m_MinimumRelativeMicToSelectFeature{MINIMUM_RELATIVE_MIC_TO_SELECT_FEATURE};
+    double m_RedundancyWeight{REDUNDANCY_WEIGHT};
+    std::size_t m_NumberThreads{1};
+    const core::CDataFrame* m_Frame{nullptr};
     core::CPackedBitVector m_RowMask;
     TSizeVec m_ColumnMask;
     std::size_t m_TargetColumn;

--- a/include/maths/common/CNaturalBreaksClassifier.h
+++ b/include/maths/common/CNaturalBreaksClassifier.h
@@ -133,9 +133,9 @@ public:
     //! \note This will store as much information about the points
     //! subject to this constraint so will generally hold approximately
     //! \p space tuples.
-    CNaturalBreaksClassifier(std::size_t space,
-                             double decayRate = 0.0,
-                             double minimumCategoryCount = MINIMUM_CATEGORY_COUNT);
+    explicit CNaturalBreaksClassifier(std::size_t space,
+                                      double decayRate = 0.0,
+                                      double minimumCategoryCount = MINIMUM_CATEGORY_COUNT);
 
     //! Create from part of a state document.
     bool acceptRestoreTraverser(const SDistributionRestoreParams& params,
@@ -237,10 +237,10 @@ public:
     //! Get a checksum for this object.
     std::uint64_t checksum(std::uint64_t seed = 0) const;
 
-    //! Get the memory used by this component
+    //! Get the memory used by this object.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const;
 
-    //! Get the memory used by this component
+    //! Get the memory used by this object.
     std::size_t memoryUsage() const;
 
     //! Get the minimum within class total deviation partition

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -14,6 +14,7 @@
 #include <core/CContainerPrinter.h>
 #include <core/CDataFrame.h>
 #include <core/CLogger.h>
+#include <core/CMemory.h>
 #include <core/CRapidJsonConcurrentLineWriter.h>
 
 #include <maths/analytics/CBoostedTree.h>
@@ -353,6 +354,8 @@ CDataFrameTrainBoostedTreeClassifierRunner::inferenceModelMetadata() const {
     m_InferenceModelMetadata.lossGap(this->boostedTree().lossGap());
     m_InferenceModelMetadata.numDataSummarizationRows(static_cast<std::size_t>(
         this->boostedTree().dataSummarization().manhattan()));
+    m_InferenceModelMetadata.trainedModelMemoryUsage(
+        core::CMemory::dynamicSize(this->boostedTree().trainedModel()));
     return m_InferenceModelMetadata;
 }
 

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -568,24 +568,23 @@ std::size_t CDataFrameTrainBoostedTreeRunner::estimateBookkeepingMemoryUsage(
     std::size_t totalNumberRows,
     std::size_t /*partitionNumberRows*/,
     std::size_t numberColumns) const {
+    std::size_t numberTrainingRows{static_cast<std::size_t>(
+        static_cast<double>(totalNumberRows) * m_TrainingPercent + 0.5)};
     switch (m_Task) {
     case E_Encode:
         return m_BoostedTreeFactory->estimateMemoryUsageForEncode(
-            static_cast<std::size_t>(static_cast<double>(totalNumberRows) * m_TrainingPercent + 0.5),
-            numberColumns, this->spec().categoricalFieldNames().size());
+            numberTrainingRows, numberColumns,
+            this->spec().categoricalFieldNames().size());
     case E_Train:
-        return m_BoostedTreeFactory->estimateMemoryUsageForTrain(
-            static_cast<std::size_t>(static_cast<double>(totalNumberRows) * m_TrainingPercent + 0.5),
-            numberColumns);
+        return m_BoostedTreeFactory->estimateMemoryUsageForTrain(numberTrainingRows,
+                                                                 numberColumns);
     case E_Update:
         return m_TrainedModelMemoryUsage +
                m_BoostedTreeFactory->estimateMemoryUsageForTrainIncremental(
-                   static_cast<std::size_t>(
-                       static_cast<double>(totalNumberRows) * m_TrainingPercent + 0.5),
-                   numberColumns);
+                   numberTrainingRows, numberColumns);
     case E_Predict:
-        return m_TrainedModelMemoryUsage +
-               m_BoostedTreeFactory->estimateMemoryUsageForPredict();
+        return m_TrainedModelMemoryUsage + m_BoostedTreeFactory->estimateMemoryUsageForPredict(
+                                               numberTrainingRows, numberColumns);
     }
 }
 

--- a/lib/api/CInferenceModelMetadata.cc
+++ b/lib/api/CInferenceModelMetadata.cc
@@ -197,6 +197,8 @@ void CInferenceModelMetadata::writeTrainProperties(TRapidJsonWriter& writer) con
         writer.Uint64(m_NumTrainRows);
         writer.Key(JSON_LOSS_GAP_TAG);
         writer.Double(m_LossGap);
+        writer.Key(JSON_TRAINED_MODEL_MEMORY_USAGE_TAG);
+        writer.Uint64(m_TrainedModelMemoryUsage);
         writer.EndObject();
     }
 }
@@ -314,6 +316,10 @@ void CInferenceModelMetadata::numDataSummarizationRows(std::size_t numRows) {
     m_NumDataSummarizationRows = numRows;
 }
 
+void CInferenceModelMetadata::trainedModelMemoryUsage(std::size_t memoryUsage) {
+    m_TrainedModelMemoryUsage = memoryUsage;
+}
+
 // clang-format off
 const std::string CInferenceModelMetadata::JSON_ABSOLUTE_IMPORTANCE_TAG{"absolute_importance"};
 const std::string CInferenceModelMetadata::JSON_BASELINE_TAG{"baseline"};
@@ -337,6 +343,7 @@ const std::string CInferenceModelMetadata::JSON_NUM_TRAIN_ROWS_TAG{"num_train_ro
 const std::string CInferenceModelMetadata::JSON_RELATIVE_IMPORTANCE_TAG{"relative_importance"};
 const std::string CInferenceModelMetadata::JSON_TOTAL_FEATURE_IMPORTANCE_TAG{"total_feature_importance"};
 const std::string CInferenceModelMetadata::JSON_TRAIN_PROPERTIES_TAG{"train_properties"};
+const std::string CInferenceModelMetadata::JSON_TRAINED_MODEL_MEMORY_USAGE_TAG{"trained_model_memory_usage"};
 // clang-format on
 }
 }

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -2218,7 +2218,7 @@ BOOST_AUTO_TEST_CASE(testCreationForEncoding) {
     ml::core::CLogger& logger{ml::core::CLogger::instance()};
     logger.reset();
     logger.setLoggingLevel(ml::core::CLogger::E_Error);
-    boost::shared_ptr<std::ostream> logDataSPtr = boost::make_shared<std::stringstream>();
+    auto logDataSPtr = boost::make_shared<std::stringstream>();
     logger.reconfigure(logDataSPtr);
 
     auto makeSpec = [&](std::size_t rows, TDataFrameUPtrTemporaryDirectoryPtrPr& frameAndDirectory,
@@ -2259,12 +2259,11 @@ BOOST_AUTO_TEST_CASE(testCreationForEncoding) {
         TLossFunctionType::E_MseRegression, fieldNames, fieldValues, analyzer, rowsEncode);
     analyzer.handleRecord(fieldNames, {"", "", "", "", "", "", "", "$"});
 
-    TStrVec persistedStates{
-        splitOnNull(std::stringstream{std::move(persistenceStream->str())})};
+    TStrVec persistedStates{splitOnNull(std::stringstream{persistenceStream->str()})};
 
-    BOOST_REQUIRE(persistedStates.size() > 0);
+    BOOST_REQUIRE(persistedStates.empty() == false);
 
-    // pass persisted state as a state to restore from in the new analyzer
+    // Pass persisted state as a state to restore from in the new analyzer.
     std::istringstream lastStateStream{persistedStates[0]};
     TRestoreSearcherSupplier restoreSearcherSupplier{[&lastStateStream]() {
         return std::make_unique<CTestDataSearcher>(lastStateStream.str());
@@ -2281,6 +2280,8 @@ BOOST_AUTO_TEST_CASE(testCreationForEncoding) {
 
     // reset logger for next tests
     logger.reset();
+
+    LOG_DEBUG(<< "messages = '" << logDataSPtr->str() << "'");
 
     // Check that no error messages were logged
     BOOST_TEST_REQUIRE(logDataSPtr->rdbuf()->in_avail() == 0);

--- a/lib/api/unittest/testfiles/model_meta_data/model_meta_data.schema.json
+++ b/lib/api/unittest/testfiles/model_meta_data/model_meta_data.schema.json
@@ -112,6 +112,9 @@
                 },
                 "loss_gap" : {
                     "type" : "number"
+                },
+                "trained_model_memory_usage": {
+                    "type" : "number"
                 }
             },
             "required" : [

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -1630,8 +1630,8 @@ std::size_t
 CBoostedTreeFactory::estimateMemoryUsageForEncode(std::size_t numberRows,
                                                   std::size_t numberColumns,
                                                   std::size_t numberCategoricalColumns) const {
-    return CMakeDataFrameCategoryEncoder::estimateMemoryUsage(
-        numberRows, numberColumns, numberCategoricalColumns);
+    return sizeof(*this) + CMakeDataFrameCategoryEncoder::estimateMemoryUsage(
+                               numberRows, numberColumns, numberCategoricalColumns);
 }
 
 std::size_t CBoostedTreeFactory::estimateMemoryUsageForTrain(std::size_t numberRows,
@@ -1642,7 +1642,7 @@ std::size_t CBoostedTreeFactory::estimateMemoryUsageForTrain(std::size_t numberR
             : computeEta(numberColumns))};
     CScopeBoostedTreeParameterOverrides<std::size_t> overrides;
     overrides.apply(m_TreeImpl->m_Hyperparameters.maximumNumberTrees(), maximumNumberTrees);
-    return m_TreeImpl->estimateMemoryUsageForTrain(numberRows, numberColumns);
+    return sizeof(*this) + m_TreeImpl->estimateMemoryUsageForTrain(numberRows, numberColumns);
 }
 
 std::size_t
@@ -1654,12 +1654,13 @@ CBoostedTreeFactory::estimateMemoryUsageForTrainIncremental(std::size_t numberRo
             : computeEta(numberColumns))};
     CScopeBoostedTreeParameterOverrides<std::size_t> overrides;
     overrides.apply(m_TreeImpl->m_Hyperparameters.maximumNumberTrees(), maximumNumberTrees);
-    return m_TreeImpl->estimateMemoryUsageForTrainIncremental(numberRows, numberColumns);
+    return sizeof(*this) + m_TreeImpl->estimateMemoryUsageForTrainIncremental(
+                               numberRows, numberColumns);
 }
 
 std::size_t CBoostedTreeFactory::estimateMemoryUsageForPredict() const {
     // We use no _additional_ memory for prediction.
-    return 0;
+    return sizeof(*this) + sizeof(CBoostedTreeImpl);
 }
 
 std::size_t CBoostedTreeFactory::estimateExtraColumnsForEncode() {
@@ -1672,7 +1673,7 @@ std::size_t CBoostedTreeFactory::estimateExtraColumnsForEncode() {
 std::size_t CBoostedTreeFactory::estimateExtraColumnsForTrain(std::size_t numberColumns,
                                                               std::size_t numberLossParameters) {
     // We store as follows:
-    //   1. The predicted values for the dependent variable
+    //   1. The predicted values
     //   2. The gradient of the loss function
     //   3. The upper triangle of the hessian of the loss function
     //   4. The example's splits packed into std::uint8_t
@@ -1685,7 +1686,7 @@ std::size_t
 CBoostedTreeFactory::estimateExtraColumnsForTrainIncremental(std::size_t numberColumns,
                                                              std::size_t numberLossParameters) {
     // We store as follows:
-    //   1. The predicted values for the dependent variable
+    //   1. The predicted values
     //   2. The gradient of the loss function
     //   3. The upper triangle of the hessian of the loss function
     //   4. The previous prediction
@@ -1696,7 +1697,7 @@ CBoostedTreeFactory::estimateExtraColumnsForTrainIncremental(std::size_t numberC
 }
 
 std::size_t CBoostedTreeFactory::estimateExtraColumnsForPredict(std::size_t numberLossParameters) {
-    // We store the predicted values for the dependent variable.
+    // We store the predicted values.
     //
     // See prepareDataFrameForPredict for details.
     return numberLossParameters;

--- a/lib/maths/analytics/CDataFrameCategoryEncoder.cc
+++ b/lib/maths/analytics/CDataFrameCategoryEncoder.cc
@@ -713,7 +713,7 @@ std::size_t CMakeDataFrameCategoryEncoder::estimateMemoryUsage(std::size_t numbe
             core::CMemory::dynamicSize(TDoubleVec())};
     std::size_t micsMemoryUsage{numberColumns * sizeof(double)};
     std::size_t encodingMapMemoryUsage{2 * numberColumns * sizeof(std::size_t)};
-    return sizeof(CMakeDataFrameCategoryEncoder{}) + missingFeatureMaskMemoryUsage +
+    return sizeof(CMakeDataFrameCategoryEncoder) + missingFeatureMaskMemoryUsage +
            columnMaskMemoryUsage + frequencyEncodingMemoryUsage +
            oneHotMemoryUsage + rareCategoriesMemoryUsage + meanFrequencyMemoryUsage +
            meanValuesMemoryUsage + micsMemoryUsage + encodingMapMemoryUsage;

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -50,22 +50,26 @@
 #include <utility>
 #include <vector>
 
-namespace ml {
-namespace maths {
-namespace analytics {
+using namespace ml;
+
 class CBoostedTreeImplForTest {
 public:
-    using TAnalysisInstrumentationPtr = CBoostedTreeImpl::TAnalysisInstrumentationPtr;
-    using TLossFunctionUPtr = CBoostedTreeImpl::TLossFunctionUPtr;
-    using TSizeVec = CBoostedTreeImpl::TSizeVec;
-    using TDoubleVec = CBoostedTreeImpl::TDoubleVec;
-    using TBoostedTreeUPtr = std::unique_ptr<CBoostedTree>;
+    using TAnalysisInstrumentationPtr = maths::analytics::CBoostedTreeImpl::TAnalysisInstrumentationPtr;
+    using TLossFunctionUPtr = maths::analytics::CBoostedTreeImpl::TLossFunctionUPtr;
+    using TSizeVec = maths::analytics::CBoostedTreeImpl::TSizeVec;
+    using TDoubleVec = maths::analytics::CBoostedTreeImpl::TDoubleVec;
+    using TBoostedTreeUPtr = std::unique_ptr<maths::analytics::CBoostedTree>;
 
 public:
-    explicit CBoostedTreeImplForTest(CBoostedTreeImpl& treeImpl)
+    explicit CBoostedTreeImplForTest(maths::analytics::CBoostedTreeImpl& treeImpl)
         : m_TreeImpl{treeImpl} {}
     CBoostedTreeImplForTest(const CBoostedTreeImplForTest&) = delete;
     CBoostedTreeImplForTest& operator=(const CBoostedTreeImplForTest&) = delete;
+
+    static double correctedMemoryUsage(double memoryUsageBytes) {
+        return static_cast<double>(maths::analytics::CBoostedTreeImpl::correctedMemoryUsageForTraining(
+            memoryUsageBytes));
+    }
 
     const TDoubleVec& featureSampleProbabilities() const {
         return m_TreeImpl.featureSampleProbabilities();
@@ -99,15 +103,10 @@ public:
     }
 
 private:
-    CBoostedTreeImpl& m_TreeImpl;
+    maths::analytics::CBoostedTreeImpl& m_TreeImpl;
 };
-}
-}
-}
 
-using namespace ml;
-
-BOOST_TEST_DONT_PRINT_LOG_VALUE(maths::analytics::CBoostedTreeImplForTest::TSizeVec::iterator)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(CBoostedTreeImplForTest::TSizeVec::iterator)
 
 BOOST_AUTO_TEST_SUITE(CBoostedTreeTest)
 
@@ -116,6 +115,7 @@ using TBoolVec = std::vector<bool>;
 using TDoubleVec = std::vector<double>;
 using TDoubleVecVec = std::vector<TDoubleVec>;
 using TSizeVec = std::vector<std::size_t>;
+using TStrVec = std::vector<std::string>;
 using TFactoryFunc = std::function<std::unique_ptr<core::CDataFrame>()>;
 using TFactoryFuncVec = std::vector<TFactoryFunc>;
 using TFactoryFuncVecVec = std::vector<TFactoryFuncVec>;
@@ -1543,7 +1543,7 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalAddNewTrees) {
     double gamma{baseModel->hyperparameters().treeSizePenaltyMultiplier().value()};
     double lambda{baseModel->hyperparameters().leafWeightPenaltyMultiplier().value()};
 
-    maths::analytics::CBoostedTreeImplForTest baseImpl{baseModel->impl()};
+    CBoostedTreeImplForTest baseImpl{baseModel->impl()};
 
     auto cloneBaseModel = [&](core::CDataFrame& frame) {
         auto tmp_ = makeBatch2();
@@ -1596,7 +1596,7 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalAddNewTrees) {
     auto computePenalisedTestError =
         [&](core::CDataFrame& frame,
             const maths::analytics::CBoostedTreeFactory::TBoostedTreeUPtr& model) {
-            auto modelForTest = maths::analytics::CBoostedTreeImplForTest{model->impl()};
+            auto modelForTest = CBoostedTreeImplForTest{model->impl()};
             return modelForTest.meanChangePenalisedLoss(frame, holdoutRowMask);
         };
 
@@ -1663,11 +1663,9 @@ BOOST_AUTO_TEST_CASE(testThreading) {
     TDoubleVec modelBias;
     TDoubleVec modelMse;
 
-    std::string tests[]{"serial", "parallel"};
+    for (const auto& test : {"serial", "parallel"}) {
 
-    for (std::size_t test = 0; test < 2; ++test) {
-
-        LOG_DEBUG(<< tests[test]);
+        LOG_DEBUG(<< test);
 
         auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
 
@@ -1766,8 +1764,8 @@ BOOST_AUTO_TEST_CASE(testConstantTarget) {
     std::size_t capacity{500};
 
     TDoubleVecVec x(cols - 1);
-    for (std::size_t i = 0; i < x.size(); ++i) {
-        rng.generateUniformSamples(0.0, 10.0, rows, x[i]);
+    for (auto& xi : x) {
+        rng.generateUniformSamples(0.0, 10.0, rows, xi);
     }
 
     auto frame = core::makeMainStorageDataFrame(cols, capacity).first;
@@ -1928,7 +1926,7 @@ BOOST_AUTO_TEST_CASE(testFeatureBags) {
                           1, std::make_unique<maths::analytics::boosted_tree::CMse>())
                           .buildForTrain(*frame, cols - 1);
 
-    maths::analytics::CBoostedTreeImplForTest impl{regression->impl()};
+    CBoostedTreeImplForTest impl{regression->impl()};
 
     TSizeVec selectedForTree(impl.featureSampleProbabilities().size(), 0);
     TSizeVec selectedForNode(impl.featureSampleProbabilities().size(), 0);
@@ -2710,18 +2708,16 @@ BOOST_AUTO_TEST_CASE(testClassificationWeightsOverride) {
 
     // Test that the overrides are reflected in the classification weights used.
 
-    using TStrVec = std::vector<std::string>;
-
     test::CRandomNumbers rng;
 
-    std::size_t classes[]{1, 0};
-    std::size_t classesRowCounts[]{50, 50};
+    TSizeVec classes{1, 0};
+    TSizeVec classesRowCounts{50, 50};
     std::size_t cols{3};
 
     TDoubleVecVec x;
     TDoubleVec means{0.0, 3.0};
     TDoubleVec variances{6.0, 6.0};
-    for (std::size_t i = 0; i < std::size(classes); ++i) {
+    for (std::size_t i = 0; i < classes.size(); ++i) {
         TDoubleVecVec xi;
         double mean{means[classes[i]]};
         double variance{variances[classes[i]]};
@@ -2733,9 +2729,9 @@ BOOST_AUTO_TEST_CASE(testClassificationWeightsOverride) {
     auto frame = core::makeMainStorageDataFrame(cols).first;
     frame->categoricalColumns(TBoolVec{false, false, true});
 
-    std::string classValues[]{"foo", "bar"};
+    TStrVec classValues{"foo", "bar"};
     TStrVec row(cols);
-    for (std::size_t i = 0, index = 0; i < std::size(classes); ++i) {
+    for (std::size_t i = 0, index = 0; i < classes.size(); ++i) {
         for (std::size_t j = 0; j < classesRowCounts[i]; ++j, ++index) {
             row[0] = std::to_string(x[index][0]);
             row[1] = std::to_string(x[index][1]);
@@ -3114,7 +3110,7 @@ BOOST_AUTO_TEST_CASE(testProgressMonitoring) {
 
     core::stopDefaultAsyncExecutor();
 
-    std::string tests[]{"serial", "parallel"};
+    TStrVec tests{"serial", "parallel"};
 
     for (std::size_t threads : {1, 2}) {
 
@@ -3590,29 +3586,19 @@ BOOST_AUTO_TEST_CASE(testRestoreErrorHandling) {
 
 BOOST_AUTO_TEST_CASE(testWorstCaseMemoryCorrection) {
     // test for 15mb
-    BOOST_REQUIRE_CLOSE(static_cast<double>(maths::analytics::CBoostedTreeImpl::correctedMemoryUsage(
-                            15.0 * BYTES_IN_MB)) /
-                            BYTES_IN_MB,
+    BOOST_REQUIRE_CLOSE(CBoostedTreeImplForTest::correctedMemoryUsage(15.0 * BYTES_IN_MB) / BYTES_IN_MB,
                         15.0, 1.0);
     // test for 50mb
-    BOOST_REQUIRE_CLOSE(static_cast<double>(maths::analytics::CBoostedTreeImpl::correctedMemoryUsage(
-                            50.0 * BYTES_IN_MB)) /
-                            BYTES_IN_MB,
+    BOOST_REQUIRE_CLOSE(CBoostedTreeImplForTest::correctedMemoryUsage(50.0 * BYTES_IN_MB) / BYTES_IN_MB,
                         24.76, 1.0);
     // test for 300mb
-    BOOST_REQUIRE_CLOSE(static_cast<double>(maths::analytics::CBoostedTreeImpl::correctedMemoryUsage(
-                            300.0 * BYTES_IN_MB)) /
-                            BYTES_IN_MB,
+    BOOST_REQUIRE_CLOSE(CBoostedTreeImplForTest::correctedMemoryUsage(300.0 * BYTES_IN_MB) / BYTES_IN_MB,
                         64.4, 1.0);
     // test for 1024mb
-    BOOST_REQUIRE_CLOSE(static_cast<double>(maths::analytics::CBoostedTreeImpl::correctedMemoryUsage(
-                            1024.0 * BYTES_IN_MB)) /
-                            BYTES_IN_MB,
+    BOOST_REQUIRE_CLOSE(CBoostedTreeImplForTest::correctedMemoryUsage(1024.0 * BYTES_IN_MB) / BYTES_IN_MB,
                         179.2, 1.0);
     // test for 18000mb
-    BOOST_REQUIRE_CLOSE(static_cast<double>(maths::analytics::CBoostedTreeImpl::correctedMemoryUsage(
-                            18000.0 * BYTES_IN_MB)) /
-                            BYTES_IN_MB,
+    BOOST_REQUIRE_CLOSE(CBoostedTreeImplForTest::correctedMemoryUsage(18000.0 * BYTES_IN_MB) / BYTES_IN_MB,
                         1355.75, 1.0);
 
     // test for monotonicity
@@ -3625,10 +3611,9 @@ BOOST_AUTO_TEST_CASE(testWorstCaseMemoryCorrection) {
     rng.generateUniformSamples(0.0, 20000.0, numberSamples, lhs);
     rng.generateUniformSamples(0.0, 20000.0, numberSamples, rhs);
     for (std::size_t i = 0; i < numberSamples; ++i) {
-        BOOST_TEST_REQUIRE(
-            (lhs[i] <= rhs[i]) ==
-            (maths::analytics::CBoostedTreeImpl::correctedMemoryUsage(lhs[i]) <=
-             maths::analytics::CBoostedTreeImpl::correctedMemoryUsage(rhs[i])));
+        BOOST_TEST_REQUIRE((lhs[i] <= rhs[i]) ==
+                           (CBoostedTreeImplForTest::correctedMemoryUsage(lhs[i]) <=
+                            CBoostedTreeImplForTest::correctedMemoryUsage(rhs[i])));
     }
 }
 

--- a/lib/maths/analytics/unittest/CDataFrameCategoryEncoderTest.cc
+++ b/lib/maths/analytics/unittest/CDataFrameCategoryEncoderTest.cc
@@ -616,7 +616,7 @@ BOOST_AUTO_TEST_CASE(testUnseenCategoryEncoding) {
 
     maths::analytics::CDataFrameCategoryEncoder encoder{{1, *frame, 3}};
 
-    TFloatVec unseen{3.0f, 5.0f, 4.0f, 1.5f};
+    TFloatVec unseen{3.0F, 5.0F, 4.0F, 1.5F};
     core::CDataFrame::TRowRef row{rows, unseen.begin(), unseen.end(), 0};
 
     auto encodedRow = encoder.encode(row);
@@ -659,11 +659,10 @@ BOOST_AUTO_TEST_CASE(testDiscardNuisanceFeatures) {
     for (std::size_t i = 0; i < rows; ++i) {
         auto writeOneRow = [&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
             double target{0.0};
-            std::size_t j = 0;
-            for (/**/; j + 2 < cols; ++j, ++column) {
+            for (std::size_t j = 0; j + 1 < features.size(); ++j, ++column) {
                 target += * column = features[j][i];
             }
-            *(column++) = features[j][i];
+            *(column++) = features[cols - 2][i];
             *column = target;
         };
 
@@ -683,11 +682,115 @@ BOOST_AUTO_TEST_CASE(testDiscardNuisanceFeatures) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testEstimateMemoryUsage) {
+
+    // Check that we don't exceed the memory estimate for a variety of problem sizes.
+
+    test::CRandomNumbers rng;
+
+    auto makeDataFrame = [&](std::size_t rows, std::size_t metricCols,
+                             std::size_t categoricalCols) {
+
+        std::size_t cols{metricCols + categoricalCols};
+        auto frame = core::makeMainStorageDataFrame(cols + 1).first;
+
+        TBoolVec categoricalColumns(metricCols, false);
+        categoricalColumns.resize(cols, true);
+        categoricalColumns.resize(cols + 1, false);
+        frame->categoricalColumns(std::move(categoricalColumns));
+
+        TDoubleVec metricFeatures;
+        TDoubleVec categoricalFeatures;
+        auto writeOneRow = [&](core::CDataFrame::TFloatVecItr column, std::int32_t&) {
+            double target{0.0};
+            for (std::size_t i = 0; i < metricFeatures.size(); ++i, ++column) {
+                *column = metricFeatures[i];
+                target += *column;
+            }
+            for (std::size_t i = 0; i < categoricalFeatures.size(); ++i, ++column) {
+                *column = std::floor(categoricalFeatures[i] /
+                                     std::min(0.5 * static_cast<double>(i + 1), 10.0));
+                target += 2.0 * *column;
+            }
+            *column = target;
+        };
+
+        for (std::size_t i = 0; i < rows; ++i) {
+            rng.generateUniformSamples(0.0, 6.0, metricCols, metricFeatures);
+            rng.generateUniformSamples(0.0, 500.0, categoricalCols, categoricalFeatures);
+            frame->writeRow(writeOneRow);
+        }
+        frame->finishWritingRows();
+
+        return frame;
+    };
+
+    {
+        LOG_DEBUG(<< "500 x 10");
+        auto frame = makeDataFrame(500, 1, 9);
+        maths::analytics::CMakeDataFrameCategoryEncoder encoder{1, *frame, 10};
+        encoder.makeEncodings();
+        LOG_DEBUG(<< "actual   = " << sizeof(encoder) + encoder.memoryUsage());
+        LOG_DEBUG(<< "estimate = "
+                  << maths::analytics::CMakeDataFrameCategoryEncoder::estimateMemoryUsage(
+                         500, 11, 9));
+        BOOST_TEST_REQUIRE(2 * (sizeof(encoder) + encoder.memoryUsage()) >
+                           maths::analytics::CMakeDataFrameCategoryEncoder::estimateMemoryUsage(
+                               500, 11, 9));
+        BOOST_TEST_REQUIRE(sizeof(encoder) + encoder.memoryUsage() <
+                           maths::analytics::CMakeDataFrameCategoryEncoder::estimateMemoryUsage(
+                               500, 11, 9));
+    }
+    {
+        LOG_DEBUG(<< "5000 x 10");
+        auto frame = makeDataFrame(5000, 1, 9);
+        maths::analytics::CMakeDataFrameCategoryEncoder encoder{1, *frame, 10};
+        encoder.makeEncodings();
+        LOG_DEBUG(<< "actual   = " << sizeof(encoder) + encoder.memoryUsage());
+        LOG_DEBUG(<< "estimate = "
+                  << maths::analytics::CMakeDataFrameCategoryEncoder::estimateMemoryUsage(
+                         5000, 11, 9));
+        BOOST_TEST_REQUIRE(2 * (sizeof(encoder) + encoder.memoryUsage()) >
+                           maths::analytics::CMakeDataFrameCategoryEncoder::estimateMemoryUsage(
+                               5000, 11, 9));
+        BOOST_TEST_REQUIRE(sizeof(encoder) + encoder.memoryUsage() <
+                           maths::analytics::CMakeDataFrameCategoryEncoder::estimateMemoryUsage(
+                               5000, 11, 9));
+    }
+    {
+        LOG_DEBUG(<< "50000 x 50");
+        auto frame = makeDataFrame(50000, 30, 20);
+        maths::analytics::CMakeDataFrameCategoryEncoder encoder{1, *frame, 50};
+        encoder.makeEncodings();
+        LOG_DEBUG(<< "actual   = " << sizeof(encoder) + encoder.memoryUsage());
+        LOG_DEBUG(<< "estimate = "
+                  << maths::analytics::CMakeDataFrameCategoryEncoder::estimateMemoryUsage(
+                         50000, 51, 20));
+        BOOST_TEST_REQUIRE(5 * (sizeof(encoder) + encoder.memoryUsage()) >
+                           maths::analytics::CMakeDataFrameCategoryEncoder::estimateMemoryUsage(
+                               50000, 51, 20));
+        BOOST_TEST_REQUIRE(sizeof(encoder) + encoder.memoryUsage() <
+                           maths::analytics::CMakeDataFrameCategoryEncoder::estimateMemoryUsage(
+                               50000, 51, 20));
+    }
+    {
+        // Flag if the memory estimate changes a lot.
+        LOG_DEBUG(<< "1000000 x 2000");
+        LOG_DEBUG(<< "estimate = "
+                  << maths::analytics::CMakeDataFrameCategoryEncoder::estimateMemoryUsage(
+                         1000000, 2001, 1000));
+        BOOST_TEST_REQUIRE(20000000 < maths::analytics::CMakeDataFrameCategoryEncoder::estimateMemoryUsage(
+                                          1000000, 2001, 1000));
+        BOOST_TEST_REQUIRE(30000000 > maths::analytics::CMakeDataFrameCategoryEncoder::estimateMemoryUsage(
+                                          1000000, 2001, 1000));
+    }
+}
+
 BOOST_AUTO_TEST_CASE(testPersistRestore) {
 
     // Test checksum of restored encoder matches persisted one.
 
-    TDoubleVec categoryValue[2]{{-15.0, 20.0, 0.0}, {10.0, -10.0, 0.0}};
+    TDoubleVecVec categoryValue{{-15.0, 20.0, 0.0}, {10.0, -10.0, 0.0}};
 
     auto target = [&](const TDoubleVecVec& features, std::size_t row) {
         std::size_t categories[]{
@@ -728,9 +831,9 @@ BOOST_AUTO_TEST_CASE(testPersistRestore) {
 
     std::stringstream persistTo;
     core::CJsonStatePersistInserter inserter{persistTo};
-    inserter.insertLevel("top-level", std::bind(&maths::analytics::CDataFrameCategoryEncoder::acceptPersistInserter,
-                                                &encoder, std::placeholders::_1));
-    encoder.acceptPersistInserter(inserter);
+    inserter.insertLevel("top-level", [&](auto& inserter_) {
+        encoder.acceptPersistInserter(inserter_);
+    });
     persistTo.flush();
 
     LOG_DEBUG(<< "persisted " << persistTo.str());

--- a/lib/maths/analytics/unittest/COutliersTest.cc
+++ b/lib/maths/analytics/unittest/COutliersTest.cc
@@ -619,7 +619,8 @@ BOOST_AUTO_TEST_CASE(testEstimateMemoryUsedByCompute) {
         CTestInstrumentation instrumentation;
 
         auto memoryUsageCallback = [&](std::int64_t delta) {
-            std::int64_t memoryUsage_{memoryUsage.fetch_add(delta)};
+            // fetch_add returns the value immediately _before_ adding delta.
+            std::int64_t memoryUsage_{memoryUsage.fetch_add(delta) + delta};
 
             std::int64_t prevMaxMemoryUsage{maxMemoryUsage};
             while (prevMaxMemoryUsage < memoryUsage_ &&


### PR DESCRIPTION
We were missing memory management for the new incremental training, prediction and compute encodings tasks. This change adds it in. Note that we also need to write out the trained model size to meta data and supply this when we call tasks which load a pre-existing model to do proper accounting.

Closes #1790.