### PR TITLE
[ML] Early stopping for coarse parameter tuning

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -30,6 +30,7 @@ Checks: >
   -readability-named-parameter,
   -readability-redundant-access-specifiers,
   -readability-simplify-boolean-expr,
+  -readability-identifier-length,
   
 WarningsAsErrors: false
 AnalyzeTemporaryDtors: false

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -37,6 +37,8 @@
   {ml-pull}2285[#2285], issue: {ml-issue}2276[#2276].)
 * Fairer application of size penalty for model selection for training classification
   and regression models. (See {ml-pull}2291[#2291].)
+* Accelerate training for data frame analytics by skipping fine parameter tuning if it 
+  is unnecessary. (See {ml-pull}2298[#2298])
 
 == {es} version 8.3.0
 

--- a/include/core/CContainerPrinter.h
+++ b/include/core/CContainerPrinter.h
@@ -238,7 +238,7 @@ private:
         return Printer::print(ml::core::unwrap_ref(value));
     }
 
-    //! Print a non associative element pointer to const for debug.
+    //! Print const pointer.
     template<typename T>
     static std::string printElement(const T* value) {
         if (value == nullptr) {
@@ -249,7 +249,7 @@ private:
         return result.str();
     }
 
-    //! Print a non associative element pointer for debug.
+    //! Print a raw pointer.
     template<typename T>
     static std::string printElement(T* value) {
         if (value == nullptr) {
@@ -293,7 +293,7 @@ private:
     // If you find yourself using some different smart pointer and
     // it isn't printing please feel free to add an overload here.
 
-    //! Print a non associative (boost) optional element for debug.
+    //! Print a (boost) optional.
     template<typename T>
     static std::string printElement(const boost::optional<T>& value) {
         if (!value) {
@@ -304,12 +304,27 @@ private:
         return result.str();
     }
 
-    //! Print an associative container element for debug.
+    //! Print a std::pair.
     template<typename U, typename V>
     static std::string printElement(const std::pair<U, V>& value) {
         std::ostringstream result;
         result << "(" << printElement(ml::core::unwrap_ref(value.first)) << ", "
                << printElement(ml::core::unwrap_ref(value.second)) << ")";
+        return result.str();
+    }
+
+    //! Print a std::tuple.
+    template<typename... ARGS>
+    static std::string printElement(const std::tuple<ARGS...>& value) {
+        std::ostringstream result;
+        std::apply(
+            [&result](ARGS const&... args) {
+                result << '(';
+                std::size_t n{0};
+                ((result << args << (++n != sizeof...(ARGS) ? ", " : "")), ...);
+                result << ')';
+            },
+            value);
         return result.str();
     }
 

--- a/include/maths/analytics/CBoostedTreeFactory.h
+++ b/include/maths/analytics/CBoostedTreeFactory.h
@@ -163,6 +163,7 @@ public:
 private:
     using TDoubleDoublePr = std::pair<double, double>;
     using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
+    using TDoubleSizePr = std::pair<double, std::size_t>;
     using TOptionalDouble = boost::optional<double>;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
     using TBoostedTreeImplUPtr = std::unique_ptr<CBoostedTreeImpl>;
@@ -200,11 +201,11 @@ private:
     //! Initialize the feature sample distribution.
     bool initializeFeatureSampleDistribution() const;
 
-    //! Set the initial values for hyperparameters.
-    void initializeHyperparameters(core::CDataFrame& frame);
-
     //! Setup before setting initial values for hyperparameters.
     void initializeHyperparametersSetup(core::CDataFrame& frame);
+
+    //! Set the initial values for hyperparameters.
+    void initializeHyperparameters(core::CDataFrame& frame);
 
     //! Estimate a good initial value and bounding box to search for regularisation
     //! hyperparameters.
@@ -287,6 +288,8 @@ private:
     double m_GainPerNode90thPercentile{0.0};
     double m_TotalCurvaturePerNode1stPercentile{0.0};
     double m_TotalCurvaturePerNode90thPercentile{0.0};
+    double m_LossGap{0.0};
+    std::size_t m_NumberTrees{0};
     std::size_t m_NumberThreads{1};
     std::string m_RowWeightColumnName;
     TBoostedTreeImplUPtr m_TreeImpl;

--- a/include/maths/analytics/CBoostedTreeFactory.h
+++ b/include/maths/analytics/CBoostedTreeFactory.h
@@ -288,7 +288,6 @@ private:
     double m_GainPerNode90thPercentile{0.0};
     double m_TotalCurvaturePerNode1stPercentile{0.0};
     double m_TotalCurvaturePerNode90thPercentile{0.0};
-    double m_LossGap{0.0};
     std::size_t m_NumberTrees{0};
     std::size_t m_NumberThreads{1};
     std::string m_RowWeightColumnName;

--- a/include/maths/analytics/CBoostedTreeHyperparameters.h
+++ b/include/maths/analytics/CBoostedTreeHyperparameters.h
@@ -539,12 +539,11 @@ public:
     //! Compute the fine tune search interval for \p parameter.
     //!
     //! \return The best number of trees to use for the current hyperparameter settings.
-    TOptionalDoubleSizePr
-    initializeFineTuneSearchInterval(const CInitializeFineTuneArguments& args,
-                                     TDoubleParameter& parameter) const;
+    TOptionalSize initializeFineTuneSearchInterval(const CInitializeFineTuneArguments& args,
+                                                   TDoubleParameter& parameter) const;
 
     //! Initialize the search for best values of tunable hyperparameters.
-    void initializeFineTuneSearch(double lossGap, std::size_t numberTrees);
+    void initializeFineTuneSearch(std::size_t numberTrees);
 
     //! Check if search is making no progress improving the test loss.
     bool optimisationMakingNoProgress() const;
@@ -640,10 +639,9 @@ private:
     using TBayesinOptimizationUPtr = std::unique_ptr<common::CBayesianOptimisation>;
     using TDoubleVec = std::vector<double>;
     using TDoubleVecVec = std::vector<TDoubleVec>;
-    using TDoubleDoubleDoubleSizeTupleVec =
-        std::vector<std::tuple<double, double, double, std::size_t>>;
+    using TDoubleDoubleSizeTupleVec = std::vector<std::tuple<double, double, std::size_t>>;
     using TOptionalVector3x1 = boost::optional<TVector3x1>;
-    using TOptionalVector3x1DoubleSizeTr = std::tuple<TOptionalVector3x1, double, std::size_t>;
+    using TOptionalVector3x1SizePr = std::pair<TOptionalVector3x1, std::size_t>;
     using TVectorDoublePr = std::pair<TVector, double>;
     using TVectorDoublePrVec = std::vector<TVectorDoublePr>;
 
@@ -652,19 +650,18 @@ private:
     void initialTestLossLineSearch(const CInitializeFineTuneArguments& args,
                                    double intervalLeftEnd,
                                    double intervalRightEnd,
-                                   TDoubleDoubleDoubleSizeTupleVec& testLosses) const;
-    TOptionalVector3x1DoubleSizeTr testLossLineSearch(const CInitializeFineTuneArguments& args,
-                                                      double intervalLeftEnd,
-                                                      double intervalRightEnd) const;
+                                   TDoubleDoubleSizeTupleVec& testLosses) const;
+    TOptionalVector3x1SizePr testLossLineSearch(const CInitializeFineTuneArguments& args,
+                                                double intervalLeftEnd,
+                                                double intervalRightEnd) const;
     void fineTuneTestLoss(const CInitializeFineTuneArguments& args,
                           double intervalLeftEnd,
                           double intervalRightEnd,
-                          TDoubleDoubleDoubleSizeTupleVec& testLosses) const;
-    TOptionalVector3x1DoubleSizeTr
-    minimizeTestLoss(double intervalLeftEnd,
-                     double intervalRightEnd,
-                     TDoubleDoubleDoubleSizeTupleVec testLosses) const;
-    void checkIfCanSkipFineTuneSearch(double lossGap, std::size_t numberTrees);
+                          TDoubleDoubleSizeTupleVec& testLosses) const;
+    TOptionalVector3x1SizePr minimizeTestLoss(double intervalLeftEnd,
+                                              double intervalRightEnd,
+                                              TDoubleDoubleSizeTupleVec testLosses) const;
+    void checkIfCanSkipFineTuneSearch(std::size_t numberTrees);
     void captureHyperparametersAndLoss(double loss);
     TVector selectParametersVector(const THyperparametersVec& selectedHyperparameters) const;
     void setHyperparameterValues(TVector parameters);

--- a/include/maths/analytics/CBoostedTreeHyperparameters.h
+++ b/include/maths/analytics/CBoostedTreeHyperparameters.h
@@ -33,6 +33,7 @@
 #include <locale>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <utility>
 
 namespace ml {
@@ -349,20 +350,22 @@ private:
 //! DESCRIPTION:\n
 //! This stores and manages persistence of all the boosted tree training and
 //! incremental training hyperparameters. It also provides functionality for
-//! optimizing these using a combination of random (Sobolov sequence) search
+//! optimizing these using a combination of random (Sobolev sequence) search
 //! and Bayesian Optimisation.
 class MATHS_ANALYTICS_EXPORT CBoostedTreeHyperparameters {
 public:
-    using TDoubleDoublePrVec = std::vector<std::pair<double, double>>;
     using TStrVec = std::vector<std::string>;
+    using TOptionalSize = boost::optional<std::size_t>;
+    using TOptionalDoubleSizePr = boost::optional<std::pair<double, std::size_t>>;
     using TDoubleParameter = CBoostedTreeParameter<double>;
     using TSizeParameter = CBoostedTreeParameter<std::size_t>;
+    using TVector = common::CDenseVector<double>;
     using TVector3x1 = common::CVectorNx1<double, 3>;
-    using TOptionalVector3x1 = boost::optional<TVector3x1>;
     using TMeanAccumulator = common::CBasicStatistics::SSampleMean<double>::TAccumulator;
     using TMeanVarAccumulator = common::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
     using THyperparameterImportanceVec =
         std::vector<boosted_tree_detail::SHyperparameterImportance>;
+    using THyperparametersVec = std::vector<boosted_tree_detail::EHyperparameter>;
 
     //! \brief The arguments to the initial search we perform for each parameter.
     class MATHS_ANALYTICS_EXPORT CInitializeFineTuneArguments {
@@ -494,9 +497,9 @@ public:
         return m_FeatureBagFraction;
     }
 
-    //! Get the writeable weight shinkage.
+    //! Get the writeable weight shrinkage.
     TDoubleParameter& eta() { return m_Eta; }
-    //! Get the weight shinkage.
+    //! Get the weight shrinkage.
     const TDoubleParameter& eta() const { return m_Eta; }
 
     //! Get the writeable growth in weight shrinkage per tree which is added.
@@ -525,47 +528,37 @@ public:
     void bayesianOptimisationRestarts(std::size_t restarts);
 
     //! Get the maximum number of iterations used in testLossLineSearch.
-    std::size_t maxLineSearchIterations() const { return 10; }
+    static std::size_t maxLineSearchIterations() { return 10; }
 
     //! Get the number of hyperparameters to tune.
     std::size_t numberToTune() const;
 
     //! Reset search state.
-    void resetSearch();
+    void resetFineTuneSearch();
 
     //! Compute the fine tune search interval for \p parameter.
-    void initializeFineTuneSearchInterval(const CInitializeFineTuneArguments& args,
-                                          TDoubleParameter& parameter) const;
-
-    //! Perform a line search for the test loss w.r.t. a single hyperparameter.
-    //! At the end we use a smooth curve fit through all test loss values (using
-    //! LOWESS regression) and use this to get a best estimate of where the true
-    //! minimum occurs.
     //!
-    //! \return A vector comprising
-    //! <pre>
-    //!   | minimum value for fine tune |
-    //!   |       initial value         |
-    //!   | maximum value for fine tune |
-    //! </pre>
-    TOptionalVector3x1 testLossLineSearch(const CInitializeFineTuneArguments& args,
-                                          double intervalLeftEnd,
-                                          double intervalRightEnd) const;
+    //! \return The best number of trees to use for the current hyperparameter settings.
+    TOptionalDoubleSizePr
+    initializeFineTuneSearchInterval(const CInitializeFineTuneArguments& args,
+                                     TDoubleParameter& parameter) const;
 
     //! Initialize the search for best values of tunable hyperparameters.
-    void initializeSearch();
+    void initializeFineTuneSearch(double lossGap, std::size_t numberTrees);
+
+    //! Check if search is making no progress improving the test loss.
+    bool optimisationMakingNoProgress() const;
 
     //! Initialize a search for the best hyperparameters.
-    void startSearch();
+    void startFineTuneSearch();
 
     //! Check if the search for the best hyperparameter values has finished.
-    bool searchNotFinished() const {
-        return m_StoppedHyperparameterOptimizationEarly == false &&
-               m_CurrentRound < m_NumberRounds;
+    bool fineTuneSearchNotFinished() const {
+        return m_StopHyperparameterOptimizationEarly == false && m_CurrentRound < m_NumberRounds;
     }
 
     //! Start a new round of hyperparameter search.
-    void startNextSearchRound() { ++m_CurrentRound; }
+    void startNextRound() { ++m_CurrentRound; }
 
     //! Get the current round of the search for the best hyperparameters.
     std::size_t currentRound() const { return m_CurrentRound; }
@@ -647,22 +640,38 @@ private:
     using TBayesinOptimizationUPtr = std::unique_ptr<common::CBayesianOptimisation>;
     using TDoubleVec = std::vector<double>;
     using TDoubleVecVec = std::vector<TDoubleVec>;
-    using THyperparametersVec = std::vector<boosted_tree_detail::EHyperparameter>;
-    using TOptionalSize = boost::optional<std::size_t>;
+    using TDoubleDoubleDoubleSizeTupleVec =
+        std::vector<std::tuple<double, double, double, std::size_t>>;
+    using TOptionalVector3x1 = boost::optional<TVector3x1>;
+    using TOptionalVector3x1DoubleSizeTr = std::tuple<TOptionalVector3x1, double, std::size_t>;
+    using TVectorDoublePr = std::pair<TVector, double>;
+    using TVectorDoublePrVec = std::vector<TVectorDoublePr>;
 
 private:
     void initializeTunableHyperparameters();
     void initialTestLossLineSearch(const CInitializeFineTuneArguments& args,
                                    double intervalLeftEnd,
                                    double intervalRightEnd,
-                                   TDoubleDoublePrVec& testLosses) const;
-    void fineTineTestLoss(const CInitializeFineTuneArguments& args,
+                                   TDoubleDoubleDoubleSizeTupleVec& testLosses) const;
+    TOptionalVector3x1DoubleSizeTr testLossLineSearch(const CInitializeFineTuneArguments& args,
+                                                      double intervalLeftEnd,
+                                                      double intervalRightEnd) const;
+    void fineTuneTestLoss(const CInitializeFineTuneArguments& args,
                           double intervalLeftEnd,
                           double intervalRightEnd,
-                          TDoubleDoublePrVec& testLosses) const;
-    TVector3x1 minimizeTestLoss(double intervalLeftEnd,
-                                double intervalRightEnd,
-                                TDoubleDoublePrVec testLosses) const;
+                          TDoubleDoubleDoubleSizeTupleVec& testLosses) const;
+    TOptionalVector3x1DoubleSizeTr
+    minimizeTestLoss(double intervalLeftEnd,
+                     double intervalRightEnd,
+                     TDoubleDoubleDoubleSizeTupleVec testLosses) const;
+    void checkIfCanSkipFineTuneSearch(double lossGap, std::size_t numberTrees);
+    void captureHyperparametersAndLoss(double loss);
+    TVector selectParametersVector(const THyperparametersVec& selectedHyperparameters) const;
+    void setHyperparameterValues(TVector parameters);
+    //! \note Only tunable parameters should be passed in \p parameters. If \p reestimate
+    //! is set to true, kernel parameters of the GP are re-estimated.
+    void addObservation(TVector parameters, double loss, double variance, bool reestimate = false);
+    void resetBayesianOptimization();
     void saveCurrent();
 
 private:
@@ -682,8 +691,8 @@ private:
 
     //@ \name Hyperparameter Optimisation
     //@{
-    bool m_StopHyperparameterOptimizationEarly{true};
-    bool m_StoppedHyperparameterOptimizationEarly{false};
+    bool m_EarlyHyperparameterOptimizationStoppingEnabled{true};
+    bool m_StopHyperparameterOptimizationEarly{false};
     bool m_ScalingDisabled{false};
     std::size_t m_MaximumOptimisationRoundsPerHyperparameter{2};
     TOptionalSize m_BayesianOptimisationRestarts;
@@ -696,6 +705,7 @@ private:
     double m_BestForestNumberNodes{0.0};
     TMeanAccumulator m_MeanForestSizeAccumulator;
     TMeanAccumulator m_MeanTestLossAccumulator;
+    TVectorDoublePrVec m_LineSearchHyperparameterLosses;
     //@}
 };
 }

--- a/include/maths/common/CBayesianOptimisation.h
+++ b/include/maths/common/CBayesianOptimisation.h
@@ -61,6 +61,7 @@ public:
     using TDoubleDoublePrVec = std::vector<TDoubleDoublePr>;
     using TOptionalDouble = boost::optional<double>;
     using TVector = CDenseVector<double>;
+    using TVectorVectorPr = std::pair<TVector, TVector>;
     using TLikelihoodFunc = std::function<double(const TVector&)>;
     using TLikelihoodGradientFunc = std::function<TVector(const TVector&)>;
     using TEIFunc = std::function<double(const TVector&)>;
@@ -76,6 +77,8 @@ public:
 public:
     explicit CBayesianOptimisation(TDoubleDoublePrVec parameterBounds,
                                    std::size_t restarts = RESTARTS);
+    explicit CBayesianOptimisation(TVectorVectorPr parameterBounds,
+                                   std::size_t restarts = RESTARTS);
     explicit CBayesianOptimisation(core::CStateRestoreTraverser& traverser);
 
     //! Add the result of evaluating the function to be \p fx at \p x where the
@@ -87,7 +90,7 @@ public:
     void explainedErrorVariance(double vx);
 
     //! Get the bounding box (in the function domain) in which we're minimizing.
-    std::pair<TVector, TVector> boundingBox() const;
+    TVectorVectorPr boundingBox() const;
 
     //! Compute the location which maximizes the expected improvement given the
     //! function evaluations added so far.

--- a/include/maths/common/CLinearAlgebraEigen.h
+++ b/include/maths/common/CLinearAlgebraEigen.h
@@ -271,9 +271,9 @@ public:
     //! \name Copy and Move Semantics
     //@{
     CDenseVector(const CDenseVector& other) = default;
-    CDenseVector(CDenseVector&& other) = default;
+    CDenseVector(CDenseVector&& other) noexcept = default;
     CDenseVector& operator=(const CDenseVector& other) = default;
-    CDenseVector& operator=(CDenseVector&& other) = default;
+    CDenseVector& operator=(CDenseVector&& other) noexcept = default;
     template<typename EXPR>
     CDenseVector& operator=(const EXPR& expr) {
         static_cast<TBase&>(*this) = expr;

--- a/lib/core/unittest/CContainerPrinterTest.cc
+++ b/lib/core/unittest/CContainerPrinterTest.cc
@@ -18,6 +18,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -35,13 +36,16 @@ BOOST_AUTO_TEST_CASE(testAll) {
     LOG_DEBUG(<< "vec = " << CContainerPrinter::print(vec));
     BOOST_REQUIRE_EQUAL(std::string("[1.1, 3.2]"), CContainerPrinter::print(vec));
 
-    std::list<std::pair<int, int>> list;
-    list.push_back(std::make_pair(1, 2));
-    list.push_back(std::make_pair(2, 2));
-    list.push_back(std::make_pair(3, 2));
+    std::list<std::pair<int, int>> list{{1, 2}, {2, 2}, {3, 2}};
     LOG_DEBUG(<< "list = " << CContainerPrinter::print(list));
     BOOST_REQUIRE_EQUAL(std::string("[(1, 2), (2, 2), (3, 2)]"),
                         CContainerPrinter::print(list));
+
+    std::vector<std::tuple<double, double, double>> tuples{{1.1, 1.2, 1.3},
+                                                           {2.2, 2.3, 2.4}};
+    LOG_DEBUG(<< "tuples = " << core::CContainerPrinter::print(tuples));
+    BOOST_REQUIRE_EQUAL(std::string("[(1.1, 1.2, 1.3), (2.2, 2.3, 2.4)]"),
+                        core::CContainerPrinter::print(tuples));
 
     std::list<std::shared_ptr<double>> plist;
     plist.push_back(std::shared_ptr<double>());
@@ -53,16 +57,15 @@ BOOST_AUTO_TEST_CASE(testAll) {
     double three = 3.0;
     double fivePointOne = 5.1;
     std::map<double, double*> map;
-    map.insert(std::make_pair(1.1, &three));
-    map.insert(std::make_pair(3.3, &fivePointOne));
-    map.insert(std::make_pair(1.0, static_cast<double*>(nullptr)));
+    map.emplace(1.1, &three);
+    map.emplace(3.3, &fivePointOne);
+    map.emplace(1.0, static_cast<double*>(nullptr));
     LOG_DEBUG(<< "map = " << CContainerPrinter::print(map));
     BOOST_REQUIRE_EQUAL(std::string("[(1, \"null\"), (1.1, 3), (3.3, 5.1)]"),
                         CContainerPrinter::print(map));
 
-    std::unique_ptr<int> pints[] = {std::unique_ptr<int>(new int(2)),
-                                    std::unique_ptr<int>(new int(3)),
-                                    std::unique_ptr<int>(new int(2))};
+    std::unique_ptr<int> pints[]{std::make_unique<int>(2), std::make_unique<int>(3),
+                                 std::make_unique<int>(2)};
     LOG_DEBUG(<< "pints = "
               << CContainerPrinter::print(std::begin(pints), std::end(pints)));
     BOOST_REQUIRE_EQUAL(std::string("[2, 3, 2]"),
@@ -74,9 +77,9 @@ BOOST_AUTO_TEST_CASE(testAll) {
                         CContainerPrinter::print(ovec));
 
     std::vector<std::pair<std::list<std::pair<int, int>>, double>> aggregate;
-    aggregate.push_back(std::make_pair(list, 1.3));
-    aggregate.push_back(std::make_pair(std::list<std::pair<int, int>>(), 0.0));
-    aggregate.push_back(std::make_pair(list, 5.1));
+    aggregate.emplace_back(list, 1.3);
+    aggregate.emplace_back(std::list<std::pair<int, int>>(), 0.0);
+    aggregate.emplace_back(list, 5.1);
     LOG_DEBUG(<< "aggregate = " << CContainerPrinter::print(aggregate));
     BOOST_REQUIRE_EQUAL(std::string("[([(1, 2), (2, 2), (3, 2)], 1.3), ([], 0), ([(1, 2), (2, 2), (3, 2)], 5.1)]"),
                         CContainerPrinter::print(aggregate));

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -128,7 +128,7 @@ CBoostedTreeFactory::buildFor(core::CDataFrame& frame, std::size_t dependentVari
 
     if (initializeHyperparameters) {
         this->initializeHyperparameters(frame);
-        m_TreeImpl->m_Hyperparameters.initializeSearch();
+        m_TreeImpl->m_Hyperparameters.initializeFineTuneSearch(m_LossGap, m_NumberTrees);
     }
 
     auto treeImpl = std::make_unique<CBoostedTreeImpl>(m_NumberThreads,
@@ -448,6 +448,16 @@ void CBoostedTreeFactory::initializeHyperparametersSetup(core::CDataFrame& frame
         computeMaximumNumberTrees(hyperparameters.eta().value()));
 }
 
+void CBoostedTreeFactory::initializeHyperparameters(core::CDataFrame& frame) {
+    skipIfAfter(CBoostedTreeImpl::E_EncodingInitialized,
+                [&] { this->initializeHyperparametersSetup(frame); });
+    this->initializeUnsetRegularizationHyperparameters(frame);
+    this->initializeUnsetDownsampleFactor(frame);
+    this->initializeUnsetFeatureBagFraction(frame);
+    this->initializeUnsetEta(frame);
+    this->initializeUnsetRetrainedTreeEta();
+}
+
 void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDataFrame& frame) {
 
     // The strategy here is to:
@@ -456,16 +466,18 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
     //      zeroed,
     //   2) Use these to extract reasonable intervals to search for the multipliers
     //      for the various regularisation penalties,
-    //   3) Line search these intervales for a turning point in the test loss for
-    //      the base learner, i.e. the point at which transition to overfit occurs.
+    //   3) Line search these intervals for a turning point in the test loss, i.e.
+    //      the point at which transition to overfit occurs.
     //
     // We'll search intervals in the vicinity of these values in the hyperparameter
     // optimisation loop.
 
     auto& hyperparameters = m_TreeImpl->m_Hyperparameters;
     auto& depthPenaltyMultiplierParameter = hyperparameters.depthPenaltyMultiplier();
+    auto& leafWeightPenaltyMultiplier = hyperparameters.leafWeightPenaltyMultiplier();
     auto& softTreeDepthLimitParameter = hyperparameters.softTreeDepthLimit();
     auto& softTreeDepthToleranceParameter = hyperparameters.softTreeDepthTolerance();
+    auto& treeSizePenaltyMultiplier = hyperparameters.treeSizePenaltyMultiplier();
     double log2MaxTreeSize{std::log2(static_cast<double>(m_TreeImpl->maximumTreeSize(
                                m_TreeImpl->m_TrainingRowMasks[0]))) +
                            1.0};
@@ -496,6 +508,23 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
                   << core::CContainerPrinter::print(gainAndTotalCurvaturePerNode));
     });
 
+    skipIfAfter(CBoostedTreeImpl::E_SoftTreeDepthLimitInitialized, [&] {
+        m_LossGap = hyperparameters.bestForestLossGap();
+        m_NumberTrees = hyperparameters.maximumNumberTrees().value();
+    });
+
+    // Initialize regularization multipliers with their minimum permitted values.
+    if (treeSizePenaltyMultiplier.rangeFixed() == false) {
+        treeSizePenaltyMultiplier.set(minBoundary(
+            treeSizePenaltyMultiplier, m_GainPerNode90thPercentile,
+            2.0 * m_GainPerNode90thPercentile / m_GainPerNode1stPercentile));
+    }
+    if (leafWeightPenaltyMultiplier.rangeFixed() == false) {
+        leafWeightPenaltyMultiplier.set(minBoundary(
+            leafWeightPenaltyMultiplier, m_TotalCurvaturePerNode90thPercentile,
+            2.0 * m_TotalCurvaturePerNode90thPercentile / m_TotalCurvaturePerNode1stPercentile));
+    }
+
     // Search for depth limit at which the tree starts to overfit.
     if (softTreeDepthLimitParameter.rangeFixed() == false) {
         if (this->skipCheckpointIfAtOrAfter(CBoostedTreeImpl::E_SoftTreeDepthLimitInitialized, [&] {
@@ -506,18 +535,22 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
                     double maxSearchValue{
                         softTreeDepthLimitParameter.toSearchValue(maxSoftDepthLimit)};
                     depthPenaltyMultiplierParameter.set(m_GainPerNode50thPercentile);
-                    hyperparameters.initializeFineTuneSearchInterval(
-                        CBoostedTreeHyperparameters::CInitializeFineTuneArguments{
-                            frame, *m_TreeImpl, maxSoftDepthLimit, log2MaxTreeSize,
-                            [](CBoostedTreeImpl& tree, double softDepthLimit) {
-                                auto& parameter = tree.m_Hyperparameters.softTreeDepthLimit();
-                                parameter.set(parameter.fromSearchValue(softDepthLimit));
-                                return true;
-                            }}
-                            .truncateParameter([&](TVector& range) {
-                                range = truncate(range, minSearchValue, maxSearchValue);
-                            }),
-                        softTreeDepthLimitParameter);
+                    std::tie(m_LossGap, m_NumberTrees) =
+                        hyperparameters
+                            .initializeFineTuneSearchInterval(
+                                CBoostedTreeHyperparameters::CInitializeFineTuneArguments{
+                                    frame, *m_TreeImpl, maxSoftDepthLimit, log2MaxTreeSize,
+                                    [](CBoostedTreeImpl& tree, double softDepthLimit) {
+                                        auto& parameter =
+                                            tree.m_Hyperparameters.softTreeDepthLimit();
+                                        parameter.set(parameter.fromSearchValue(softDepthLimit));
+                                        return true;
+                                    }}
+                                    .truncateParameter([&](TVector& range) {
+                                        range = truncate(range, minSearchValue, maxSearchValue);
+                                    }),
+                                softTreeDepthLimitParameter)
+                            .value_or(std::make_pair(m_LossGap, m_NumberTrees));
                 } else {
                     softTreeDepthLimitParameter.fix();
                 }
@@ -539,16 +572,20 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
     // to overfit.
     if (depthPenaltyMultiplierParameter.rangeFixed() == false) {
         if (this->skipCheckpointIfAtOrAfter(CBoostedTreeImpl::E_DepthPenaltyMultiplierInitialized, [&] {
-                hyperparameters.initializeFineTuneSearchInterval(
-                    CBoostedTreeHyperparameters::CInitializeFineTuneArguments{
-                        frame, *m_TreeImpl, m_GainPerNode90thPercentile,
-                        2.0 * m_GainPerNode90thPercentile / m_GainPerNode1stPercentile,
-                        [](CBoostedTreeImpl& tree, double depthPenalty) {
-                            auto& parameter = tree.m_Hyperparameters.depthPenaltyMultiplier();
-                            parameter.set(parameter.fromSearchValue(depthPenalty));
-                            return true;
-                        }},
-                    depthPenaltyMultiplierParameter);
+                std::tie(m_LossGap, m_NumberTrees) =
+                    hyperparameters
+                        .initializeFineTuneSearchInterval(
+                            CBoostedTreeHyperparameters::CInitializeFineTuneArguments{
+                                frame, *m_TreeImpl, m_GainPerNode90thPercentile,
+                                2.0 * m_GainPerNode90thPercentile / m_GainPerNode1stPercentile,
+                                [](CBoostedTreeImpl& tree, double depthPenalty) {
+                                    auto& parameter =
+                                        tree.m_Hyperparameters.depthPenaltyMultiplier();
+                                    parameter.set(parameter.fromSearchValue(depthPenalty));
+                                    return true;
+                                }},
+                            depthPenaltyMultiplierParameter)
+                        .value_or(std::make_pair(m_LossGap, m_NumberTrees));
             })) {
             m_TreeImpl->m_TrainingProgress.increment(
                 this->lineSearchMaximumNumberIterations(frame));
@@ -565,21 +602,23 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
 
     // Search for the value of the tree size penalty multiplier at which the
     // model starts to overfit.
-    if (hyperparameters.treeSizePenaltyMultiplier().rangeFixed() == false) {
-        if (this->skipCheckpointIfAtOrAfter(
-                CBoostedTreeImpl::E_TreeSizePenaltyMultiplierInitialized, [&] {
-                    hyperparameters.initializeFineTuneSearchInterval(
-                        CBoostedTreeHyperparameters::CInitializeFineTuneArguments{
-                            frame, *m_TreeImpl, m_GainPerNode90thPercentile,
-                            2.0 * m_GainPerNode90thPercentile / m_GainPerNode1stPercentile,
-                            [](CBoostedTreeImpl& tree, double treeSizePenalty) {
-                                auto& parameter =
-                                    tree.m_Hyperparameters.treeSizePenaltyMultiplier();
-                                parameter.set(parameter.fromSearchValue(treeSizePenalty));
-                                return true;
-                            }},
-                        hyperparameters.treeSizePenaltyMultiplier());
-                })) {
+    if (treeSizePenaltyMultiplier.rangeFixed() == false) {
+        if (this->skipCheckpointIfAtOrAfter(CBoostedTreeImpl::E_TreeSizePenaltyMultiplierInitialized, [&] {
+                std::tie(m_LossGap, m_NumberTrees) =
+                    hyperparameters
+                        .initializeFineTuneSearchInterval(
+                            CBoostedTreeHyperparameters::CInitializeFineTuneArguments{
+                                frame, *m_TreeImpl, m_GainPerNode90thPercentile,
+                                2.0 * m_GainPerNode90thPercentile / m_GainPerNode1stPercentile,
+                                [](CBoostedTreeImpl& tree, double treeSizePenalty) {
+                                    auto& parameter =
+                                        tree.m_Hyperparameters.treeSizePenaltyMultiplier();
+                                    parameter.set(parameter.fromSearchValue(treeSizePenalty));
+                                    return true;
+                                }},
+                            treeSizePenaltyMultiplier)
+                        .value_or(std::make_pair(m_LossGap, m_NumberTrees));
+            })) {
             m_TreeImpl->m_TrainingProgress.increment(
                 this->lineSearchMaximumNumberIterations(frame));
         }
@@ -587,25 +626,30 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
 
     // Search for the value of the leaf weight penalty multiplier at which the
     // model starts to overfit.
-    if (hyperparameters.leafWeightPenaltyMultiplier().rangeFixed() == false) {
-        if (this->skipCheckpointIfAtOrAfter(
-                CBoostedTreeImpl::E_LeafWeightPenaltyMultiplierInitialized, [&] {
-                    hyperparameters.initializeFineTuneSearchInterval(
-                        CBoostedTreeHyperparameters::CInitializeFineTuneArguments{
-                            frame, *m_TreeImpl, m_TotalCurvaturePerNode90thPercentile,
-                            2.0 * m_TotalCurvaturePerNode90thPercentile / m_TotalCurvaturePerNode1stPercentile,
-                            [](CBoostedTreeImpl& tree, double leafWeightPenalty) {
-                                auto& parameter =
-                                    tree.m_Hyperparameters.leafWeightPenaltyMultiplier();
-                                parameter.set(parameter.fromSearchValue(leafWeightPenalty));
-                                return true;
-                            }},
-                        hyperparameters.leafWeightPenaltyMultiplier());
-                })) {
+    if (leafWeightPenaltyMultiplier.rangeFixed() == false) {
+        if (this->skipCheckpointIfAtOrAfter(CBoostedTreeImpl::E_LeafWeightPenaltyMultiplierInitialized, [&] {
+                std::tie(m_LossGap, m_NumberTrees) =
+                    hyperparameters
+                        .initializeFineTuneSearchInterval(
+                            CBoostedTreeHyperparameters::CInitializeFineTuneArguments{
+                                frame, *m_TreeImpl, m_TotalCurvaturePerNode90thPercentile,
+                                2.0 * m_TotalCurvaturePerNode90thPercentile / m_TotalCurvaturePerNode1stPercentile,
+                                [](CBoostedTreeImpl& tree, double leafWeightPenalty) {
+                                    auto& parameter =
+                                        tree.m_Hyperparameters.leafWeightPenaltyMultiplier();
+                                    parameter.set(parameter.fromSearchValue(leafWeightPenalty));
+                                    return true;
+                                }},
+                            leafWeightPenaltyMultiplier)
+                        .value_or(std::make_pair(m_LossGap, m_NumberTrees));
+            })) {
             m_TreeImpl->m_TrainingProgress.increment(
                 this->lineSearchMaximumNumberIterations(frame));
         }
     }
+
+    this->initializeUnsetPredictionChangeCost();
+    this->initializeUnsetTreeTopologyPenalty(frame);
 }
 
 void CBoostedTreeFactory::initializeUnsetDownsampleFactor(core::CDataFrame& frame) {
@@ -640,33 +684,37 @@ void CBoostedTreeFactory::initializeUnsetDownsampleFactor(core::CDataFrame& fram
                     tree.scaleRegularizationMultipliers(downsampleFactor / initialDownsampleFactor);
                 };
 
-                hyperparameters.initializeFineTuneSearchInterval(
-                    CBoostedTreeHyperparameters::CInitializeFineTuneArguments{
-                        frame, *m_TreeImpl, maxDownsampleFactor, searchIntervalSize,
-                        [&](CBoostedTreeImpl& tree, double downsampleFactor) {
-                            auto& parameter = tree.m_Hyperparameters.downsampleFactor();
-                            downsampleFactor = parameter.fromSearchValue(downsampleFactor);
-                            parameter.set(downsampleFactor);
-                            scaleRegularizers(tree, downsampleFactor);
-                            return downsampleFactor * numberTrainingRows > 10.0;
-                        }}
-                        .adjustLoss([&](double downsampleFactor, double minTestLoss, double testLoss) {
-                            // If there is very little relative difference in the loss prefer
-                            // smaller downsample factors because they train faster. We add a
-                            // penalty which is  eps * lmin * (x - xmin) / (xmax - xmin) for x
-                            // the downsample factor, [xmin, xmax] the search interval and lmin
-                            // the minimum test loss. This means we'll never use a parameter
-                            // whose loss is more than 1 + eps times larger than the minimum.
-                            return testLoss +
-                                   common::CTools::linearlyInterpolate(
-                                       searchIntervalStart, searchIntervalEnd, 0.0,
-                                       SMALL_RELATIVE_TEST_LOSS_INCREASE * minTestLoss,
-                                       downsampleFactor);
-                        })
-                        .truncateParameter([&](TVector& range) {
-                            range = truncate(range, minSearchValue, maxSearchValue);
-                        }),
-                    downsampleFactorParameter);
+                std::tie(m_LossGap, m_NumberTrees) =
+                    hyperparameters
+                        .initializeFineTuneSearchInterval(
+                            CBoostedTreeHyperparameters::CInitializeFineTuneArguments{
+                                frame, *m_TreeImpl, maxDownsampleFactor, searchIntervalSize,
+                                [&](CBoostedTreeImpl& tree, double downsampleFactor) {
+                                    auto& parameter = tree.m_Hyperparameters.downsampleFactor();
+                                    downsampleFactor = parameter.fromSearchValue(downsampleFactor);
+                                    parameter.set(downsampleFactor);
+                                    scaleRegularizers(tree, downsampleFactor);
+                                    return downsampleFactor * numberTrainingRows > 10.0;
+                                }}
+                                .adjustLoss([&](double downsampleFactor,
+                                                double minTestLoss, double testLoss) {
+                                    // If there is very little relative difference in the loss prefer
+                                    // smaller downsample factors because they train faster. We add a
+                                    // penalty which is  eps * lmin * (x - xmin) / (xmax - xmin) for x
+                                    // the downsample factor, [xmin, xmax] the search interval and lmin
+                                    // the minimum test loss. This means we'll never use a parameter
+                                    // whose loss is more than 1 + eps times larger than the minimum.
+                                    return testLoss +
+                                           common::CTools::linearlyInterpolate(
+                                               searchIntervalStart, searchIntervalEnd,
+                                               0.0, SMALL_RELATIVE_TEST_LOSS_INCREASE * minTestLoss,
+                                               downsampleFactor);
+                                })
+                                .truncateParameter([&](TVector& range) {
+                                    range = truncate(range, minSearchValue, maxSearchValue);
+                                }),
+                            downsampleFactorParameter)
+                        .value_or(std::make_pair(m_LossGap, m_NumberTrees));
 
                 scaleRegularizers(*m_TreeImpl, downsampleFactorParameter.value());
 
@@ -706,32 +754,38 @@ void CBoostedTreeFactory::initializeUnsetFeatureBagFraction(core::CDataFrame& fr
                 double maxSearchValue{hyperparameters.featureBagFraction().toSearchValue(
                     MAX_FEATURE_BAG_FRACTION)};
 
-                hyperparameters.initializeFineTuneSearchInterval(
-                    CBoostedTreeHyperparameters::CInitializeFineTuneArguments{
-                        frame, *m_TreeImpl, maxFeatureBagFraction, searchIntervalSize,
-                        [&](CBoostedTreeImpl& tree, double featureBagFraction) {
-                            auto& parameter = tree.m_Hyperparameters.featureBagFraction();
-                            featureBagFraction = parameter.fromSearchValue(featureBagFraction);
-                            parameter.set(featureBagFraction);
-                            return tree.featureBagSize(featureBagFraction) > 1;
-                        }}
-                        .adjustLoss([&](double featureBagFraction, double minTestLoss, double testLoss) {
-                            // If there is very little relative difference in the loss prefer
-                            // smaller feature bag fractions because they train faster. We add
-                            // a penalty which is eps * lmin * (x - xmin) / (xmax - xmin) for x
-                            // the feature bag fraction, [xmin, xmax] the search interval and
-                            // lmin the minimum test loss. This means we'll never use a parameter
-                            // whose loss is more than 1 + eps times larger than the minimum.
-                            return testLoss +
-                                   common::CTools::linearlyInterpolate(
-                                       searchIntervalStart, searchIntervalEnd, 0.0,
-                                       SMALL_RELATIVE_TEST_LOSS_INCREASE * minTestLoss,
-                                       featureBagFraction);
-                        })
-                        .truncateParameter([&](TVector& range) {
-                            range = truncate(range, minSearchValue, maxSearchValue);
-                        }),
-                    hyperparameters.featureBagFraction());
+                std::tie(m_LossGap, m_NumberTrees) =
+                    hyperparameters
+                        .initializeFineTuneSearchInterval(
+                            CBoostedTreeHyperparameters::CInitializeFineTuneArguments{
+                                frame, *m_TreeImpl, maxFeatureBagFraction, searchIntervalSize,
+                                [&](CBoostedTreeImpl& tree, double featureBagFraction) {
+                                    auto& parameter =
+                                        tree.m_Hyperparameters.featureBagFraction();
+                                    featureBagFraction =
+                                        parameter.fromSearchValue(featureBagFraction);
+                                    parameter.set(featureBagFraction);
+                                    return tree.featureBagSize(featureBagFraction) > 1;
+                                }}
+                                .adjustLoss([&](double featureBagFraction,
+                                                double minTestLoss, double testLoss) {
+                                    // If there is very little relative difference in the loss prefer
+                                    // smaller feature bag fractions because they train faster. We add
+                                    // a penalty which is eps * lmin * (x - xmin) / (xmax - xmin) for x
+                                    // the feature bag fraction, [xmin, xmax] the search interval and
+                                    // lmin the minimum test loss. This means we'll never use a parameter
+                                    // whose loss is more than 1 + eps times larger than the minimum.
+                                    return testLoss +
+                                           common::CTools::linearlyInterpolate(
+                                               searchIntervalStart, searchIntervalEnd,
+                                               0.0, SMALL_RELATIVE_TEST_LOSS_INCREASE * minTestLoss,
+                                               featureBagFraction);
+                                })
+                                .truncateParameter([&](TVector& range) {
+                                    range = truncate(range, minSearchValue, maxSearchValue);
+                                }),
+                            hyperparameters.featureBagFraction())
+                        .value_or(std::make_pair(m_LossGap, m_NumberTrees));
             })) {
             m_TreeImpl->m_TrainingProgress.increment(
                 this->lineSearchMaximumNumberIterations(frame));
@@ -761,13 +815,16 @@ void CBoostedTreeFactory::initializeUnsetEta(core::CDataFrame& frame) {
                     return true;
                 };
 
-                hyperparameters.initializeFineTuneSearchInterval(
-                    CBoostedTreeHyperparameters::CInitializeFineTuneArguments{
-                        frame, *m_TreeImpl, maxEta, searchIntervalSize, applyEta}
-                        .truncateParameter([&](TVector& range) {
-                            range = truncate(range, minSearchValue, maxSearchValue);
-                        }),
-                    hyperparameters.eta());
+                std::tie(m_LossGap, m_NumberTrees) =
+                    hyperparameters
+                        .initializeFineTuneSearchInterval(
+                            CBoostedTreeHyperparameters::CInitializeFineTuneArguments{
+                                frame, *m_TreeImpl, maxEta, searchIntervalSize, applyEta}
+                                .truncateParameter([&](TVector& range) {
+                                    range = truncate(range, minSearchValue, maxSearchValue);
+                                }),
+                            hyperparameters.eta())
+                        .value_or(std::make_pair(m_LossGap, m_NumberTrees));
 
                 applyEta(*m_TreeImpl, hyperparameters.eta().toSearchValue());
                 hyperparameters.maximumNumberTrees().set(computeMaximumNumberTrees(
@@ -777,6 +834,7 @@ void CBoostedTreeFactory::initializeUnsetEta(core::CDataFrame& frame) {
                 this->lineSearchMaximumNumberIterations(frame, 0.5));
         }
     }
+
     if (hyperparameters.eta().fixed() == false &&
         hyperparameters.etaGrowthRatePerTree().rangeFixed() == false) {
         double rate{m_TreeImpl->m_Hyperparameters.etaGrowthRatePerTree().value() - 1.0};
@@ -1175,7 +1233,7 @@ CBoostedTreeFactory::lineSearchMaximumNumberIterations(const core::CDataFrame& f
     double eta{m_TreeImpl->m_Hyperparameters.eta().fixed()
                    ? m_TreeImpl->m_Hyperparameters.eta().value()
                    : computeEta(frame.numberColumns() - m_PaddedExtraColumns)};
-    return m_TreeImpl->m_Hyperparameters.maxLineSearchIterations() *
+    return CBoostedTreeHyperparameters::maxLineSearchIterations() *
            computeMaximumNumberTrees(etaScale * eta);
 }
 
@@ -1231,7 +1289,10 @@ const std::string FACTORY_TAG{"factory"};
 const std::string GAIN_PER_NODE_1ST_PERCENTILE_TAG{"gain_per_node_1st_percentile"};
 const std::string GAIN_PER_NODE_50TH_PERCENTILE_TAG{"gain_per_node_50th_percentile"};
 const std::string GAIN_PER_NODE_90TH_PERCENTILE_TAG{"gain_per_node_90th_percentile"};
+const std::string HYPERPARAMETERS_LOSSES_TAG{"hyperparameters_losses"};
 const std::string INITIALIZATION_CHECKPOINT_TAG{"initialization_checkpoint"};
+const std::string LOSS_GAP_TAG{"loss_gap"};
+const std::string NUMBER_TREES_TAG{"number_trees"};
 const std::string ROW_WEIGHT_COLUMN_NAME_TAG{"row_weight_column_name"};
 const std::string TOTAL_CURVATURE_PER_NODE_1ST_PERCENTILE_TAG{"total_curvature_per_node_1st_percentile"};
 const std::string TOTAL_CURVATURE_PER_NODE_90TH_PERCENTILE_TAG{"total_curvature_per_node_90th_percentile"};
@@ -1249,6 +1310,8 @@ void CBoostedTreeFactory::acceptPersistInserter(core::CStatePersistInserter& ins
                                      m_GainPerNode50thPercentile, inserter);
         core::CPersistUtils::persist(GAIN_PER_NODE_90TH_PERCENTILE_TAG,
                                      m_GainPerNode90thPercentile, inserter);
+        core::CPersistUtils::persist(LOSS_GAP_TAG, m_LossGap, inserter);
+        core::CPersistUtils::persist(NUMBER_TREES_TAG, m_NumberTrees, inserter);
         core::CPersistUtils::persist(ROW_WEIGHT_COLUMN_NAME_TAG,
                                      m_RowWeightColumnName, inserter);
         core::CPersistUtils::persist(TOTAL_CURVATURE_PER_NODE_1ST_PERCENTILE_TAG,
@@ -1284,6 +1347,11 @@ bool CBoostedTreeFactory::acceptRestoreTraverser(core::CStateRestoreTraverser& t
                                 core::CPersistUtils::restore(
                                     GAIN_PER_NODE_90TH_PERCENTILE_TAG,
                                     m_GainPerNode90thPercentile, traverser))
+                        RESTORE(LOSS_GAP_TAG, core::CPersistUtils::restore(
+                                                  LOSS_GAP_TAG, m_LossGap, traverser))
+                        RESTORE(NUMBER_TREES_TAG,
+                                core::CPersistUtils::restore(
+                                    NUMBER_TREES_TAG, m_NumberTrees, traverser))
                         RESTORE(ROW_WEIGHT_COLUMN_NAME_TAG,
                                 core::CPersistUtils::restore(ROW_WEIGHT_COLUMN_NAME_TAG,
                                                              m_RowWeightColumnName, traverser))

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -233,7 +233,7 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
                                       1 /*single tree*/);
         LOG_TRACE(<< "Test loss = " << m_Hyperparameters.bestForestTestLoss());
 
-    } else if (m_Hyperparameters.searchNotFinished() || m_BestForest.empty()) {
+    } else if (m_Hyperparameters.fineTuneSearchNotFinished() || m_BestForest.empty()) {
         TMeanVarAccumulator timeAccumulator;
         core::CStopWatch stopWatch;
         stopWatch.start();
@@ -243,7 +243,9 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
         this->initializePerFoldTestLosses();
 
-        for (m_Hyperparameters.startSearch(); m_Hyperparameters.searchNotFinished(); /**/) {
+        for (m_Hyperparameters.startFineTuneSearch();
+             m_Hyperparameters.fineTuneSearchNotFinished();
+             /**/) {
 
             LOG_TRACE(<< "Optimisation round = " << m_Hyperparameters.currentRound() + 1);
             m_Instrumentation->iteration(m_Hyperparameters.currentRound() + 1);
@@ -270,9 +272,9 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
             if (m_Hyperparameters.selectNext(crossValidationResult.s_TestLossMoments,
                                              this->betweenFoldTestLossVariance()) == false) {
-                LOG_INFO(<< "Exiting hyperparameter optimisation loop on round "
-                         << m_Hyperparameters.currentRound() << " out of "
-                         << m_Hyperparameters.numberRounds() << ".");
+                LOG_DEBUG(<< "Stopping fine tune hyperparameters on round "
+                          << m_Hyperparameters.currentRound() << " out of "
+                          << m_Hyperparameters.numberRounds());
                 break;
             }
 
@@ -282,7 +284,7 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
             // We need to update the current round before we persist so we don't
             // perform an extra round when we fail over.
-            m_Hyperparameters.startNextSearchRound();
+            m_Hyperparameters.startNextRound();
 
             // Store the training state after each hyperparameter search step.
             LOG_TRACE(<< "Round " << m_Hyperparameters.currentRound()

--- a/lib/maths/analytics/unittest/CBoostedTreeHyperparametersTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeHyperparametersTest.cc
@@ -1,0 +1,599 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the following additional limitation. Functionality enabled by the
+ * files subject to the Elastic License 2.0 may only be used in production when
+ * invoked by an Elasticsearch process with a license key installed that permits
+ * use of machine learning features. You may not use this file except in
+ * compliance with the Elastic License 2.0 and the foregoing additional
+ * limitation.
+ */
+
+#include <core/CJsonStatePersistInserter.h>
+#include <core/CJsonStateRestoreTraverser.h>
+
+#include <maths/analytics/CBoostedTreeHyperparameters.h>
+#include <maths/analytics/CBoostedTreeImpl.h>
+#include <maths/analytics/CBoostedTreeLoss.h>
+
+#include <test/CRandomNumbers.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <limits>
+#include <utility>
+
+BOOST_AUTO_TEST_SUITE(CBoostedTreeHyperparametersTest)
+
+using namespace ml;
+
+using TDoubleVec = std::vector<double>;
+using TDoubleVecVec = std::vector<TDoubleVec>;
+using TDoubleParameter = maths::analytics::CBoostedTreeParameter<double>;
+using TMeanAccumulator = maths::analytics::CBoostedTreeHyperparameters::TMeanAccumulator;
+using TMeanVarAccumulator = maths::analytics::CBoostedTreeHyperparameters::TMeanVarAccumulator;
+
+BOOST_AUTO_TEST_CASE(testBoostedTreeParameter) {
+
+    TDoubleParameter parameter1{10.0};
+
+    BOOST_REQUIRE_EQUAL(10.0, parameter1.value());
+
+    parameter1.save();
+    parameter1.set(5.0);
+
+    BOOST_REQUIRE_EQUAL(5.0, parameter1.value());
+
+    parameter1.load();
+
+    BOOST_REQUIRE_EQUAL(10.0, parameter1.value());
+
+    parameter1.fixTo(12.0);
+
+    BOOST_TEST_REQUIRE(parameter1.fixed());
+    BOOST_REQUIRE_EQUAL(12.0, parameter1.value());
+
+    parameter1.set(10.0);
+
+    BOOST_REQUIRE_EQUAL(12.0, parameter1.value());
+
+    TDoubleParameter parameter2{10.0};
+
+    parameter2.fixToRange(8.0, 12.0);
+
+    BOOST_TEST_REQUIRE(parameter2.rangeFixed());
+
+    parameter2.set(11.0);
+
+    BOOST_REQUIRE_EQUAL(11.0, parameter2.value());
+
+    parameter2.set(7.0);
+
+    BOOST_REQUIRE_EQUAL(8.0, parameter2.value());
+
+    parameter2.set(15.0);
+
+    BOOST_REQUIRE_EQUAL(12.0, parameter2.value());
+
+    TDoubleParameter parameter3{10.0};
+
+    parameter3.fixTo(TDoubleVec{11.0});
+
+    BOOST_TEST_REQUIRE(parameter3.fixed());
+    BOOST_REQUIRE_EQUAL(11.0, parameter3.value());
+
+    TDoubleParameter parameter4{10.0};
+
+    parameter4.fixTo(TDoubleVec{12.0, 14.0});
+
+    BOOST_TEST_REQUIRE(parameter4.rangeFixed());
+}
+
+BOOST_AUTO_TEST_CASE(testBoostedTreeParameterScaling) {
+
+    TDoubleParameter parameter{10.0};
+
+    parameter.scale(1.5);
+    BOOST_REQUIRE_EQUAL(1.5, parameter.scale());
+    BOOST_REQUIRE_EQUAL(15.0, parameter.value());
+
+    parameter.scale(1.2).captureScale();
+    BOOST_REQUIRE_EQUAL(1.0, parameter.scale());
+    BOOST_REQUIRE_EQUAL(12.0, parameter.value());
+
+    parameter.fixToRange(12.0, 15.0);
+
+    parameter.scale(0.1);
+    BOOST_REQUIRE_CLOSE(1.2, parameter.value(), 1e-6);
+    BOOST_REQUIRE_EQUAL(12.0, parameter.toSearchValue());
+    BOOST_REQUIRE_EQUAL(12.0, parameter.searchRange().first);
+    BOOST_REQUIRE_EQUAL(15.0, parameter.searchRange().second);
+
+    parameter.captureScale();
+    BOOST_REQUIRE_CLOSE(1.2, parameter.value(), 1e-6);
+    BOOST_REQUIRE_EQUAL(1.0, parameter.scale());
+    BOOST_REQUIRE_CLOSE(1.2, parameter.toSearchValue(), 1e-6);
+    BOOST_REQUIRE_CLOSE(1.2, parameter.searchRange().first, 1e-6);
+    BOOST_REQUIRE_CLOSE(1.5, parameter.searchRange().second, 1e-6);
+}
+
+BOOST_AUTO_TEST_CASE(testBoostedTreeParameterPersist) {
+
+    // Test that checksums of the original and restored parameters agree.
+
+    TDoubleParameter origParameter{10.0};
+    origParameter.save();
+    origParameter.set(5.0);
+
+    std::stringstream state;
+    {
+        // We need to call the inserter destructor to finish writing the state.
+        core::CJsonStatePersistInserter inserter{state};
+        origParameter.acceptPersistInserter(inserter);
+        state.flush();
+    }
+
+    core::CJsonStateRestoreTraverser traverser(state);
+
+    TDoubleParameter restoredParameter{1.0};
+    BOOST_TEST_REQUIRE(restoredParameter.acceptRestoreTraverser(traverser));
+
+    BOOST_REQUIRE_EQUAL(origParameter.checksum(), restoredParameter.checksum());
+}
+
+BOOST_AUTO_TEST_CASE(testBoostedTreeHyperparametersAccessors) {
+
+    // Check that setters and getters work for all hyperparameters.
+
+    auto asConst = [](const maths::analytics::CBoostedTreeHyperparameters& parameters) {
+        return &parameters;
+    };
+
+    maths::analytics::CBoostedTreeHyperparameters origHyperaparameters;
+    origHyperaparameters.treeSizePenaltyMultiplier().set(1.0);
+    BOOST_REQUIRE_EQUAL(
+        1.0, asConst(origHyperaparameters)->treeSizePenaltyMultiplier().value());
+    origHyperaparameters.leafWeightPenaltyMultiplier().set(5.0);
+    BOOST_REQUIRE_EQUAL(
+        5.0, asConst(origHyperaparameters)->leafWeightPenaltyMultiplier().value());
+    origHyperaparameters.softTreeDepthLimit().set(8.0);
+    BOOST_REQUIRE_EQUAL(8.0, asConst(origHyperaparameters)->softTreeDepthLimit().value());
+    origHyperaparameters.treeTopologyChangePenalty().set(1.5);
+    BOOST_REQUIRE_EQUAL(
+        1.5, asConst(origHyperaparameters)->treeTopologyChangePenalty().value());
+    origHyperaparameters.downsampleFactor().set(0.2);
+    BOOST_REQUIRE_EQUAL(0.2, asConst(origHyperaparameters)->downsampleFactor().value());
+    origHyperaparameters.featureBagFraction().set(0.5);
+    BOOST_REQUIRE_EQUAL(0.5, asConst(origHyperaparameters)->featureBagFraction().value());
+    origHyperaparameters.eta().set(0.3);
+    BOOST_REQUIRE_EQUAL(0.3, asConst(origHyperaparameters)->eta().value());
+    origHyperaparameters.etaGrowthRatePerTree().set(0.05);
+    BOOST_REQUIRE_EQUAL(
+        0.05, asConst(origHyperaparameters)->etaGrowthRatePerTree().value());
+    origHyperaparameters.retrainedTreeEta().set(0.9);
+    BOOST_REQUIRE_EQUAL(0.9, asConst(origHyperaparameters)->retrainedTreeEta().value());
+    origHyperaparameters.predictionChangeCost().set(20.0);
+    BOOST_REQUIRE_EQUAL(
+        20.0, asConst(origHyperaparameters)->predictionChangeCost().value());
+    origHyperaparameters.maximumNumberTrees().set(100);
+    BOOST_REQUIRE_EQUAL(100, asConst(origHyperaparameters)->maximumNumberTrees().value());
+}
+
+BOOST_AUTO_TEST_CASE(testBoostedTreeHyperparametersOptimisationCaptureBest) {
+
+    // Check that we do recover best hyperparameters with minimum loss.
+
+    maths::analytics::CBoostedTreeHyperparameters hyperparameters;
+
+    hyperparameters.stopHyperparameterOptimizationEarly(false);
+
+    hyperparameters.depthPenaltyMultiplier().fixToRange(0.1, 1.0);
+    hyperparameters.treeSizePenaltyMultiplier().fixToRange(0.1, 1.0);
+    hyperparameters.leafWeightPenaltyMultiplier().fixToRange(0.1, 1.0);
+    hyperparameters.softTreeDepthLimit().fixToRange(0.1, 1.0);
+    hyperparameters.softTreeDepthTolerance().fixToRange(0.1, 1.0);
+    hyperparameters.downsampleFactor().fixToRange(0.1, 1.0);
+    hyperparameters.featureBagFraction().fixToRange(0.1, 1.0);
+    hyperparameters.eta().fixToRange(0.1, 1.0);
+    hyperparameters.etaGrowthRatePerTree().fixToRange(0.1, 1.0);
+
+    hyperparameters.initializeFineTuneSearch(0.0, 0);
+
+    test::CRandomNumbers rng;
+    TDoubleVec losses;
+
+    double minimumLoss{std::numeric_limits<double>::max()};
+    TDoubleVec expectedBestParameters;
+
+    for (hyperparameters.startFineTuneSearch();
+         hyperparameters.fineTuneSearchNotFinished(); hyperparameters.startNextRound()) {
+
+        TMeanVarAccumulator testLossMoments;
+        rng.generateUniformSamples(0.5, 1.5, 3, losses);
+        testLossMoments.add(losses);
+
+        hyperparameters.captureBest(testLossMoments, 0.0, 100, 0, 50);
+
+        double loss{maths::analytics::CBoostedTreeHyperparameters::lossAtNSigma(1, testLossMoments)};
+        if (loss < minimumLoss) {
+            expectedBestParameters.assign(
+                {hyperparameters.depthPenaltyMultiplier().value(),
+                 hyperparameters.treeSizePenaltyMultiplier().value(),
+                 hyperparameters.leafWeightPenaltyMultiplier().value(),
+                 hyperparameters.softTreeDepthLimit().value(),
+                 hyperparameters.softTreeDepthTolerance().value(),
+                 hyperparameters.downsampleFactor().value(),
+                 hyperparameters.featureBagFraction().value(),
+                 hyperparameters.etaGrowthRatePerTree().value(),
+                 hyperparameters.eta().value()});
+        }
+    }
+
+    hyperparameters.restoreBest();
+
+    BOOST_REQUIRE_EQUAL(expectedBestParameters[0],
+                        hyperparameters.depthPenaltyMultiplier().value());
+    BOOST_REQUIRE_EQUAL(expectedBestParameters[1],
+                        hyperparameters.treeSizePenaltyMultiplier().value());
+    BOOST_REQUIRE_EQUAL(expectedBestParameters[2],
+                        hyperparameters.leafWeightPenaltyMultiplier().value());
+    BOOST_REQUIRE_EQUAL(expectedBestParameters[3],
+                        hyperparameters.softTreeDepthLimit().value());
+    BOOST_REQUIRE_EQUAL(expectedBestParameters[4],
+                        hyperparameters.softTreeDepthTolerance().value());
+    BOOST_REQUIRE_EQUAL(expectedBestParameters[5],
+                        hyperparameters.downsampleFactor().value());
+    BOOST_REQUIRE_EQUAL(expectedBestParameters[6],
+                        hyperparameters.featureBagFraction().value());
+    BOOST_REQUIRE_EQUAL(expectedBestParameters[7],
+                        hyperparameters.etaGrowthRatePerTree().value());
+    BOOST_REQUIRE_EQUAL(expectedBestParameters[8], hyperparameters.eta().value());
+}
+
+BOOST_AUTO_TEST_CASE(testBoostedTreeHyperparametersOptimisationWithOverrides) {
+
+    // Check that fixed parameters are not adjusted.
+
+    maths::analytics::CBoostedTreeHyperparameters hyperparameters;
+
+    hyperparameters.maximumOptimisationRoundsPerHyperparameter(2);
+
+    hyperparameters.depthPenaltyMultiplier().fixToRange(0.1, 1.0);
+    hyperparameters.treeSizePenaltyMultiplier().fixToRange(0.1, 1.0);
+    hyperparameters.leafWeightPenaltyMultiplier().fixToRange(0.1, 1.0);
+    hyperparameters.softTreeDepthLimit().fixToRange(0.1, 1.0);
+    hyperparameters.softTreeDepthTolerance().fixToRange(0.1, 1.0);
+    hyperparameters.downsampleFactor().fixToRange(0.1, 1.0);
+    hyperparameters.featureBagFraction().fixToRange(0.1, 1.0);
+    hyperparameters.eta().fixToRange(0.1, 1.0);
+    hyperparameters.etaGrowthRatePerTree().fixToRange(0.1, 1.0);
+
+    auto testFix = [&](TDoubleParameter& parameter, std::size_t& numberToTune) {
+
+        parameter.fixTo(TDoubleVec{0.5});
+
+        hyperparameters.initializeFineTuneSearch(0.0, 0);
+
+        BOOST_REQUIRE_EQUAL(--numberToTune, hyperparameters.numberToTune());
+        BOOST_REQUIRE_EQUAL(2 * hyperparameters.numberToTune(),
+                            hyperparameters.numberRounds());
+
+        test::CRandomNumbers rng;
+        TDoubleVec losses;
+        for (hyperparameters.startFineTuneSearch();
+             hyperparameters.fineTuneSearchNotFinished();
+             hyperparameters.startNextRound()) {
+
+            TMeanVarAccumulator testLossMoments;
+            rng.generateUniformSamples(0.1, 1.0, 3, losses);
+            testLossMoments.add(losses);
+            hyperparameters.selectNext(testLossMoments);
+
+            BOOST_REQUIRE_EQUAL(0.5, parameter.value());
+        }
+    };
+
+    std::size_t numberToTune{hyperparameters.numberToTune()};
+
+    testFix(hyperparameters.downsampleFactor(), numberToTune);
+    testFix(hyperparameters.depthPenaltyMultiplier(), numberToTune);
+    testFix(hyperparameters.treeSizePenaltyMultiplier(), numberToTune);
+    testFix(hyperparameters.leafWeightPenaltyMultiplier(), numberToTune);
+    testFix(hyperparameters.softTreeDepthLimit(), numberToTune);
+    testFix(hyperparameters.softTreeDepthTolerance(), numberToTune);
+    testFix(hyperparameters.featureBagFraction(), numberToTune);
+    testFix(hyperparameters.etaGrowthRatePerTree(), numberToTune);
+    testFix(hyperparameters.eta(), numberToTune);
+}
+
+BOOST_AUTO_TEST_CASE(testBoostedTreeHyperparametersOptimisationWithRangeOverrides) {
+
+    // Check that fixed parameters are not adjusted.
+
+    maths::analytics::CBoostedTreeHyperparameters hyperparameters;
+
+    hyperparameters.maximumOptimisationRoundsPerHyperparameter(2);
+
+    // Since downsample factor acts exactly like a divisor of the regularisation
+    // multipliers we adjust them as we vary this parameter to keep the amount
+    // of regularisation fixed. As such we override it so we can assess we really
+    // do keep all parameters in range subject without scaling.
+    hyperparameters.downsampleFactor().fixToRange(0.5, 0.5);
+
+    hyperparameters.depthPenaltyMultiplier().fixToRange(0.1, 1.0);
+    hyperparameters.treeSizePenaltyMultiplier().fixToRange(0.1, 1.0);
+    hyperparameters.leafWeightPenaltyMultiplier().fixToRange(0.1, 1.0);
+    hyperparameters.softTreeDepthLimit().fixToRange(0.1, 1.0);
+    hyperparameters.softTreeDepthTolerance().fixToRange(0.1, 1.0);
+    hyperparameters.featureBagFraction().fixToRange(0.1, 1.0);
+    hyperparameters.eta().fixToRange(0.1, 1.0);
+    hyperparameters.etaGrowthRatePerTree().fixToRange(0.1, 1.0);
+
+    auto testFixToRange = [&](TDoubleParameter& parameter, std::size_t& numberToTune) {
+
+        parameter.fixTo(TDoubleVec{0.25, 0.75});
+
+        BOOST_REQUIRE_EQUAL(numberToTune, hyperparameters.numberToTune());
+
+        hyperparameters.initializeFineTuneSearch(0.0, 0);
+
+        BOOST_REQUIRE_EQUAL(2 * hyperparameters.numberToTune(),
+                            hyperparameters.numberRounds());
+
+        test::CRandomNumbers rng;
+        TDoubleVec losses;
+
+        for (hyperparameters.startFineTuneSearch();
+             hyperparameters.fineTuneSearchNotFinished();
+             hyperparameters.startNextRound()) {
+
+            TMeanVarAccumulator testLossMoments;
+            rng.generateUniformSamples(0.1, 1.0, 3, losses);
+            testLossMoments.add(losses);
+            hyperparameters.selectNext(testLossMoments);
+
+            BOOST_TEST_REQUIRE(hyperparameters.downsampleFactor().value(), 0.5);
+            BOOST_TEST_REQUIRE(parameter.value() >= 0.25);
+            BOOST_TEST_REQUIRE(parameter.value() <= 0.75);
+        }
+    };
+
+    std::size_t numberToTune{hyperparameters.numberToTune()};
+
+    testFixToRange(hyperparameters.depthPenaltyMultiplier(), numberToTune);
+    testFixToRange(hyperparameters.treeSizePenaltyMultiplier(), numberToTune);
+    testFixToRange(hyperparameters.leafWeightPenaltyMultiplier(), numberToTune);
+    testFixToRange(hyperparameters.softTreeDepthLimit(), numberToTune);
+    testFixToRange(hyperparameters.softTreeDepthTolerance(), numberToTune);
+    testFixToRange(hyperparameters.featureBagFraction(), numberToTune);
+    testFixToRange(hyperparameters.etaGrowthRatePerTree(), numberToTune);
+    testFixToRange(hyperparameters.eta(), numberToTune);
+}
+
+BOOST_AUTO_TEST_CASE(testBoostedTreeHyperparametersResetSearch) {
+
+    // Check that we generate exactly the same sequence of hyperparameters after reset
+    // and the same best values.
+
+    maths::analytics::CBoostedTreeHyperparameters hyperparameters;
+
+    auto initHyperaparameters = [&] {
+        hyperparameters.depthPenaltyMultiplier().set(0.5).scale(1.0);
+        hyperparameters.treeSizePenaltyMultiplier().set(0.5).scale(1.0);
+        hyperparameters.leafWeightPenaltyMultiplier().set(0.5).scale(1.0);
+        hyperparameters.softTreeDepthLimit().set(0.5).scale(1.0);
+        hyperparameters.softTreeDepthTolerance().set(0.5).scale(1.0);
+        hyperparameters.downsampleFactor().set(0.5).scale(1.0);
+        hyperparameters.featureBagFraction().set(0.5).scale(1.0);
+        hyperparameters.etaGrowthRatePerTree().set(0.5).scale(1.0);
+        hyperparameters.eta().set(0.5).scale(1.0);
+    };
+
+    hyperparameters.stopHyperparameterOptimizationEarly(false);
+    hyperparameters.depthPenaltyMultiplier().fixToRange(0.1, 1.0);
+    hyperparameters.treeSizePenaltyMultiplier().fixToRange(0.1, 1.0);
+    hyperparameters.leafWeightPenaltyMultiplier().fixToRange(0.1, 1.0);
+    hyperparameters.softTreeDepthLimit().fixToRange(0.1, 1.0);
+    hyperparameters.softTreeDepthTolerance().fixToRange(0.1, 1.0);
+    hyperparameters.downsampleFactor().fixToRange(0.1, 1.0);
+    hyperparameters.featureBagFraction().fixToRange(0.1, 1.0);
+    hyperparameters.eta().fixToRange(0.1, 1.0);
+    hyperparameters.etaGrowthRatePerTree().fixToRange(0.1, 1.0);
+
+    hyperparameters.initializeFineTuneSearch(0.0, 0);
+
+    test::CRandomNumbers rng;
+
+    TDoubleVec losses;
+    rng.generateUniformSamples(0.1, 1.0, 3 * hyperparameters.numberRounds(), losses);
+
+    TDoubleVecVec previousHyperparameters;
+
+    initHyperaparameters();
+
+    for (hyperparameters.startFineTuneSearch();
+         hyperparameters.fineTuneSearchNotFinished(); hyperparameters.startNextRound()) {
+        TMeanVarAccumulator testLossMoments;
+        testLossMoments.add(losses[3 * hyperparameters.currentRound() + 0]);
+        testLossMoments.add(losses[3 * hyperparameters.currentRound() + 1]);
+        testLossMoments.add(losses[3 * hyperparameters.currentRound() + 2]);
+
+        hyperparameters.selectNext(testLossMoments);
+        hyperparameters.captureBest(testLossMoments, 0.0, 100, 0, 50);
+
+        previousHyperparameters.push_back(
+            TDoubleVec{hyperparameters.depthPenaltyMultiplier().value(),
+                       hyperparameters.treeSizePenaltyMultiplier().value(),
+                       hyperparameters.leafWeightPenaltyMultiplier().value(),
+                       hyperparameters.softTreeDepthLimit().value(),
+                       hyperparameters.softTreeDepthTolerance().value(),
+                       hyperparameters.downsampleFactor().value(),
+                       hyperparameters.featureBagFraction().value(),
+                       hyperparameters.etaGrowthRatePerTree().value(),
+                       hyperparameters.eta().value()});
+    }
+
+    hyperparameters.restoreBest();
+
+    TDoubleVec previousBestHyperparameters;
+    previousBestHyperparameters.assign(
+        {hyperparameters.depthPenaltyMultiplier().value(),
+         hyperparameters.treeSizePenaltyMultiplier().value(),
+         hyperparameters.leafWeightPenaltyMultiplier().value(),
+         hyperparameters.softTreeDepthLimit().value(),
+         hyperparameters.softTreeDepthTolerance().value(),
+         hyperparameters.downsampleFactor().value(),
+         hyperparameters.featureBagFraction().value(),
+         hyperparameters.etaGrowthRatePerTree().value(), hyperparameters.eta().value()});
+
+    hyperparameters.resetFineTuneSearch();
+    hyperparameters.initializeFineTuneSearch(0.0, 0);
+
+    initHyperaparameters();
+    TDoubleVec bestParameters;
+
+    for (hyperparameters.startFineTuneSearch();
+         hyperparameters.fineTuneSearchNotFinished(); hyperparameters.startNextRound()) {
+
+        TMeanVarAccumulator testLossMoments;
+        testLossMoments.add(losses[3 * hyperparameters.currentRound() + 0]);
+        testLossMoments.add(losses[3 * hyperparameters.currentRound() + 1]);
+        testLossMoments.add(losses[3 * hyperparameters.currentRound() + 2]);
+
+        hyperparameters.selectNext(testLossMoments);
+        hyperparameters.captureBest(testLossMoments, 0.0, 100, 0, 50);
+
+        BOOST_REQUIRE_EQUAL(previousHyperparameters[hyperparameters.currentRound()][0],
+                            hyperparameters.depthPenaltyMultiplier().value());
+        BOOST_REQUIRE_EQUAL(previousHyperparameters[hyperparameters.currentRound()][1],
+                            hyperparameters.treeSizePenaltyMultiplier().value());
+        BOOST_REQUIRE_EQUAL(previousHyperparameters[hyperparameters.currentRound()][2],
+                            hyperparameters.leafWeightPenaltyMultiplier().value());
+        BOOST_REQUIRE_EQUAL(previousHyperparameters[hyperparameters.currentRound()][3],
+                            hyperparameters.softTreeDepthLimit().value());
+        BOOST_REQUIRE_EQUAL(previousHyperparameters[hyperparameters.currentRound()][4],
+                            hyperparameters.softTreeDepthTolerance().value());
+        BOOST_REQUIRE_EQUAL(previousHyperparameters[hyperparameters.currentRound()][5],
+                            hyperparameters.downsampleFactor().value());
+        BOOST_REQUIRE_EQUAL(previousHyperparameters[hyperparameters.currentRound()][6],
+                            hyperparameters.featureBagFraction().value());
+        BOOST_REQUIRE_EQUAL(previousHyperparameters[hyperparameters.currentRound()][7],
+                            hyperparameters.etaGrowthRatePerTree().value());
+        BOOST_REQUIRE_EQUAL(previousHyperparameters[hyperparameters.currentRound()][8],
+                            hyperparameters.eta().value());
+    }
+
+    hyperparameters.restoreBest();
+
+    BOOST_REQUIRE_EQUAL(previousBestHyperparameters[0],
+                        hyperparameters.depthPenaltyMultiplier().value());
+    BOOST_REQUIRE_EQUAL(previousBestHyperparameters[1],
+                        hyperparameters.treeSizePenaltyMultiplier().value());
+    BOOST_REQUIRE_EQUAL(previousBestHyperparameters[2],
+                        hyperparameters.leafWeightPenaltyMultiplier().value());
+    BOOST_REQUIRE_EQUAL(previousBestHyperparameters[3],
+                        hyperparameters.softTreeDepthLimit().value());
+    BOOST_REQUIRE_EQUAL(previousBestHyperparameters[4],
+                        hyperparameters.softTreeDepthTolerance().value());
+    BOOST_REQUIRE_EQUAL(previousBestHyperparameters[5],
+                        hyperparameters.downsampleFactor().value());
+    BOOST_REQUIRE_EQUAL(previousBestHyperparameters[6],
+                        hyperparameters.featureBagFraction().value());
+    BOOST_REQUIRE_EQUAL(previousBestHyperparameters[7],
+                        hyperparameters.etaGrowthRatePerTree().value());
+    BOOST_REQUIRE_EQUAL(previousBestHyperparameters[8], hyperparameters.eta().value());
+}
+
+BOOST_AUTO_TEST_CASE(testBoostedTreeHyperparametersPersistWithOverrides) {
+
+    // Test that checksums of the original and restored parameters agree when
+    // overrides are defined.
+
+    maths::analytics::CBoostedTreeHyperparameters origHyperaparameters;
+    origHyperaparameters.treeSizePenaltyMultiplier().set(1.0);
+    origHyperaparameters.leafWeightPenaltyMultiplier().set(5.0);
+    origHyperaparameters.softTreeDepthLimit().set(8.0);
+    origHyperaparameters.treeTopologyChangePenalty().set(1.5);
+    origHyperaparameters.downsampleFactor().set(0.2);
+    origHyperaparameters.featureBagFraction().set(0.5);
+    origHyperaparameters.eta().set(0.3);
+    origHyperaparameters.etaGrowthRatePerTree().set(0.05);
+    origHyperaparameters.retrainedTreeEta().set(0.9);
+    origHyperaparameters.predictionChangeCost().set(20.0);
+    origHyperaparameters.maximumNumberTrees().set(100);
+
+    TMeanVarAccumulator testLossMoments;
+    testLossMoments.add(1.0);
+    origHyperaparameters.captureBest(testLossMoments, 0.0, 0.0, 100.0, 500);
+
+    std::stringstream state;
+    {
+        // We need to call the inserter destructor to finish writing the state.
+        core::CJsonStatePersistInserter inserter{state};
+        origHyperaparameters.acceptPersistInserter(inserter);
+        state.flush();
+    }
+
+    core::CJsonStateRestoreTraverser traverser(state);
+
+    maths::analytics::CBoostedTreeHyperparameters restoredHyperaparameters;
+    BOOST_TEST_REQUIRE(restoredHyperaparameters.acceptRestoreTraverser(traverser));
+
+    BOOST_REQUIRE_EQUAL(origHyperaparameters.checksum(),
+                        restoredHyperaparameters.checksum());
+}
+
+BOOST_AUTO_TEST_CASE(testBoostedTreeHyperparametersPersistWithOptimisation) {
+
+    // Test that checksums of the original and restored parameters agree when
+    // after starting hyperparameter search.
+
+    maths::analytics::CBoostedTreeHyperparameters origHyperaparameters;
+
+    origHyperaparameters.depthPenaltyMultiplier().fixToRange(0.1, 1.0);
+    origHyperaparameters.treeSizePenaltyMultiplier().fixToRange(0.1, 1.0);
+    origHyperaparameters.leafWeightPenaltyMultiplier().fixToRange(0.1, 1.0);
+    origHyperaparameters.softTreeDepthLimit().fixToRange(0.1, 1.0);
+    origHyperaparameters.softTreeDepthTolerance().fixToRange(0.1, 1.0);
+    origHyperaparameters.downsampleFactor().fixToRange(0.1, 1.0);
+    origHyperaparameters.featureBagFraction().fixToRange(0.1, 1.0);
+    origHyperaparameters.eta().fixToRange(0.1, 1.0);
+    origHyperaparameters.etaGrowthRatePerTree().fixToRange(0.1, 1.0);
+
+    origHyperaparameters.initializeFineTuneSearch(0.0, 0);
+
+    origHyperaparameters.startFineTuneSearch();
+
+    maths::analytics::CBoostedTreeHyperparameters::TMeanAccumulator forestSize;
+    forestSize.add(103.0);
+    double meanTestLoss{1.0};
+    origHyperaparameters.addRoundStats(forestSize, meanTestLoss);
+
+    TMeanVarAccumulator testLossMoments;
+    testLossMoments.add(1.0);
+    testLossMoments.add(1.2);
+    testLossMoments.add(1.1);
+    origHyperaparameters.captureBest(testLossMoments, 0.0, 0.0, 100.0, 500);
+
+    origHyperaparameters.selectNext(testLossMoments);
+
+    std::stringstream state;
+    {
+        // We need to call the inserter destructor to finish writing the state.
+        core::CJsonStatePersistInserter inserter{state};
+        origHyperaparameters.acceptPersistInserter(inserter);
+        state.flush();
+    }
+
+    core::CJsonStateRestoreTraverser traverser(state);
+
+    maths::analytics::CBoostedTreeHyperparameters restoredHyperaparameters;
+    BOOST_TEST_REQUIRE(restoredHyperaparameters.acceptRestoreTraverser(traverser));
+
+    restoredHyperaparameters.startFineTuneSearch();
+
+    BOOST_REQUIRE_EQUAL(origHyperaparameters.checksum(),
+                        restoredHyperaparameters.checksum());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/maths/analytics/unittest/CBoostedTreeHyperparametersTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeHyperparametersTest.cc
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(testBoostedTreeHyperparametersOptimisationCaptureBest) {
     hyperparameters.eta().fixToRange(0.1, 1.0);
     hyperparameters.etaGrowthRatePerTree().fixToRange(0.1, 1.0);
 
-    hyperparameters.initializeFineTuneSearch(0.0, 0);
+    hyperparameters.initializeFineTuneSearch(0);
 
     test::CRandomNumbers rng;
     TDoubleVec losses;
@@ -272,7 +272,7 @@ BOOST_AUTO_TEST_CASE(testBoostedTreeHyperparametersOptimisationWithOverrides) {
 
         parameter.fixTo(TDoubleVec{0.5});
 
-        hyperparameters.initializeFineTuneSearch(0.0, 0);
+        hyperparameters.initializeFineTuneSearch(0);
 
         BOOST_REQUIRE_EQUAL(--numberToTune, hyperparameters.numberToTune());
         BOOST_REQUIRE_EQUAL(2 * hyperparameters.numberToTune(),
@@ -335,7 +335,7 @@ BOOST_AUTO_TEST_CASE(testBoostedTreeHyperparametersOptimisationWithRangeOverride
 
         BOOST_REQUIRE_EQUAL(numberToTune, hyperparameters.numberToTune());
 
-        hyperparameters.initializeFineTuneSearch(0.0, 0);
+        hyperparameters.initializeFineTuneSearch(0);
 
         BOOST_REQUIRE_EQUAL(2 * hyperparameters.numberToTune(),
                             hyperparameters.numberRounds());
@@ -400,7 +400,7 @@ BOOST_AUTO_TEST_CASE(testBoostedTreeHyperparametersResetSearch) {
     hyperparameters.eta().fixToRange(0.1, 1.0);
     hyperparameters.etaGrowthRatePerTree().fixToRange(0.1, 1.0);
 
-    hyperparameters.initializeFineTuneSearch(0.0, 0);
+    hyperparameters.initializeFineTuneSearch(0);
 
     test::CRandomNumbers rng;
 
@@ -447,7 +447,7 @@ BOOST_AUTO_TEST_CASE(testBoostedTreeHyperparametersResetSearch) {
          hyperparameters.etaGrowthRatePerTree().value(), hyperparameters.eta().value()});
 
     hyperparameters.resetFineTuneSearch();
-    hyperparameters.initializeFineTuneSearch(0.0, 0);
+    hyperparameters.initializeFineTuneSearch(0);
 
     initHyperaparameters();
     TDoubleVec bestParameters;
@@ -560,7 +560,7 @@ BOOST_AUTO_TEST_CASE(testBoostedTreeHyperparametersPersistWithOptimisation) {
     origHyperaparameters.eta().fixToRange(0.1, 1.0);
     origHyperaparameters.etaGrowthRatePerTree().fixToRange(0.1, 1.0);
 
-    origHyperaparameters.initializeFineTuneSearch(0.0, 0);
+    origHyperaparameters.initializeFineTuneSearch(0);
 
     origHyperaparameters.startFineTuneSearch();
 

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1620,7 +1620,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
 
     LOG_DEBUG(<< "mean log relative error = "
               << maths::common::CBasicStatistics::mean(meanLogRelativeError));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 0.53);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanLogRelativeError) < 0.54);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {
@@ -1850,7 +1850,7 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {
         LOG_DEBUG(<< "log relative error = "
                   << maths::common::CBasicStatistics::mean(logRelativeError));
 
-        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 1.9);
+        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 2.0);
         meanLogRelativeError.add(maths::common::CBasicStatistics::mean(logRelativeError));
     }
 

--- a/lib/maths/common/unittest/CBayesianOptimisationTest.cc
+++ b/lib/maths/common/unittest/CBayesianOptimisationTest.cc
@@ -25,6 +25,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <limits>
+#include <tuple>
 #include <vector>
 
 BOOST_AUTO_TEST_SUITE(CBayesianOptimisationTest)
@@ -528,7 +529,8 @@ BOOST_AUTO_TEST_CASE(testPersistRestore) {
 BOOST_AUTO_TEST_CASE(testEvaluate) {
     TDoubleVec coordinates{0.25, 0.5, 0.75};
     for (auto scale : {1.0, 0.5, 2.0}) {
-        maths::common::CBayesianOptimisation bopt{{{0.0, scale}, {0.0, scale}}};
+        maths::common::CBayesianOptimisation bopt{maths::common::CBayesianOptimisation::TDoubleDoublePrVec(
+            {{0.0, scale}, {0.0, scale}})};
         for (std::size_t i = 0; i < 3; ++i) {
             for (std::size_t j = 0; j < 3; ++j) {
                 TVector x{vector({scale * coordinates[i], scale * coordinates[j]})};
@@ -729,6 +731,46 @@ BOOST_AUTO_TEST_CASE(testAnovaInvariants) {
                        totalCoefficientOfVariationResults[0]);
     BOOST_REQUIRE_CLOSE(totalCoefficientOfVariationResults[2],
                         totalCoefficientOfVariationResults[0], 1e-3);
+}
+
+BOOST_AUTO_TEST_CASE(testAnovaOutOfBoundaries) {
+    // Ensure that ANOVA integrates correctly within given boundaries even if some
+    // observations are outside of the boundaries.
+    std::size_t dim{1};
+    std::size_t numSamples{30};
+
+    test::CRandomNumbers rng;
+    auto calculateAnovaValues = [&](double totalMin, double boundaryMin, double boundaryMax,
+                                    double totalMax) -> std::tuple<double, double, double> {
+        TDoubleVec trainSamples(numSamples * dim);
+        rng.generateUniformSamples(totalMin, totalMax, trainSamples.size(), trainSamples);
+        maths::common::CBayesianOptimisation::TDoubleDoublePrVec boundaries;
+        boundaries.reserve(dim);
+        for (std::size_t d = 0; d < dim; ++d) {
+            boundaries.emplace_back(boundaryMin, boundaryMax);
+        }
+        maths::common::CBayesianOptimisation bopt{boundaries};
+        for (std::size_t i = 0; i < numSamples; ++i) {
+            TVector x{vector({trainSamples[i]})};
+            bopt.add(x, x.norm(), (boundaryMax - boundaryMin) * 1e-3);
+            // bopt.maximumLikelihoodKernel();
+        }
+
+        TDoubleVec kernelParameters(dim + 1, 0.5);
+        kernelParameters[0] = 0.7;
+        bopt.kernelParameters(vector(kernelParameters));
+        double f0{bopt.anovaConstantFactor()};
+        double totalVariance{bopt.anovaTotalVariance()};
+        double totalCoefficientOfVariation{bopt.anovaTotalCoefficientOfVariation()};
+        return {f0, totalVariance, totalCoefficientOfVariation};
+    };
+
+    auto[expectedConst, expectedTV, expectedCoV] = calculateAnovaValues(1.0, 1.0, 2.0, 2.0);
+    auto[actualConst, actualTV, actualCoV] = calculateAnovaValues(0.0, 1.0, 2.0, 3.0);
+    BOOST_REQUIRE_CLOSE(expectedConst, actualConst, 1);
+    BOOST_REQUIRE_CLOSE(expectedTV, actualTV, 1);
+    // TODO Activate this test once #2259 is backported into the feature brunch
+    // BOOST_REQUIRE_CLOSE(expectedCoV, actualCoV, 27);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR enables the early stopping of hyperparameter tuning after the coarse parameter tuning. Skipping fine parameter tuning should improve training time at the cost of potentially slightly lower accuracy.