### PR TITLE
[ML] Add an assertion to CCompressedLfuCacheTest

### DIFF
--- a/lib/core/unittest/CCompressedLfuCacheTest.cc
+++ b/lib/core/unittest/CCompressedLfuCacheTest.cc
@@ -385,6 +385,7 @@ BOOST_AUTO_TEST_CASE(testSingleThreadPerformance) {
 
     TDoubleVec u01;
     rng.generateUniformSamples(0.0, 1.0, 50000, u01);
+    BOOST_REQUIRE_EQUAL(50000, u01.size());
 
     core::CStopWatch watch{true};
 


### PR DESCRIPTION
Similar to #2348, this PR is adding an assertion to a test
that didn't previously have one, so that it doesn't mess
up the CI test report format.