### PR TITLE
[ML] Fix edge case early stopping when parameters are fixed during coarse tuning

### DIFF
--- a/include/maths/analytics/CBoostedTreeFactory.h
+++ b/include/maths/analytics/CBoostedTreeFactory.h
@@ -173,7 +173,7 @@ public:
     //! Set the number of training examples we need per feature we'll include.
     CBoostedTreeFactory& numberTopShapValues(std::size_t numberTopShapValues);
     //! Set the flag to enable or disable early stopping.
-    CBoostedTreeFactory& earlyStoppingEnabled(bool enable);
+    CBoostedTreeFactory& stopHyperparameterOptimizationEarly(bool enable);
     //! Set the fraction of data rows for data summarization in (0.0, 1.0].
     CBoostedTreeFactory& dataSummarizationFraction(double fraction);
     //! Set the row mask for new data with which we want to incrementally train.

--- a/include/maths/analytics/CBoostedTreeHyperparameters.h
+++ b/include/maths/analytics/CBoostedTreeHyperparameters.h
@@ -318,7 +318,7 @@ const std::string CBoostedTreeParameter<T>::VALUE_TAG{"value"};
 template<typename T>
 class CScopeBoostedTreeParameterOverrides {
 public:
-    CScopeBoostedTreeParameterOverrides() = default;
+    CScopeBoostedTreeParameterOverrides() noexcept = default;
     ~CScopeBoostedTreeParameterOverrides() {
         // Undo changes in reverse order to which they were applied.
         for (std::size_t i = m_Parameters.size(); i > 0; --i) {
@@ -701,14 +701,13 @@ private:
     minimizeTestLoss(double intervalLeftEnd,
                      double intervalRightEnd,
                      TDoubleDoubleDoubleSizeTupleVec testLosses) const;
-    void checkIfCanSkipFineTuneSearch(const TIndexVec& relevantParameters,
-                                      double lossGap,
-                                      std::size_t numberTrees);
+    void checkIfCanSkipFineTuneSearch(double testLossVariance);
     void captureHyperparametersAndLoss(double loss);
-    TVector selectParametersVector(const THyperparametersVec& selectedHyperparameters) const;
+    TVector currentParametersVector() const;
     void setHyperparameterValues(TVector parameters);
-    void resetBayesianOptimization();
     void saveCurrent();
+    template<typename F>
+    void foreachTunableParameter(const F& f) const;
 
 private:
     bool m_IncrementalTraining{false};
@@ -730,7 +729,7 @@ private:
     TSizeParameter m_MaximumNumberTrees{20, TSizeParameter::E_LinearSearch};
     //@}
 
-    //@ \name Hyperparameter Optimisation
+    //! \name Hyperparameter Optimisation
     //@{
     bool m_EarlyHyperparameterOptimizationStoppingEnabled{true};
     bool m_StopHyperparameterOptimizationEarly{false};
@@ -748,6 +747,7 @@ private:
     double m_BestForestLossGap{0.0};
     TMeanAccumulator m_MeanForestSizeAccumulator;
     TMeanAccumulator m_MeanTestLossAccumulator;
+    TIndexVec m_LineSearchRelevantParameters;
     TVectorDoublePrVec m_LineSearchHyperparameterLosses;
     //@}
 };

--- a/include/maths/common/CBayesianOptimisation.h
+++ b/include/maths/common/CBayesianOptimisation.h
@@ -89,13 +89,17 @@ public:
     //! shouldn't be included in the kernel.
     void explainedErrorVariance(double vx);
 
+    //! Get the number of restarts to use in global optimisation.
+    std::size_t restarts() const;
+
     //! Get the bounding box (in the function domain) in which we're minimizing.
     TVectorVectorPr boundingBox() const;
 
     //! Compute the location which maximizes the expected improvement given the
     //! function evaluations added so far.
     std::pair<TVector, TOptionalDouble>
-    maximumExpectedImprovement(double negligibleExpectedImprovement = NEGLIGIBLE_EXPECTED_IMPROVEMENT);
+    maximumExpectedImprovement(std::size_t numberRounds = 1,
+                               double negligibleExpectedImprovement = NEGLIGIBLE_EXPECTED_IMPROVEMENT);
 
     //! Estimate the maximum booking memory used by this class for optimising
     //! \p numberParameters using \p numberRounds rounds.
@@ -154,7 +158,7 @@ public:
     std::pair<TEIFunc, TEIGradientFunc> minusExpectedImprovementAndGradient() const;
 
     //! Compute the maximum likelihood kernel parameters.
-    const TVector& maximumLikelihoodKernel();
+    const TVector& maximumLikelihoodKernel(std::size_t numberRounds = 1);
     //@}
 
 private:

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -157,7 +157,8 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     auto numberRoundsPerHyperparameter =
         parameters[MAX_OPTIMIZATION_ROUNDS_PER_HYPERPARAMETER].fallback(
             NUMBER_ROUNDS_PER_HYPERPARAMETER_IS_UNSET);
-    auto earlyStoppingEnabled = parameters[EARLY_STOPPING_ENABLED].fallback(true);
+    auto stopHyperparameterOptimizationEarly =
+        parameters[EARLY_STOPPING_ENABLED].fallback(true);
     auto bayesianOptimisationRestarts =
         parameters[BAYESIAN_OPTIMISATION_RESTARTS].fallback(std::size_t{0});
     auto stopCrossValidationEarly = parameters[STOP_CROSS_VALIDATION_EARLY].fallback(true);
@@ -270,7 +271,7 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
         .stopCrossValidationEarly(stopCrossValidationEarly)
         .analysisInstrumentation(m_Instrumentation)
         .trainingStateCallback(this->statePersister())
-        .earlyStoppingEnabled(earlyStoppingEnabled)
+        .stopHyperparameterOptimizationEarly(stopHyperparameterOptimizationEarly)
         .forceAcceptIncrementalTraining(forceAcceptIncrementalTraining)
         .disableHyperparameterScaling(disableHyperparameterScaling)
         .downsampleFactor(std::move(downsampleFactor))

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -1638,7 +1638,7 @@ CBoostedTreeFactory& CBoostedTreeFactory::trainingStateCallback(TTrainingStateCa
     return *this;
 }
 
-CBoostedTreeFactory& CBoostedTreeFactory::earlyStoppingEnabled(bool enable) {
+CBoostedTreeFactory& CBoostedTreeFactory::stopHyperparameterOptimizationEarly(bool enable) {
     m_TreeImpl->m_Hyperparameters.stopHyperparameterOptimizationEarly(enable);
     return *this;
 }

--- a/lib/maths/analytics/CBoostedTreeHyperparameters.cc
+++ b/lib/maths/analytics/CBoostedTreeHyperparameters.cc
@@ -665,11 +665,11 @@ void CBoostedTreeHyperparameters::checkRestoredInvariants(bool expectOptimizerIn
 
 std::size_t CBoostedTreeHyperparameters::estimateMemoryUsage() const {
     std::size_t numberToTune{this->numberToTune()};
-    return sizeof(*this) + numberToTune * sizeof(int) +
-           (m_NumberRounds / 3 + 1) * numberToTune * sizeof(double) +
+    return sizeof(*this) + numberToTune * sizeof(int) + // m_TunableHyperparameters
+           (m_NumberRounds / 3 + 1) * numberToTune * sizeof(double) + // m_HyperparameterSamples
            common::CBayesianOptimisation::estimateMemoryUsage(numberToTune, m_NumberRounds) +
-           numberToTune * sizeof(std::size_t) +
-           numberToTune * maxLineSearchIterations() * sizeof(double);
+           numberToTune * sizeof(std::size_t) + // m_LineSearchRelevantParameters
+           numberToTune * maxLineSearchIterations() * sizeof(double); // m_LineSearchHyperparameterLosses
 }
 
 std::size_t CBoostedTreeHyperparameters::memoryUsage() const {

--- a/lib/maths/analytics/CBoostedTreeHyperparameters.cc
+++ b/lib/maths/analytics/CBoostedTreeHyperparameters.cc
@@ -27,6 +27,7 @@
 #include <boost/optional/optional_io.hpp>
 
 #include <cmath>
+#include <limits>
 #include <memory>
 
 namespace ml {
@@ -55,6 +56,7 @@ const std::string ETA_GROWTH_RATE_PER_TREE_TAG{"eta_growth_rate_per_tree"};
 const std::string ETA_TAG{"eta"};
 const std::string FEATURE_BAG_FRACTION_TAG{"feature_bag_fraction"};
 const std::string LINE_SEARCH_HYPERPARAMETER_LOSSES_TAG{"line_search_hyperparameters_losses"};
+const std::string LINE_SEARCH_RELEVANT_PARAMETERS_TAG{"line_search_relevant_parameters"};
 const std::string LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG{"leaf_weight_penalty_multiplier"};
 const std::string MAXIMUM_NUMBER_TREES_TAG{"maximum_number_trees"};
 const std::string MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG{"maximum_optimisation_rounds_per_hyperparameter"};
@@ -330,68 +332,40 @@ void CBoostedTreeHyperparameters::initializeFineTuneSearch(double lossGap, std::
     // naturally measured as a ratio, i.e. diff(p_1, p_0) = p_1 / p_0 for p_0
     // less than p_1, This translates to using log parameter values.
 
-    TIndexVec relevantParameters;
-    relevantParameters.reserve(m_TunableHyperparameters.size());
+    // If we decided to fix any parameter we should just exclude all losses
+    // which don't matched the fixed parameter value.
+    m_LineSearchHyperparameterLosses.erase(
+        std::remove_if(m_LineSearchHyperparameterLosses.begin(),
+                       m_LineSearchHyperparameterLosses.end(),
+                       [this](const auto& loss) {
+                           bool result{false};
+                           this->foreachTunableParameter([&](std::size_t i, const auto& parameter) {
+                               result |= parameter.fixed() &&
+                                         loss.first(i) != parameter.value();
+                           });
+                           return result;
+                       }),
+        m_LineSearchHyperparameterLosses.end());
 
     auto recordedHyperparameters = m_TunableHyperparameters;
 
     this->initializeTunableHyperparameters();
 
+    m_LineSearchRelevantParameters.reserve(m_TunableHyperparameters.size());
     for (auto parameter : m_TunableHyperparameters) {
         auto coordinate = std::find(recordedHyperparameters.begin(),
                                     recordedHyperparameters.end(), parameter);
         if (coordinate != recordedHyperparameters.end()) {
-            relevantParameters.push_back(coordinate - recordedHyperparameters.begin());
+            m_LineSearchRelevantParameters.push_back(
+                coordinate - recordedHyperparameters.begin());
         }
     }
 
     common::CBayesianOptimisation::TDoubleDoublePrVec boundingBox;
     boundingBox.reserve(m_TunableHyperparameters.size());
-    for (const auto& parameter : m_TunableHyperparameters) {
-        switch (parameter) {
-        case E_Alpha:
-            boundingBox.push_back(m_DepthPenaltyMultiplier.searchRange());
-            break;
-        case E_DownsampleFactor:
-            boundingBox.push_back(m_DownsampleFactor.searchRange());
-            break;
-        case E_Eta:
-            boundingBox.push_back(m_Eta.searchRange());
-            break;
-        case E_EtaGrowthRatePerTree:
-            boundingBox.push_back(m_EtaGrowthRatePerTree.searchRange());
-            break;
-        case E_FeatureBagFraction:
-            boundingBox.push_back(m_FeatureBagFraction.searchRange());
-            break;
-        case E_Gamma:
-            boundingBox.push_back(m_TreeSizePenaltyMultiplier.searchRange());
-            break;
-        case E_Lambda:
-            boundingBox.push_back(m_LeafWeightPenaltyMultiplier.searchRange());
-            break;
-        case E_MaximumNumberTrees:
-            // Maximum number trees is not tuned directly and estimated from
-            // loss curves.
-            break;
-        case E_SoftTreeDepthLimit:
-            boundingBox.push_back(m_SoftTreeDepthLimit.searchRange());
-            break;
-        case E_SoftTreeDepthTolerance:
-            boundingBox.push_back(m_SoftTreeDepthTolerance.searchRange());
-            break;
-            // Incremental training only parameters.
-        case E_PredictionChangeCost:
-            boundingBox.push_back(m_PredictionChangeCost.searchRange());
-            break;
-        case E_RetrainedTreeEta:
-            boundingBox.push_back(m_RetrainedTreeEta.searchRange());
-            break;
-        case E_TreeTopologyChangePenalty:
-            boundingBox.push_back(m_TreeTopologyChangePenalty.searchRange());
-            break;
-        }
-    }
+    this->foreachTunableParameter([&](std::size_t, const auto& parameter) {
+        boundingBox.push_back(parameter.searchRange());
+    });
     LOG_TRACE(<< "hyperparameter search bounding box = "
               << core::CContainerPrinter::print(boundingBox));
 
@@ -402,40 +376,8 @@ void CBoostedTreeHyperparameters::initializeFineTuneSearch(double lossGap, std::
     m_CurrentRound = 0;
     m_NumberRounds = m_MaximumOptimisationRoundsPerHyperparameter *
                      m_TunableHyperparameters.size();
-    this->checkIfCanSkipFineTuneSearch(relevantParameters, lossGap, numberTrees);
-}
 
-void CBoostedTreeHyperparameters::checkIfCanSkipFineTuneSearch(const TIndexVec& relevantParameters,
-                                                               double lossGap,
-                                                               std::size_t numberTrees) {
-    if (m_EarlyHyperparameterOptimizationStoppingEnabled && m_IncrementalTraining == false) {
-        // Add information about observed line search training runs to the GP.
-        for (auto & [ parameters, loss ] : m_LineSearchHyperparameterLosses) {
-            TVector parameters_{
-                static_cast<TVector::TIndexType>(relevantParameters.size())};
-            for (std::size_t i = 0; i < relevantParameters.size(); ++i) {
-                parameters_(static_cast<TVector::TIndexType>(i)) =
-                    parameters(relevantParameters[i]);
-            }
-            m_BayesianOptimization->add(std::move(parameters_), loss, 0.0);
-        }
-
-        // Perform 3 additional rounds of kernel parameter optimization.
-        for (std::size_t i = 0; i < 3; ++i) {
-            m_BayesianOptimization->maximumLikelihoodKernel();
-        }
-
-        m_StopHyperparameterOptimizationEarly = this->optimisationMakingNoProgress();
-        if (m_StopHyperparameterOptimizationEarly) {
-            LOG_DEBUG(<< "Skipping fine-tune hyperparameters");
-        } else {
-            // Only reset Bayesian optimisation if we are going to fine tune or
-            // else we won't be  able to compute hyperparameter importances.
-            this->resetBayesianOptimization();
-        }
-        m_LineSearchHyperparameterLosses.clear();
-        m_LineSearchHyperparameterLosses.shrink_to_fit();
-    }
+    this->checkIfCanSkipFineTuneSearch(0.0 /*test loss variance*/);
 
     // We purposely don't record the test loss because it isn't comparable with the
     // value computed in fine tune. However, an estimate of the test train loss gap
@@ -448,6 +390,39 @@ void CBoostedTreeHyperparameters::checkIfCanSkipFineTuneSearch(const TIndexVec& 
     m_MaximumNumberTrees.set(numberTrees);
     this->saveCurrent();
     m_MaximumNumberTrees.set(numberTreesToRestore);
+}
+
+void CBoostedTreeHyperparameters::checkIfCanSkipFineTuneSearch(double testLossVariance) {
+
+    if (m_EarlyHyperparameterOptimizationStoppingEnabled && m_IncrementalTraining == false) {
+
+        auto toRestore = std::make_unique<common::CBayesianOptimisation>(
+            m_BayesianOptimization->boundingBox(), m_BayesianOptimization->restarts());
+        std::swap(toRestore, m_BayesianOptimization);
+
+        // Add information about observed line search training runs to the GP.
+        for (auto & [ parameters, loss ] : m_LineSearchHyperparameterLosses) {
+            TVector parameters_{static_cast<TVector::TIndexType>(
+                m_LineSearchRelevantParameters.size())};
+            for (std::size_t i = 0; i < m_LineSearchRelevantParameters.size(); ++i) {
+                parameters_(i) = parameters(m_LineSearchRelevantParameters[i]);
+            }
+            m_BayesianOptimization->add(std::move(parameters_), loss, testLossVariance);
+        }
+
+        // Perform 3 rounds of kernel parameter optimization.
+        m_BayesianOptimization->maximumLikelihoodKernel(3);
+
+        m_StopHyperparameterOptimizationEarly = this->optimisationMakingNoProgress();
+
+        if (m_StopHyperparameterOptimizationEarly) {
+            LOG_DEBUG(<< "Skipping fine-tune hyperparameters");
+        } else {
+            // Only reset Bayesian optimisation if we are going to fine tune or
+            // else we won't be  able to compute hyperparameter importances.
+            std::swap(m_BayesianOptimization, toRestore);
+        }
+    }
 }
 
 bool CBoostedTreeHyperparameters::optimisationMakingNoProgress() const {
@@ -477,7 +452,7 @@ void CBoostedTreeHyperparameters::addRoundStats(const TMeanAccumulator& meanFore
 bool CBoostedTreeHyperparameters::selectNext(const TMeanVarAccumulator& testLossMoments,
                                              double explainedVariance) {
 
-    TVector parameters{this->selectParametersVector(m_TunableHyperparameters)};
+    TVector parameters{this->currentParametersVector()};
 
     double meanTestLoss{common::CBasicStatistics::mean(testLossMoments)};
     double testLossVariance{common::CBasicStatistics::variance(testLossMoments)};
@@ -505,12 +480,19 @@ bool CBoostedTreeHyperparameters::selectNext(const TMeanVarAccumulator& testLoss
         std::copy(m_HyperparameterSamples[m_CurrentRound].begin(),
                   m_HyperparameterSamples[m_CurrentRound].end(), parameters.data());
         parameters = minBoundary + parameters.cwiseProduct(maxBoundary - minBoundary);
+        if (m_CurrentRound == 0) {
+            // First time through we recheck if we can skip using the test loss
+            // variance we measure across folds. This gives us a better sense of
+            // whether the improvement we are likely to see is in the measurement
+            // noise.
+            this->checkIfCanSkipFineTuneSearch(testLossVariance);
+        }
     } else if (this->optimisationMakingNoProgress()) {
         m_StopHyperparameterOptimizationEarly = true;
         return false;
     } else {
         std::tie(parameters, std::ignore) =
-            m_BayesianOptimization->maximumExpectedImprovement();
+            m_BayesianOptimization->maximumExpectedImprovement(3);
     }
 
     this->setHyperparameterValues(parameters);
@@ -611,7 +593,6 @@ CBoostedTreeHyperparameters::importances() const {
         case E_SoftTreeDepthTolerance:
             hyperparameterValue = m_SoftTreeDepthTolerance.value();
             break;
-        // Incremental training.
         case E_PredictionChangeCost:
             hyperparameterValue = m_PredictionChangeCost.value();
             skip = (m_IncrementalTraining == false);
@@ -687,6 +668,7 @@ std::size_t CBoostedTreeHyperparameters::estimateMemoryUsage() const {
     return sizeof(*this) + numberToTune * sizeof(int) +
            (m_NumberRounds / 3 + 1) * numberToTune * sizeof(double) +
            common::CBayesianOptimisation::estimateMemoryUsage(numberToTune, m_NumberRounds) +
+           numberToTune * sizeof(std::size_t) +
            numberToTune * maxLineSearchIterations() * sizeof(double);
 }
 
@@ -694,6 +676,7 @@ std::size_t CBoostedTreeHyperparameters::memoryUsage() const {
     std::size_t mem{core::CMemory::dynamicSize(m_TunableHyperparameters)};
     mem += core::CMemory::dynamicSize(m_HyperparameterSamples);
     mem += core::CMemory::dynamicSize(m_BayesianOptimization);
+    mem += core::CMemory::dynamicSize(m_LineSearchRelevantParameters);
     mem += core::CMemory::dynamicSize(m_LineSearchHyperparameterLosses);
     return mem;
 }
@@ -719,6 +702,8 @@ void CBoostedTreeHyperparameters::acceptPersistInserter(core::CStatePersistInser
                                  m_LeafWeightPenaltyMultiplier, inserter);
     core::CPersistUtils::persist(LINE_SEARCH_HYPERPARAMETER_LOSSES_TAG,
                                  m_LineSearchHyperparameterLosses, inserter);
+    core::CPersistUtils::persist(LINE_SEARCH_RELEVANT_PARAMETERS_TAG,
+                                 m_LineSearchRelevantParameters, inserter);
     core::CPersistUtils::persist(MAXIMUM_NUMBER_TREES_TAG, m_MaximumNumberTrees, inserter);
     core::CPersistUtils::persist(MAXIMUM_OPTIMISATION_ROUNDS_PER_HYPERPARAMETER_TAG,
                                  m_MaximumOptimisationRoundsPerHyperparameter, inserter);
@@ -784,6 +769,9 @@ bool CBoostedTreeHyperparameters::acceptRestoreTraverser(core::CStateRestoreTrav
         RESTORE(LINE_SEARCH_HYPERPARAMETER_LOSSES_TAG,
                 core::CPersistUtils::restore(LINE_SEARCH_HYPERPARAMETER_LOSSES_TAG,
                                              m_LineSearchHyperparameterLosses, traverser))
+        RESTORE(LINE_SEARCH_RELEVANT_PARAMETERS_TAG,
+                core::CPersistUtils::restore(LINE_SEARCH_RELEVANT_PARAMETERS_TAG,
+                                             m_LineSearchRelevantParameters, traverser))
         RESTORE(LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
                 core::CPersistUtils::restore(LEAF_WEIGHT_PENALTY_MULTIPLIER_TAG,
                                              m_LeafWeightPenaltyMultiplier, traverser))
@@ -844,6 +832,7 @@ std::uint64_t CBoostedTreeHyperparameters::checksum(std::uint64_t seed) const {
     seed = common::CChecksum::calculate(seed, m_FeatureBagFraction);
     seed = common::CChecksum::calculate(seed, m_HyperparameterSamples);
     seed = common::CChecksum::calculate(seed, m_LeafWeightPenaltyMultiplier);
+    seed = common::CChecksum::calculate(seed, m_LineSearchRelevantParameters);
     seed = common::CChecksum::calculate(seed, m_LineSearchHyperparameterLosses);
     seed = common::CChecksum::calculate(seed, m_MaximumNumberTrees);
     seed = common::CChecksum::calculate(seed, m_MaximumOptimisationRoundsPerHyperparameter);
@@ -940,7 +929,6 @@ void CBoostedTreeHyperparameters::initializeTunableHyperparameters() {
         case E_FeatureBagFraction:
             addTrainHyperparameter(E_FeatureBagFraction, m_FeatureBagFraction);
             break;
-        // Incremental train hyperparameters.
         case E_PredictionChangeCost:
             addIncrementalHyperparameter(E_PredictionChangeCost, m_PredictionChangeCost);
             break;
@@ -950,8 +938,9 @@ void CBoostedTreeHyperparameters::initializeTunableHyperparameters() {
         case E_TreeTopologyChangePenalty:
             addIncrementalHyperparameter(E_TreeTopologyChangePenalty, m_TreeTopologyChangePenalty);
             break;
-        // Not tuned directly.
         case E_MaximumNumberTrees:
+            // Maximum number trees is not tuned directly and estimated from
+            // loss curves.
             break;
         }
     }
@@ -1009,59 +998,16 @@ void CBoostedTreeHyperparameters::captureScale() {
 
 void CBoostedTreeHyperparameters::captureHyperparametersAndLoss(double testLoss) {
     if (m_EarlyHyperparameterOptimizationStoppingEnabled) {
-        auto parameters = this->selectParametersVector(m_TunableHyperparameters);
-        m_LineSearchHyperparameterLosses.emplace_back(std::move(parameters), testLoss);
+        m_LineSearchHyperparameterLosses.emplace_back(this->currentParametersVector(), testLoss);
     }
 }
 
 CBoostedTreeHyperparameters::TVector
-CBoostedTreeHyperparameters::selectParametersVector(const THyperparametersVec& selectedHyperparameters) const {
-    TVector parameters{selectedHyperparameters.size()};
-
-    // Read parameters for last round.
-    for (std::size_t i = 0; i < selectedHyperparameters.size(); ++i) {
-        switch (selectedHyperparameters[i]) {
-        case E_Alpha:
-            parameters(i) = m_DepthPenaltyMultiplier.toSearchValue();
-            break;
-        case E_DownsampleFactor:
-            parameters(i) = m_DownsampleFactor.toSearchValue();
-            break;
-        case E_Eta:
-            parameters(i) = m_Eta.toSearchValue();
-            break;
-        case E_EtaGrowthRatePerTree:
-            parameters(i) = m_EtaGrowthRatePerTree.toSearchValue();
-            break;
-        case E_FeatureBagFraction:
-            parameters(i) = m_FeatureBagFraction.toSearchValue();
-            break;
-        case E_MaximumNumberTrees:
-            parameters(i) = m_MaximumNumberTrees.toSearchValue();
-            break;
-        case E_Gamma:
-            parameters(i) = m_TreeSizePenaltyMultiplier.toSearchValue();
-            break;
-        case E_Lambda:
-            parameters(i) = m_LeafWeightPenaltyMultiplier.toSearchValue();
-            break;
-        case E_SoftTreeDepthLimit:
-            parameters(i) = m_SoftTreeDepthLimit.toSearchValue();
-            break;
-        case E_SoftTreeDepthTolerance:
-            parameters(i) = m_SoftTreeDepthTolerance.toSearchValue();
-            break;
-        case E_PredictionChangeCost:
-            parameters(i) = m_PredictionChangeCost.toSearchValue();
-            break;
-        case E_RetrainedTreeEta:
-            parameters(i) = m_RetrainedTreeEta.toSearchValue();
-            break;
-        case E_TreeTopologyChangePenalty:
-            parameters(i) = m_TreeTopologyChangePenalty.toSearchValue();
-            break;
-        }
-    }
+CBoostedTreeHyperparameters::currentParametersVector() const {
+    TVector parameters{m_TunableHyperparameters.size()};
+    this->foreachTunableParameter([&](std::size_t i, const auto& parameter) {
+        parameters(i) = parameter.toSearchValue();
+    });
     return parameters;
 }
 
@@ -1108,10 +1054,6 @@ void CBoostedTreeHyperparameters::setHyperparameterValues(TVector parameters) {
         case E_FeatureBagFraction:
             m_FeatureBagFraction.set(m_FeatureBagFraction.fromSearchValue(parameters(i)));
             break;
-        case E_MaximumNumberTrees:
-            m_MaximumNumberTrees.set(
-                m_MaximumNumberTrees.fromSearchValue(std::ceil(parameters(i))));
-            break;
         case E_Gamma:
             m_TreeSizePenaltyMultiplier
                 .set(m_TreeSizePenaltyMultiplier.fromSearchValue(parameters(i)))
@@ -1141,16 +1083,55 @@ void CBoostedTreeHyperparameters::setHyperparameterValues(TVector parameters) {
                 .set(m_TreeTopologyChangePenalty.fromSearchValue(parameters(i)))
                 .scale(scale);
             break;
+        case E_MaximumNumberTrees:
+            break;
         }
     }
 }
 
-void CBoostedTreeHyperparameters::resetBayesianOptimization() {
-    if (m_BayesianOptimization != nullptr) {
-        auto boundingBox = m_BayesianOptimization->boundingBox();
-        m_BayesianOptimization = std::make_unique<common::CBayesianOptimisation>(
-            boundingBox, m_BayesianOptimisationRestarts.value_or(
-                             common::CBayesianOptimisation::RESTARTS));
+template<typename F>
+void CBoostedTreeHyperparameters::foreachTunableParameter(const F& f) const {
+    for (std::size_t i = 0; i < m_TunableHyperparameters.size(); ++i) {
+        switch (m_TunableHyperparameters[i]) {
+        case E_Alpha:
+            f(i, m_DepthPenaltyMultiplier);
+            break;
+        case E_DownsampleFactor:
+            f(i, m_DownsampleFactor);
+            break;
+        case E_Eta:
+            f(i, m_Eta);
+            break;
+        case E_EtaGrowthRatePerTree:
+            f(i, m_EtaGrowthRatePerTree);
+            break;
+        case E_FeatureBagFraction:
+            f(i, m_FeatureBagFraction);
+            break;
+        case E_Gamma:
+            f(i, m_TreeSizePenaltyMultiplier);
+            break;
+        case E_Lambda:
+            f(i, m_LeafWeightPenaltyMultiplier);
+            break;
+        case E_SoftTreeDepthLimit:
+            f(i, m_SoftTreeDepthLimit);
+            break;
+        case E_SoftTreeDepthTolerance:
+            f(i, m_SoftTreeDepthTolerance);
+            break;
+        case E_PredictionChangeCost:
+            f(i, m_PredictionChangeCost);
+            break;
+        case E_RetrainedTreeEta:
+            f(i, m_RetrainedTreeEta);
+            break;
+        case E_TreeTopologyChangePenalty:
+            f(i, m_TreeTopologyChangePenalty);
+            break;
+        case E_MaximumNumberTrees:
+            break;
+        }
     }
 }
 }

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -300,7 +300,7 @@ void CBoostedTreeImpl::train(core::CDataFrame& frame,
 
             if (m_Hyperparameters.selectNext(crossValidationResult.s_TestLossMoments,
                                              this->betweenFoldTestLossVariance()) == false) {
-                LOG_DEBUG(<< "Stopping fine tune hyperparameters on round "
+                LOG_DEBUG(<< "Stopping fine-tune hyperparameters on round "
                           << m_Hyperparameters.currentRound() << " out of "
                           << m_Hyperparameters.numberRounds());
                 break;
@@ -482,7 +482,7 @@ void CBoostedTreeImpl::trainIncremental(core::CDataFrame& frame,
 
         if (m_Hyperparameters.selectNext(crossValidationResult.s_TestLossMoments,
                                          this->betweenFoldTestLossVariance()) == false) {
-            LOG_DEBUG(<< "Stopping fine tune hyperparameters on round "
+            LOG_DEBUG(<< "Stopping fine-tune hyperparameters on round "
                       << m_Hyperparameters.currentRound() << " out of "
                       << m_Hyperparameters.numberRounds());
             break;

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1619,12 +1619,12 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalAddNewTrees) {
               << ", 5 new trees = " << testError5 << ", 10 new trees = " << testError10);
     // The initial model has too little capacity so we should get substantial
     // improvements for adding trees.
-    BOOST_TEST_REQUIRE(0.9 * testError0 >= testError5);
+    BOOST_TEST_REQUIRE(0.95 * testError0 >= testError5);
     BOOST_TEST_REQUIRE(0.9 * testError0 >= testError10);
     // Since we perturb the hyperparameter optimisation we aren't guaranteed
     // to have lower test error for 10 vs 5 trees, but it should be very close
     // if it is larger.
-    BOOST_TEST_REQUIRE(1.02 * testError5 >= testError10);
+    BOOST_TEST_REQUIRE(1.03 * testError5 >= testError10);
 }
 
 BOOST_AUTO_TEST_CASE(testThreading) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -3852,8 +3852,8 @@ BOOST_AUTO_TEST_CASE(testEarlyStoppingAccuracy) {
     std::tie(biasNotStopEarly, rSquaredNotStopEarly) = computeMetrics(false);
 
     LOG_DEBUG(<< "biasStopEarly = " << biasStopEarly
-              << " rSquaredStopEarly = " << rSquaredStopEarly << "\n"
-              << "biasNotStopEarly = " << biasNotStopEarly
+              << " rSquaredStopEarly = " << rSquaredStopEarly);
+    LOG_DEBUG(<< "biasNotStopEarly = " << biasNotStopEarly
               << " rSquaredNotStopEarly = " << rSquaredNotStopEarly);
     BOOST_REQUIRE_CLOSE_ABSOLUTE(
         0.0, biasStopEarly,

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1013,7 +1013,6 @@ BOOST_AUTO_TEST_CASE(testHoldoutRowMask) {
     auto regression = maths::analytics::CBoostedTreeFactory::constructFromParameters(
                           1, std::make_unique<maths::analytics::boosted_tree::CMse>())
                           .numberHoldoutRows(numberHoldoutRows)
-                          .earlyStoppingEnabled(false)
                           .buildForTrain(*frame, cols - 1);
 
     regression->train();
@@ -3163,7 +3162,7 @@ BOOST_AUTO_TEST_CASE(testProgressMonitoring) {
                 maths::analytics::CBoostedTreeFactory::constructFromParameters(
                     threads, std::make_unique<maths::analytics::boosted_tree::CMse>())
                     .analysisInstrumentation(instrumentation)
-                    .earlyStoppingEnabled(false)
+                    .stopHyperparameterOptimizationEarly(false)
                     .buildForTrain(*frame, cols - 1);
 
             regression->train();
@@ -3826,7 +3825,7 @@ BOOST_AUTO_TEST_CASE(testEarlyStoppingAccuracy) {
 
         auto factory = maths::analytics::CBoostedTreeFactory::constructFromParameters(
             1, std::make_unique<maths::analytics::boosted_tree::CMse>());
-        factory.numberHoldoutRows(numberHoldoutRows).earlyStoppingEnabled(earlyStoppingEnabled);
+        factory.numberHoldoutRows(numberHoldoutRows).stopHyperparameterOptimizationEarly(earlyStoppingEnabled);
         auto regression = factory.buildForTrain(*frame, cols - 1);
         regression->train();
         regression->predict();

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -175,15 +175,20 @@ void CBayesianOptimisation::explainedErrorVariance(double vx) {
     m_ExplainedErrorVariance = CTools::pow2(m_RangeScale) * vx;
 }
 
+std::size_t CBayesianOptimisation::restarts() const {
+    return m_Restarts;
+}
+
 CBayesianOptimisation::TVectorVectorPr CBayesianOptimisation::boundingBox() const {
     return {m_MinBoundary, m_MaxBoundary};
 }
 
 std::pair<CBayesianOptimisation::TVector, CBayesianOptimisation::TOptionalDouble>
-CBayesianOptimisation::maximumExpectedImprovement(double negligibleExpectedImprovement) {
+CBayesianOptimisation::maximumExpectedImprovement(std::size_t numberRounds,
+                                                  double negligibleExpectedImprovement) {
 
     // Reapply conditioning and recompute the maximum likelihood kernel parameters.
-    this->maximumLikelihoodKernel();
+    this->maximumLikelihoodKernel(numberRounds);
 
     TVector xmax;
     double fmax{-1.0};
@@ -220,7 +225,6 @@ CBayesianOptimisation::maximumExpectedImprovement(double negligibleExpectedImpro
                 xmax = x;
             }
         }
-
     } else {
 
         for (std::size_t i = 0; i < interpolates.size(); /**/) {
@@ -623,7 +627,8 @@ CBayesianOptimisation::minusExpectedImprovementAndGradient() const {
     return {std::move(EI), std::move(EIGradient)};
 }
 
-const CBayesianOptimisation::TVector& CBayesianOptimisation::maximumLikelihoodKernel() {
+const CBayesianOptimisation::TVector&
+CBayesianOptimisation::maximumLikelihoodKernel(std::size_t numberRounds) {
 
     if (m_FunctionMeanValues.size() < 2) {
         return m_KernelParameters;
@@ -631,61 +636,70 @@ const CBayesianOptimisation::TVector& CBayesianOptimisation::maximumLikelihoodKe
 
     using TDoubleVecVec = std::vector<TDoubleVec>;
 
-    this->precondition();
+    auto lastKernelParameters = m_KernelParameters;
+    do {
+        this->precondition();
 
-    TLikelihoodFunc l;
-    TLikelihoodGradientFunc g;
-    std::tie(l, g) = this->minusLikelihoodAndGradient();
+        TLikelihoodFunc l;
+        TLikelihoodGradientFunc g;
+        std::tie(l, g) = this->minusLikelihoodAndGradient();
 
-    CLbfgs<TVector> lbfgs{10};
+        CLbfgs<TVector> lbfgs{10};
 
-    double lmax{l(m_KernelParameters)};
-    TVector amax{m_KernelParameters};
+        double lmax{l(m_KernelParameters)};
+        TVector amax{m_KernelParameters};
 
-    // Try the current values first.
-    double la;
-    TVector a;
-    std::tie(a, la) = lbfgs.minimize(l, g, m_KernelParameters, 1e-8, 75);
-    if (COrderings::lexicographical_compare(la, a.norm(), lmax, amax.norm())) {
-        lmax = la;
-        amax = a;
-    }
-
-    TMinAccumulator probes{m_Restarts - 1};
-
-    // We restart optimization with scales of the current values for global probing.
-    std::size_t n(m_KernelParameters.size());
-    TDoubleVecVec scales;
-    scales.reserve(10 * (m_Restarts - 1));
-    CSampling::sobolSequenceSample(n, 10 * (m_Restarts - 1), scales);
-
-    for (const auto& scale : scales) {
-        a.noalias() = m_KernelParameters;
-        for (std::size_t j = 0; j < n; ++j) {
-            a(j) *= CTools::stableExp(CTools::linearlyInterpolate(
-                0.0, 1.0, std::log(0.2), std::log(2.0), scale[j]));
-        }
-        la = l(a);
+        // Try the current values first.
+        double la;
+        TVector a;
+        std::tie(a, la) = lbfgs.minimize(l, g, m_KernelParameters, 1e-8, 75);
         if (COrderings::lexicographical_compare(la, a.norm(), lmax, amax.norm())) {
             lmax = la;
             amax = a;
         }
-        probes.add({la, std::move(a)});
-    }
 
-    for (auto& a0 : probes) {
-        std::tie(a, la) = lbfgs.minimize(l, g, std::move(a0.second), 1e-8, 75);
-        if (COrderings::lexicographical_compare(la, a.norm(), lmax, amax.norm())) {
-            lmax = la;
-            amax = std::move(a);
+        TMinAccumulator probes{m_Restarts - 1};
+
+        // We restart optimization with scales of the current values for global probing.
+        TVector::TIndexType n{m_KernelParameters.size()};
+        TDoubleVecVec scales;
+        scales.reserve(10 * (m_Restarts - 1));
+        CSampling::sobolSequenceSample(n, 10 * (m_Restarts - 1), scales);
+
+        for (const auto& scale : scales) {
+            a.noalias() = m_KernelParameters;
+            for (TVector::TIndexType i = 0; i < n; ++i) {
+                a(i) *= CTools::stableExp(CTools::linearlyInterpolate(
+                    0.0, 1.0, std::log(0.2), std::log(2.0), scale[i]));
+            }
+            la = l(a);
+            if (COrderings::lexicographical_compare(la, a.norm(), lmax, amax.norm())) {
+                lmax = la;
+                amax = a;
+            }
+            probes.add({la, std::move(a)});
         }
-    }
 
-    // Ensure that kernel lengths are always positive. It shouldn't change the results
-    // but improves traceability.
-    m_KernelParameters = amax.cwiseAbs();
-    LOG_TRACE(<< "kernel parameters = " << m_KernelParameters.transpose());
-    LOG_TRACE(<< "likelihood = " << -lmax);
+        for (auto& a0 : probes) {
+            std::tie(a, la) = lbfgs.minimize(l, g, std::move(a0.second), 1e-8, 75);
+            if (COrderings::lexicographical_compare(la, a.norm(), lmax, amax.norm())) {
+                lmax = la;
+                amax = std::move(a);
+            }
+        }
+
+        // Ensure that kernel lengths are always positive. It shouldn't change the results
+        // but improves traceability.
+        m_KernelParameters = amax.cwiseAbs();
+        LOG_TRACE(<< "kernel parameters = " << m_KernelParameters.transpose());
+        LOG_TRACE(<< "likelihood = " << -lmax);
+    } while ([&] {
+        bool result = (--numberRounds > 0 &&
+                       (m_KernelParameters - lastKernelParameters).norm() >
+                           5e-3 * m_KernelParameters.norm());
+        lastKernelParameters = m_KernelParameters;
+        return result;
+    }());
 
     return m_KernelParameters;
 }


### PR DESCRIPTION
There was a mistake when we decided to lock down hyperparameter values during coarse search. We would skip the parameter when initialising BO but retain the loss points. This change simply discards the points for which the parameter value doesn't match the fixed value. (It would be better to update the GP code so it can handle zero width dimensions but that is a larger change.)

We now also recheck the stopping condition after one round of fine-tune. At this point we have an estimate of cross-fold variation. Generally, non-zero variance increases the chance of stopping since maximum likelihood will prefer a flat process if the variation in the loss between parameter values is within their margin of error.

Finally, I use the several rounds of maximum likelihood when we estimate parameters in the fine-tune loop. This increases the chance that the estimates are fully converged before computing quantities from them.

This all follows on from #2298 so marking as a non-issue.