### PR TITLE
[ML] Address some bottlenecks training classification and regression models on large data sets

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -36,6 +36,8 @@
   and regression models. (See {ml-pull}2291[#2291].)
 * Accelerate training for data frame analytics by skipping fine parameter tuning if it 
   is unnecessary. (See {ml-pull}2298[#2298].)
+* Address some causes of high runtimes training regression and classification models
+  on large data sets with many features. (See 2332[#2332].)
 
 == {es} version 8.3.0
 

--- a/include/maths/analytics/CDataFrameUtils.h
+++ b/include/maths/analytics/CDataFrameUtils.h
@@ -33,7 +33,7 @@ class CPackedBitVector;
 }
 namespace maths {
 namespace common {
-class CQuantileSketch;
+class CFastQuantileSketch;
 }
 namespace analytics {
 class CDataFrameCategoryEncoder;
@@ -82,7 +82,7 @@ public:
     using TDoubleVector = common::CDenseVector<double>;
     using TMemoryMappedFloatVector = common::CMemoryMappedDenseVector<common::CFloatStorage>;
     using TReadPredictionFunc = std::function<TMemoryMappedFloatVector(const TRowRef&)>;
-    using TQuantileSketchVec = std::vector<common::CQuantileSketch>;
+    using TQuantileSketchVec = std::vector<common::CFastQuantileSketch>;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
 
     //! \brief Defines the data type of a collection of numbers.
@@ -103,7 +103,7 @@ public:
     //! \brief Used to extract the value from a specific column of the data frame.
     class MATHS_ANALYTICS_EXPORT CColumnValue {
     public:
-        CColumnValue(std::size_t column) : m_Column{column} {}
+        explicit CColumnValue(std::size_t column) : m_Column{column} {}
         virtual ~CColumnValue() = default;
         virtual double operator()(const TRowRef& row) const = 0;
         virtual double operator()(const TFloatVec& row) const = 0;
@@ -119,7 +119,8 @@ public:
     //! \brief Used to extract the value from a metric column of the data frame.
     class MATHS_ANALYTICS_EXPORT CMetricColumnValue final : public CColumnValue {
     public:
-        CMetricColumnValue(std::size_t column) : CColumnValue{column} {}
+        explicit CMetricColumnValue(std::size_t column)
+            : CColumnValue{column} {}
         double operator()(const TRowRef& row) const override {
             return row[this->column()];
         }
@@ -265,7 +266,7 @@ public:
                     const core::CDataFrame& frame,
                     const core::CPackedBitVector& rowMask,
                     const TSizeVec& columnMask,
-                    common::CQuantileSketch quantileEstimator,
+                    common::CFastQuantileSketch quantileEstimator,
                     const CDataFrameCategoryEncoder* encoder = nullptr,
                     const TWeightFunc& weight = unitWeight);
 

--- a/include/maths/analytics/CDataFrameUtils.h
+++ b/include/maths/analytics/CDataFrameUtils.h
@@ -33,6 +33,7 @@ class CPackedBitVector;
 }
 namespace maths {
 namespace common {
+class CQuantileSketch;
 class CFastQuantileSketch;
 }
 namespace analytics {
@@ -82,7 +83,8 @@ public:
     using TDoubleVector = common::CDenseVector<double>;
     using TMemoryMappedFloatVector = common::CMemoryMappedDenseVector<common::CFloatStorage>;
     using TReadPredictionFunc = std::function<TMemoryMappedFloatVector(const TRowRef&)>;
-    using TQuantileSketchVec = std::vector<common::CFastQuantileSketch>;
+    using TQuantileSketchVec = std::vector<common::CQuantileSketch>;
+    using TFastQuantileSketchVec = std::vector<common::CFastQuantileSketch>;
     using TPackedBitVectorVec = std::vector<core::CPackedBitVector>;
 
     //! \brief Defines the data type of a collection of numbers.
@@ -261,7 +263,7 @@ public:
     //! quantiles.
     //! \param[in] weight The weight to assign each row. The default is unity for
     //! all rows.
-    static std::pair<TQuantileSketchVec, bool>
+    static std::pair<TFastQuantileSketchVec, bool>
     columnQuantiles(std::size_t numberThreads,
                     const core::CDataFrame& frame,
                     const core::CPackedBitVector& rowMask,

--- a/include/maths/common/CBasicStatistics.h
+++ b/include/maths/common/CBasicStatistics.h
@@ -66,10 +66,10 @@ public:
     static double mean(const TDoubleVec& data);
 
     //! Compute the sample median.
-    static double median(const TDoubleVec& data);
+    static double median(TDoubleVec data);
 
     //! Compute the median absolute deviation.
-    static double mad(const TDoubleVec& data);
+    static double mad(TDoubleVec data);
 
     //! Compute the maximum of \p first, \p second and \p third.
     template<typename T>

--- a/include/maths/common/CQuantileSketch.h
+++ b/include/maths/common/CQuantileSketch.h
@@ -202,7 +202,7 @@ public:
 //! \brief This tunes the quantile sketch for performance when space is less important.
 //!
 //! DESCRIPTION:\n
-//! This uses around 2.5x the memory than `CQuantileSketch` but updating is around 3.0x
+//! This uses around 1.5x the memory than `CQuantileSketch` but updating is around 2-3x
 //! faster when using its default reduction factor.
 class MATHS_COMMON_EXPORT CFastQuantileSketch final : public CQuantileSketch {
 public:

--- a/include/maths/common/CQuantileSketch.h
+++ b/include/maths/common/CQuantileSketch.h
@@ -145,6 +145,9 @@ protected:
     static double cost(const TFloatFloatPr& vl, const TFloatFloatPr& vr);
 
 private:
+    //! Get the target size for fastReduce.
+    virtual std::size_t fastReduceTargetSize() const;
+
     //! A possibly accelerated implementation of reduce.
     virtual void fastReduce();
 
@@ -230,6 +233,9 @@ public:
     std::size_t staticSize() const override;
 
 private:
+    //! Get the target size for fastReduce.
+    std::size_t fastReduceTargetSize() const override;
+
     //! Reduce to the maximum permitted size.
     void fastReduce() override;
 

--- a/include/maths/common/CQuantileSketch.h
+++ b/include/maths/common/CQuantileSketch.h
@@ -123,28 +123,33 @@ protected:
     using TSizeVec = std::vector<std::size_t>;
 
 protected:
-    //! Reduce to the maximum permitted size.
-    virtual void reduce();
-
     //! Get the target size for sketch post reduce.
     virtual std::size_t target() const;
 
     //! Reduce to the maximum permitted size.
-    void reduce(CPRNG::CXorOShiro128Plus& rng,
-                TFloatFloatPrVec& mergeCosts,
-                TSizeVec& mergeCandidates,
-                TBoolVec& stale);
+    void reduceWithSuppliedCosts(TFloatFloatPrVec& mergeCosts,
+                                 TSizeVec& mergeCandidates,
+                                 TBoolVec& stale);
 
     //! Sort and combine any co-located values.
     void orderAndDeduplicate();
 
-    //! Compute the cost of combining \p vl and \p vr.
-    static double cost(const TFloatFloatPr& vl, const TFloatFloatPr& vr);
+    //! The result of merging knots at positions \p l and \p r.
+    TFloatFloatPr mergedKnot(std::size_t l, std::size_t r, double tieBreaker) const;
+
+    //! Get the knot values which can be written.
+    TFloatFloatPrVec& writeableKnots() { return m_Knots; }
 
     //! The maximum permitted size for the sketch.
     std::size_t maxSize() const { return m_MaxSize; }
 
+    //! Compute the cost of combining \p vl and \p vr.
+    static double cost(const TFloatFloatPr& vl, const TFloatFloatPr& vr);
+
 private:
+    //! Reduce to the maximum permitted size.
+    virtual void reduce();
+
     //! Compute quantiles on the supplied knots.
     static void quantile(EInterpolation interpolation,
                          const TFloatFloatPrVec& knots,
@@ -197,7 +202,7 @@ public:
 //! \brief This tunes the quantile sketch for performance when space is less important.
 //!
 //! DESCRIPTION:\n
-//! This uses around 2.5x the memory than `CQuantileSketch` but updating is around 2.0x
+//! This uses around 2.5x the memory than `CQuantileSketch` but updating is around 3.0x
 //! faster when using its default reduction factor.
 class MATHS_COMMON_EXPORT CFastQuantileSketch final : public CQuantileSketch {
 public:
@@ -224,9 +229,6 @@ public:
     std::size_t staticSize() const override;
 
 private:
-    using CQuantileSketch::reduce;
-
-private:
     //! Reduce to the maximum permitted size.
     void reduce() override;
 
@@ -237,7 +239,6 @@ private:
     CPRNG::CXorOShiro128Plus m_Rng;
     TFloatFloatPrVec m_MergeCosts;
     TSizeVec m_MergeCandidates;
-    TBoolVec m_Stale;
     double m_ReductionFraction;
 };
 

--- a/include/maths/common/CQuantileSketch.h
+++ b/include/maths/common/CQuantileSketch.h
@@ -123,11 +123,9 @@ protected:
     using TSizeVec = std::vector<std::size_t>;
 
 protected:
-    //! Get the target size for sketch post reduce.
-    virtual std::size_t target() const;
-
     //! Reduce to the maximum permitted size.
-    void reduceWithSuppliedCosts(TFloatFloatPrVec& mergeCosts,
+    void reduceWithSuppliedCosts(std::size_t target,
+                                 TFloatFloatPrVec& mergeCosts,
                                  TSizeVec& mergeCandidates,
                                  TBoolVec& stale);
 
@@ -147,8 +145,11 @@ protected:
     static double cost(const TFloatFloatPr& vl, const TFloatFloatPr& vr);
 
 private:
-    //! Reduce to the maximum permitted size.
-    virtual void reduce();
+    //! A possibly accelerated implementation of reduce.
+    virtual void fastReduce();
+
+    //! Reduce to \p target size.
+    void reduce(std::size_t target);
 
     //! Compute quantiles on the supplied knots.
     static void quantile(EInterpolation interpolation,
@@ -230,10 +231,7 @@ public:
 
 private:
     //! Reduce to the maximum permitted size.
-    void reduce() override;
-
-    //! Get the target size for sketch post reduce.
-    std::size_t target() const override;
+    void fastReduce() override;
 
 private:
     CPRNG::CXorOShiro128Plus m_Rng;

--- a/jupyter/scripts/incremental_learning/origin/experiment_driver.py
+++ b/jupyter/scripts/incremental_learning/origin/experiment_driver.py
@@ -210,7 +210,7 @@ def my_main(_run, dataset_name, force_update, verbose):
 
     _run.run_logger.info("Update started")
     hyperparameters = trained_model.get_hyperparameters()
-    del hyperparameters['retrained_tree_eta']
+    hyperparameters.pop('retrained_tree_eta', None)
     updated_model = update(dataset_name, update_dataset, trained_model, force=force_update, 
                            verbose=verbose, run=_run, hyperparameter_overrides=hyperparameters)
     elapsed_time = updated_model.wait_to_complete(clean=False)

--- a/jupyter/src/incremental_learning/job.py
+++ b/jupyter/src/incremental_learning/job.py
@@ -52,7 +52,7 @@ class Job:
                  persist: Union[None, str, tempfile._TemporaryFileWrapper] = None,
                  restore: Union[None, str, tempfile._TemporaryFileWrapper] = None,
                  verbose: bool = True, run=None):
-        """Initialize the class .
+        """Initialize the class.
 
         Args:
             input (Union[str, tempfile._TemporaryFileWrapper]): input filename or temp file handler
@@ -207,7 +207,7 @@ class Job:
                     self.run.add_artifact(self.config.name)
                 if is_temp(self.input):
                     self.run.add_artifact(self.input.name)
-                logger.info("Temprory files are stored as artifacts.")
+                logger.info("Temporary files are stored as artifacts.")
             if clean:
                 self.clean()
             raise RuntimeError("Running data_frame_analyzer failed.")
@@ -243,7 +243,7 @@ class Job:
         Note: Only works for binary classification.
 
         Returns:
-            Union[None, list]: prediction probabilities. 
+            Union[None, list]: prediction probabilities.
         """
         if self.analysis_name == 'regression':
             raise ValueError(
@@ -495,9 +495,9 @@ def run_job(input, config, persist=None, restore=None, verbose=True, run=None) -
     return job
 
 
-def train(dataset_name: str, dataset: pandas.DataFrame, 
+def train(dataset_name: str, dataset: pandas.DataFrame,
           encode_job: Job=None, verbose: bool = True, run=None) -> Job:
-    """Train a model on the dataset .
+    """Train a model on the dataset.
 
     Args:
         dataset_name (str): [description]
@@ -530,7 +530,7 @@ def train(dataset_name: str, dataset: pandas.DataFrame,
         restore_file = None
 
     job = run_job(input=data_file, config=config_file,
-                  persist=model_file, restore=restore_file, 
+                  persist=model_file, restore=restore_file,
                   verbose=verbose, run=run)
     return job
 
@@ -636,7 +636,7 @@ def encode(dataset_name: str,
     fdata.file.close()
     with open(configs_dir / f'{dataset_name}.json', encoding='utf-8') as fc:
         config = json.load(fc)
-    config['rows'] = dataset.shape[0] 
+    config['rows'] = dataset.shape[0]
     config = update_config(config, run=run)
 
     config['analysis']['parameters']['task'] = 'encode'

--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -608,6 +608,8 @@ BOOST_FIXTURE_TEST_CASE(testRegressionFeatureImportanceAllShap, SFixture) {
     //
     // we expect c2 > c1 > c3 \approx c4.
 
+    LOG_DEBUG(<< "c1Sum = " << c1Sum << ", c2Sum = " << c2Sum
+              << ", c3Sum = " << c3Sum << ", c4Sum = " << c4Sum);
     BOOST_TEST_REQUIRE(c2Sum > c1Sum);
     // since c1 is categorical -10 or 10, it's influence is generally higher than that of c3 and c4 which are sampled
     // randomly on [-10, 10].
@@ -735,11 +737,9 @@ BOOST_FIXTURE_TEST_CASE(testClassificationFeatureImportanceAllShap, SFixture) {
 
     LOG_DEBUG(<< "c1Sum = " << c1Sum << ", c2Sum = " << c2Sum
               << ", c3Sum = " << c3Sum << ", c4Sum = " << c4Sum);
-
     BOOST_TEST_REQUIRE(c2Sum > c1Sum);
     BOOST_TEST_REQUIRE(c1Sum > c3Sum);
     BOOST_TEST_REQUIRE(c1Sum > c4Sum);
-    BOOST_REQUIRE_CLOSE(c3Sum, c4Sum, 20.0); // c3 and c4 within 20% of each other
 
     BOOST_TEST_REQUIRE(hasTotalFeatureImportance);
     for (std::size_t i = 0; i < classes.size(); ++i) {
@@ -906,6 +906,8 @@ BOOST_FIXTURE_TEST_CASE(testMissingFeatures, SFixture) {
         }
     }
 
+    LOG_DEBUG(<< "c1Sum = " << c1Sum << ", c2Sum = " << c2Sum
+              << ", c3Sum = " << c3Sum << ", c4Sum = " << c4Sum);
     BOOST_REQUIRE_CLOSE(c1Sum, c2Sum, 20.0); // c1 and c2 within 20% of each other
     BOOST_REQUIRE_CLOSE(c1Sum, c3Sum, 20.0); // c1 and c3 within 20% of each other
     BOOST_REQUIRE_CLOSE(c1Sum, c4Sum, 20.0); // c1 and c4 within 20% of each other

--- a/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerFeatureImportanceTest.cc
@@ -666,7 +666,7 @@ BOOST_FIXTURE_TEST_CASE(testClassificationFeatureImportanceAllShap, SFixture) {
     // values are indeed a local approximation of the predicted log-odds.
 
     std::size_t topShapValues{4};
-    auto resultsPair{runBinaryClassification(topShapValues, {0.5, -0.7, 0.3, -0.3})};
+    auto resultsPair{runBinaryClassification(topShapValues, {0.5, -0.7, 0.2, -0.2})};
     auto results{std::move(resultsPair.first)};
     TMeanAccumulator c1TotalShapExpected;
     TMeanAccumulator c2TotalShapExpected;
@@ -784,7 +784,10 @@ BOOST_FIXTURE_TEST_CASE(testMultiClassClassificationFeatureImportanceAllShap, SF
     double classProbabilities[3];
     for (const auto& result : results.GetArray()) {
         if (result.HasMember("row_results")) {
-            double c1{0.0}, c2{0.0}, c3{0.0}, c4{0.0};
+            double c1{0.0};
+            double c2{0.0};
+            double c3{0.0};
+            double c4{0.0};
             double denominator{0.0};
             for (std::size_t i = 0; i < classes.size(); ++i) {
                 // class shap values should sum(abs()) to the overall feature importance

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -787,10 +787,10 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
 
         // Make sure all line search intervals are not empty.
         m_GainPerNode1stPercentile = common::CTools::truncate(
-            m_GainPerNode1stPercentile, 1e-6 * m_GainPerNode90thPercentile,
+            m_GainPerNode1stPercentile, 1e-7 * m_GainPerNode90thPercentile,
             0.1 * m_GainPerNode90thPercentile);
         m_TotalCurvaturePerNode1stPercentile = common::CTools::truncate(
-            m_TotalCurvaturePerNode1stPercentile, 1e-6 * m_TotalCurvaturePerNode90thPercentile,
+            m_TotalCurvaturePerNode1stPercentile, 1e-7 * m_TotalCurvaturePerNode90thPercentile,
             0.1 * m_TotalCurvaturePerNode90thPercentile);
 
         LOG_TRACE(<< "max depth = " << softTreeDepthLimitParameter.print());

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -770,6 +770,7 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
     double log2MaxTreeSize{std::log2(static_cast<double>(m_TreeImpl->maximumTreeSize(
                                m_TreeImpl->m_TrainingRowMasks[0]))) +
                            1.0};
+
     skipIfAfter(CBoostedTreeImpl::E_EncodingInitialized, [&] {
         softTreeDepthLimitParameter.set(log2MaxTreeSize);
         softTreeDepthToleranceParameter.set(
@@ -803,11 +804,18 @@ void CBoostedTreeFactory::initializeUnsetRegularizationHyperparameters(core::CDa
         m_NumberTrees = hyperparameters.maximumNumberTrees().value();
 
         if (m_GainPerNode90thPercentile == 0.0) {
-            softTreeDepthLimitParameter.fixTo(MIN_SOFT_DEPTH_LIMIT);
-            depthPenaltyMultiplierParameter.fixTo(0.0);
-            treeSizePenaltyMultiplier.fixTo(0.0);
+            if (softTreeDepthLimitParameter.rangeFixed() == false) {
+                softTreeDepthLimitParameter.fixTo(MIN_SOFT_DEPTH_LIMIT);
+            }
+            if (depthPenaltyMultiplierParameter.rangeFixed() == false) {
+                depthPenaltyMultiplierParameter.fixTo(0.0);
+            }
+            if (treeSizePenaltyMultiplier.rangeFixed() == false) {
+                treeSizePenaltyMultiplier.fixTo(0.0);
+            }
         }
-        if (m_TotalCurvaturePerNode90thPercentile == 0.0) {
+        if (m_TotalCurvaturePerNode90thPercentile == 0.0 &&
+            leafWeightPenaltyMultiplier.rangeFixed() == false) {
             leafWeightPenaltyMultiplier.fixTo(0.0);
         }
 

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -219,7 +219,7 @@ std::size_t minimumSplitRefreshInterval(double eta, std::size_t numberFeatures) 
     // of features so we scale by the number of features to ensure their cost
     // is always negligible.
     return static_cast<std::size_t>(std::round(std::max(
-        {0.5 / eta, 3.0 * static_cast<double>(numberFeatures) / 50.0, 3.0})));
+        {0.5 / eta, static_cast<double>(numberFeatures) / 50.0, 3.0})));
 }
 }
 

--- a/lib/maths/analytics/CDataFrameUtils.cc
+++ b/lib/maths/analytics/CDataFrameUtils.cc
@@ -174,10 +174,11 @@ regressionStratifiedCrossValidationRowSampler(std::size_t numberThreads,
                                               std::size_t numberBuckets,
                                               const core::CPackedBitVector& rowMask) {
 
-    auto quantiles = CDataFrameUtils::columnQuantiles(
-                         numberThreads, frame, rowMask, {targetColumn},
-                         common::CQuantileSketch{common::CQuantileSketch::E_Linear, 50})
-                         .first;
+    auto quantiles =
+        CDataFrameUtils::columnQuantiles(
+            numberThreads, frame, rowMask, {targetColumn},
+            common::CFastQuantileSketch{common::CFastQuantileSketch::E_Linear, 50})
+            .first;
 
     TDoubleVec buckets;
     for (double step = 100.0 / static_cast<double>(numberBuckets), percentile = step;
@@ -482,7 +483,7 @@ CDataFrameUtils::columnQuantiles(std::size_t numberThreads,
                                  const core::CDataFrame& frame,
                                  const core::CPackedBitVector& rowMask,
                                  const TSizeVec& columnMask,
-                                 common::CQuantileSketch estimateQuantiles,
+                                 common::CFastQuantileSketch quantileEstimator,
                                  const CDataFrameCategoryEncoder* encoder,
                                  const TWeightFunc& weight) {
 
@@ -507,7 +508,7 @@ CDataFrameUtils::columnQuantiles(std::size_t numberThreads,
                 }
             }
         },
-        TQuantileSketchVec(columnMask.size(), estimateQuantiles));
+        TQuantileSketchVec(columnMask.size(), quantileEstimator));
     auto copyQuantiles = [](TQuantileSketchVec quantiles, TQuantileSketchVec& result) {
         result = std::move(quantiles);
     };
@@ -1222,7 +1223,8 @@ CDataFrameUtils::maximizeMinimumRecallForBinary(std::size_t numberThreads,
                 }
             }
         },
-        TQuantileSketchVec(2, common::CQuantileSketch{common::CQuantileSketch::E_Linear, 100}));
+        TQuantileSketchVec(2, common::CFastQuantileSketch{
+                                  common::CFastQuantileSketch::E_Linear, 100}));
     auto copyQuantiles = [](TQuantileSketchVec quantiles, TQuantileSketchVec& result) {
         result = std::move(quantiles);
     };

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -845,7 +845,7 @@ BOOST_AUTO_TEST_CASE(testNonUnitWeights) {
     LOG_DEBUG(<< "biasWithWeights    = " << biasWithWeights
               << ", rSquaredWithWeights    = " << rSquaredWithWeights);
 
-    BOOST_TEST_REQUIRE(std::fabs(biasWithWeights) < 0.2 * std::fabs(biasWithoutWeights));
+    BOOST_TEST_REQUIRE(std::fabs(biasWithWeights) < 0.25 * std::fabs(biasWithoutWeights));
     BOOST_TEST_REQUIRE(1.0 - rSquaredWithWeights < 0.8 * (1.0 - rSquaredWithoutWeights));
 }
 
@@ -1010,9 +1010,11 @@ BOOST_AUTO_TEST_CASE(testHoldoutRowMask) {
     auto frame = core::makeMainStorageDataFrame(cols, rows).first;
     fillDataFrame(rows, 0, cols, x, noise, target, *frame);
 
+    // We disable early stopping because we test hold losses from fine tuning.
     auto regression = maths::analytics::CBoostedTreeFactory::constructFromParameters(
                           1, std::make_unique<maths::analytics::boosted_tree::CMse>())
                           .numberHoldoutRows(numberHoldoutRows)
+                          .stopHyperparameterOptimizationEarly(false)
                           .buildForTrain(*frame, cols - 1);
 
     regression->train();

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1620,12 +1620,8 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalAddNewTrees) {
               << ", 5 new trees = " << testError5 << ", 10 new trees = " << testError10);
     // The initial model has too little capacity so we should get substantial
     // improvements for adding trees.
-    BOOST_TEST_REQUIRE(0.95 * testError0 >= testError5);
+    BOOST_TEST_REQUIRE(0.9 * testError0 >= testError5);
     BOOST_TEST_REQUIRE(0.9 * testError0 >= testError10);
-    // Since we perturb the hyperparameter optimisation we aren't guaranteed
-    // to have lower test error for 10 vs 5 trees, but it should be very close
-    // if it is larger.
-    BOOST_TEST_REQUIRE(1.03 * testError5 >= testError10);
 }
 
 BOOST_AUTO_TEST_CASE(testThreading) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -3784,8 +3784,8 @@ BOOST_AUTO_TEST_CASE(testStopAfterCoarseParameterTuning) {
         return regression->hyperparameters().optimisationMakingNoProgress();
     };
 
-    BOOST_REQUIRE_EQUAL(verify(0.01), false);
-    BOOST_REQUIRE_EQUAL(verify(1000), true);
+    BOOST_REQUIRE_EQUAL(verify(0.001), false);
+    BOOST_REQUIRE_EQUAL(verify(1000.0), true);
 }
 
 BOOST_AUTO_TEST_CASE(testEarlyStoppingAccuracy) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -908,7 +908,7 @@ BOOST_AUTO_TEST_CASE(testLowCardinalityFeatures) {
         target, noiseVariance / static_cast<double>(rows));
     LOG_DEBUG(<< "bias = " << bias << ", rSquared = " << rSquared);
 
-    BOOST_TEST_REQUIRE(rSquared > 0.95);
+    BOOST_TEST_REQUIRE(rSquared > 0.94);
 }
 
 BOOST_AUTO_TEST_CASE(testLowTrainFractionPerFold) {
@@ -2625,7 +2625,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticIncrementalForOutOfDomain) {
 
     LOG_DEBUG(<< "increase on old = " << errorIncreaseOnOld);
     LOG_DEBUG(<< "decrease on new = " << errorDecreaseOnNew);
-    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 5.0 * errorIncreaseOnOld);
+    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 15.0 * errorIncreaseOnOld);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -1613,15 +1613,12 @@ BOOST_AUTO_TEST_CASE(testMseIncrementalAddNewTrees) {
     double testError0{computePenalisedTestError(*frame0, updateBaseModel(*frame0, 0))};
     auto frame1 = makeBatch2();
     double testError5{computePenalisedTestError(*frame1, updateBaseModel(*frame1, 5))};
-    auto frame2 = makeBatch2();
-    double testError10{computePenalisedTestError(*frame2, updateBaseModel(*frame2, 10))};
 
-    LOG_DEBUG(<< "Holdout errors: base = " << testErrorBase << ", 0 new trees = " << testError0
-              << ", 5 new trees = " << testError5 << ", 10 new trees = " << testError10);
+    LOG_DEBUG(<< "Holdout errors: base = " << testErrorBase
+              << ", 0 new trees = " << testError0 << ", 5 new trees = " << testError5);
     // The initial model has too little capacity so we should get substantial
-    // improvements for adding trees.
+    // improvements for adding trees vs just retraining.
     BOOST_TEST_REQUIRE(0.9 * testError0 >= testError5);
-    BOOST_TEST_REQUIRE(0.9 * testError0 >= testError10);
 }
 
 BOOST_AUTO_TEST_CASE(testThreading) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -845,7 +845,7 @@ BOOST_AUTO_TEST_CASE(testNonUnitWeights) {
     LOG_DEBUG(<< "biasWithWeights    = " << biasWithWeights
               << ", rSquaredWithWeights    = " << rSquaredWithWeights);
 
-    BOOST_TEST_REQUIRE(std::fabs(biasWithWeights) < 0.25 * std::fabs(biasWithoutWeights));
+    BOOST_TEST_REQUIRE(std::fabs(biasWithWeights) < 0.2 * std::fabs(biasWithoutWeights));
     BOOST_TEST_REQUIRE(1.0 - rSquaredWithWeights < 0.8 * (1.0 - rSquaredWithoutWeights));
 }
 
@@ -2290,7 +2290,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
         LOG_DEBUG(<< "log relative error = "
                   << maths::common::CBasicStatistics::mean(logRelativeError));
 
-        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 0.7);
+        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(logRelativeError) < 0.74);
         meanLogRelativeError.add(maths::common::CBasicStatistics::mean(logRelativeError));
     }
 
@@ -2625,7 +2625,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticIncrementalForOutOfDomain) {
 
     LOG_DEBUG(<< "increase on old = " << errorIncreaseOnOld);
     LOG_DEBUG(<< "decrease on new = " << errorDecreaseOnNew);
-    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 15.0 * errorIncreaseOnOld);
+    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 5.0 * errorIncreaseOnOld);
 }
 
 BOOST_AUTO_TEST_CASE(testImbalancedClasses) {

--- a/lib/maths/analytics/unittest/CDataFrameUtilsTest.cc
+++ b/lib/maths/analytics/unittest/CDataFrameUtilsTest.cc
@@ -379,11 +379,11 @@ BOOST_AUTO_TEST_CASE(testColumnQuantiles) {
             for (auto& columnMae : columnsMae) {
                 LOG_DEBUG(<< "Column MAE = "
                           << maths::common::CBasicStatistics::mean(columnMae));
-                BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(columnMae) < 0.08);
+                BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(columnMae) < 0.07);
                 mae += columnMae;
             }
             LOG_DEBUG(<< "MAE = " << maths::common::CBasicStatistics::mean(mae));
-            BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(mae) < 0.05);
+            BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(mae) < 0.04);
         }
 
         core::startDefaultAsyncExecutor();

--- a/lib/maths/common/CBasicStatistics.cc
+++ b/lib/maths/common/CBasicStatistics.cc
@@ -8,6 +8,7 @@
  * compliance with the Elastic License 2.0 and the foregoing additional
  * limitation.
  */
+
 #include <maths/common/CBasicStatistics.h>
 
 #include <core/CLogger.h>
@@ -34,7 +35,7 @@ double medianInPlace(std::vector<double>& data) {
     // For an odd number of elements, this will get the median element into
     // place.  For an even number of elements, it will get the second element
     // of the middle pair into place.
-    size_t index{size / 2};
+    std::size_t index{size / 2};
     std::nth_element(data.begin(), data.begin() + index, data.end());
 
     if (useMean) {
@@ -60,27 +61,25 @@ double CBasicStatistics::mean(const TDoubleVec& data) {
                               static_cast<double>(data.size());
 }
 
-double CBasicStatistics::median(const TDoubleVec& data) {
+double CBasicStatistics::median(TDoubleVec data) {
     if (data.empty()) {
         return 0.0;
     }
     if (data.size() == 1) {
         return data[0];
     }
-    TDoubleVec data_{data};
-    return medianInPlace(data_);
+    return medianInPlace(data);
 }
 
-double CBasicStatistics::mad(const TDoubleVec& data) {
+double CBasicStatistics::mad(TDoubleVec data) {
     if (data.size() < 2) {
         return 0.0;
     }
-    TDoubleVec data_{data};
-    double median{medianInPlace(data_)};
-    for (auto& datum : data_) {
-        datum = std::fabs(datum - median);
+    double median{medianInPlace(data)};
+    for (auto& x : data) {
+        x = std::fabs(x - median);
     }
-    return medianInPlace(data_);
+    return medianInPlace(data);
 }
 
 double CBasicStatistics::varianceAtPercentile(double percentage, double variance, double degreesFreedom) {

--- a/lib/maths/common/CQuantileSketch.cc
+++ b/lib/maths/common/CQuantileSketch.cc
@@ -471,7 +471,9 @@ void CQuantileSketch::reduceWithSuppliedCosts(TFloatFloatPrVec& mergeCosts,
             LOG_TRACE(<< "Merging " << l << " and " << r
                       << ", cost = " << mergeCosts[l - 1].first);
 
-            auto mergedKnot = this->mergedKnot(l, r, mergeCosts[l].second);
+            // Note that mergeCosts[l - 1].second isn't truly random because
+            // it is used for selecting the merge order, but it's good enough.
+            auto mergedKnot = this->mergedKnot(l, r, mergeCosts[l - 1].second);
 
             // Find the points that have been merged with xl and xr if any.
             std::ptrdiff_t ll{previousDifferent(m_Knots, l)};
@@ -533,6 +535,7 @@ CQuantileSketch::mergedKnot(std::size_t l, std::size_t r, double tieBreaker) con
     double nr{m_Knots[r].second};
     LOG_TRACE(<< "(xl,nl) = (" << xl << "," << nl << "), (xr,nr) = (" << xr
               << "," << nr << ")");
+
     TFloatFloatPr mergedKnot;
     switch (m_Interpolation) {
     case E_Linear:
@@ -544,6 +547,7 @@ CQuantileSketch::mergedKnot(std::size_t l, std::size_t r, double tieBreaker) con
         mergedKnot.second = nl + nr;
         break;
     }
+
     return mergedKnot;
 }
 
@@ -620,7 +624,7 @@ void CFastQuantileSketch::reduce() {
         for (std::size_t i = 0; i < numberToMerge; ++i) {
             std::size_t l{m_MergeCandidates[i] + 1};
             std::size_t r{static_cast<std::size_t>(nextDifferent(knots, l))};
-            auto mergedKnot = this->mergedKnot(l, r, m_MergeCosts[l].second);
+            auto mergedKnot = this->mergedKnot(l, r, m_MergeCosts[l - 1].second);
 
             // Find the points that have been merged with xl and xr if any.
             std::ptrdiff_t ll{previousDifferent(knots, l)};

--- a/lib/maths/common/CQuantileSketch.cc
+++ b/lib/maths/common/CQuantileSketch.cc
@@ -627,10 +627,10 @@ void CFastQuantileSketch::fastReduce() {
 
         std::size_t numberToMerge{knots.size() - this->fastReduceTargetSize()};
 
-        // This is pseudo greedy since unlike CQuantileSketch which is greedy.
-        // We simply ignore the fact that we have slightly different costs for
-        // merging the knots we've just merged. This allows us to avoid using
-        // a heap altogeter which dominates the computational cost of reduce.
+        // This is pseudo greedy unlike CQuantileSketch which is greedy: we
+        // simply ignore the fact that we have slightly different costs after
+        // each merge. This allows us to avoid using a heap altogether which
+        // dominates the computational cost of reduce.
 
         std::nth_element(m_MergeCandidates.begin(), m_MergeCandidates.begin() + numberToMerge,
                          m_MergeCandidates.end(), [&](auto lhs, auto rhs) {

--- a/lib/maths/common/unittest/CBasicStatisticsTest.cc
+++ b/lib/maths/common/unittest/CBasicStatisticsTest.cc
@@ -1121,63 +1121,14 @@ BOOST_AUTO_TEST_CASE(testCovariancesLedoitWolf) {
 }
 
 BOOST_AUTO_TEST_CASE(testMedian) {
-    {
-        maths::common::CBasicStatistics::TDoubleVec sampleVec;
-
-        double median = maths::common::CBasicStatistics::median(sampleVec);
-
-        BOOST_REQUIRE_EQUAL(0.0, median);
-    }
-    {
-        double sample[] = {1.0};
-
-        maths::common::CBasicStatistics::TDoubleVec sampleVec(
-            sample, sample + sizeof(sample) / sizeof(sample[0]));
-
-        double median = maths::common::CBasicStatistics::median(sampleVec);
-
-        BOOST_REQUIRE_EQUAL(1.0, median);
-    }
-    {
-        double sample[] = {2.0, 1.0};
-
-        maths::common::CBasicStatistics::TDoubleVec sampleVec(
-            sample, sample + sizeof(sample) / sizeof(sample[0]));
-
-        double median = maths::common::CBasicStatistics::median(sampleVec);
-
-        BOOST_REQUIRE_EQUAL(1.5, median);
-    }
-    {
-        double sample[] = {3.0, 1.0, 2.0};
-
-        maths::common::CBasicStatistics::TDoubleVec sampleVec(
-            sample, sample + sizeof(sample) / sizeof(sample[0]));
-
-        double median = maths::common::CBasicStatistics::median(sampleVec);
-
-        BOOST_REQUIRE_EQUAL(2.0, median);
-    }
-    {
-        double sample[] = {3.0, 5.0, 9.0, 1.0, 2.0, 6.0, 7.0, 4.0, 8.0};
-
-        maths::common::CBasicStatistics::TDoubleVec sampleVec(
-            sample, sample + sizeof(sample) / sizeof(sample[0]));
-
-        double median = maths::common::CBasicStatistics::median(sampleVec);
-
-        BOOST_REQUIRE_EQUAL(5.0, median);
-    }
-    {
-        double sample[] = {3.0, 5.0, 10.0, 2.0, 6.0, 7.0, 1.0, 9.0, 4.0, 8.0};
-
-        maths::common::CBasicStatistics::TDoubleVec sampleVec(
-            sample, sample + sizeof(sample) / sizeof(sample[0]));
-
-        double median = maths::common::CBasicStatistics::median(sampleVec);
-
-        BOOST_REQUIRE_EQUAL(5.5, median);
-    }
+    BOOST_REQUIRE_EQUAL(0.0, maths::common::CBasicStatistics::median({}));
+    BOOST_REQUIRE_EQUAL(1.0, maths::common::CBasicStatistics::median({1.0}));
+    BOOST_REQUIRE_EQUAL(1.5, maths::common::CBasicStatistics::median({2.0, 1.0}));
+    BOOST_REQUIRE_EQUAL(2.0, maths::common::CBasicStatistics::median({3.0, 1.0, 2.0}));
+    BOOST_REQUIRE_EQUAL(5.0, maths::common::CBasicStatistics::median(
+                                 {3.0, 5.0, 9.0, 1.0, 2.0, 6.0, 7.0, 4.0, 8.0}));
+    BOOST_REQUIRE_EQUAL(5.5, maths::common::CBasicStatistics::median(
+                                 {3.0, 5.0, 10.0, 2.0, 6.0, 7.0, 1.0, 9.0, 4.0, 8.0}));
 }
 
 BOOST_AUTO_TEST_CASE(testMad) {

--- a/lib/maths/common/unittest/CQuantileSketchTest.cc
+++ b/lib/maths/common/unittest/CQuantileSketchTest.cc
@@ -473,14 +473,13 @@ BOOST_AUTO_TEST_CASE(testQuantileAccuracy) {
             for (double t = 1.0; t <= 50.0; t += 1.0) {
                 TDoubleVec samples;
                 rng.generateUniformSamples(0.0, 20.0 * t, 1000, samples);
-                testSketch(sketch, samples, 0.04 * t, 0.12 * t, meanBias, meanError);
+                testSketch(sketch, samples, 0.10 * t, 0.12 * t, meanBias, meanError);
             }
-            LOG_DEBUG(<< "mean bias = "
-                      << std::fabs(maths::common::CBasicStatistics::mean(meanBias)) << ", mean error "
-                      << maths::common::CBasicStatistics::mean(meanError));
+            LOG_DEBUG(<< "mean bias = " << maths::common::CBasicStatistics::mean(meanBias)
+                      << ", mean error = " << maths::common::CBasicStatistics::mean(meanError));
             BOOST_TEST_REQUIRE(
                 std::fabs(maths::common::CBasicStatistics::mean(meanBias)) < 0.0007);
-            BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.003);
+            BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.004);
         };
 
         maths::common::CQuantileSketch sketch{maths::common::CQuantileSketch::E_Linear, 20};
@@ -500,12 +499,12 @@ BOOST_AUTO_TEST_CASE(testQuantileAccuracy) {
             for (double t = 1.0; t <= 50.0; t += 1.0) {
                 TDoubleVec samples;
                 rng.generateNormalSamples(20.0 * (t - 1.0), 20.0 * t, 1000, samples);
-                testSketch(sketch, samples, 0.03 * t, 0.09 * t, meanBias, meanError);
+                testSketch(sketch, samples, 0.03 * t, 0.1 * t, meanBias, meanError);
             }
-            LOG_DEBUG(<< "mean bias = " << maths::common::CBasicStatistics::mean(meanBias) << ", mean error "
-                      << maths::common::CBasicStatistics::mean(meanError));
+            LOG_DEBUG(<< "mean bias = " << maths::common::CBasicStatistics::mean(meanBias)
+                      << ", mean error = " << maths::common::CBasicStatistics::mean(meanError));
             BOOST_TEST_REQUIRE(
-                std::fabs(maths::common::CBasicStatistics::mean(meanBias)) < 0.002);
+                std::fabs(maths::common::CBasicStatistics::mean(meanBias)) < 0.0005);
             BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.003);
         };
 
@@ -528,10 +527,10 @@ BOOST_AUTO_TEST_CASE(testQuantileAccuracy) {
                 rng.generateLogNormalSamples(0.03 * (t - 1.0), 0.12 * t, 1000, samples);
                 testSketch(sketch, samples, 0.05 * t, 0.1 * t, meanBias, meanError);
             }
-            LOG_DEBUG(<< "mean bias = " << maths::common::CBasicStatistics::mean(meanBias) << ", mean error "
-                      << maths::common::CBasicStatistics::mean(meanError));
+            LOG_DEBUG(<< "mean bias = " << maths::common::CBasicStatistics::mean(meanBias)
+                      << ", mean error = " << maths::common::CBasicStatistics::mean(meanError));
             BOOST_TEST_REQUIRE(
-                std::fabs(maths::common::CBasicStatistics::mean(meanBias)) < 0.0006);
+                std::fabs(maths::common::CBasicStatistics::mean(meanBias)) < 0.0005);
             BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.0009);
         };
 
@@ -565,8 +564,8 @@ BOOST_AUTO_TEST_CASE(testQuantileAccuracy) {
                 rng.random_shuffle(samples.begin(), samples.end());
                 testSketch(sketch, samples, maxBias * t, maxError * t, meanBias, meanError);
             }
-            LOG_DEBUG(<< "mean bias = " << maths::common::CBasicStatistics::mean(meanBias) << ", mean error "
-                      << maths::common::CBasicStatistics::mean(meanError));
+            LOG_DEBUG(<< "mean bias = " << maths::common::CBasicStatistics::mean(meanBias)
+                      << ", mean error = " << maths::common::CBasicStatistics::mean(meanError));
             BOOST_TEST_REQUIRE(std::fabs(maths::common::CBasicStatistics::mean(meanBias)) <
                                maxMeanBias);
             BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < maxMeanError);

--- a/lib/maths/time_series/unittest/CCalendarCyclicTestTest.cc
+++ b/lib/maths/time_series/unittest/CCalendarCyclicTestTest.cc
@@ -13,7 +13,6 @@
 #include <core/CRapidXmlParser.h>
 #include <core/CRapidXmlStatePersistInserter.h>
 #include <core/CRapidXmlStateRestoreTraverser.h>
-#include <core/CTimezone.h>
 #include <core/Constants.h>
 #include <core/CoreTypes.h>
 
@@ -95,7 +94,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
                                                                   : falsePositive) += 1.0;
                 }
             }
-            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 850);
+            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 720);
         }
     }
     LOG_DEBUG(<< "true positive = " << truePositive);
@@ -140,7 +139,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
                          : falsePositive) += 1.0;
                 }
             }
-            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 850);
+            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 720);
         }
     }
     LOG_DEBUG(<< "true positive = " << truePositive);
@@ -183,7 +182,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
                          : falsePositive) += 1.0;
                 }
             }
-            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 850);
+            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 720);
         }
     }
     LOG_DEBUG(<< "true positive = " << truePositive);
@@ -226,7 +225,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
                          : falsePositive) += 1.0;
                 }
             }
-            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 850);
+            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 720);
         }
     }
     LOG_DEBUG(<< "true positive = " << truePositive);
@@ -280,7 +279,6 @@ BOOST_AUTO_TEST_CASE(testTimeZones) {
                 if (feature == boost::none) {
                     falseNegative += 1.0;
                 } else {
-                    LOG_DEBUG(<< feature->first.print() << " " << feature->second);
                     (feature->first.print() == "1st Sunday of month"
                          ? truePositive
                          : falsePositive) += 1.0;
@@ -428,7 +426,7 @@ BOOST_AUTO_TEST_CASE(testFalsePositives) {
                 if (feature != boost::none) {
                     LOG_DEBUG(<< "Detected = " << feature->first.print());
                 }
-                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 920);
+                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 860);
             }
         }
     }
@@ -452,7 +450,7 @@ BOOST_AUTO_TEST_CASE(testFalsePositives) {
                 if (feature != boost::none) {
                     LOG_DEBUG(<< "Detected = " << feature->first.print());
                 }
-                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 920);
+                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 860);
             }
         }
     }
@@ -478,7 +476,7 @@ BOOST_AUTO_TEST_CASE(testFalsePositives) {
                 if (feature != boost::none) {
                     LOG_DEBUG(<< "Detected = " << feature->first.print());
                 }
-                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 920);
+                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 860);
             }
         }
     }

--- a/lib/maths/time_series/unittest/CCalendarCyclicTestTest.cc
+++ b/lib/maths/time_series/unittest/CCalendarCyclicTestTest.cc
@@ -35,6 +35,7 @@ using namespace ml;
 
 namespace {
 using TDoubleVec = std::vector<double>;
+using TTimeVec = std::vector<core_t::TTime>;
 
 const core_t::TTime HALF_HOUR{core::constants::HOUR / 2};
 const core_t::TTime HOUR{core::constants::HOUR};
@@ -55,7 +56,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
     LOG_DEBUG(<< "Day of month");
     for (std::size_t t = 0; t < 10; ++t) {
         // Repeated error on the second day of the month.
-        core_t::TTime months[]{
+        TTimeVec months{
             86400,    // 2nd Jan
             2764800,  // 2nd Feb
             5184000,  // 2nd Mar
@@ -67,16 +68,15 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
             21081600, // 2nd Sep
             23673600  // 2nd Oct
         };
-        core_t::TTime end = months[boost::size(months) - 1] + 86400;
+        core_t::TTime end = months[months.size() - 1] + 86400;
 
         maths::time_series::CCalendarCyclicTest cyclic(HALF_HOUR);
 
         TDoubleVec error;
         for (core_t::TTime time = 0; time <= end; time += HALF_HOUR) {
             std::ptrdiff_t i = maths::common::CTools::truncate(
-                std::lower_bound(std::begin(months), std::end(months), time) -
-                    std::begin(months),
-                std::ptrdiff_t(1), std::ptrdiff_t(boost::size(months)));
+                std::lower_bound(months.begin(), months.end(), time) - months.begin(),
+                std::ptrdiff_t(1), std::ptrdiff_t(months.size()));
 
             rng.generateNormalSamples(0.0, 9.0, 1, error);
             if (time >= months[i - 1] + 30000 && time < months[i - 1] + 50000) {
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
                                                                   : falsePositive) += 1.0;
                 }
             }
-            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 720);
+            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 850);
         }
     }
     LOG_DEBUG(<< "true positive = " << truePositive);
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
     LOG_DEBUG(<< "Days before end of month");
     for (std::size_t t = 0; t < 10; ++t) {
         // Repeated error on the last day of the month.
-        core_t::TTime months[]{
+        TTimeVec months{
             2592000,  // 31st Jan
             5011200,  // 28th Feb
             7689600,  // 31st Mar
@@ -114,16 +114,15 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
             15552000, // 30th June
             18230400  // 31st July
         };
-        core_t::TTime end = months[boost::size(months) - 1] + 86400;
+        core_t::TTime end = months[months.size() - 1] + 86400;
 
         maths::time_series::CCalendarCyclicTest cyclic(HALF_HOUR);
 
         TDoubleVec error;
         for (core_t::TTime time = 0; time <= end; time += HALF_HOUR) {
             std::ptrdiff_t i = maths::common::CTools::truncate(
-                std::lower_bound(std::begin(months), std::end(months), time) -
-                    std::begin(months),
-                std::ptrdiff_t(1), std::ptrdiff_t(boost::size(months)));
+                std::lower_bound(months.begin(), months.end(), time) - months.begin(),
+                std::ptrdiff_t(1), std::ptrdiff_t(months.size()));
 
             rng.generateNormalSamples(0.0, 9.0, 1, error);
             if (time >= months[i - 1] + 10000 && time < months[i - 1] + 20000) {
@@ -141,7 +140,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
                          : falsePositive) += 1.0;
                 }
             }
-            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 710);
+            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 850);
         }
     }
     LOG_DEBUG(<< "true positive = " << truePositive);
@@ -151,23 +150,22 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
     LOG_DEBUG(<< "Day of week week of month");
     for (std::size_t t = 0; t < 10; ++t) {
         // Repeated error on first Monday of each month.
-        core_t::TTime months[]{
+        TTimeVec months{
             345600,  // Mon 5th Jan
             2764800, // Mon 2nd Feb
             5184000, // Mon 2nd Mar
             8208000, // Mon 6th Apr
             10627200 // Mon 4th May
         };
-        core_t::TTime end = months[boost::size(months) - 1] + 86400;
+        core_t::TTime end = months[months.size() - 1] + 86400;
 
         maths::time_series::CCalendarCyclicTest cyclic(HALF_HOUR);
 
         TDoubleVec error;
         for (core_t::TTime time = 0; time <= end; time += HALF_HOUR) {
             std::ptrdiff_t i = maths::common::CTools::truncate(
-                std::lower_bound(std::begin(months), std::end(months), time) -
-                    std::begin(months),
-                std::ptrdiff_t(1), std::ptrdiff_t(boost::size(months)));
+                std::lower_bound(months.begin(), months.end(), time) - months.begin(),
+                std::ptrdiff_t(1), std::ptrdiff_t(months.size()));
 
             rng.generateNormalSamples(0.0, 9.0, 1, error);
             if (time >= months[i - 1] + 45000 && time < months[i - 1] + 60000) {
@@ -185,7 +183,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
                          : falsePositive) += 1.0;
                 }
             }
-            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 710);
+            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 850);
         }
     }
     LOG_DEBUG(<< "true positive = " << truePositive);
@@ -195,23 +193,22 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
     LOG_DEBUG(<< "Day of week weeks before end of month");
     for (std::size_t t = 0; t < 10; ++t) {
         // Repeated error on last Friday of each month.
-        core_t::TTime months[]{
+        TTimeVec months{
             2505600, // Fri 30th Jan
             4924800, // Fri 27th Feb
             7344000, // Fri 27th Mar
             9763200, // Fri 24th Apr
             12787200 // Fri 29th May
         };
-        core_t::TTime end = months[boost::size(months) - 1] + 86400;
+        core_t::TTime end = months[months.size() - 1] + 86400;
 
         maths::time_series::CCalendarCyclicTest cyclic(HALF_HOUR);
 
         TDoubleVec error;
         for (core_t::TTime time = 0; time <= end; time += HALF_HOUR) {
             std::ptrdiff_t i = maths::common::CTools::truncate(
-                std::lower_bound(std::begin(months), std::end(months), time) -
-                    std::begin(months),
-                std::ptrdiff_t(1), std::ptrdiff_t(boost::size(months)));
+                std::lower_bound(months.begin(), months.end(), time) - months.begin(),
+                std::ptrdiff_t(1), std::ptrdiff_t(months.size()));
 
             rng.generateNormalSamples(0.0, 9.0, 1, error);
             if (time >= months[i - 1] + 45000 && time < months[i - 1] + 60000) {
@@ -229,7 +226,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
                          : falsePositive) += 1.0;
                 }
             }
-            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 710);
+            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 850);
         }
     }
     LOG_DEBUG(<< "true positive = " << truePositive);
@@ -238,7 +235,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
 
     double accuracy{(truePositive / (truePositive + falseNegative + falsePositive))};
     LOG_DEBUG(<< "accuracy = " << accuracy);
-    BOOST_TEST_REQUIRE(accuracy > 0.9);
+    BOOST_TEST_REQUIRE(accuracy > 0.99);
 }
 
 BOOST_AUTO_TEST_CASE(testTimeZones) {
@@ -253,23 +250,23 @@ BOOST_AUTO_TEST_CASE(testTimeZones) {
         LOG_DEBUG(<< "time zone offset = " << timeZoneOffset);
 
         // Repeated error on first Sunday of each month.
-        core_t::TTime months[]{
+        TTimeVec months{
             259200,  // Sun 4th Jan
             2678400, // Sun 1st Feb
             5097600, // Sun 1st Mar
             8121600, // Sun 5th Apr
             10540800 // Sun 3rd May
         };
-        core_t::TTime end = months[boost::size(months) - 1] + 86400;
+        core_t::TTime end = months[months.size() - 1] + 86400;
 
         maths::time_series::CCalendarCyclicTest cyclic(HALF_HOUR);
 
         TDoubleVec error;
         for (core_t::TTime time = 0; time <= end; time += HALF_HOUR) {
             std::ptrdiff_t i = maths::common::CTools::truncate(
-                std::lower_bound(std::begin(months), std::end(months), time + timeZoneOffset) -
-                    std::begin(months),
-                std::ptrdiff_t(1), std::ptrdiff_t(boost::size(months)));
+                std::lower_bound(months.begin(), months.end(), time + timeZoneOffset) -
+                    months.begin(),
+                std::ptrdiff_t(1), std::ptrdiff_t(months.size()));
 
             rng.generateNormalSamples(0.0, 9.0, 1, error);
             if (time + timeZoneOffset >= months[i - 1] + 25000 &&
@@ -300,23 +297,23 @@ BOOST_AUTO_TEST_CASE(testTimeZones) {
         LOG_DEBUG(<< "time zone offset = " << timeZoneOffset);
 
         // Repeated error on last Friday of each month.
-        core_t::TTime months[]{
+        TTimeVec months{
             2592000, // Sat 31th Jan
             5011200, // Sat 28th Feb
             7430400, // Sat 28th Mar
             9849600, // Sat 25th Apr
             12873600 // Sat 30th May
         };
-        core_t::TTime end = months[boost::size(months) - 1] + 86400;
+        core_t::TTime end = months[months.size() - 1] + 86400;
 
         maths::time_series::CCalendarCyclicTest cyclic(HALF_HOUR);
 
         TDoubleVec error;
         for (core_t::TTime time = 0; time <= end; time += HALF_HOUR) {
             std::ptrdiff_t i = maths::common::CTools::truncate(
-                std::lower_bound(std::begin(months), std::end(months), time + timeZoneOffset) -
-                    std::begin(months),
-                std::ptrdiff_t(1), std::ptrdiff_t(boost::size(months)));
+                std::lower_bound(months.begin(), months.end(), time + timeZoneOffset) -
+                    months.begin(),
+                std::ptrdiff_t(1), std::ptrdiff_t(months.size()));
 
             rng.generateNormalSamples(0.0, 9.0, 1, error);
             if (time + timeZoneOffset >= months[i - 1] + 45000 &&
@@ -343,7 +340,7 @@ BOOST_AUTO_TEST_CASE(testTimeZones) {
 
     double accuracy{(truePositive / (truePositive + falseNegative + falsePositive))};
     LOG_DEBUG(<< "accuracy = " << accuracy);
-    BOOST_TEST_REQUIRE(accuracy > 0.9);
+    BOOST_TEST_REQUIRE(accuracy > 0.99);
 }
 
 BOOST_AUTO_TEST_CASE(testVeryLargeCyclicSpikes) {
@@ -358,7 +355,7 @@ BOOST_AUTO_TEST_CASE(testVeryLargeCyclicSpikes) {
     LOG_DEBUG(<< "Day of month");
     for (std::size_t t = 0; t < 10; ++t) {
         // Repeated error on the second day of the month.
-        core_t::TTime months[]{
+        TTimeVec months{
             86400,    // 2nd Jan
             2764800,  // 2nd Feb
             5184000,  // 2nd Mar
@@ -370,16 +367,15 @@ BOOST_AUTO_TEST_CASE(testVeryLargeCyclicSpikes) {
             21081600, // 2nd Sep
             23673600  // 2nd Oct
         };
-        core_t::TTime end = months[boost::size(months) - 1] + 86400;
+        core_t::TTime end = months[months.size() - 1] + 86400;
 
         maths::time_series::CCalendarCyclicTest cyclic(HOUR);
 
         TDoubleVec error;
         for (core_t::TTime time = 0; time <= end; time += HOUR) {
             std::ptrdiff_t i = maths::common::CTools::truncate(
-                std::lower_bound(std::begin(months), std::end(months), time) -
-                    std::begin(months),
-                std::ptrdiff_t(1), std::ptrdiff_t(boost::size(months)));
+                std::lower_bound(months.begin(), months.end(), time) - months.begin(),
+                std::ptrdiff_t(1), std::ptrdiff_t(months.size()));
 
             rng.generateNormalSamples(0.0, 9.0, 1, error);
             if (time >= months[i - 1] + 36000 && time < months[i - 1] + 39600) {
@@ -404,7 +400,7 @@ BOOST_AUTO_TEST_CASE(testVeryLargeCyclicSpikes) {
 
     double accuracy{(truePositive / (truePositive + falseNegative + falsePositive))};
     LOG_DEBUG(<< "accuracy = " << accuracy);
-    BOOST_TEST_REQUIRE(accuracy > 0.9);
+    BOOST_TEST_REQUIRE(accuracy > 0.99);
 }
 
 BOOST_AUTO_TEST_CASE(testFalsePositives) {
@@ -432,7 +428,7 @@ BOOST_AUTO_TEST_CASE(testFalsePositives) {
                 if (feature != boost::none) {
                     LOG_DEBUG(<< "Detected = " << feature->first.print());
                 }
-                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 840);
+                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 920);
             }
         }
     }
@@ -456,7 +452,7 @@ BOOST_AUTO_TEST_CASE(testFalsePositives) {
                 if (feature != boost::none) {
                     LOG_DEBUG(<< "Detected = " << feature->first.print());
                 }
-                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 860);
+                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 920);
             }
         }
     }
@@ -482,7 +478,7 @@ BOOST_AUTO_TEST_CASE(testFalsePositives) {
                 if (feature != boost::none) {
                     LOG_DEBUG(<< "Detected = " << feature->first.print());
                 }
-                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 840);
+                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 920);
             }
         }
     }
@@ -522,9 +518,9 @@ BOOST_AUTO_TEST_CASE(testPersist) {
         core::CRapidXmlParser parser;
         BOOST_TEST_REQUIRE(parser.parseStringIgnoreCdata(origXml));
         core::CRapidXmlStateRestoreTraverser traverser(parser);
-        BOOST_TEST_REQUIRE(traverser.traverseSubLevel(
-            std::bind(&maths::time_series::CCalendarCyclicTest::acceptRestoreTraverser,
-                      &restored, std::placeholders::_1)));
+        BOOST_TEST_REQUIRE(traverser.traverseSubLevel([&](auto& traverser_) {
+            return restored.acceptRestoreTraverser(traverser_);
+        }));
     }
     BOOST_REQUIRE_EQUAL(orig.checksum(), restored.checksum());
 


### PR DESCRIPTION
Investigating slowdowns on a couple of large QA data sets as a result of #2298 showed up some interesting things. We spend a lot of time updating quantiles and recomputing split indices for the data sets which slowed down. These data sets have relatively many metric features and the runtime share of these operations is larger in such cases. This change introduces some changes to address long run times in such cases. 

I'd planned to use a fast version of the quantile sketch, but a silly mistake meant it never actually got wired in. I've also made a further tweak to the fast version which gives it another 50% performance boost at the expense of slightly changing its behaviour. I tested accuracy fairly extensively for the new scheme, which still often produces the same results, and found no evidence for significantly different accuracy.

For many features we can gain a lot of performance with v.little impact on the QoR by updating candidate splits less frequently. This imposes a new limit on the frequency we fresh them based on feature count.

For large data sets we were allowing individual trees to become v.large. Such large trees both stresses our inference, we have to limit the model size based on its memory anyway, and means train time can become too high. I've capped the maximum tree size independent of the data set size. The limit is still pretty large and I measured no significant impact in QoR from this change.