### PR TITLE
[ML] Adjust PyTorch thread setting naming and validation

### DIFF
--- a/bin/pytorch_inference/CThreadSettings.cc
+++ b/bin/pytorch_inference/CThreadSettings.cc
@@ -18,9 +18,12 @@
 namespace ml {
 namespace torch {
 
-CThreadSettings::CThreadSettings(std::int32_t numThreadsPerAllocation, std::int32_t numAllocations)
-    : m_NumThreadsPerAllocation(numThreadsPerAllocation),
-      m_NumAllocations(numAllocations) {
+CThreadSettings::CThreadSettings(std::int32_t maxThreads,
+                                 std::int32_t numThreadsPerAllocation,
+                                 std::int32_t numAllocations)
+    : m_MaxThreads{maxThreads}, m_NumThreadsPerAllocation{numThreadsPerAllocation},
+      m_NumAllocations{numAllocations} {
+    validateThreadingParameters(m_MaxThreads, m_NumThreadsPerAllocation, m_NumAllocations);
 }
 
 std::int32_t CThreadSettings::numThreadsPerAllocation() const {
@@ -32,44 +35,52 @@ std::int32_t CThreadSettings::numAllocations() const {
 }
 
 void CThreadSettings::numAllocations(std::int32_t numAllocations) {
-    m_NumAllocations = numAllocations;
-}
-
-void CThreadSettings::validateThreadingParameters(std::int32_t maxThreads,
-                                                  std::int32_t& numThreadsPerAllocation,
-                                                  std::int32_t& numAllocations) {
-    if (maxThreads == 0) {
-        LOG_WARN(<< "Could not determine hardware concurrency; setting max threads to 1");
-        maxThreads = 1;
-    }
-    if (numThreadsPerAllocation < 1) {
-        LOG_WARN(<< "Setting number of threads per allocation to minimum value of 1; value was "
-                 << numThreadsPerAllocation);
-        numThreadsPerAllocation = 1;
-    } else if (numThreadsPerAllocation >= maxThreads) {
-        // leave one allocation thread
-        LOG_WARN(<< "Setting number of threads per allocation to maximum value of "
-                 << std::max(1, maxThreads - 1) << "; value was " << numThreadsPerAllocation);
-        numThreadsPerAllocation = std::max(1, maxThreads - 1);
-    }
+    std::int32_t maxAllocations{(m_MaxThreads + m_NumThreadsPerAllocation - 1) /
+                                m_NumThreadsPerAllocation};
     if (numAllocations < 1) {
         LOG_WARN(<< "Setting number of allocations to minimum value of 1; value was "
                  << numAllocations);
         numAllocations = 1;
-    } else if (numAllocations >= maxThreads) {
-        // leave one thread for inference
+    } else if (numAllocations > maxAllocations) {
         LOG_WARN(<< "Setting number of allocations to maximum value of "
-                 << std::max(1, maxThreads - 1) << "; value was " << numAllocations);
-        numAllocations = std::max(1, maxThreads - 1);
+                 << maxAllocations << " (given " << m_NumThreadsPerAllocation
+                 << " threads per allocation); value was " << numAllocations);
+        numAllocations = maxAllocations;
+    }
+    m_NumAllocations = numAllocations;
+}
+
+void CThreadSettings::validateThreadingParameters(std::int32_t& maxThreads,
+                                                  std::int32_t& numThreadsPerAllocation,
+                                                  std::int32_t& numAllocations) {
+    if (maxThreads < 1) {
+        LOG_WARN(<< "Could not determine hardware concurrency; setting max threads to 1");
+        maxThreads = 1;
     }
 
-    if (numAllocations + numThreadsPerAllocation > maxThreads) {
-        std::int32_t oldInferenceThreadCount{numThreadsPerAllocation};
-        numThreadsPerAllocation = std::max(1, maxThreads - numAllocations);
-        LOG_WARN(<< "Sum of allocation count [" << numAllocations << "] and inference threads ["
-                 << oldInferenceThreadCount << "] is greater than max threads ["
-                 << maxThreads << "]. Setting number of allocations to " << numAllocations
-                 << " and number of threads per allocation to " << numThreadsPerAllocation);
+    if (numAllocations < 1) {
+        LOG_WARN(<< "Setting number of allocations to minimum value of 1; value was "
+                 << numAllocations);
+        numAllocations = 1;
+    } else if (numAllocations > maxThreads) {
+        LOG_WARN(<< "Setting number of allocations to maximum value of "
+                 << maxThreads << "; value was " << numAllocations);
+        numAllocations = maxThreads;
+    }
+
+    // Max threads per allocation would ideally fit within the available
+    // concurrency when multiplied by the number of allocations, but we allow
+    // rounding up if there isn't a perfect fit.
+    std::int32_t maxThreadsPerAllocation{(maxThreads + numAllocations - 1) / numAllocations};
+    if (numThreadsPerAllocation < 1) {
+        LOG_WARN(<< "Setting number of threads per allocation to minimum value of 1; value was "
+                 << numThreadsPerAllocation);
+        numThreadsPerAllocation = 1;
+    } else if (numThreadsPerAllocation > maxThreadsPerAllocation) {
+        LOG_WARN(<< "Setting number of threads per allocation to maximum value of "
+                 << maxThreadsPerAllocation << " (given number of allocations "
+                 << numAllocations << "); value was " << numThreadsPerAllocation);
+        numThreadsPerAllocation = maxThreadsPerAllocation;
     }
 }
 }

--- a/bin/pytorch_inference/CThreadSettings.h
+++ b/bin/pytorch_inference/CThreadSettings.h
@@ -23,17 +23,31 @@ namespace torch {
 class CThreadSettings {
 public:
 public:
-    explicit CThreadSettings(std::int32_t numThreadsPerAllocation, std::int32_t numAllocations);
+    explicit CThreadSettings(std::int32_t maxThreads,
+                             std::int32_t numThreadsPerAllocation,
+                             std::int32_t numAllocations);
 
     std::int32_t numThreadsPerAllocation() const;
     std::int32_t numAllocations() const;
+
+    //! Set the number of allocations, but constraining the value given the
+    //! current values of max threads and threads per allocation. The way the
+    //! number of allocations is constrained is different to how it's done in
+    //! validateThreadingParameters(), because we cannot change threads per
+    //! allocation after it's initially set.
     void numAllocations(std::int32_t numAllocations);
 
-    static void validateThreadingParameters(std::int32_t maxThreads,
+    //! Validate the max threads, number of threads per allocation and number
+    //! of allocations to ensure that CPU is not overcommitted, as this leads
+    //! to worse performance than running with fewer threads. This method
+    //! prefers to constrain threads per allocation instead of number of
+    //! allocations.
+    static void validateThreadingParameters(std::int32_t& maxThreads,
                                             std::int32_t& numThreadsPerAllocation,
                                             std::int32_t& numAllocations);
 
 private:
+    std::int32_t m_MaxThreads;
     std::int32_t m_NumThreadsPerAllocation;
     std::int32_t m_NumAllocations;
 };

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -282,9 +282,9 @@ void handleControlMessage(const ml::torch::CCommandParser::SControlMessage& cont
 
     // No need to check the control message type there is only 1
     threadSettings.numAllocations(controlMessage.s_NumAllocations);
-    ml::core::defaultAsyncExecutor().numberThreadsInUse(controlMessage.s_NumAllocations);
-    LOG_DEBUG(<< "Updated number of allocations to ["
-              << controlMessage.s_NumAllocations << "]");
+    ml::core::defaultAsyncExecutor().numberThreadsInUse(threadSettings.numAllocations());
+    LOG_DEBUG(<< "Updated number of allocations to [" << threadSettings.numAllocations()
+              << "] ([" << controlMessage.s_NumAllocations << "] requested)");
     writeThreadSettings(wrappedOutputStream, controlMessage.s_RequestId, threadSettings);
 }
 
@@ -314,20 +314,20 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    ml::torch::CThreadSettings::validateThreadingParameters(
+    ml::torch::CThreadSettings threadSettings{
         static_cast<std::int32_t>(std::thread::hardware_concurrency()),
-        numThreadsPerAllocation, numAllocations);
-
-    ml::torch::CThreadSettings threadSettings{numThreadsPerAllocation, numAllocations};
+        numThreadsPerAllocation, numAllocations};
 
     // Setting the number of threads used by libtorch also sets
     // the number of threads used by MKL or OMP libs. However,
-    // this doesn't address the Accelerated.Framework found on macs.
+    // this doesn't address the Accelerate framework found on Macs.
     // Thus, we set the environment variable that controls threading for that one.
     // It doesn't hurt to set variables that won't have any effect on some platforms.
     ml::core::CSetEnv::setEnv(
         "VECLIB_MAXIMUM_THREADS",
-        ml::core::CStringUtils::typeToString(numThreadsPerAllocation).c_str(), 0);
+        ml::core::CStringUtils::typeToString(threadSettings.numThreadsPerAllocation())
+            .c_str(),
+        0);
 
     ml::core::CBlockingCallCancellingTimer cancellerThread{
         ml::core::CThread::currentThreadId(), std::chrono::seconds{namedPipeConnectTimeout}};
@@ -379,6 +379,14 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
+    // On Linux we use libgomp (GNU's OMP implementation) for threading and have
+    // found that setting this to "threads per allocation" really does allow
+    // that number of threads to be used per allocation. On other platforms,
+    // particularly macOS where we use the Accelerate framework instead of OMP,
+    // it may be that this sets a number of threads to be shared across all
+    // allocations rather than per allocation. But macOS is not supported for
+    // production, but just as a convenience for developers. So the most
+    // important thing is that the threading works as intended on Linux.
     at::set_num_threads(threadSettings.numThreadsPerAllocation());
 
     // This is not used as we don't call at::launch anywhere.
@@ -415,7 +423,7 @@ int main(int argc, char** argv) {
     // so we can grow and shrink the threadpool dynamically
     ml::core::startDefaultAsyncExecutor();
     // Set the number of threads to use
-    ml::core::defaultAsyncExecutor().numberThreadsInUse(numAllocations);
+    ml::core::defaultAsyncExecutor().numberThreadsInUse(threadSettings.numAllocations());
 
     commandParser.ioLoop(
         [&module_, &wrappedOutputStream](ml::torch::CCommandParser::CRequestCacheInterface& cache,

--- a/bin/pytorch_inference/unittest/CThreadSettingsTest.cc
+++ b/bin/pytorch_inference/unittest/CThreadSettingsTest.cc
@@ -17,81 +17,95 @@
 BOOST_AUTO_TEST_SUITE(CThreadSettingsTest)
 
 BOOST_AUTO_TEST_CASE(testValidationNoChanges) {
-    std::int32_t modelThreads{4};
-    std::int32_t inferenceThreads{4};
-    ml::torch::CThreadSettings::validateThreadingParameters(16, inferenceThreads, modelThreads);
-    BOOST_REQUIRE_EQUAL(4, modelThreads);
-    BOOST_REQUIRE_EQUAL(4, inferenceThreads);
+    std::int32_t maxThreads{16};
+    std::int32_t numAllocations{4};
+    std::int32_t numThreadsPerAllocation{4};
+    ml::torch::CThreadSettings::validateThreadingParameters(
+        maxThreads, numThreadsPerAllocation, numAllocations);
+    BOOST_REQUIRE_EQUAL(4, numAllocations);
+    BOOST_REQUIRE_EQUAL(4, numThreadsPerAllocation);
 }
 
 BOOST_AUTO_TEST_CASE(testValidationValuesAreCapped) {
-    std::int32_t modelThreads{1};
-    std::int32_t inferenceThreads{32};
-    ml::torch::CThreadSettings::validateThreadingParameters(16, inferenceThreads, modelThreads);
-    BOOST_REQUIRE_EQUAL(1, modelThreads);
-    BOOST_REQUIRE_EQUAL(15, inferenceThreads);
+    std::int32_t maxThreads{16};
+    std::int32_t numAllocations{1};
+    std::int32_t numThreadsPerAllocation{32};
+    ml::torch::CThreadSettings::validateThreadingParameters(
+        maxThreads, numThreadsPerAllocation, numAllocations);
+    BOOST_REQUIRE_EQUAL(1, numAllocations);
+    BOOST_REQUIRE_EQUAL(16, numThreadsPerAllocation);
 
-    modelThreads = 32;
-    inferenceThreads = 1;
-    ml::torch::CThreadSettings::validateThreadingParameters(16, inferenceThreads, modelThreads);
-    BOOST_REQUIRE_EQUAL(15, modelThreads);
-    BOOST_REQUIRE_EQUAL(1, inferenceThreads);
+    numAllocations = 32;
+    numThreadsPerAllocation = 1;
+    ml::torch::CThreadSettings::validateThreadingParameters(
+        maxThreads, numThreadsPerAllocation, numAllocations);
+    BOOST_REQUIRE_EQUAL(16, numAllocations);
+    BOOST_REQUIRE_EQUAL(1, numThreadsPerAllocation);
 }
 
 BOOST_AUTO_TEST_CASE(testValidationNegativeValues) {
-    std::int32_t modelThreads{-1};
-    std::int32_t inferenceThreads{-2};
-    ml::torch::CThreadSettings::validateThreadingParameters(16, inferenceThreads, modelThreads);
-    BOOST_REQUIRE_EQUAL(1, modelThreads);
-    BOOST_REQUIRE_EQUAL(1, inferenceThreads);
+    std::int32_t maxThreads{16};
+    std::int32_t numAllocations{-1};
+    std::int32_t numThreadsPerAllocation{-2};
+    ml::torch::CThreadSettings::validateThreadingParameters(
+        maxThreads, numThreadsPerAllocation, numAllocations);
+    BOOST_REQUIRE_EQUAL(1, numAllocations);
+    BOOST_REQUIRE_EQUAL(1, numThreadsPerAllocation);
 }
 
 BOOST_AUTO_TEST_CASE(testValidationMaxThreadsUnknown) {
-    std::int32_t modelThreads{4};
-    std::int32_t inferenceThreads{4};
     // 0 == maxThreads is not known
-    ml::torch::CThreadSettings::validateThreadingParameters(0, inferenceThreads, modelThreads);
-    BOOST_REQUIRE_EQUAL(1, modelThreads);
-    BOOST_REQUIRE_EQUAL(1, inferenceThreads);
+    std::int32_t maxThreads{0};
+    std::int32_t numAllocations{4};
+    std::int32_t numThreadsPerAllocation{4};
+    ml::torch::CThreadSettings::validateThreadingParameters(
+        maxThreads, numThreadsPerAllocation, numAllocations);
+    BOOST_REQUIRE_EQUAL(1, numAllocations);
+    BOOST_REQUIRE_EQUAL(1, numThreadsPerAllocation);
 }
 
 BOOST_AUTO_TEST_CASE(testValidationTotalGreaterThanMaxThreads) {
+    std::int32_t maxThreads{16};
     {
-        std::int32_t modelThreads{10};
-        std::int32_t inferenceThreads{10};
-        ml::torch::CThreadSettings::validateThreadingParameters(16, inferenceThreads,
-                                                                modelThreads);
-        BOOST_REQUIRE_EQUAL(10, modelThreads);
-        BOOST_REQUIRE_EQUAL(6, inferenceThreads);
+        std::int32_t numAllocations{10};
+        std::int32_t numThreadsPerAllocation{10};
+        ml::torch::CThreadSettings::validateThreadingParameters(
+            maxThreads, numThreadsPerAllocation, numAllocations);
+        BOOST_REQUIRE_EQUAL(10, numAllocations);
+        BOOST_REQUIRE_EQUAL(2, numThreadsPerAllocation);
     }
     {
-        std::int32_t modelThreads{1};
-        std::int32_t inferenceThreads{32};
-        ml::torch::CThreadSettings::validateThreadingParameters(16, inferenceThreads,
-                                                                modelThreads);
-        BOOST_REQUIRE_EQUAL(1, modelThreads);
-        BOOST_REQUIRE_EQUAL(15, inferenceThreads);
+        std::int32_t numAllocations{1};
+        std::int32_t numThreadsPerAllocation{32};
+        ml::torch::CThreadSettings::validateThreadingParameters(
+            maxThreads, numThreadsPerAllocation, numAllocations);
+        BOOST_REQUIRE_EQUAL(1, numAllocations);
+        BOOST_REQUIRE_EQUAL(16, numThreadsPerAllocation);
+    }
+    maxThreads = 4;
+    {
+        std::int32_t numAllocations{4};
+        std::int32_t numThreadsPerAllocation{1};
+        ml::torch::CThreadSettings::validateThreadingParameters(
+            maxThreads, numThreadsPerAllocation, numAllocations);
+        BOOST_REQUIRE_EQUAL(4, numAllocations);
+        BOOST_REQUIRE_EQUAL(1, numThreadsPerAllocation);
     }
     {
-        std::int32_t modelThreads{4};
-        std::int32_t inferenceThreads{1};
-        ml::torch::CThreadSettings::validateThreadingParameters(4, inferenceThreads, modelThreads);
-        BOOST_REQUIRE_EQUAL(3, modelThreads);
-        BOOST_REQUIRE_EQUAL(1, inferenceThreads);
+        std::int32_t numAllocations{1};
+        std::int32_t numThreadsPerAllocation{4};
+        ml::torch::CThreadSettings::validateThreadingParameters(
+            maxThreads, numThreadsPerAllocation, numAllocations);
+        BOOST_REQUIRE_EQUAL(1, numAllocations);
+        BOOST_REQUIRE_EQUAL(4, numThreadsPerAllocation);
     }
     {
-        std::int32_t modelThreads{1};
-        std::int32_t inferenceThreads{4};
-        ml::torch::CThreadSettings::validateThreadingParameters(4, inferenceThreads, modelThreads);
-        BOOST_REQUIRE_EQUAL(1, modelThreads);
-        BOOST_REQUIRE_EQUAL(3, inferenceThreads);
-    }
-    {
-        std::int32_t modelThreads{2};
-        std::int32_t inferenceThreads{4};
-        ml::torch::CThreadSettings::validateThreadingParameters(4, inferenceThreads, modelThreads);
-        BOOST_REQUIRE_EQUAL(2, modelThreads);
-        BOOST_REQUIRE_EQUAL(2, inferenceThreads);
+        std::int32_t numAllocations{2};
+        std::int32_t numThreadsPerAllocation{4};
+        ml::torch::CThreadSettings::validateThreadingParameters(
+            maxThreads, numThreadsPerAllocation, numAllocations);
+        BOOST_REQUIRE_EQUAL(2, numAllocations);
+        BOOST_REQUIRE_EQUAL(2, numThreadsPerAllocation);
     }
 }
 


### PR DESCRIPTION
The Java code now works on the basis that `num_threads_per_allocation`
should be multiplied by the number of allocations to give the total
number of threads required.

This PR changes the C++ code to reflect that.

The logic for calling `at::set_num_threads()` and
`ml::core::defaultAsyncExecutor().numberThreadsInUse()` was already
correct given how libgomp on Linux does threading, but this PR
fixes the validation, adds comments and corrects the variable
names in the unit test.