### PR TITLE
[ML] Bootstrap estimate sample error in the test loss for training classification and regression models

### DIFF
--- a/include/core/CPersistUtils.h
+++ b/include/core/CPersistUtils.h
@@ -27,7 +27,10 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <sstream>
 #include <string>
+#include <string_view>
+#include <tuple>
 #include <type_traits>
 #include <vector>
 
@@ -40,6 +43,7 @@ const TPersistenceTag FIRST_TAG("a", "first");
 const TPersistenceTag SECOND_TAG("b", "second");
 const TPersistenceTag MAP_TAG("c", "map");
 const TPersistenceTag SIZE_TAG("d", "size");
+const std::string TUPLE_PREFIX{"t_"};
 
 template<typename T>
 struct remove_const {
@@ -210,7 +214,7 @@ public:
     //! \brief Converts a built in type to a string using CStringUtils functions.
     class CORE_EXPORT CBuiltinToString {
     public:
-        CBuiltinToString(const char pairDelimiter)
+        explicit CBuiltinToString(const char pairDelimiter)
             : m_PairDelimiter(pairDelimiter) {}
 
         std::string operator()(double value) const {
@@ -254,6 +258,17 @@ public:
                    this->operator()(value.second);
         }
 
+        template<typename... T>
+        std::string operator()(const std::tuple<T...>& value) const {
+            std::ostringstream result;
+            std::apply(
+                [&](const auto&... element) {
+                    ((result << this->operator()(element) << m_PairDelimiter), ...);
+                },
+                value);
+            return result.str();
+        }
+
     private:
         char m_PairDelimiter;
     };
@@ -261,7 +276,7 @@ public:
     //! \brief Converts a string to a built in type using CStringUtils functions.
     class CORE_EXPORT CBuiltinFromString {
     public:
-        CBuiltinFromString(const char pairDelimiter)
+        explicit CBuiltinFromString(const char pairDelimiter)
             : m_PairDelimiter(pairDelimiter) {}
 
         template<typename T>
@@ -332,6 +347,35 @@ public:
             }
             m_Token.assign(token, delimPos + 1, token.length() - delimPos);
             return this->operator()(m_Token, value.second);
+        }
+
+        template<typename... T>
+        bool operator()(const std::string& token, std::tuple<T...>& value) const {
+            if (std::count(token.begin(), token.end(), m_PairDelimiter) !=
+                std::tuple_size_v<std::tuple<T...>>) {
+                return false;
+            }
+
+            auto popOneItem = [this](std::string_view& tokenView, auto& element) {
+                std::size_t delimPos(tokenView.find(m_PairDelimiter));
+                if (delimPos == std::string::npos) {
+                    return false;
+                }
+                m_Token = tokenView.substr(0, delimPos);
+                bool result{this->operator()(m_Token, element)};
+                tokenView.remove_prefix(delimPos + 1);
+                return result;
+            };
+
+            bool success{true};
+            std::string_view tokenView{token};
+            std::apply(
+                [&](auto&... element) {
+                    // Note we want to shortcircuit if not successful.
+                    ((success = success && popOneItem(tokenView, element)), ...);
+                },
+                value);
+            return success;
         }
 
     private:
@@ -697,6 +741,24 @@ public:
                              [&t](auto& inserter_) { newLevel(t, inserter_); });
     }
 
+    template<typename... T>
+    static void dispatch(const std::string& tag,
+                         const std::tuple<T...>& t,
+                         CStatePersistInserter& inserter) {
+        auto newLevel = [](std::size_t pos, const auto& element,
+                           CStatePersistInserter& inserter_) {
+            persist(TUPLE_PREFIX + std::to_string(pos), element, inserter_);
+        };
+        inserter.insertLevel(tag, [&](auto& inserter_) {
+            std::size_t pos{0};
+            std::apply(
+                [&](const auto&... element) {
+                    ((newLevel(pos++, element, inserter_)), ...);
+                },
+                t);
+        });
+    }
+
 private:
     template<typename A, typename B>
     static void newLevel(const std::pair<A, B>& t, CStatePersistInserter& inserter) {
@@ -879,6 +941,50 @@ public:
             }
             return traverser.traverseSubLevel(
                 [&t](auto& traverser_) { return subLevel(t, traverser_); });
+        }
+        return true;
+    }
+
+    template<typename... T>
+    static bool
+    dispatch(const std::string& tag, std::tuple<T...>& t, CStateRestoreTraverser& traverser) {
+        if (traverser.name() == tag) {
+            if (traverser.hasSubLevel() == false) {
+                LOG_ERROR(<< "SubLevel mismatch in restore, at " << traverser.name());
+                return false;
+            }
+            auto subLevel = [](std::size_t pos, auto& element,
+                               CStateRestoreTraverser& traverser_) {
+                if (traverser_.name() != TUPLE_PREFIX + std::to_string(pos)) {
+                    LOG_ERROR(<< "Tag mismatch at " << traverser_.name() << ", expected "
+                              << TUPLE_PREFIX + std::to_string(pos));
+                    return false;
+                }
+                if (restore(traverser_.name(), element, traverser_) == false) {
+                    LOG_ERROR(<< "Restore error at " << traverser_.name()
+                              << ": " << traverser_.value());
+                    return false;
+                }
+                if (pos + 1 < std::tuple_size_v<std::tuple<T...>>) {
+                    if (traverser_.next() == false) {
+                        LOG_ERROR(<< "Restore error at " << traverser_.name()
+                                  << ": " << traverser_.value());
+                        return false;
+                    }
+                }
+                return true;
+            };
+            return traverser.traverseSubLevel([&](auto& traverser_) {
+                bool success{true};
+                std::size_t pos{0};
+                std::apply(
+                    [&](auto&... element) {
+                        // Note we want to shortcircuit if not successful.
+                        ((success = success && subLevel(pos++, element, traverser_)), ...);
+                    },
+                    t);
+                return success;
+            });
         }
         return true;
     }

--- a/include/maths/analytics/CBoostedTreeHyperparameters.h
+++ b/include/maths/analytics/CBoostedTreeHyperparameters.h
@@ -628,13 +628,6 @@ public:
     //! The penalty to apply based on the model size.
     double modelSizePenalty(double numberKeptNodes, double numberNewNodes) const;
 
-    //! Compute the loss at \p n standard deviations of \p lossMoments above
-    //! the mean.
-    static double lossAtNSigma(double n, const TMeanVarAccumulator& lossMoments) {
-        return common::CBasicStatistics::mean(lossMoments) +
-               n * std::sqrt(common::CBasicStatistics::variance(lossMoments));
-    }
-
     //! Get the vector of hyperparameter importances.
     THyperparameterImportanceVec importances() const;
     //@}
@@ -681,8 +674,8 @@ private:
     using TOptionalVector3x1 = boost::optional<TVector3x1>;
     using TIndexVec = std::vector<TVector::TIndexType>;
     using TOptionalVector3x1DoubleSizeTr = std::tuple<TOptionalVector3x1, double, std::size_t>;
-    using TVectorDoublePr = std::pair<TVector, double>;
-    using TVectorDoublePrVec = std::vector<TVectorDoublePr>;
+    using TVectorMeanVarAccumulatorPr = std::pair<TVector, TMeanVarAccumulator>;
+    using TVectorMeanVarAccumulatorPrVec = std::vector<TVectorMeanVarAccumulatorPr>;
 
 private:
     void initializeTunableHyperparameters();
@@ -701,8 +694,8 @@ private:
     minimizeTestLoss(double intervalLeftEnd,
                      double intervalRightEnd,
                      TDoubleDoubleDoubleSizeTupleVec testLosses) const;
-    void checkIfCanSkipFineTuneSearch(double testLossVariance);
-    void captureHyperparametersAndLoss(double loss);
+    void checkIfCanSkipFineTuneSearch();
+    void captureHyperparametersAndLoss(const TMeanVarAccumulator& loss);
     TVector currentParametersVector() const;
     void setHyperparameterValues(TVector parameters);
     void saveCurrent();
@@ -748,7 +741,7 @@ private:
     TMeanAccumulator m_MeanForestSizeAccumulator;
     TMeanAccumulator m_MeanTestLossAccumulator;
     TIndexVec m_LineSearchRelevantParameters;
-    TVectorDoublePrVec m_LineSearchHyperparameterLosses;
+    TVectorMeanVarAccumulatorPrVec m_LineSearchHyperparameterLosses;
     //@}
 };
 }

--- a/include/maths/analytics/CBoostedTreeHyperparameters.h
+++ b/include/maths/analytics/CBoostedTreeHyperparameters.h
@@ -674,8 +674,8 @@ private:
     using TOptionalVector3x1 = boost::optional<TVector3x1>;
     using TIndexVec = std::vector<TVector::TIndexType>;
     using TOptionalVector3x1DoubleSizeTr = std::tuple<TOptionalVector3x1, double, std::size_t>;
-    using TVectorMeanVarAccumulatorPr = std::pair<TVector, TMeanVarAccumulator>;
-    using TVectorMeanVarAccumulatorPrVec = std::vector<TVectorMeanVarAccumulatorPr>;
+    using TVectorDoubleDoubleTr = std::tuple<TVector, double, double>;
+    using TVectorDoubleDoubleTrVec = std::vector<TVectorDoubleDoubleTr>;
 
 private:
     void initializeTunableHyperparameters();
@@ -741,7 +741,7 @@ private:
     TMeanAccumulator m_MeanForestSizeAccumulator;
     TMeanAccumulator m_MeanTestLossAccumulator;
     TIndexVec m_LineSearchRelevantParameters;
-    TVectorMeanVarAccumulatorPrVec m_LineSearchHyperparameterLosses;
+    TVectorDoubleDoubleTrVec m_LineSearchHyperparameterLosses;
     //@}
 };
 }

--- a/include/maths/analytics/CBoostedTreeImpl.h
+++ b/include/maths/analytics/CBoostedTreeImpl.h
@@ -226,11 +226,11 @@ private:
 
     //! \brief The result of training a single forest.
     struct STrainForestResult {
-        std::tuple<TNodeVecVec, double, double, TDoubleVec> asTuple() {
+        std::tuple<TNodeVecVec, TMeanVarAccumulator, double, TDoubleVec> asTuple() {
             return {std::move(s_Forest), s_TestLoss, s_LossGap, std::move(s_TestLosses)};
         }
         TNodeVecVec s_Forest;
-        double s_TestLoss{0.0};
+        TMeanVarAccumulator s_TestLoss{0.0};
         double s_LossGap{0.0};
         TDoubleVec s_TestLosses;
     };
@@ -400,12 +400,13 @@ private:
                             const TUpdateRowPrediction& updateRowPrediction) const;
 
     //! Compute the mean of the loss function on the masked rows of \p frame.
-    double meanLoss(const core::CDataFrame& frame, const core::CPackedBitVector& rowMask) const;
+    TMeanVarAccumulator meanLoss(const core::CDataFrame& frame,
+                                 const core::CPackedBitVector& rowMask) const;
 
     //! Compute the mean of the loss function on the masked rows of \p frame
     //! adjusted for incremental training.
-    double meanChangePenalisedLoss(const core::CDataFrame& frame,
-                                   const core::CPackedBitVector& rowMask) const;
+    TMeanVarAccumulator meanChangePenalisedLoss(const core::CDataFrame& frame,
+                                                const core::CPackedBitVector& rowMask) const;
 
     //! Compute the overall variance of the error we see between folds.
     double betweenFoldTestLossVariance() const;
@@ -489,6 +490,7 @@ private:
     //@{
     TSizeParameter m_NumberFolds{4};
     TDoubleParameter m_TrainFractionPerFold{0.75};
+    bool m_UserSuppliedHoldOutSet{false};
     bool m_StopCrossValidationEarly{true};
     TOptionalDoubleVecVec m_FoldRoundTestLosses;
     //@}

--- a/include/maths/common/CBayesianOptimisation.h
+++ b/include/maths/common/CBayesianOptimisation.h
@@ -113,16 +113,17 @@ public:
     //! \p dimension for the values \p input.
     double evaluate1D(double input, int dimension) const;
 
-    //! Get the constant factor of the ANOVA decomposition of the Gaussian process.
-    double anovaConstantFactor() const;
+    //! Get the coefficient of variation after subtracting the measurement error
+    //! variance for the Gaussian process in the search bounding box using ANOVA
+    //! decomposition.
+    double excessCoefficientOfVariation();
 
     //! Get the total variance of the Gaussian process in the search bounding box
     //! using ANOVA decomposition.
     double anovaTotalVariance() const;
 
-    //! Get the coefficiet of variation of the Gaussian process in the search
-    //! bounding box using ANOVA decomposition.
-    double anovaTotalCoefficientOfVariation();
+    //! Get the constant factor of the ANOVA decomposition of the Gaussian process.
+    double anovaConstantFactor() const;
 
     //! Get the main effect of the parameter \p dimension in the Gaussian process
     //! using ANOVA decomposition.

--- a/include/maths/common/CSampling.h
+++ b/include/maths/common/CSampling.h
@@ -201,8 +201,8 @@ public:
         using TVec = std::vector<T>;
 
     public:
-        CVectorDissimilaritySampler(std::size_t targetSampleSize,
-                                    const CPRNG::CXorOShiro128Plus& rng = CPRNG::CXorOShiro128Plus{})
+        explicit CVectorDissimilaritySampler(std::size_t targetSampleSize,
+                                             const CPRNG::CXorOShiro128Plus& rng = CPRNG::CXorOShiro128Plus{})
             : CStreamSampler<T>(targetSampleSize, rng),
               m_SampleWeights(targetSampleSize, 0.0) {
             m_Samples.reserve(targetSampleSize);
@@ -294,7 +294,7 @@ public:
 
     private:
         TVec m_Samples;
-        double m_MinWeight = std::numeric_limits<double>::max();
+        double m_MinWeight{std::numeric_limits<double>::max()};
         TDoubleVec m_SampleWeights;
         TDoubleVec m_Probabilities;
     };
@@ -432,6 +432,17 @@ public:
                              double variance,
                              std::size_t n,
                              TDoubleVec& result);
+
+    //! Get \p n samples of a Poisson random variable with rate \p rate using \p rng.
+    static void poissonSample(double rate, std::size_t n, TSizeVec& result);
+
+    //! Get \p n samples of a Poisson random variable with rate \p rate using \p rng.
+    static void
+    poissonSample(CPRNG::CXorOShiro128Plus& rng, double rate, std::size_t n, TSizeVec& result);
+
+    //! Get \p n samples of a Poisson random variable with rate \p rate using \p rng.
+    static void
+    poissonSample(CPRNG::CXorShift1024Mult& rng, double rate, std::size_t n, TSizeVec& result);
 
     //! Get \p n samples of a \f$\chi^2\f$ random variable with \p f
     //! degrees of freedom.

--- a/lib/maths/analytics/CBoostedTreeHyperparameters.cc
+++ b/lib/maths/analytics/CBoostedTreeHyperparameters.cc
@@ -435,9 +435,9 @@ bool CBoostedTreeHyperparameters::optimisationMakingNoProgress() const {
     if (m_StopHyperparameterOptimizationEarly) {
         return true;
     }
-    double anovaCoV{m_BayesianOptimization->excessCoefficientOfVariation()};
-    LOG_TRACE(<< "anovaTotalCoefficientOfVariation " << anovaCoV);
-    return anovaCoV < 1e-3;
+    double cov{m_BayesianOptimization->excessCoefficientOfVariation()};
+    LOG_TRACE(<< "excessCoefficientOfVariation " << cov);
+    return cov < 1e-3;
 }
 
 void CBoostedTreeHyperparameters::startFineTuneSearch() {

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -2076,7 +2076,7 @@ CBoostedTreeImpl::meanLoss(const core::CDataFrame& frame,
 
     auto results = frame.readRows(
         m_NumberThreads, 0, frame.numberRows(),
-        core::bindRetrievableState( // Prevent weird formatting.
+        core::bindRetrievableState( // Prevents weird formatting.
             [ this, rng = m_Rng, samples = TSizeVec{} ](
                 TMeanAccumulatorVec & losses, const TRowItr& beginRows, const TRowItr& endRows) mutable {
                 std::size_t numberLossParameters{m_Loss->numberParameters()};

--- a/lib/maths/analytics/unittest/CBoostedTreeHyperparametersTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeHyperparametersTest.cc
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(testBoostedTreeHyperparametersOptimisationCaptureBest) {
 
         hyperparameters.captureBest(testLossMoments, 0.0, 100, 0, 50);
 
-        double loss{maths::analytics::CBoostedTreeHyperparameters::lossAtNSigma(1, testLossMoments)};
+        double loss{maths::common::CBasicStatistics::mean(testLossMoments)};
         if (loss < minimumLoss) {
             expectedBestParameters.assign(
                 {hyperparameters.depthPenaltyMultiplier().value(),

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -3740,10 +3740,10 @@ BOOST_AUTO_TEST_CASE(testStopAfterCoarseParameterTuning) {
     // on the optimisation objective.
 
     test::CRandomNumbers rng;
-    std::size_t rows{1500};
+    std::size_t rows{2000};
     std::size_t cols{3};
 
-    std::size_t numberHoldoutRows{1000};
+    std::size_t numberHoldoutRows{1500};
 
     auto verify = [&](double noiseVariance) {
         auto target = [&] {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -100,7 +100,8 @@ public:
 
     double meanChangePenalisedLoss(core::CDataFrame& frame,
                                    const core::CPackedBitVector& rowMask) const {
-        return m_TreeImpl.meanChangePenalisedLoss(frame, rowMask);
+        return maths::common::CBasicStatistics::mean(
+            m_TreeImpl.meanChangePenalisedLoss(frame, rowMask));
     }
 
 private:
@@ -3739,10 +3740,10 @@ BOOST_AUTO_TEST_CASE(testStopAfterCoarseParameterTuning) {
     // on the optimisation objective.
 
     test::CRandomNumbers rng;
-    std::size_t rows{500};
+    std::size_t rows{1500};
     std::size_t cols{3};
 
-    std::size_t numberHoldoutRows{200};
+    std::size_t numberHoldoutRows{1000};
 
     auto verify = [&](double noiseVariance) {
         auto target = [&] {
@@ -3770,10 +3771,11 @@ BOOST_AUTO_TEST_CASE(testStopAfterCoarseParameterTuning) {
         auto frame = core::makeMainStorageDataFrame(cols, rows).first;
         fillDataFrame(rows, 0, cols, x, noise, target, *frame);
 
-        auto factory = maths::analytics::CBoostedTreeFactory::constructFromParameters(
-            1, std::make_unique<maths::analytics::boosted_tree::CMse>());
-        factory.numberHoldoutRows(numberHoldoutRows);
-        auto regression = factory.buildForTrain(*frame, cols - 1);
+        auto regression =
+            maths::analytics::CBoostedTreeFactory::constructFromParameters(
+                1, std::make_unique<maths::analytics::boosted_tree::CMse>())
+                .numberHoldoutRows(numberHoldoutRows)
+                .buildForTrain(*frame, cols - 1);
         return regression->hyperparameters().optimisationMakingNoProgress();
     };
 

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -387,15 +387,15 @@ double CBayesianOptimisation::anovaTotalVariance(const TVector& Kinvf) const {
     return std::max(0.0, (theta2 * theta2 * sum - f0 * f0) / scale2);
 }
 
-double CBayesianOptimisation::anovaTotalCoefficientOfVariation() {
-    this->precondition();
-    LOG_TRACE(<< "anovaTotalVariance " << this->anovaTotalVariance() << " m_RangeShift "
-              << m_RangeShift << " m_RangeScale " << m_RangeScale);
-    return std::sqrt(this->anovaTotalVariance()) / m_RangeShift;
-}
-
 double CBayesianOptimisation::anovaTotalVariance() const {
     return this->anovaTotalVariance(this->kinvf());
+}
+
+double CBayesianOptimisation::excessCoefficientOfVariation() {
+    double errorVariance{this->meanErrorVariance() / CTools::pow2(m_RangeScale)};
+    LOG_TRACE(<< "anovaTotalVariance " << this->anovaTotalVariance()
+              << ", mean error variance = " << errorVariance);
+    return std::sqrt(std::max(this->anovaTotalVariance() - errorVariance, 0.0)) / m_RangeShift;
 }
 
 double CBayesianOptimisation::anovaMainEffect(const TVector& Kinvf, int dimension) const {

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -393,7 +393,7 @@ double CBayesianOptimisation::anovaTotalVariance() const {
 
 double CBayesianOptimisation::excessCoefficientOfVariation() {
     double errorVariance{this->meanErrorVariance() / CTools::pow2(m_RangeScale)};
-    LOG_TRACE(<< "anovaTotalVariance " << this->anovaTotalVariance()
+    LOG_DEBUG(<< "anovaTotalVariance " << this->anovaTotalVariance()
               << ", mean error variance = " << errorVariance);
     return std::sqrt(std::max(this->anovaTotalVariance() - errorVariance, 0.0)) / m_RangeShift;
 }

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -393,8 +393,6 @@ double CBayesianOptimisation::anovaTotalVariance() const {
 
 double CBayesianOptimisation::excessCoefficientOfVariation() {
     double errorVariance{this->meanErrorVariance() / CTools::pow2(m_RangeScale)};
-    LOG_DEBUG(<< "anovaTotalVariance " << this->anovaTotalVariance()
-              << ", mean error variance = " << errorVariance);
     return std::sqrt(std::max(this->anovaTotalVariance() - errorVariance, 0.0)) / m_RangeShift;
 }
 

--- a/lib/maths/common/CSampling.cc
+++ b/lib/maths/common/CSampling.cc
@@ -9,7 +9,6 @@
  * limitation.
  */
 
-#include <boost/random/poisson_distribution.hpp>
 #include <maths/common/CSampling.h>
 
 #include <core/CContainerPrinter.h>
@@ -29,6 +28,7 @@
 #include <boost/random/binomial_distribution.hpp>
 #include <boost/random/chi_squared_distribution.hpp>
 #include <boost/random/normal_distribution.hpp>
+#include <boost/random/poisson_distribution.hpp>
 #include <boost/random/sobol.hpp>
 #include <boost/random/uniform_01.hpp>
 #include <boost/random/uniform_real_distribution.hpp>


### PR DESCRIPTION
We can use bootstrap estimates of the sample error in the test loss to better decide if we should continue searching hyperparameters: any variation which is small on the scale of the sample error is not worth burning runtime on.

Also, I've allowed us to decide just to use a hold out set if training data are plentiful rather than cross-validating. This will save us 50% of fine tune on large data sets.

This logically belongs with #2332: speed ups for large data sets. As such I don't want to document separately and marking as a non-issue.