### PR TITLE
[ML] Make C++ code match new meanings for threading inputs

### DIFF
--- a/bin/pytorch_inference/CThreadSettings.h
+++ b/bin/pytorch_inference/CThreadSettings.h
@@ -27,6 +27,7 @@ public:
 
     std::int32_t numThreadsPerAllocation() const;
     std::int32_t numAllocations() const;
+    std::int32_t pyTorchThreadpoolThreads() const;
     void numAllocations(std::int32_t numAllocations);
 
     static void validateThreadingParameters(std::int32_t maxThreads,

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -325,7 +325,9 @@ int main(int argc, char** argv) {
     // It doesn't hurt to set variables that won't have any effect on some platforms.
     ml::core::CSetEnv::setEnv(
         "VECLIB_MAXIMUM_THREADS",
-        ml::core::CStringUtils::typeToString(numThreadsPerAllocation).c_str(), 0);
+        ml::core::CStringUtils::typeToString(threadSettings.pyTorchThreadpoolThreads())
+            .c_str(),
+        0);
 
     ml::core::CBlockingCallCancellingTimer cancellerThread{
         ml::core::CThread::currentThreadId(), std::chrono::seconds{namedPipeConnectTimeout}};
@@ -377,7 +379,7 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    at::set_num_threads(threadSettings.numThreadsPerAllocation());
+    at::set_num_threads(threadSettings.pyTorchThreadpoolThreads());
 
     // This is not used as we don't call at::launch anywhere.
     // Setting it to 1 to ensure there is no thread pool sitting around.

--- a/bin/pytorch_inference/unittest/CThreadSettingsTest.cc
+++ b/bin/pytorch_inference/unittest/CThreadSettingsTest.cc
@@ -17,81 +17,95 @@
 BOOST_AUTO_TEST_SUITE(CThreadSettingsTest)
 
 BOOST_AUTO_TEST_CASE(testValidationNoChanges) {
-    std::int32_t modelThreads{4};
-    std::int32_t inferenceThreads{4};
-    ml::torch::CThreadSettings::validateThreadingParameters(16, inferenceThreads, modelThreads);
-    BOOST_REQUIRE_EQUAL(4, modelThreads);
-    BOOST_REQUIRE_EQUAL(4, inferenceThreads);
+    std::int32_t maxThreads{16};
+    std::int32_t numAllocations{4};
+    std::int32_t numThreadsPerAllocation{4};
+    ml::torch::CThreadSettings::validateThreadingParameters(
+        maxThreads, numThreadsPerAllocation, numAllocations);
+    BOOST_REQUIRE_EQUAL(4, numAllocations);
+    BOOST_REQUIRE_EQUAL(4, numThreadsPerAllocation);
 }
 
 BOOST_AUTO_TEST_CASE(testValidationValuesAreCapped) {
-    std::int32_t modelThreads{1};
-    std::int32_t inferenceThreads{32};
-    ml::torch::CThreadSettings::validateThreadingParameters(16, inferenceThreads, modelThreads);
-    BOOST_REQUIRE_EQUAL(1, modelThreads);
-    BOOST_REQUIRE_EQUAL(15, inferenceThreads);
+    std::int32_t maxThreads{16};
+    std::int32_t numAllocations{1};
+    std::int32_t numThreadsPerAllocation{32};
+    ml::torch::CThreadSettings::validateThreadingParameters(
+        maxThreads, numThreadsPerAllocation, numAllocations);
+    BOOST_REQUIRE_EQUAL(1, numAllocations);
+    BOOST_REQUIRE_EQUAL(16, numThreadsPerAllocation);
 
-    modelThreads = 32;
-    inferenceThreads = 1;
-    ml::torch::CThreadSettings::validateThreadingParameters(16, inferenceThreads, modelThreads);
-    BOOST_REQUIRE_EQUAL(15, modelThreads);
-    BOOST_REQUIRE_EQUAL(1, inferenceThreads);
+    numAllocations = 32;
+    numThreadsPerAllocation = 1;
+    ml::torch::CThreadSettings::validateThreadingParameters(
+        maxThreads, numThreadsPerAllocation, numAllocations);
+    BOOST_REQUIRE_EQUAL(16, numAllocations);
+    BOOST_REQUIRE_EQUAL(1, numThreadsPerAllocation);
 }
 
 BOOST_AUTO_TEST_CASE(testValidationNegativeValues) {
-    std::int32_t modelThreads{-1};
-    std::int32_t inferenceThreads{-2};
-    ml::torch::CThreadSettings::validateThreadingParameters(16, inferenceThreads, modelThreads);
-    BOOST_REQUIRE_EQUAL(1, modelThreads);
-    BOOST_REQUIRE_EQUAL(1, inferenceThreads);
+    std::int32_t maxThreads{16};
+    std::int32_t numAllocations{-1};
+    std::int32_t numThreadsPerAllocation{-2};
+    ml::torch::CThreadSettings::validateThreadingParameters(
+        maxThreads, numThreadsPerAllocation, numAllocations);
+    BOOST_REQUIRE_EQUAL(1, numAllocations);
+    BOOST_REQUIRE_EQUAL(1, numThreadsPerAllocation);
 }
 
 BOOST_AUTO_TEST_CASE(testValidationMaxThreadsUnknown) {
-    std::int32_t modelThreads{4};
-    std::int32_t inferenceThreads{4};
     // 0 == maxThreads is not known
-    ml::torch::CThreadSettings::validateThreadingParameters(0, inferenceThreads, modelThreads);
-    BOOST_REQUIRE_EQUAL(1, modelThreads);
-    BOOST_REQUIRE_EQUAL(1, inferenceThreads);
+    std::int32_t maxThreads{0};
+    std::int32_t numAllocations{4};
+    std::int32_t numThreadsPerAllocation{4};
+    ml::torch::CThreadSettings::validateThreadingParameters(
+        maxThreads, numThreadsPerAllocation, numAllocations);
+    BOOST_REQUIRE_EQUAL(1, numAllocations);
+    BOOST_REQUIRE_EQUAL(1, numThreadsPerAllocation);
 }
 
 BOOST_AUTO_TEST_CASE(testValidationTotalGreaterThanMaxThreads) {
+    std::int32_t maxThreads{16};
     {
-        std::int32_t modelThreads{10};
-        std::int32_t inferenceThreads{10};
-        ml::torch::CThreadSettings::validateThreadingParameters(16, inferenceThreads,
-                                                                modelThreads);
-        BOOST_REQUIRE_EQUAL(10, modelThreads);
-        BOOST_REQUIRE_EQUAL(6, inferenceThreads);
+        std::int32_t numAllocations{10};
+        std::int32_t numThreadsPerAllocation{10};
+        ml::torch::CThreadSettings::validateThreadingParameters(
+            maxThreads, numThreadsPerAllocation, numAllocations);
+        BOOST_REQUIRE_EQUAL(10, numAllocations);
+        BOOST_REQUIRE_EQUAL(2, numThreadsPerAllocation);
     }
     {
-        std::int32_t modelThreads{1};
-        std::int32_t inferenceThreads{32};
-        ml::torch::CThreadSettings::validateThreadingParameters(16, inferenceThreads,
-                                                                modelThreads);
-        BOOST_REQUIRE_EQUAL(1, modelThreads);
-        BOOST_REQUIRE_EQUAL(15, inferenceThreads);
+        std::int32_t numAllocations{1};
+        std::int32_t numThreadsPerAllocation{32};
+        ml::torch::CThreadSettings::validateThreadingParameters(
+            maxThreads, numThreadsPerAllocation, numAllocations);
+        BOOST_REQUIRE_EQUAL(1, numAllocations);
+        BOOST_REQUIRE_EQUAL(16, numThreadsPerAllocation);
+    }
+    maxThreads = 4;
+    {
+        std::int32_t numAllocations{4};
+        std::int32_t numThreadsPerAllocation{1};
+        ml::torch::CThreadSettings::validateThreadingParameters(
+            maxThreads, numThreadsPerAllocation, numAllocations);
+        BOOST_REQUIRE_EQUAL(4, numAllocations);
+        BOOST_REQUIRE_EQUAL(1, numThreadsPerAllocation);
     }
     {
-        std::int32_t modelThreads{4};
-        std::int32_t inferenceThreads{1};
-        ml::torch::CThreadSettings::validateThreadingParameters(4, inferenceThreads, modelThreads);
-        BOOST_REQUIRE_EQUAL(3, modelThreads);
-        BOOST_REQUIRE_EQUAL(1, inferenceThreads);
+        std::int32_t numAllocations{1};
+        std::int32_t numThreadsPerAllocation{4};
+        ml::torch::CThreadSettings::validateThreadingParameters(
+            maxThreads, numThreadsPerAllocation, numAllocations);
+        BOOST_REQUIRE_EQUAL(1, numAllocations);
+        BOOST_REQUIRE_EQUAL(4, numThreadsPerAllocation);
     }
     {
-        std::int32_t modelThreads{1};
-        std::int32_t inferenceThreads{4};
-        ml::torch::CThreadSettings::validateThreadingParameters(4, inferenceThreads, modelThreads);
-        BOOST_REQUIRE_EQUAL(1, modelThreads);
-        BOOST_REQUIRE_EQUAL(3, inferenceThreads);
-    }
-    {
-        std::int32_t modelThreads{2};
-        std::int32_t inferenceThreads{4};
-        ml::torch::CThreadSettings::validateThreadingParameters(4, inferenceThreads, modelThreads);
-        BOOST_REQUIRE_EQUAL(2, modelThreads);
-        BOOST_REQUIRE_EQUAL(2, inferenceThreads);
+        std::int32_t numAllocations{2};
+        std::int32_t numThreadsPerAllocation{4};
+        ml::torch::CThreadSettings::validateThreadingParameters(
+            maxThreads, numThreadsPerAllocation, numAllocations);
+        BOOST_REQUIRE_EQUAL(2, numAllocations);
+        BOOST_REQUIRE_EQUAL(2, numThreadsPerAllocation);
     }
 }
 


### PR DESCRIPTION
The Java code now works on the basis that num_threads_per_allocation
should be multiplied by the number of allocations to give the total
number of threads required.

This PR changes the C++ code to reflect that.

There are a couple of subtle changes:

1. There's an assumption that either our outer thread pool _or_
   PyTorch's inner thread pool are busy, but not both at the same
   time. We are assuming that when a PyTorch inference fans out
   work across the threads of its inner thread pool the thread
   that requested the inference will block awaiting the inner
   results. This is consistent with how `parallel_for_each` works,
   so a reasonable assumption.
2. When multiple allocations are in the same process they are
   all sharing the same PyTorch inner thread pool. This means
   the allocations are sharing those "threads per allocation".
   For example, if number of allocations is 3 and threads per
   allocation is 4 then PyTorch's inner thread pool will have
   12 threads. But if 3 inferences are being done simultaneously
   then each will fan out large steps over 12 threads rather
   than 4. The 12 subtasks may then queue for a thread while the
   12 subtasks of the other inferences run. The total number of
   threads used is as specified, but they are not dedicated to
   particular allocations.