### PR TITLE
[ML] Improve performance of early stopping steps

### DIFF
--- a/include/maths/analytics/CBoostedTreeHyperparameters.h
+++ b/include/maths/analytics/CBoostedTreeHyperparameters.h
@@ -707,9 +707,6 @@ private:
     void captureHyperparametersAndLoss(double loss);
     TVector selectParametersVector(const THyperparametersVec& selectedHyperparameters) const;
     void setHyperparameterValues(TVector parameters);
-    //! \note Only tunable parameters should be passed in \p parameters. If \p reestimate
-    //! is set to true, kernel parameters of the GP are re-estimated.
-    void addObservation(TVector parameters, double loss, double variance, bool reestimate = false);
     void resetBayesianOptimization();
     void saveCurrent();
 


### PR DESCRIPTION
We can get away with fewer kernel parameter optimization rounds to speed up training. Instead of recalibrating GP kernel parameters every time we get a new observation, we spend a couple of additional optimization rounds before calculating the early stopping criterion.