### PR TITLE
[7.17] [ML] Clean up CI test reports

### DIFF
--- a/lib/core/unittest/CLoggerTest.cc
+++ b/lib/core/unittest/CLoggerTest.cc
@@ -93,7 +93,9 @@ void loggedExpectedMessages(const std::string& logging, const TStrVec& messages)
 }
 
 BOOST_FIXTURE_TEST_CASE(testLogging, CTestFixture) {
-    std::string t("Test message");
+    std::string t{"Test message"};
+
+    BOOST_TEST_REQUIRE(ml::core::CLogger::instance().hasBeenReconfigured() == false);
 
     LOG_TRACE(<< "Trace");
     LOG_AT_LEVEL(ml::core::CLogger::E_Trace, << "Dynamic TRACE " << 1);

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -450,13 +450,10 @@ BOOST_AUTO_TEST_CASE(testEdgeCases) {
     fillDataFrame(5, 0, 2, {{1.0}, {1.0}, {1.0}, {1.0}, {1.0}},
                   {0.0, 0.0, 0.0, 0.0, 0.0}, [](const TRowRef&) { return 1.0; }, *frame);
 
-    try {
-        auto regression =
-            maths::analytics::CBoostedTreeFactory::constructFromParameters(
-                1, std::make_unique<maths::analytics::boosted_tree::CMse>())
-                .buildFor(*frame, cols - 1);
-        regression->train();
-    } catch (...) { BOOST_FAIL("Shouldn't throw"); }
+    BOOST_REQUIRE_NO_THROW(maths::analytics::CBoostedTreeFactory::constructFromParameters(
+                               1, std::make_unique<maths::analytics::boosted_tree::CMse>())
+                               .buildFor(*frame, cols - 1)
+                               ->train());
 }
 
 BOOST_AUTO_TEST_CASE(testPiecewiseConstant) {
@@ -705,9 +702,9 @@ BOOST_AUTO_TEST_CASE(testHuber) {
     BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanModelRSquared) > 0.95);
 }
 
-BOOST_AUTO_TEST_CASE(testMsle) {
-    // TODO #1744 test quality of MSLE on data with log-normal errors.
-}
+// TODO #1744 test quality of MSLE on data with log-normal errors.
+//BOOST_AUTO_TEST_CASE(testMsle) {
+//}
 
 BOOST_AUTO_TEST_CASE(testLowTrainFractionPerFold) {
 

--- a/lib/maths/analytics/unittest/Main.cc
+++ b/lib/maths/analytics/unittest/Main.cc
@@ -9,7 +9,7 @@
  * limitation.
  */
 
-#define BOOST_TEST_MODULE lib.maths
+#define BOOST_TEST_MODULE lib.maths.analytics
 // Defining BOOST_TEST_MODULE usually auto-generates main(), but we don't want
 // this as we need custom initialisation to allow for output in both console and
 // Boost.Test XML formats

--- a/lib/maths/common/unittest/Main.cc
+++ b/lib/maths/common/unittest/Main.cc
@@ -9,7 +9,7 @@
  * limitation.
  */
 
-#define BOOST_TEST_MODULE lib.maths
+#define BOOST_TEST_MODULE lib.maths.common
 // Defining BOOST_TEST_MODULE usually auto-generates main(), but we don't want
 // this as we need custom initialisation to allow for output in both console and
 // Boost.Test XML formats

--- a/lib/maths/time_series/unittest/CSignalTest.cc
+++ b/lib/maths/time_series/unittest/CSignalTest.cc
@@ -533,7 +533,7 @@ BOOST_AUTO_TEST_CASE(testReweightOutliers) {
 
         const auto& component = components[test % components.size()];
 
-        values.assign(values.size(), maths::time_series::CSignal::TFloatMeanAccumulator{});
+        values.assign(100, maths::time_series::CSignal::TFloatMeanAccumulator{});
         rng.generateUniformSamples(0.0, 1.0, values.size(), u01);
         rng.generateNormalSamples(0.0, 4.0, values.size(), noise);
 

--- a/lib/maths/time_series/unittest/Main.cc
+++ b/lib/maths/time_series/unittest/Main.cc
@@ -9,7 +9,7 @@
  * limitation.
  */
 
-#define BOOST_TEST_MODULE lib.maths
+#define BOOST_TEST_MODULE lib.maths.time_series
 // Defining BOOST_TEST_MODULE usually auto-generates main(), but we don't want
 // this as we need custom initialisation to allow for output in both console and
 // Boost.Test XML formats


### PR DESCRIPTION
Currently our CI test reports are not great.

- They mix the results from the three maths libraries together,
  which confuses the timings.
- Tests that don't make any assertions cause a very weird test
  result structure.

This change:

- Splits out the results from the three maths libraries into
  different packages.
- Ensures every test makes at least one assertion.

Backport of #2348