### PR TITLE
[ML] External master -> main renames

### DIFF
--- a/dev-tools/mlcpp-release-notes.pl
+++ b/dev-tools/mlcpp-release-notes.pl
@@ -221,7 +221,7 @@ sub load_github_key {
     my ($file) = glob("~/.github_auth");
     unless ( -e $file ) {
         warn "File ~/.github_auth doesn't exist - using anonymous API. "
-            . "Generate a personal access token that has repo scope. See https://github.com/elastic/dev/blob/master/shared/development_process.md \n";
+            . "Generate a personal access token that has repo scope. See https://github.com/elastic/dev/blob/main/shared/development_process.md \n";
         return '';
     }
     open my $fh, $file or die "Couldn't open $file: $!";

--- a/dev-tools/run_es_tests.sh
+++ b/dev-tools/run_es_tests.sh
@@ -36,7 +36,7 @@ function isCloneTargetValid {
 }
 
 SELECTED_FORK=elastic
-SELECTED_BRANCH=master
+SELECTED_BRANCH=main
 
 function pickCloneTarget {
 


### PR DESCRIPTION
We renamed the master branch to main in this repo a while ago.
This change renames a couple of references to master in other
repos where the branch rename occurred later.