### PR TITLE
[7.17] [ML] Do not set runtime Java home for ES tests

### DIFF
--- a/dev-tools/run_es_tests.sh
+++ b/dev-tools/run_es_tests.sh
@@ -91,7 +91,6 @@ fi
 
 echo "Setting JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA"
 export JAVA_HOME="$HOME/.java/$ES_BUILD_JAVA"
-export RUNTIME_JAVA_HOME="$JAVA_HOME"
 
 # For the ES build we need to:
 # 1. Convince it that this is not part of a PR build, becuase it will get


### PR DESCRIPTION
Our script for running ES integration tests on the code
built from the PR branch was setting RUNTIME_JAVA_HOME.
This dated back to when ML was testing on linux-aarch64
but Elasticsearch was not. Now Elasticsearch contains the
logic to decide the best runtime Java version on both
x86_64 and aarch64, and in 8.0 and above the runtime Java
cannot currently be the same as the build Java (because
the build requires Java 16 but Java 17 is required to run).

Backport of #2090