### PR TITLE
[ML] Fix edge cases for early stopping for training classification and regression models

### DIFF
--- a/include/maths/analytics/CBoostedTreeHyperparameters.h
+++ b/include/maths/analytics/CBoostedTreeHyperparameters.h
@@ -641,6 +641,7 @@ private:
     using TDoubleVecVec = std::vector<TDoubleVec>;
     using TDoubleDoubleSizeTupleVec = std::vector<std::tuple<double, double, std::size_t>>;
     using TOptionalVector3x1 = boost::optional<TVector3x1>;
+    using TIndexVec = std::vector<TVector::TIndexType>;
     using TOptionalVector3x1SizePr = std::pair<TOptionalVector3x1, std::size_t>;
     using TVectorDoublePr = std::pair<TVector, double>;
     using TVectorDoublePrVec = std::vector<TVectorDoublePr>;
@@ -661,7 +662,8 @@ private:
     TOptionalVector3x1SizePr minimizeTestLoss(double intervalLeftEnd,
                                               double intervalRightEnd,
                                               TDoubleDoubleSizeTupleVec testLosses) const;
-    void checkIfCanSkipFineTuneSearch(std::size_t numberTrees);
+    void checkIfCanSkipFineTuneSearch(const TIndexVec& relevantParameters,
+                                      std::size_t numberTrees);
     void captureHyperparametersAndLoss(double loss);
     TVector selectParametersVector(const THyperparametersVec& selectedHyperparameters) const;
     void setHyperparameterValues(TVector parameters);

--- a/include/maths/common/CLinearAlgebraEigen.h
+++ b/include/maths/common/CLinearAlgebraEigen.h
@@ -200,6 +200,7 @@ template<typename SCALAR>
 class CDenseMatrix : public Eigen::Matrix<SCALAR, Eigen::Dynamic, Eigen::Dynamic> {
 public:
     using TBase = Eigen::Matrix<SCALAR, Eigen::Dynamic, Eigen::Dynamic>;
+    using TIndexType = typename TBase::Index;
 
 public:
     //! Forwarding constructor.
@@ -259,6 +260,7 @@ template<typename SCALAR>
 class CDenseVector : public Eigen::Matrix<SCALAR, Eigen::Dynamic, 1> {
 public:
     using TBase = Eigen::Matrix<SCALAR, Eigen::Dynamic, 1>;
+    using TIndexType = typename TBase::Index;
 
 public:
     static const std::string DENSE_VECTOR_TAG;
@@ -380,6 +382,7 @@ class CMemoryMappedDenseMatrix
     : public Eigen::Map<typename CDenseMatrix<SCALAR>::TBase, ALIGNMENT> {
 public:
     using TBase = Eigen::Map<typename CDenseMatrix<SCALAR>::TBase, ALIGNMENT>;
+    using TIndexType = typename TBase::Index;
 
     //! See core::CMemory.
     static bool dynamicSizeAlwaysZero() { return true; }
@@ -498,6 +501,7 @@ class CMemoryMappedDenseVector
 public:
     using TDenseVector = CDenseVector<SCALAR>;
     using TBase = Eigen::Map<typename TDenseVector::TBase, ALIGNMENT>;
+    using TIndexType = typename TBase::Index;
 
     //! See core::CMemory.
     static bool dynamicSizeAlwaysZero() { return true; }

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -514,14 +514,22 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
 
     // Initialize regularization multipliers with their minimum permitted values.
     if (treeSizePenaltyMultiplier.rangeFixed() == false) {
-        treeSizePenaltyMultiplier.set(minBoundary(
-            treeSizePenaltyMultiplier, m_GainPerNode90thPercentile,
-            2.0 * m_GainPerNode90thPercentile / m_GainPerNode1stPercentile));
+        if (m_GainPerNode90thPercentile == 0.0) {
+            treeSizePenaltyMultiplier.fixTo(0.0);
+        } else {
+            treeSizePenaltyMultiplier.set(minBoundary(
+                treeSizePenaltyMultiplier, m_GainPerNode90thPercentile,
+                2.0 * m_GainPerNode90thPercentile / m_GainPerNode1stPercentile));
+        }
     }
     if (leafWeightPenaltyMultiplier.rangeFixed() == false) {
-        leafWeightPenaltyMultiplier.set(minBoundary(
-            leafWeightPenaltyMultiplier, m_TotalCurvaturePerNode90thPercentile,
-            2.0 * m_TotalCurvaturePerNode90thPercentile / m_TotalCurvaturePerNode1stPercentile));
+        if (m_TotalCurvaturePerNode90thPercentile == 0.0) {
+            leafWeightPenaltyMultiplier.fixTo(0.0);
+        } else {
+            leafWeightPenaltyMultiplier.set(minBoundary(
+                leafWeightPenaltyMultiplier, m_TotalCurvaturePerNode90thPercentile,
+                2.0 * m_TotalCurvaturePerNode90thPercentile / m_TotalCurvaturePerNode1stPercentile));
+        }
     }
 
     // Search for depth limit at which the tree starts to overfit.

--- a/lib/maths/analytics/CBoostedTreeHyperparameters.cc
+++ b/lib/maths/analytics/CBoostedTreeHyperparameters.cc
@@ -302,7 +302,20 @@ void CBoostedTreeHyperparameters::initializeFineTuneSearch(std::size_t numberTre
     // naturally measured as a ratio, i.e. diff(p_1, p_0) = p_1 / p_0 for p_0
     // less than p_1, This translates to using log parameter values.
 
+    TIndexVec relevantParameters;
+    relevantParameters.reserve(m_TunableHyperparameters.size());
+
+    auto recordedHyperparameters = m_TunableHyperparameters;
+
     this->initializeTunableHyperparameters();
+
+    for (auto parameter : m_TunableHyperparameters) {
+        auto coordinate = std::find(recordedHyperparameters.begin(),
+                                    recordedHyperparameters.end(), parameter);
+        if (coordinate != recordedHyperparameters.end()) {
+            relevantParameters.push_back(coordinate - recordedHyperparameters.begin());
+        }
+    }
 
     common::CBayesianOptimisation::TDoubleDoublePrVec boundingBox;
     boundingBox.reserve(m_TunableHyperparameters.size());
@@ -354,11 +367,18 @@ void CBoostedTreeHyperparameters::initializeFineTuneSearch(std::size_t numberTre
     this->checkIfCanSkipFineTuneSearch(numberTrees);
 }
 
-void CBoostedTreeHyperparameters::checkIfCanSkipFineTuneSearch(std::size_t numberTrees) {
+void CBoostedTreeHyperparameters::checkIfCanSkipFineTuneSearch(const TIndexVec& relevantParameters,
+                                                               std::size_t numberTrees) {
     if (m_EarlyHyperparameterOptimizationStoppingEnabled) {
         // Add information about observed line search training runs to the GP.
         for (auto & [ parameters, loss ] : m_LineSearchHyperparameterLosses) {
-            this->addObservation(std::move(parameters), loss, 0.0, true);
+            TVector parameters_{
+                static_cast<TVector::TIndexType>(relevantParameters.size())};
+            for (std::size_t i = 0; i < relevantParameters.size(); ++i) {
+                parameters_(static_cast<TVector::TIndexType>(i)) =
+                    parameters(relevantParameters[i]);
+            }
+            this->addObservation(std::move(parameters_), loss, 0.0, true);
         }
         m_StopHyperparameterOptimizationEarly = this->optimisationMakingNoProgress();
         if (m_StopHyperparameterOptimizationEarly) {
@@ -854,8 +874,8 @@ void CBoostedTreeHyperparameters::captureHyperparametersAndLoss(double testLoss)
     }
 }
 
-CBoostedTreeHyperparameters::TVector CBoostedTreeHyperparameters::selectParametersVector(
-    const CBoostedTreeHyperparameters::THyperparametersVec& selectedHyperparameters) const {
+CBoostedTreeHyperparameters::TVector
+CBoostedTreeHyperparameters::selectParametersVector(const THyperparametersVec& selectedHyperparameters) const {
     TVector parameters{selectedHyperparameters.size()};
 
     // Read parameters for last round.
@@ -896,7 +916,7 @@ CBoostedTreeHyperparameters::TVector CBoostedTreeHyperparameters::selectParamete
     return parameters;
 }
 
-void CBoostedTreeHyperparameters::setHyperparameterValues(CBoostedTreeHyperparameters::TVector parameters) {
+void CBoostedTreeHyperparameters::setHyperparameterValues(TVector parameters) {
     TVector minBoundary;
     TVector maxBoundary;
     std::tie(minBoundary, maxBoundary) = m_BayesianOptimization->boundingBox();
@@ -964,11 +984,11 @@ void CBoostedTreeHyperparameters::setHyperparameterValues(CBoostedTreeHyperparam
     }
 }
 
-void CBoostedTreeHyperparameters::addObservation(CBoostedTreeHyperparameters::TVector parameters,
+void CBoostedTreeHyperparameters::addObservation(TVector parameters,
                                                  double loss,
                                                  double variance,
                                                  bool reestimate) {
-    m_BayesianOptimization->add(parameters, loss, variance);
+    m_BayesianOptimization->add(std::move(parameters), loss, variance);
     if (reestimate) {
         m_BayesianOptimization->maximumLikelihoodKernel();
     }

--- a/lib/maths/analytics/CBoostedTreeHyperparameters.cc
+++ b/lib/maths/analytics/CBoostedTreeHyperparameters.cc
@@ -364,7 +364,7 @@ void CBoostedTreeHyperparameters::initializeFineTuneSearch(std::size_t numberTre
     m_CurrentRound = 0;
     m_NumberRounds = m_MaximumOptimisationRoundsPerHyperparameter *
                      m_TunableHyperparameters.size();
-    this->checkIfCanSkipFineTuneSearch(numberTrees);
+    this->checkIfCanSkipFineTuneSearch(relevantParameters, numberTrees);
 }
 
 void CBoostedTreeHyperparameters::checkIfCanSkipFineTuneSearch(const TIndexVec& relevantParameters,


### PR DESCRIPTION
We were running into an issue where we decide during coarse tuning that there was no advantage in adjusting a hyperparameter further, but this wasn't reflected in vectors we captured for testing whether to skip fine tuning parameters. This caused a dimension mismatch when we came to perform ANOVA, which blows up an Eigen assertion in debug builds, and also caused the results to be wrong in this case.

Since this fixes a problem with #2298, which is not released yet, I've marked as a non-issue.