### PR TITLE
[ML] Improve quantile estimation accuracy and median accuracy for anomaly detection

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -37,8 +37,10 @@
 * Accelerate training for data frame analytics by skipping fine parameter tuning if it 
   is unnecessary. (See {ml-pull}2298[#2298].)
 * Address some causes of high runtimes training regression and classification models
-  on large data sets with many features. (See 2332[#2332].)
-* Add caching for PyTorch inference. (See 2305[#2305].)
+  on large data sets with many features. (See {ml-pull}2332[#2332].)
+* Add caching for PyTorch inference. (See {ml-pull}2305[#2305].)
+* Improve accuracy of anomaly detection median estimation. (See {ml-pull}2367[#2367],
+  issue: {ml-issue}2364[#2364].)
 
 == {es} version 8.3.0
 

--- a/include/maths/common/CQuantileSketch.h
+++ b/include/maths/common/CQuantileSketch.h
@@ -161,6 +161,9 @@ private:
                          double percentage,
                          double& result);
 
+    //! The interpolation scheme to use for the cdf and quantile calculation.
+    EInterpolation cdfAndQuantileInterpolation() const;
+
 private:
     //! The style of interpolation to use.
     EInterpolation m_Interpolation;

--- a/include/maths/common/CQuantileSketch.h
+++ b/include/maths/common/CQuantileSketch.h
@@ -94,11 +94,14 @@ public:
     //! Get the quantile corresponding to \p percentage.
     bool quantile(double percentage, double& result) const;
 
-    //! Get the knot values.
+    //! Get the knot values as (value, count) pairs.
     const TFloatFloatPrVec& knots() const;
 
     //! Get the total count of points added.
     double count() const;
+
+    //! Check if this holds all distinct values supplied to the sketch.
+    bool isExact() const;
 
     //! Get a checksum of this object.
     virtual std::uint64_t checksum(std::uint64_t seed = 0) const;

--- a/include/maths/common/CQuantileSketch.h
+++ b/include/maths/common/CQuantileSketch.h
@@ -21,6 +21,7 @@
 #include <boost/operators.hpp>
 
 #include <cstddef>
+#include <optional>
 #include <vector>
 
 namespace ml {
@@ -57,6 +58,8 @@ public:
     //! The types of interpolation used for computing the quantile.
     enum EInterpolation { E_Linear, E_PiecewiseConstant };
 
+    using TOptionalInterpolation = std::optional<EInterpolation>;
+
 public:
     CQuantileSketch(EInterpolation interpolation, std::size_t size);
     virtual ~CQuantileSketch() = default;
@@ -80,7 +83,7 @@ public:
     void age(double factor);
 
     //! Get the c.d.f at \p x.
-    bool cdf(double x, double& result) const;
+    bool cdf(double x, double& result, TOptionalInterpolation interpolation = std::nullopt) const;
 
     //! Get the minimum value added.
     bool minimum(double& result) const;
@@ -92,16 +95,15 @@ public:
     bool mad(double& result) const;
 
     //! Get the quantile corresponding to \p percentage.
-    bool quantile(double percentage, double& result) const;
+    bool quantile(double percentage,
+                  double& result,
+                  TOptionalInterpolation interpolation = std::nullopt) const;
 
     //! Get the knot values as (value, count) pairs.
     const TFloatFloatPrVec& knots() const;
 
     //! Get the total count of points added.
     double count() const;
-
-    //! Check if this holds all distinct values supplied to the sketch.
-    bool isExact() const;
 
     //! Get a checksum of this object.
     virtual std::uint64_t checksum(std::uint64_t seed = 0) const;

--- a/include/model/CGathererTools.h
+++ b/include/model/CGathererTools.h
@@ -63,11 +63,9 @@ public:
     using TSampleVec = std::vector<CSample>;
     using TMeanAccumulator = maths::common::CBasicStatistics::SSampleMean<double>::TAccumulator;
     using TMedianAccumulator =
-        maths::common::CFixedQuantileSketch<maths::common::CQuantileSketch::E_PiecewiseConstant, 30>;
-    using TMinAccumulator =
-        maths::common::CBasicStatistics::COrderStatisticsStack<double, 1u>;
-    using TMaxAccumulator =
-        maths::common::CBasicStatistics::COrderStatisticsStack<double, 1u, std::greater<double>>;
+        maths::common::CFixedQuantileSketch<maths::common::CQuantileSketch::E_Linear, 30>;
+    using TMinAccumulator = maths::common::CBasicStatistics::SMin<double>::TAccumulator;
+    using TMaxAccumulator = maths::common::CBasicStatistics::SMax<double>::TAccumulator;
     using TVarianceAccumulator =
         maths::common::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
     using TMultivariateMeanAccumulator = CMetricMultivariateStatistic<TMeanAccumulator>;

--- a/include/model/CMetricStatisticWrappers.h
+++ b/include/model/CMetricStatisticWrappers.h
@@ -63,7 +63,7 @@ struct MODEL_EXPORT CMetricStatisticWrappers {
     using TVarianceAccumulator =
         maths::common::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
     using TMedianAccumulator =
-        maths::common::CFixedQuantileSketch<maths::common::CQuantileSketch::E_PiecewiseConstant, 30>;
+        maths::common::CFixedQuantileSketch<maths::common::CQuantileSketch::E_Linear, 30>;
 
     //! Make a statistic.
     template<typename STATISTIC>

--- a/lib/api/CHierarchicalResultsWriter.cc
+++ b/lib/api/CHierarchicalResultsWriter.cc
@@ -154,7 +154,6 @@ void CHierarchicalResultsWriter::writePopulationResult(const model::CHierarchica
             : model_t::outputFunctionName(
                   node.s_AnnotatedProbability.s_AttributeProbabilities[0].s_Feature);
 
-    TOptionalDouble null;
     for (std::size_t i = 0;
          i < node.s_AnnotatedProbability.s_AttributeProbabilities.size(); ++i) {
         const model::SAttributeProbability& attributeProbability =

--- a/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
+++ b/lib/api/unittest/CDataFrameAnalyzerTrainingTest.cc
@@ -648,7 +648,7 @@ BOOST_AUTO_TEST_CASE(testRegressionTraining) {
 
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(
                            counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 7000000);
-    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 2000000);
+    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 2100000);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }
@@ -1216,7 +1216,7 @@ BOOST_AUTO_TEST_CASE(testClassificationTraining) {
 
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(
                            counter_t::E_DFTPMEstimatedPeakMemoryUsage) < 7000000);
-    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 2000000);
+    BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMPeakMemoryUsage) < 2100000);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) > 0);
     BOOST_TEST_REQUIRE(core::CProgramCounters::counter(counter_t::E_DFTPMTimeToTrain) <= duration);
 }

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -1518,7 +1518,7 @@ CBoostedTreeImpl::candidateSplits(const core::CDataFrame& frame,
                                                     featureCandidateSplits.end(),
                                                     [&dataType](double split) {
                                                         return split <= dataType.s_Min ||
-                                                               split > dataType.s_Max;
+                                                               split >= dataType.s_Max;
                                                     }),
                                      featureCandidateSplits.end());
     }

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -843,7 +843,7 @@ BOOST_AUTO_TEST_CASE(testNonUnitWeights) {
     LOG_DEBUG(<< "biasWithWeights    = " << biasWithWeights
               << ", rSquaredWithWeights    = " << rSquaredWithWeights);
 
-    BOOST_TEST_REQUIRE(std::fabs(biasWithWeights) < 0.2 * std::fabs(biasWithoutWeights));
+    BOOST_TEST_REQUIRE(std::fabs(biasWithWeights) < 0.25 * std::fabs(biasWithoutWeights));
     BOOST_TEST_REQUIRE(1.0 - rSquaredWithWeights < 0.8 * (1.0 - rSquaredWithoutWeights));
 }
 
@@ -1984,8 +1984,8 @@ BOOST_AUTO_TEST_CASE(testFeatureBags) {
 
     LOG_DEBUG(<< "distanceToSorted(selectedForTree) = " << distanceToSorted(selectedForTree)
               << ", distanceToSorted(selectedForNode) = " << distanceToSorted(selectedForNode));
-    BOOST_TEST_REQUIRE(distanceToSorted(selectedForTree) < 0.008);
-    BOOST_TEST_REQUIRE(distanceToSorted(selectedForNode) < 0.01);
+    BOOST_TEST_REQUIRE(distanceToSorted(selectedForTree) < 0.017);
+    BOOST_TEST_REQUIRE(distanceToSorted(selectedForNode) < 0.017);
 }
 
 BOOST_AUTO_TEST_CASE(testIntegerRegressor) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -2465,7 +2465,7 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticIncrementalForTargetDrift) {
 
     LOG_DEBUG(<< "increase on old = " << errorIncreaseOnOld);
     LOG_DEBUG(<< "decrease on new = " << errorDecreaseOnNew);
-    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 100.0 * errorIncreaseOnOld);
+    BOOST_TEST_REQUIRE(errorDecreaseOnNew > 30.0 * errorIncreaseOnOld);
 }
 
 BOOST_AUTO_TEST_CASE(testBinomialLogisticIncrementalForOutOfDomain) {

--- a/lib/maths/common/CQuantileSketch.cc
+++ b/lib/maths/common/CQuantileSketch.cc
@@ -186,6 +186,9 @@ bool CQuantileSketch::cdf(double x_, double& result) const {
                        m_Knots.begin();
     LOG_TRACE(<< "k = " << k);
 
+    // This must make the same assumptions as quantile regarding the distribution
+    // of values for each histogram bucket. See that function for more details.
+
     switch (m_Interpolation) {
     case E_Linear: {
         if (k == 0) {
@@ -211,25 +214,16 @@ bool CQuantileSketch::cdf(double x_, double& result) const {
                  i < m; ++i) {
                 partial += m_Knots[i].second;
             }
-            partial /= m_Count;
-            double dn;
-            if (loc) {
-                double xll = k > 1 ? static_cast<double>(m_Knots[k - 2].first)
-                                   : 2.0 * xl - xr;
-                xr = 0.5 * (xl + xr);
-                xl = 0.5 * (xll + xl);
-                dn = m_Knots[k - 1].second / m_Count;
-            } else {
-                double xrr = k + 1 < n ? static_cast<double>(m_Knots[k + 1].first)
-                                       : 2.0 * xr - xl;
-                xl = 0.5 * (xl + xr);
-                xr = 0.5 * (xr + xrr);
-                dn = m_Knots[k].second / m_Count;
-            }
+            partial = (left ? (partial + (loc ? 1.0 * m_Knots[k - 1].second : 0.0))
+                            : (partial + (loc ? 0.0 : 1.0 * m_Knots[k].second))) /
+                      m_Count;
+            double dn{0.5 * m_Knots[loc ? k - 1 : k].second / m_Count};
             LOG_TRACE(<< "left = " << left << ", loc = " << loc << ", partial = " << partial
                       << ", xl = " << xl << ", xr = " << xr << ", dn = " << dn);
-            result = left ? partial + dn * (x - xl) / (xr - xl)
-                          : 1.0 - partial - dn * (xr - x) / (xr - xl);
+            result = left ? partial + dn * (2.0 * x - xl - xr) / (xr - xl)
+                          : 1.0 - partial - dn * (xl + xr - 2.0 * x) / (xr - xl);
+            LOG_TRACE(<< "result = " << result << " "
+                      << dn * (2.0 * x - xl - xr) / (xr - xl));
         }
         return true;
     }
@@ -380,6 +374,23 @@ void CQuantileSketch::quantile(EInterpolation interpolation,
                                double count,
                                double percentage,
                                double& result) {
+
+    // For linear interpolation we have to make some assumptions about how the
+    // merged bucket values are distributed.
+    //
+    //  We make the following assumptions:
+    //   1. The bucket centre bisects (in weight) the values it represents,
+    //   2. The bucket start and end point are the midpoints between the bucket
+    //      centre and the preceding and succeeding bucket centres, respectively,
+    //   3. Values are uniformly distributed on the intervals between the bucket
+    //      endpoints and its centre.
+    //
+    // Assumption 1 is consistent with how bucket centres are computed on merge
+    // and assumption 2 is consistent with how we decide to merge buckets. This
+    // scheme also has the highly desireable property that if the sketch contains
+    // the raw data, i.e. that the number of distinct values is less than the
+    // sketch size, it computes quantiles exactly.
+
     std::size_t n = knots.size();
 
     percentage /= 100.0;
@@ -401,12 +412,11 @@ void CQuantileSketch::quantile(EInterpolation interpolation,
                     double xb = knots[i].first;
                     double xc = i + 1 == n ? 2.0 * xb - xa
                                            : static_cast<double>(knots[i + 1].first);
-                    xa += 0.5 * (xb - xa);
-                    xb += 0.5 * (xc - xb);
-                    double dx = (xb - xa);
                     double nb = knots[i].second;
-                    double m = nb / dx;
-                    result = xb + (cutoff - partial) / m;
+                    partial -= 0.5 * nb;
+                    result = xb + (cutoff - partial) * (cutoff - partial < 0.0
+                                                            ? (xb - xa) / nb
+                                                            : (xc - xb) / nb);
                 }
                 return;
 

--- a/lib/maths/common/CQuantileSketch.cc
+++ b/lib/maths/common/CQuantileSketch.cc
@@ -320,6 +320,10 @@ double CQuantileSketch::count() const {
     return m_Count;
 }
 
+bool CQuantileSketch::isExact() const {
+    return m_Knots.size() < this->fastReduceTargetSize();
+}
+
 std::uint64_t CQuantileSketch::checksum(std::uint64_t seed) const {
     seed = CChecksum::calculate(seed, m_MaxSize);
     seed = CChecksum::calculate(seed, m_Knots);
@@ -428,7 +432,7 @@ void CQuantileSketch::quantile(EInterpolation interpolation,
         }
     }
 
-    result = knots[n - 1].second;
+    result = knots[n - 1].first;
 }
 
 CQuantileSketch::EInterpolation CQuantileSketch::cdfAndQuantileInterpolation() const {
@@ -436,7 +440,7 @@ CQuantileSketch::EInterpolation CQuantileSketch::cdfAndQuantileInterpolation() c
     // never have combined any distinct values into a single bucket and the
     // quantile and empircal cdf are computed exactly using piecewise constant
     // interpolation.
-    return m_Knots.size() < this->fastReduceTargetSize() ? E_PiecewiseConstant : m_Interpolation;
+    return this->isExact() ? E_PiecewiseConstant : m_Interpolation;
 }
 
 std::size_t CQuantileSketch::fastReduceTargetSize() const {

--- a/lib/maths/common/unittest/CQuantileSketchTest.cc
+++ b/lib/maths/common/unittest/CQuantileSketchTest.cc
@@ -23,7 +23,6 @@
 #include <test/BoostTestCloseAbsolute.h>
 #include <test/CRandomNumbers.h>
 
-#include <boost/range.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
@@ -94,32 +93,33 @@ BOOST_AUTO_TEST_CASE(testAdd) {
     BOOST_TEST_REQUIRE(sketch.checkInvariants());
 
     // Test add via operator().
-    double x[] = {1.8, 2.1};
-    sketch = std::for_each(x, x + 2, sketch);
+    TDoubleVec x{1.8, 2.1};
+    sketch = std::for_each(x.begin(), x.end(), sketch);
     BOOST_TEST_REQUIRE(sketch.checkInvariants());
 
     LOG_DEBUG(<< "sketch = " << core::CContainerPrinter::print(sketch.knots()));
     BOOST_REQUIRE_EQUAL(6.0, sketch.count());
-    BOOST_REQUIRE_EQUAL(std::string("[(1.2, 1), (0.9, 3), (1.8, 1), (2.1, 1)]"),
+    BOOST_REQUIRE_EQUAL("[(1.2, 1), (0.9, 3), (1.8, 1), (2.1, 1)]",
                         core::CContainerPrinter::print(sketch.knots()));
 }
 
 BOOST_AUTO_TEST_CASE(testReduce) {
+
     LOG_DEBUG(<< "**** Linear ****");
     {
         maths::common::CQuantileSketch sketch(maths::common::CQuantileSketch::E_Linear, 6);
 
         // Test duplicate points.
 
-        double points[][2] = {{5.0, 1.0}, {0.4, 2.0}, {0.4, 1.0}, {1.0, 1.0},
-                              {1.2, 2.0}, {1.2, 1.5}, {5.0, 1.0}};
-        for (std::size_t i = 0; i < boost::size(points); ++i) {
-            sketch.add(points[i][0], points[i][1]);
+        TDoubleVecVec points{{5.0, 1.0}, {0.4, 2.0}, {0.4, 1.0}, {1.0, 1.0},
+                             {1.2, 2.0}, {1.2, 1.5}, {5.0, 1.0}};
+        for (auto& point : points) {
+            sketch.add(point[0], point[1]);
             BOOST_TEST_REQUIRE(sketch.checkInvariants());
         }
 
         LOG_DEBUG(<< "sketch = " << core::CContainerPrinter::print(sketch.knots()));
-        BOOST_REQUIRE_EQUAL(std::string("[(0.4, 3), (1, 1), (1.2, 3.5), (5, 2)]"),
+        BOOST_REQUIRE_EQUAL("[(0.4, 3), (1, 1), (1.2, 3.5), (5, 2)]",
                             core::CContainerPrinter::print(sketch.knots()));
 
         // Regular compress (merging two point).
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(testReduce) {
         sketch.add(0.2);
         sketch.add(0.0);
         LOG_DEBUG(<< "sketch = " << core::CContainerPrinter::print(sketch.knots()));
-        BOOST_REQUIRE_EQUAL(std::string("[(0, 1), (0.15, 2), (0.4, 3), (1, 1), (1.2, 3.5), (5, 2)]"),
+        BOOST_REQUIRE_EQUAL("[(0, 1), (0.15, 2), (0.4, 3), (1, 1), (1.2, 3.5), (5, 2)]",
                             core::CContainerPrinter::print(sketch.knots()));
     }
     {
@@ -141,26 +141,26 @@ BOOST_AUTO_TEST_CASE(testReduce) {
             BOOST_TEST_REQUIRE(sketch.checkInvariants());
         }
         LOG_DEBUG(<< "sketch = " << core::CContainerPrinter::print(sketch.knots()));
-        BOOST_REQUIRE_EQUAL(std::string("[(0, 1), (1, 1), (2, 1), (3, 1), (4, 1),"
-                                        " (5.5, 2), (7, 1), (8, 1), (9, 1), (10, 1),"
-                                        " (11, 1), (12, 1), (13.5, 2), (15, 1), (16, 1),"
-                                        " (17, 1), (18, 1), (19, 1), (20, 1), (21, 1),"
-                                        " (22.5, 2), (24, 1), (25, 1), (26, 1), (27, 1),"
-                                        " (28, 1), (29, 1), (30, 1)]"),
+        BOOST_REQUIRE_EQUAL("[(0, 1), (1, 1), (2, 1), (3, 1), (4, 1),"
+                            " (5.5, 2), (7, 1), (8, 1), (9, 1), (10, 1),"
+                            " (11, 1), (12, 1), (13.5, 2), (15, 1), (16, 1),"
+                            " (17, 1), (18, 1), (19, 1), (20, 1), (21, 1),"
+                            " (22.5, 2), (24, 1), (25, 1), (26, 1), (27, 1),"
+                            " (28, 1), (29, 1), (30, 1)]",
                             core::CContainerPrinter::print(sketch.knots()));
     }
     {
         // Test the quantiles are reasonable at a compression ratio of 2:1.
 
-        double points[] = {1.0,  2.0,  40.0, 13.0, 5.0,  6.0,  4.0,
-                           7.0,  15.0, 17.0, 19.0, 44.0, 42.0, 3.0,
-                           46.0, 48.0, 50.0, 21.0, 23.0, 52.0};
-        double cdf[] = {5.0,  10.0, 15.0, 20.0, 25.0, 30.0, 35.0,
-                        40.0, 45.0, 50.0, 55.0, 60.0, 65.0, 70.0,
-                        75.0, 80.0, 85.0, 90.0, 95.0, 100.0};
+        TDoubleVec points{1.0,  2.0,  40.0, 13.0, 5.0,  6.0,  4.0,
+                          7.0,  15.0, 17.0, 19.0, 44.0, 42.0, 3.0,
+                          46.0, 48.0, 50.0, 21.0, 23.0, 52.0};
+        TDoubleVec cdf{5.0,  10.0, 15.0, 20.0, 25.0, 30.0, 35.0,
+                       40.0, 45.0, 50.0, 55.0, 60.0, 65.0, 70.0,
+                       75.0, 80.0, 85.0, 90.0, 95.0, 100.0};
 
         maths::common::CQuantileSketch sketch(maths::common::CQuantileSketch::E_Linear, 10);
-        for (std::size_t i = 0; i < boost::size(points); ++i) {
+        for (std::size_t i = 0; i < points.size(); ++i) {
             sketch.add(points[i]);
             BOOST_TEST_REQUIRE(sketch.checkInvariants());
             if ((i + 1) % 5 == 0) {
@@ -169,9 +169,9 @@ BOOST_AUTO_TEST_CASE(testReduce) {
             }
         }
 
-        std::sort(std::begin(points), std::end(points));
+        std::sort(points.begin(), points.end());
         TMeanAccumulator error;
-        for (std::size_t i = 0; i < boost::size(cdf); ++i) {
+        for (std::size_t i = 0; i < cdf.size(); ++i) {
             double x;
             BOOST_TEST_REQUIRE(sketch.quantile(cdf[i], x));
             LOG_DEBUG(<< "expected quantile = " << points[i] << ", actual quantile = " << x);
@@ -189,15 +189,15 @@ BOOST_AUTO_TEST_CASE(testReduce) {
 
         // Test duplicate points.
 
-        double points[][2] = {{5.0, 1.0}, {0.4, 2.0}, {0.4, 1.0}, {1.0, 1.0},
-                              {1.2, 2.0}, {1.2, 1.5}, {5.0, 1.0}};
-        for (std::size_t i = 0; i < boost::size(points); ++i) {
-            sketch.add(points[i][0], points[i][1]);
+        TDoubleVecVec points{{5.0, 1.0}, {0.4, 2.0}, {0.4, 1.0}, {1.0, 1.0},
+                             {1.2, 2.0}, {1.2, 1.5}, {5.0, 1.0}};
+        for (auto& point : points) {
+            sketch.add(point[0], point[1]);
             BOOST_TEST_REQUIRE(sketch.checkInvariants());
         }
 
         LOG_DEBUG(<< "sketch = " << core::CContainerPrinter::print(sketch.knots()));
-        BOOST_REQUIRE_EQUAL(std::string("[(0.4, 3), (1, 1), (1.2, 3.5), (5, 2)]"),
+        BOOST_REQUIRE_EQUAL("[(0.4, 3), (1, 1), (1.2, 3.5), (5, 2)]",
                             core::CContainerPrinter::print(sketch.knots()));
 
         // Regular compress (merging two point).
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(testReduce) {
         sketch.add(0.2);
         sketch.add(0.0);
         LOG_DEBUG(<< "sketch = " << core::CContainerPrinter::print(sketch.knots()));
-        BOOST_REQUIRE_EQUAL(std::string("[(0, 1), (0.2, 2), (0.4, 3), (1, 1), (1.2, 3.5), (5, 2)]"),
+        BOOST_REQUIRE_EQUAL("[(0, 1), (0.2, 2), (0.4, 3), (1, 1), (1.2, 3.5), (5, 2)]",
                             core::CContainerPrinter::print(sketch.knots()));
     }
     {
@@ -220,12 +220,12 @@ BOOST_AUTO_TEST_CASE(testReduce) {
             BOOST_TEST_REQUIRE(sketch.checkInvariants());
         }
         LOG_DEBUG(<< "sketch = " << core::CContainerPrinter::print(sketch.knots()));
-        BOOST_REQUIRE_EQUAL(std::string("[(0, 1), (1, 1), (2, 1), (3, 1), (4, 1),"
-                                        " (6, 2), (7, 1), (8, 1), (9, 1), (10, 1),"
-                                        " (11, 1), (12, 1), (13, 1), (14, 1), (15, 1),"
-                                        " (16, 1), (17, 1), (18, 1), (19, 1), (20, 1),"
-                                        " (21, 1), (23, 3), (25, 1), (26, 1), (27, 1),"
-                                        " (28, 1), (29, 1), (30, 1)]"),
+        BOOST_REQUIRE_EQUAL("[(0, 1), (1, 1), (2, 1), (3, 1), (4, 1),"
+                            " (6, 2), (7, 1), (8, 1), (9, 1), (10, 1),"
+                            " (11, 1), (12, 1), (13, 1), (14, 1), (15, 1),"
+                            " (16, 1), (17, 1), (18, 1), (19, 1), (20, 1),"
+                            " (21, 1), (23, 3), (25, 1), (26, 1), (27, 1),"
+                            " (28, 1), (29, 1), (30, 1)]",
                             core::CContainerPrinter::print(sketch.knots()));
     }
     {
@@ -279,23 +279,23 @@ BOOST_AUTO_TEST_CASE(testMerge) {
         sketch1 += sketch2;
         LOG_DEBUG(<< "merged sketch = "
                   << core::CContainerPrinter::print(sketch1.knots()));
-        BOOST_REQUIRE_EQUAL(std::string("[(1, 3.6), (1.1, 1), (2, 1), (3, 1), (3.1, 2), (5.1, 2)]"),
+        BOOST_REQUIRE_EQUAL("[(1, 3.6), (1.1, 1), (2, 1), (3, 1), (3.1, 2), (5.1, 2)]",
                             core::CContainerPrinter::print(sketch1.knots()));
     }
 
     {
         // Test the quantiles are reasonable at a compression ratio of 2:1.
 
-        double points[] = {1.0,  2.0,  40.0, 13.0, 5.0,  6.0,  4.0,
-                           7.0,  15.0, 17.0, 19.0, 44.0, 42.0, 3.0,
-                           46.0, 48.0, 50.0, 21.0, 23.0, 52.0};
-        double cdf[] = {5.0,  10.0, 15.0, 20.0, 25.0, 30.0, 35.0,
-                        40.0, 45.0, 50.0, 55.0, 60.0, 65.0, 70.0,
-                        75.0, 80.0, 85.0, 90.0, 95.0, 100.0};
+        TDoubleVec points{1.0,  2.0,  40.0, 13.0, 5.0,  6.0,  4.0,
+                          7.0,  15.0, 17.0, 19.0, 44.0, 42.0, 3.0,
+                          46.0, 48.0, 50.0, 21.0, 23.0, 52.0};
+        TDoubleVec cdf{5.0,  10.0, 15.0, 20.0, 25.0, 30.0, 35.0,
+                       40.0, 45.0, 50.0, 55.0, 60.0, 65.0, 70.0,
+                       75.0, 80.0, 85.0, 90.0, 95.0, 100.0};
 
         maths::common::CQuantileSketch sketch1(maths::common::CQuantileSketch::E_Linear, 10);
         maths::common::CQuantileSketch sketch2(maths::common::CQuantileSketch::E_Linear, 10);
-        for (std::size_t i = 0; i < boost::size(points); i += 2) {
+        for (std::size_t i = 0; i < points.size(); i += 2) {
             sketch1.add(points[i]);
             sketch2.add(points[i + 1]);
         }
@@ -306,9 +306,9 @@ BOOST_AUTO_TEST_CASE(testMerge) {
         LOG_DEBUG(<< "merged sketch = "
                   << core::CContainerPrinter::print(sketch3.knots()));
 
-        std::sort(std::begin(points), std::end(points));
+        std::sort(points.begin(), points.end());
         TMeanAccumulator error;
-        for (std::size_t i = 0; i < boost::size(cdf); ++i) {
+        for (std::size_t i = 0; i < cdf.size(); ++i) {
             double x;
             BOOST_TEST_REQUIRE(sketch3.quantile(cdf[i], x));
             LOG_DEBUG(<< "expected quantile = " << points[i] << ", actual quantile = " << x);
@@ -321,7 +321,12 @@ BOOST_AUTO_TEST_CASE(testMerge) {
 }
 
 BOOST_AUTO_TEST_CASE(testMedian) {
+
     LOG_DEBUG(<< "**** Exact ****");
+
+    // Test that the quantiles have zero error when the number of distinct
+    // values is less than the sketch size.
+
     {
         maths::common::CQuantileSketch sketch(
             maths::common::CQuantileSketch::E_PiecewiseConstant, 10);
@@ -354,34 +359,67 @@ BOOST_AUTO_TEST_CASE(testMedian) {
         BOOST_REQUIRE_EQUAL(5.0, median);
     }
 
-    LOG_DEBUG(<< "**** Approximate ****");
-
     test::CRandomNumbers rng;
 
-    TMeanAccumulator bias;
-    TMeanAccumulator error;
-    for (std::size_t t = 0; t < 500; ++t) {
-        TDoubleVec samples;
-        rng.generateUniformSamples(0.0, 100.0, 501, samples);
-        maths::common::CQuantileSketch sketch(
-            maths::common::CQuantileSketch::E_PiecewiseConstant, 20);
-        sketch = std::for_each(samples.begin(), samples.end(), sketch);
-        std::sort(samples.begin(), samples.end());
-        double expectedMedian = samples[250];
+    TDoubleVec samples;
+
+    for (std::size_t n = 1; n <= 200; ++n) {
+        maths::common::CQuantileSketch sketch(maths::common::CQuantileSketch::E_Linear, 220);
+
+        rng.generateLogNormalSamples(0.0, 3.0, n, samples);
+
+        for (auto sample : samples) {
+            sketch.add(sample);
+        }
+
+        double expectedMedian{maths::common::CBasicStatistics::median(samples)};
         double actualMedian;
         sketch.quantile(50.0, actualMedian);
-        BOOST_TEST_REQUIRE(std::fabs(actualMedian - expectedMedian) < 6.7);
-        bias.add(actualMedian - expectedMedian);
-        error.add(std::fabs(actualMedian - expectedMedian));
+        if (n % 10 == 0) {
+            LOG_DEBUG(<< "expectedMedian = " << expectedMedian
+                      << ", actualMedian = " << actualMedian);
+        }
+
+        BOOST_REQUIRE_CLOSE_ABSOLUTE(expectedMedian, actualMedian, 1e-6);
     }
 
-    LOG_DEBUG(<< "bias  = " << maths::common::CBasicStatistics::mean(bias));
-    LOG_DEBUG(<< "error = " << maths::common::CBasicStatistics::mean(error));
-    BOOST_TEST_REQUIRE(std::fabs(maths::common::CBasicStatistics::mean(bias)) < 0.2);
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(error) < 1.6);
+    LOG_DEBUG(<< "**** Approximate ****");
+
+    TDoubleVec maximumBias(2);
+    TDoubleVec maximumError(2);
+    maximumBias[maths::common::CQuantileSketch::E_PiecewiseConstant] = 0.2;
+    maximumError[maths::common::CQuantileSketch::E_PiecewiseConstant] = 1.1;
+    maximumBias[maths::common::CQuantileSketch::E_Linear] = 0.02;
+    maximumError[maths::common::CQuantileSketch::E_Linear] = 0.3;
+
+    for (auto interpolation : {maths::common::CQuantileSketch::E_PiecewiseConstant,
+                               maths::common::CQuantileSketch::E_Linear}) {
+        TMeanAccumulator bias;
+        TMeanAccumulator error;
+        for (std::size_t t = 0; t < 500; ++t) {
+            rng.generateUniformSamples(0.0, 100.0, 501, samples);
+            maths::common::CQuantileSketch sketch(interpolation, 30);
+            sketch = std::for_each(samples.begin(), samples.end(), sketch);
+            std::sort(samples.begin(), samples.end());
+            double expectedMedian = samples[250];
+            double actualMedian;
+            sketch.quantile(50.0, actualMedian);
+            BOOST_TEST_REQUIRE(std::fabs(actualMedian - expectedMedian) < 6.7);
+            bias.add(actualMedian - expectedMedian);
+            error.add(std::fabs(actualMedian - expectedMedian));
+        }
+
+        LOG_DEBUG(<< "bias  = " << maths::common::CBasicStatistics::mean(bias));
+        LOG_DEBUG(<< "error = " << maths::common::CBasicStatistics::mean(error));
+        BOOST_TEST_REQUIRE(std::fabs(maths::common::CBasicStatistics::mean(bias)) <
+                           maximumBias[interpolation]);
+        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(error) <
+                           maximumError[interpolation]);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(testMad) {
+
     // Check some edge cases and also accuracy verses exact values
     // some random data.
 
@@ -434,15 +472,16 @@ BOOST_AUTO_TEST_CASE(testMad) {
             }
 
             error.add(std::fabs(mad - expectedMad));
-            BOOST_REQUIRE_CLOSE_ABSOLUTE(expectedMad, mad, 0.15 * expectedMad);
+            BOOST_REQUIRE_CLOSE_ABSOLUTE(expectedMad, mad, 0.2 * expectedMad);
         }
 
         LOG_DEBUG(<< "error = " << maths::common::CBasicStatistics::mean(error));
-        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(error) < 0.075);
+        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(error) < 0.082);
     }
 }
 
 BOOST_AUTO_TEST_CASE(testPropagateForwardByTime) {
+
     // Check that the count is reduced and the invariants still hold.
 
     test::CRandomNumbers rng;
@@ -460,6 +499,7 @@ BOOST_AUTO_TEST_CASE(testPropagateForwardByTime) {
 }
 
 BOOST_AUTO_TEST_CASE(testQuantileAccuracy) {
+
     // Test on a variety of random data sets versus the corresponding
     // quantile in the raw data.
 
@@ -478,8 +518,8 @@ BOOST_AUTO_TEST_CASE(testQuantileAccuracy) {
             LOG_DEBUG(<< "mean bias = " << maths::common::CBasicStatistics::mean(meanBias)
                       << ", mean error = " << maths::common::CBasicStatistics::mean(meanError));
             BOOST_TEST_REQUIRE(
-                std::fabs(maths::common::CBasicStatistics::mean(meanBias)) < 0.0007);
-            BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.004);
+                std::fabs(maths::common::CBasicStatistics::mean(meanBias)) < 0.0005);
+            BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.003);
         };
 
         maths::common::CQuantileSketch sketch{maths::common::CQuantileSketch::E_Linear, 20};
@@ -505,7 +545,7 @@ BOOST_AUTO_TEST_CASE(testQuantileAccuracy) {
                       << ", mean error = " << maths::common::CBasicStatistics::mean(meanError));
             BOOST_TEST_REQUIRE(
                 std::fabs(maths::common::CBasicStatistics::mean(meanBias)) < 0.0005);
-            BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.003);
+            BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.002);
         };
 
         maths::common::CQuantileSketch sketch{maths::common::CQuantileSketch::E_Linear, 20};
@@ -530,8 +570,8 @@ BOOST_AUTO_TEST_CASE(testQuantileAccuracy) {
             LOG_DEBUG(<< "mean bias = " << maths::common::CBasicStatistics::mean(meanBias)
                       << ", mean error = " << maths::common::CBasicStatistics::mean(meanError));
             BOOST_TEST_REQUIRE(
-                std::fabs(maths::common::CBasicStatistics::mean(meanBias)) < 0.0005);
-            BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.0009);
+                std::fabs(maths::common::CBasicStatistics::mean(meanBias)) < 0.0002);
+            BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.0004);
         };
 
         maths::common::CQuantileSketch sketch{maths::common::CQuantileSketch::E_Linear, 20};
@@ -581,18 +621,19 @@ BOOST_AUTO_TEST_CASE(testQuantileAccuracy) {
             maths::common::CQuantileSketch::E_PiecewiseConstant, 40};
 
         LOG_DEBUG(<< "** linear sketch **");
-        testMixture(linearSketch, 60, 62, 0.021, 0.022);
+        testMixture(linearSketch, 60, 62, 0.021, 0.021);
         LOG_DEBUG(<< "** fast linear sketch **");
-        testMixture(fastLinearSketch, 60, 62, 0.021, 0.022);
+        testMixture(fastLinearSketch, 60, 62, 0.021, 0.021);
         LOG_DEBUG(<< "** piecewise sketch **");
-        testMixture(linearSketch, 55, 56, 0.021, 0.022);
+        testMixture(linearSketch, 55, 56, 0.021, 0.021);
         LOG_DEBUG(<< "** fast piecewise sketch **");
-        testMixture(fastLinearSketch, 55, 56, 0.021, 0.022);
+        testMixture(fastLinearSketch, 55, 56, 0.021, 0.021);
     }
 }
 
 BOOST_AUTO_TEST_CASE(testCdf) {
-    // Test that quantile and c.d.f. are idempotent.
+
+    // Test that quantile and c.d.f. are mutual inverses.
 
     test::CRandomNumbers rng;
 
@@ -639,37 +680,47 @@ BOOST_AUTO_TEST_CASE(testCdf) {
     }
 
     LOG_DEBUG(<< "**** Uniform ****");
-    {
-        TMeanAccumulator meanBias;
-        TMeanAccumulator meanError;
-        for (std::size_t t = 0; t < 5; ++t) {
-            LOG_DEBUG(<< "test " << t + 1);
-            TDoubleVec samples;
-            rng.generateUniformSamples(0.0, 20.0 * static_cast<double>(t + 1), 1000, samples);
-            {
-                maths::common::CQuantileSketch sketch(
-                    maths::common::CQuantileSketch::E_Linear, 20);
-                sketch = std::for_each(samples.begin(), samples.end(), sketch);
-                for (std::size_t i = 0; i <= 100; ++i) {
-                    double x;
-                    sketch.quantile(static_cast<double>(i), x);
-                    double f;
-                    sketch.cdf(x, f);
-                    if (i % 10 == 0) {
-                        LOG_DEBUG(<< "  x = " << x
-                                  << ", f(exact) = " << static_cast<double>(i) / 100.0
-                                  << ", f(actual) = " << f);
-                    }
-                    BOOST_REQUIRE_CLOSE_ABSOLUTE(static_cast<double>(i) / 100.0, f, 1e-6);
-                }
+    auto exactCdf = [](const TDoubleVec& samples, double x) {
+        return static_cast<double>((std::upper_bound(samples.begin(), samples.end(), x) -
+                                    samples.begin())) /
+               static_cast<double>(samples.size());
+    };
+    TMeanAccumulator meanBias;
+    TMeanAccumulator meanError;
+    for (std::size_t t = 0; t < 5; ++t) {
+        LOG_DEBUG(<< "test " << t + 1);
+        TDoubleVec samples;
+        rng.generateUniformSamples(0.0, 20.0 * static_cast<double>(t + 1), 1000, samples);
+        maths::common::CQuantileSketch sketch(maths::common::CQuantileSketch::E_Linear, 20);
+        sketch = std::for_each(samples.begin(), samples.end(), sketch);
+        std::sort(samples.begin(), samples.end());
+        for (std::size_t i = 0; i <= 100; ++i) {
+            double x;
+            sketch.quantile(static_cast<double>(i), x);
+            double f;
+            sketch.cdf(x, f);
+            if (i % 10 == 0) {
+                LOG_DEBUG(<< "  U[0, " << 20.0 * static_cast<double>(t + 1) << "]"
+                          << ", x = " << x << ", f(expected) = "
+                          << static_cast<double>(i) / 100.0 << ", f(actual) = " << f
+                          << ", f(exact) = " << exactCdf(samples, x));
             }
+            BOOST_REQUIRE_CLOSE_ABSOLUTE(static_cast<double>(i) / 100.0, f, 1e-6);
+            meanBias.add(f - exactCdf(samples, x));
+            meanError.add(std::fabs(f - exactCdf(samples, x)));
         }
     }
+
+    LOG_DEBUG(<< "mean bias  = " << maths::common::CBasicStatistics::mean(meanBias));
+    LOG_DEBUG(<< "mean error = " << maths::common::CBasicStatistics::mean(meanError));
+    BOOST_TEST_REQUIRE(std::fabs(maths::common::CBasicStatistics::mean(meanBias)) < 0.0002);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.0025);
 }
 
 BOOST_AUTO_TEST_CASE(testFastSketchPerformance) {
 
-    // Check that the fast sketch with the same reduction factor produces identical results.
+    // Check that the fast sketch with the same reduction factor produces
+    // identical results.
 
     test::CRandomNumbers generator;
     TDoubleVec samples;
@@ -692,6 +743,9 @@ BOOST_AUTO_TEST_CASE(testFastSketchPerformance) {
 }
 
 BOOST_AUTO_TEST_CASE(testPersist) {
+
+    // Test that persist then restore is idempotent.
+
     test::CRandomNumbers generator;
     TDoubleVec samples;
     generator.generateUniformSamples(0.0, 5000.0, 500, samples);
@@ -724,7 +778,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
     // Checksums should agree.
     BOOST_REQUIRE_EQUAL(origSketch.checksum(), restoredSketch.checksum());
 
-    // The persist and restore should be idempotent.
+    // The persist then restore should be idempotent.
     std::string newXml;
     {
         core::CRapidXmlStatePersistInserter inserter("root");

--- a/lib/maths/common/unittest/CQuantileSketchTest.cc
+++ b/lib/maths/common/unittest/CQuantileSketchTest.cc
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(testReduce) {
             BOOST_TEST_REQUIRE(sketch.checkInvariants());
         }
 
-        LOG_DEBUG(<< "sketch = " <<sketch.knots());
+        LOG_DEBUG(<< "sketch = " << sketch.knots());
         BOOST_REQUIRE_EQUAL("[(0.4, 3), (1, 1), (1.2, 3.5), (5, 2)]",
                             core::CContainerPrinter::print(sketch.knots()));
 

--- a/lib/maths/time_series/unittest/CCalendarCyclicTestTest.cc
+++ b/lib/maths/time_series/unittest/CCalendarCyclicTestTest.cc
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
                                                                   : falsePositive) += 1.0;
                 }
             }
-            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 720);
+            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 790);
         }
     }
     LOG_DEBUG(<< "true positive = " << truePositive);
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
                          : falsePositive) += 1.0;
                 }
             }
-            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 720);
+            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 790);
         }
     }
     LOG_DEBUG(<< "true positive = " << truePositive);
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
                          : falsePositive) += 1.0;
                 }
             }
-            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 720);
+            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 790);
         }
     }
     LOG_DEBUG(<< "true positive = " << truePositive);
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
                          : falsePositive) += 1.0;
                 }
             }
-            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 720);
+            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 790);
         }
     }
     LOG_DEBUG(<< "true positive = " << truePositive);
@@ -408,7 +408,6 @@ BOOST_AUTO_TEST_CASE(testFalsePositives) {
 
     double trueNegatives{0.0};
     double falsePositives{0.0};
-
     LOG_DEBUG(<< "Normal");
     for (std::size_t t = 0; t < 10; ++t) {
         LOG_DEBUG(<< "test = " << t + 1);
@@ -426,7 +425,7 @@ BOOST_AUTO_TEST_CASE(testFalsePositives) {
                 if (feature != std::nullopt) {
                     LOG_DEBUG(<< "Detected = " << feature->first.print());
                 }
-                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 860);
+                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 880);
             }
         }
     }
@@ -450,7 +449,7 @@ BOOST_AUTO_TEST_CASE(testFalsePositives) {
                 if (feature != std::nullopt) {
                     LOG_DEBUG(<< "Detected = " << feature->first.print());
                 }
-                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 860);
+                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 880);
             }
         }
     }
@@ -476,7 +475,7 @@ BOOST_AUTO_TEST_CASE(testFalsePositives) {
                 if (feature != std::nullopt) {
                     LOG_DEBUG(<< "Detected = " << feature->first.print());
                 }
-                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 860);
+                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 880);
             }
         }
     }

--- a/lib/model/unittest/CDetectorEqualizerTest.cc
+++ b/lib/model/unittest/CDetectorEqualizerTest.cc
@@ -20,17 +20,14 @@
 
 #include <test/CRandomNumbers.h>
 
-#include <boost/range.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(CDetectorEqualizerTest)
 
 using namespace ml;
 
-using TDoubleVec = std::vector<double>;
-
 namespace {
-
+using TDoubleVec = std::vector<double>;
 using TMeanAccumulator = maths::common::CBasicStatistics::SSampleMean<double>::TAccumulator;
 const double THRESHOLD = std::log(0.05);
 }
@@ -38,19 +35,19 @@ const double THRESHOLD = std::log(0.05);
 BOOST_AUTO_TEST_CASE(testCorrect) {
     // Test that the distribution of scores are more similar after correcting.
 
-    double scales[] = {1.0, 2.1, 3.2};
+    TDoubleVec scales{1.0, 2.1, 3.2};
 
     model::CDetectorEqualizer equalizer;
 
     test::CRandomNumbers rng;
 
-    for (std::size_t i = 0; i < boost::size(scales); ++i) {
+    for (std::size_t i = 0; i < scales.size(); ++i) {
         TDoubleVec logp;
         rng.generateGammaSamples(1.0, scales[i], 1000, logp);
 
-        for (std::size_t j = 0; j < logp.size(); ++j) {
-            if (-logp[j] <= THRESHOLD) {
-                double p = std::exp(-logp[j]);
+        for (double pj : logp) {
+            if (-pj <= THRESHOLD) {
+                double p = std::exp(-pj);
                 equalizer.add(static_cast<int>(i), p);
             }
         }
@@ -58,13 +55,13 @@ BOOST_AUTO_TEST_CASE(testCorrect) {
 
     TDoubleVec raw[3];
     TDoubleVec corrected[3];
-    for (std::size_t i = 0; i < boost::size(scales); ++i) {
+    for (std::size_t i = 0; i < scales.size(); ++i) {
         TDoubleVec logp;
         rng.generateGammaSamples(1.0, scales[i], 1000, logp);
 
-        for (std::size_t j = 0; j < logp.size(); ++j) {
-            if (-logp[j] <= THRESHOLD) {
-                double p = std::exp(-logp[j]);
+        for (double logpj : logp) {
+            if (-logpj <= THRESHOLD) {
+                double p = std::exp(-logpj);
                 raw[i].push_back(p);
                 corrected[i].push_back(equalizer.correct(static_cast<int>(i), p));
             }
@@ -72,7 +69,7 @@ BOOST_AUTO_TEST_CASE(testCorrect) {
     }
 
     TMeanAccumulator similarityIncrease;
-    for (std::size_t i = 1u, k = 0; i < 3; ++i) {
+    for (std::size_t i = 1, k = 0; i < 3; ++i) {
         for (std::size_t j = 0; j < i; ++j, ++k) {
             double increase =
                 maths::common::CStatisticalTests::twoSampleKS(corrected[i], corrected[j]) /
@@ -91,20 +88,20 @@ BOOST_AUTO_TEST_CASE(testCorrect) {
 BOOST_AUTO_TEST_CASE(testAge) {
     // Test that propagation doesn't introduce a bias into the corrections.
 
-    double scales[] = {1.0, 2.1, 3.2};
+    TDoubleVec scales{1.0, 2.1, 3.2};
 
     model::CDetectorEqualizer equalizer;
     model::CDetectorEqualizer equalizerAged;
 
     test::CRandomNumbers rng;
 
-    for (std::size_t i = 0; i < boost::size(scales); ++i) {
+    for (std::size_t i = 0; i < scales.size(); ++i) {
         TDoubleVec logp;
         rng.generateGammaSamples(1.0, scales[i], 1000, logp);
 
-        for (std::size_t j = 0; j < logp.size(); ++j) {
-            if (-logp[j] <= THRESHOLD) {
-                double p = std::exp(-logp[j]);
+        for (double logpj : logp) {
+            if (-logpj <= THRESHOLD) {
+                double p = std::exp(-logpj);
                 equalizer.add(static_cast<int>(i), p);
                 equalizerAged.add(static_cast<int>(i), p);
                 equalizerAged.age(0.995);
@@ -123,7 +120,7 @@ BOOST_AUTO_TEST_CASE(testAge) {
             double error = std::fabs((std::log(pca) - std::log(pc)) / std::log(pc));
             meanError.add(error);
             meanBias.add((std::log(pca) - std::log(pc)) / std::log(pc));
-            BOOST_TEST_REQUIRE(error < 0.18);
+            BOOST_TEST_REQUIRE(error < 0.2);
         }
         LOG_DEBUG(<< "mean bias  = " << maths::common::CBasicStatistics::mean(meanBias));
         LOG_DEBUG(<< "mean error = " << maths::common::CBasicStatistics::mean(meanError));
@@ -133,7 +130,7 @@ BOOST_AUTO_TEST_CASE(testAge) {
 }
 
 BOOST_AUTO_TEST_CASE(testPersist) {
-    double scales[] = {1.0, 2.1, 3.2};
+    TDoubleVec scales{1.0, 2.1, 3.2};
 
     model::CDetectorEqualizer origEqualizer;
 
@@ -142,12 +139,12 @@ BOOST_AUTO_TEST_CASE(testPersist) {
     TDoubleVec logp;
     rng.generateGammaSamples(1.0, 3.1, 1000, logp);
 
-    for (std::size_t i = 0; i < boost::size(scales); ++i) {
+    for (std::size_t i = 0; i < scales.size(); ++i) {
         rng.generateGammaSamples(1.0, scales[i], 1000, logp);
 
-        for (std::size_t j = 0; j < logp.size(); ++j) {
-            if (-logp[j] <= THRESHOLD) {
-                double p = std::exp(-logp[j]);
+        for (double logpj : logp) {
+            if (-logpj <= THRESHOLD) {
+                double p = std::exp(-logpj);
                 origEqualizer.add(static_cast<int>(i), p);
             }
         }
@@ -167,9 +164,9 @@ BOOST_AUTO_TEST_CASE(testPersist) {
         core::CRapidXmlParser parser;
         BOOST_TEST_REQUIRE(parser.parseStringIgnoreCdata(origXml));
         core::CRapidXmlStateRestoreTraverser traverser(parser);
-        BOOST_TEST_REQUIRE(traverser.traverseSubLevel(
-            std::bind(&model::CDetectorEqualizer::acceptRestoreTraverser,
-                      &restoredEqualizer, std::placeholders::_1)));
+        BOOST_TEST_REQUIRE(traverser.traverseSubLevel([&](auto& traverser_) {
+            return restoredEqualizer.acceptRestoreTraverser(traverser_);
+        }));
     }
 
     // Checksums should agree.

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -600,7 +600,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForMedian, CTestFixture) {
         if (i == anomalousBucket) {
             values.push_back(0.0);
             values.push_back(mean * 3.0);
-            values.push_back(mean * 6.0);
+            values.push_back(mean * 3.0);
         } else {
             rng.generateNormalSamples(mean, variance, bucketCounts[i], values);
         }

--- a/lib/model/unittest/CMetricModelTest.cc
+++ b/lib/model/unittest/CMetricModelTest.cc
@@ -600,7 +600,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForMedian, CTestFixture) {
         if (i == anomalousBucket) {
             values.push_back(0.0);
             values.push_back(mean * 3.0);
-            values.push_back(mean * 3.0);
+            values.push_back(mean * 6.0);
         } else {
             rng.generateNormalSamples(mean, variance, bucketCounts[i], values);
         }
@@ -639,7 +639,7 @@ BOOST_FIXTURE_TEST_CASE(testProbabilityCalculationForMedian, CTestFixture) {
     const CMetricModel::TFeatureData* fd = model.featureData(
         ml::model_t::E_IndividualMedianByPerson, pid, time - bucketLength);
 
-    // assert there is only 1 value in the last bucket and its the median
+    // Assert there is only 1 value in the last bucket and its the median.
     BOOST_REQUIRE_EQUAL(fd->s_BucketValue->value()[0], mean * 3.0);
     BOOST_REQUIRE_EQUAL(fd->s_BucketValue->value().size(), 1);
 }


### PR DESCRIPTION
We use a histogram sketch for estimating data quantiles and also computing the time bucket median for anomaly detection.

Once data are merged into buckets we have to make some assumptions about how values are distributed on buckets. Previously, we assumed data are uniformly distributed on buckets whose endpoints are the midpoints between the bucket "centres" we track. In fact, the points we track are the weighted means of the values in each bucket, so it is more accurate to assume that roughly half the data in a bucket falls either side of this point.

This changes the interpolation scheme to use the same endpoints but to incorporate this new assumption. This gives a very nice additional property: a quantile which falls between two buckets each containing a single value is computed exactly. An immediate corollary is that all quantiles are exact if the data size is less than the sketch size. Previously, we used piecewise constant interpolation for estimating the median because it is exact in this case. We now cut over to linear interpolation. This is attractive because for large data, if the data distribution is smooth, linear interpolation is significantly more accurate for fixed memory usage than piecewise constant interpolation.

Closes #2364.