### PR TITLE
[ML] Handle cache size too small for single item

### DIFF
--- a/include/core/CCompressedLfuCache.h
+++ b/include/core/CCompressedLfuCache.h
@@ -149,12 +149,19 @@ public:
 
             // Update the item counts using the Space-Saving algorithm.
             std::size_t count{1};
-            if (this->full(itemMemoryUsage)) {
+            std::size_t maxEvictedCount{0};
+            while (this->full(itemMemoryUsage)) {
                 auto itemToEvict = m_ItemStats.begin();
-                count += itemToEvict->count();
+                // It's possible that the cache is empty yet isn't big enough
+                // to hold this new item.
+                if (itemToEvict == m_ItemStats.end()) {
+                    readValue(value);
+                    return;
+                }
+                maxEvictedCount = itemToEvict->count();
                 this->removeFromCache(itemToEvict);
             }
-            readValue(this->insert(compressedKey, value, itemMemoryUsage, count));
+            readValue(this->insert(compressedKey, value, itemMemoryUsage, count + maxEvictedCount));
         });
 
         return false;

--- a/include/core/CCompressedLfuCache.h
+++ b/include/core/CCompressedLfuCache.h
@@ -28,6 +28,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <set>
@@ -128,8 +129,11 @@ public:
                 }
                 return false;
             })) {
-            this->guardWrite(TIME_OUT,
-                             [&] { this->incrementCount(compressedKey); });
+            if (this->guardWrite(TIME_OUT, [&] {
+                    this->incrementCount(compressedKey);
+                }) == false) {
+                ++m_LostCount;
+            }
             return true;
         }
 
@@ -137,32 +141,36 @@ public:
 
         std::size_t itemMemoryUsage{core::CMemory::dynamicSize(value)};
 
-        this->guardWrite(TIME_OUT, [&] {
-            // It is possible that two values with the same key check the cache
-            // before either takes the write lock. So check if this is already
-            // in the cache before going any further.
-            if (m_ItemCache.find(compressedKey) != m_ItemCache.end()) {
-                readValue(value);
-                this->incrementCount(compressedKey);
-                return;
-            }
-
-            // Update the item counts using the Space-Saving algorithm.
-            std::size_t count{1};
-            std::size_t maxEvictedCount{0};
-            while (this->full(itemMemoryUsage)) {
-                auto itemToEvict = m_ItemStats.begin();
-                // It's possible that the cache is empty yet isn't big enough
-                // to hold this new item.
-                if (itemToEvict == m_ItemStats.end()) {
+        if (this->guardWrite(TIME_OUT, [&] {
+                // It is possible that two values with the same key check the cache
+                // before either takes the write lock. So check if this is already
+                // in the cache before going any further.
+                if (m_ItemCache.find(compressedKey) != m_ItemCache.end()) {
                     readValue(value);
+                    this->incrementCount(compressedKey);
                     return;
                 }
-                maxEvictedCount = itemToEvict->count();
-                this->removeFromCache(itemToEvict);
-            }
-            readValue(this->insert(compressedKey, value, itemMemoryUsage, count + maxEvictedCount));
-        });
+
+                // Update the item counts using the Space-Saving algorithm.
+                std::size_t count{1};
+                std::size_t lastEvictedCount{0};
+                while (this->full(itemMemoryUsage)) {
+                    auto itemToEvict = m_ItemStats.begin();
+                    // It's possible that the cache is empty yet isn't big
+                    // enough to hold this new item.
+                    if (itemToEvict == m_ItemStats.end()) {
+                        readValue(value);
+                        return;
+                    }
+                    m_LostCount += lastEvictedCount;
+                    lastEvictedCount = itemToEvict->count();
+                    this->removeFromCache(itemToEvict);
+                }
+                readValue(this->insert(compressedKey, value, itemMemoryUsage,
+                                       count + lastEvictedCount));
+            }) == false) {
+            ++m_LostCount;
+        }
 
         return false;
     }
@@ -176,7 +184,7 @@ public:
 
     //! Get the number of items currently stored in the cache.
     std::size_t size() const {
-        std::size_t result;
+        std::size_t result{std::numeric_limits<std::size_t>::max()};
         this->guardRead(DONT_TIME_OUT, [&] {
             result = m_ItemCache.size();
             return true;
@@ -204,7 +212,7 @@ public:
 
     //! Get the amount of memory the cache is consuming.
     std::size_t memoryUsage() const {
-        std::size_t result;
+        std::size_t result{std::numeric_limits<std::size_t>::max()};
         this->guardRead(DONT_TIME_OUT, [&] {
             result = this->unguardedMemoryUsage();
             return true;
@@ -247,8 +255,9 @@ public:
                           << m_ItemsMemoryUsage << ".");
                 result = false;
             }
-            if (this->updatesCanTimeOut() == false && // We may be missing counts
-                m_NumberLookups != totalCount) {
+            // We may be missing counts if a single addition caused multiple
+            // evictions, or if updates can time out
+            if (m_NumberLookups - m_LostCount != totalCount) {
                 LOG_ERROR(<< "Count mismatch " << m_NumberLookups.load()
                           << " vs " << totalCount << ".");
                 result = false;
@@ -404,7 +413,7 @@ private:
 
 private:
     virtual bool guardRead(bool timeOut, TReadFunc func) const = 0;
-    virtual void guardWrite(bool timeOut, TWriteFunc func) = 0;
+    virtual bool guardWrite(bool timeOut, TWriteFunc func) = 0;
     virtual bool updatesCanTimeOut() const = 0;
 
     void maybeReallocateCache() {
@@ -461,15 +470,17 @@ private:
     }
 
     bool full(std::size_t itemMemoryUsage) const {
-        double memory{static_cast<double>(this->unguardedMemoryUsage() + itemMemoryUsage)};
+        std::size_t memory{this->unguardedMemoryUsage() + itemMemoryUsage +
+                           sizeof(typename TCompressedKeyCacheItemUMap::value_type) +
+                           sizeof(typename TCacheItemStatsSet::value_type)};
         if (this->needToResizeItemCache()) {
-            memory += (static_cast<double>(this->nextItemCacheBucketCount()) /
-                           static_cast<double>(m_ItemCache.bucket_count()) -
-                       1.0) *
-                      static_cast<double>(core::CMemory::dynamicSize(m_ItemCache));
+            memory += static_cast<std::size_t>(
+                (static_cast<double>(this->nextItemCacheBucketCount()) /
+                     static_cast<double>(m_ItemCache.bucket_count()) -
+                 1.0) *
+                static_cast<double>(core::CMemory::dynamicSize(m_ItemCache)));
         }
-        // Use a 1% tolerance.
-        return memory > 0.99 * static_cast<double>(m_MaximumMemory);
+        return memory > m_MaximumMemory;
     }
 
     std::size_t unguardedMemoryUsage() const {
@@ -542,6 +553,12 @@ private:
     // fully supported.
     alignas(64) std::atomic<std::uint64_t> m_NumberLookups{0};
     alignas(64) std::atomic<std::uint64_t> m_NumberHits{0};
+    //! We can lose count for two reasons:
+    //! 1. If we fail to obtain a write lock within the timeout period
+    //!    when trying to increment cache item counts
+    //! 2. If we have to evict multiple items to make space to add a single
+    //!    new item
+    alignas(64) std::atomic<std::uint64_t> m_LostCount{0};
     std::uint64_t m_RemovedCount{0};
     std::size_t m_MaximumMemory{0};
     std::size_t m_ItemsMemoryUsage{0};
@@ -637,20 +654,24 @@ private:
     bool guardRead(bool timeOut, TReadFunc func) const override {
         if (timeOut) {
             std::shared_lock<std::shared_timed_mutex> lock{m_Mutex, m_MaximumWait};
-            return func();
+            return lock.owns_lock() && func();
         }
         std::shared_lock<std::shared_timed_mutex> lock{m_Mutex};
         return func();
     }
 
-    void guardWrite(bool timeOut, TWriteFunc func) override {
+    bool guardWrite(bool timeOut, TWriteFunc func) override {
         if (timeOut) {
             std::unique_lock<std::shared_timed_mutex> lock{m_Mutex, m_MaximumWait};
-            func();
-            return;
+            if (lock.owns_lock()) {
+                func();
+                return true;
+            }
+            return false;
         }
         std::unique_lock<std::shared_timed_mutex> lock{m_Mutex};
         func();
+        return true;
     }
 
     bool updatesCanTimeOut() const override { return true; }
@@ -708,7 +729,10 @@ private:
 
 private:
     bool guardRead(bool, TReadFunc func) const override { return func(); }
-    void guardWrite(bool, TWriteFunc func) override { func(); }
+    bool guardWrite(bool, TWriteFunc func) override {
+        func();
+        return true;
+    }
     bool updatesCanTimeOut() const override { return false; }
 };
 }

--- a/include/core/CMemory.h
+++ b/include/core/CMemory.h
@@ -465,8 +465,7 @@ public:
         using TMultiIndex = boost::multi_index::multi_index_container<T, I, A>;
         constexpr std::size_t indexCount{
             boost::mpl::size<typename TMultiIndex::index_type_list>::value};
-        return elementDynamicSize(t) +
-               t.size() * (sizeof(T) + 2 * indexCount * sizeof(std::size_t));
+        return 2 * indexCount * sizeof(std::size_t);
     }
 
     //! Overload for boost::circular_buffer.

--- a/include/core/CMemory.h
+++ b/include/core/CMemory.h
@@ -240,6 +240,11 @@ public:
         return 0;
     }
 
+    template<typename T>
+    static constexpr std::size_t storageNodeSize(const T&) {
+        return 0;
+    }
+
     //! Default implementation for pointer types.
     template<typename T>
     static std::size_t
@@ -295,38 +300,47 @@ public:
         // These are hard-coded here, on the assumption that they will not
         // change frequently - but checked by unittests that do runtime
         // verification
-        // See http://linux/wiki/index.php/Technical_design_issues#std::string
 #ifdef MacOSX
         if (capacity <= 22) {
             // For lengths up to 22 bytes there is no allocation
             return 0;
         }
-        return capacity + 1;
-
-#else // Linux with C++11 ABI and Windows
+#else // Linux (with C++11 ABI) and Windows
         if (capacity <= 15) {
             // For lengths up to 15 bytes there is no allocation
             return 0;
         }
-        return capacity + 1;
 #endif
+        return capacity + 1;
     }
 
     //! Overload for boost::unordered_map.
     template<typename K, typename V, typename H, typename P, typename A>
     static std::size_t dynamicSize(const boost::unordered_map<K, V, H, P, A>& t) {
-        return elementDynamicSize(t) + (t.bucket_count() * sizeof(std::size_t) * 2) +
-               (t.size() * (sizeof(K) + sizeof(V) + 2 * sizeof(std::size_t)));
+        return elementDynamicSize(t) +
+               (t.bucket_count() * CMemory::storageNodeOverhead(t)) +
+               (t.size() * (sizeof(K) + sizeof(V) + storageNodeOverhead(t)));
+    }
+
+    template<typename K, typename V, typename H, typename P, typename A>
+    static constexpr std::size_t
+    storageNodeOverhead(const boost::unordered_map<K, V, H, P, A>&) {
+        return 2 * sizeof(std::size_t);
     }
 
     //! Overload for std::map.
     template<typename K, typename V, typename C, typename A>
     static std::size_t dynamicSize(const std::map<K, V, C, A>& t) {
-        // std::map appears to use 4 pointers/size_ts per tree node
-        // (colour, parent, left and right child pointers).
         return elementDynamicSize(t) +
                (memory_detail::EXTRA_NODES + t.size()) *
-                   (sizeof(K) + sizeof(V) + 4 * sizeof(std::size_t));
+                   (sizeof(K) + sizeof(V) + storageNodeOverhead(t));
+    }
+
+    template<typename K, typename V, typename C, typename A>
+    static constexpr std::size_t storageNodeOverhead(const std::map<K, V, C, A>&) {
+        // std::map appears to use 4 pointers/size_ts per tree node
+        // (colour, parent, left and right child pointers).
+        return 4 * sizeof(std::size_t);
     }
 
     //! Overload for std::multimap.
@@ -336,7 +350,14 @@ public:
         // rb tree implementation.
         return elementDynamicSize(t) +
                (memory_detail::EXTRA_NODES + t.size()) *
-                   (sizeof(K) + sizeof(V) + 4 * sizeof(std::size_t));
+                   (sizeof(K) + sizeof(V) + storageNodeOverhead(t));
+    }
+
+    template<typename K, typename V, typename C, typename A>
+    static constexpr std::size_t storageNodeOverhead(const std::multimap<K, V, C, A>&) {
+        // In practice, both std::multimap and std::map use the same
+        // rb tree implementation.
+        return 4 * sizeof(std::size_t);
     }
 
     //! Overload for boost::container::flat_map.
@@ -349,16 +370,27 @@ public:
     template<typename T, typename H, typename P, typename A>
     static std::size_t dynamicSize(const boost::unordered_set<T, H, P, A>& t) {
         return elementDynamicSize(t) + (t.bucket_count() * sizeof(std::size_t) * 2) +
-               (t.size() * (sizeof(T) + 2 * sizeof(std::size_t)));
+               (t.size() * (sizeof(T) + storageNodeOverhead(t)));
+    }
+
+    template<typename T, typename H, typename P, typename A>
+    static constexpr std::size_t
+    storageNodeOverhead(const boost::unordered_set<T, H, P, A>&) {
+        return 2 * sizeof(std::size_t);
     }
 
     //! Overload for std::set.
     template<typename T, typename C, typename A>
     static std::size_t dynamicSize(const std::set<T, C, A>& t) {
+        return elementDynamicSize(t) + (memory_detail::EXTRA_NODES + t.size()) *
+                                           (sizeof(T) + storageNodeOverhead(t));
+    }
+
+    template<typename T, typename C, typename A>
+    static constexpr std::size_t storageNodeOverhead(const std::set<T, C, A>&) {
         // std::set appears to use 4 pointers/size_ts per tree node
         // (colour, parent, left and right child pointers).
-        return elementDynamicSize(t) + (memory_detail::EXTRA_NODES + t.size()) *
-                                           (sizeof(T) + 4 * sizeof(std::size_t));
+        return 4 * sizeof(std::size_t);
     }
 
     //! Overload for std::multiset.
@@ -367,7 +399,14 @@ public:
         // In practice, both std::multiset and std::set use the same
         // rb tree implementation.
         return elementDynamicSize(t) + (memory_detail::EXTRA_NODES + t.size()) *
-                                           (sizeof(T) + 4 * sizeof(std::size_t));
+                                           (sizeof(T) + storageNodeOverhead(t));
+    }
+
+    template<typename T, typename C, typename A>
+    static constexpr std::size_t storageNodeOverhead(const std::multiset<T, C, A>&) {
+        // In practice, both std::multiset and std::set use the same
+        // rb tree implementation.
+        return 4 * sizeof(std::size_t);
     }
 
     //! Overload for boost::container::flat_set.
@@ -379,10 +418,15 @@ public:
     //! Overload for std::list.
     template<typename T, typename A>
     static std::size_t dynamicSize(const std::list<T, A>& t) {
+        return elementDynamicSize(t) + (memory_detail::EXTRA_NODES + t.size()) *
+                                           (sizeof(T) + storageNodeOverhead(t));
+    }
+
+    template<typename T, typename A>
+    static constexpr std::size_t storageNodeOverhead(const std::list<T, A>&) {
         // std::list appears to use 2 pointers per list node
         // (prev and next pointers).
-        return elementDynamicSize(t) + (memory_detail::EXTRA_NODES + t.size()) *
-                                           (sizeof(T) + 2 * sizeof(std::size_t));
+        return 2 * sizeof(std::size_t);
     }
 
     //! Overload for std::deque.
@@ -404,6 +448,12 @@ public:
     template<typename T, typename I, typename A>
     static std::size_t
     dynamicSize(const boost::multi_index::multi_index_container<T, I, A>& t) {
+        return elementDynamicSize(t) + t.size() * (sizeof(T) + storageNodeOverhead(t));
+    }
+
+    template<typename T, typename I, typename A>
+    static std::size_t
+    storageNodeOverhead(const boost::multi_index::multi_index_container<T, I, A>& t) {
         // It's tricky to determine the container overhead of a multi-index
         // container.  It can have an arbitrary number of indices, each of which
         // can be of a different type.  To accurately determine the overhead
@@ -737,8 +787,7 @@ public:
             // For lengths up to 22 bytes there is no allocation
             capacity = 0;
         }
-
-#else // Linux with C++11 ABI and Windows
+#else // Linux (with C++11 ABI) and Windows
         if (capacity > 15) {
             unused = capacity - length;
             ++capacity;
@@ -782,7 +831,7 @@ public:
         componentName += "_map";
 
         std::size_t mapSize = (memory_detail::EXTRA_NODES + t.size()) *
-                              (sizeof(K) + sizeof(V) + 4 * sizeof(std::size_t));
+                              (sizeof(K) + sizeof(V) + CMemory::storageNodeOverhead(t));
 
         CMemoryUsage::SMemoryUsage usage(componentName, mapSize);
         CMemoryUsage::TMemoryUsagePtr ptr = mem->addChild();
@@ -802,7 +851,7 @@ public:
         componentName += "_map";
 
         std::size_t mapSize = (memory_detail::EXTRA_NODES + t.size()) *
-                              (sizeof(K) + sizeof(V) + 4 * sizeof(std::size_t));
+                              (sizeof(K) + sizeof(V) + CMemory::storageNodeOverhead(t));
 
         CMemoryUsage::SMemoryUsage usage(componentName, mapSize);
         CMemoryUsage::TMemoryUsagePtr ptr = mem->addChild();
@@ -840,8 +889,8 @@ public:
         std::string componentName(name);
         componentName += "_uset";
 
-        std::size_t setSize = (t.bucket_count() * sizeof(std::size_t) * 2) +
-                              (t.size() * (sizeof(T) + 2 * sizeof(std::size_t)));
+        std::size_t setSize = (t.bucket_count() * CMemory::storageNodeOverhead(t)) +
+                              (t.size() * (sizeof(T) + CMemory::storageNodeOverhead(t)));
 
         CMemoryUsage::SMemoryUsage usage(componentName, setSize);
         CMemoryUsage::TMemoryUsagePtr ptr = mem->addChild();
@@ -861,7 +910,7 @@ public:
         componentName += "_set";
 
         std::size_t setSize = (memory_detail::EXTRA_NODES + t.size()) *
-                              (sizeof(T) + 4 * sizeof(std::size_t));
+                              (sizeof(T) + CMemory::storageNodeOverhead(t));
 
         CMemoryUsage::SMemoryUsage usage(componentName, setSize);
         CMemoryUsage::TMemoryUsagePtr ptr = mem->addChild();
@@ -881,7 +930,7 @@ public:
         componentName += "_set";
 
         std::size_t setSize = (memory_detail::EXTRA_NODES + t.size()) *
-                              (sizeof(T) + 4 * sizeof(std::size_t));
+                              (sizeof(T) + CMemory::storageNodeOverhead(t));
 
         CMemoryUsage::SMemoryUsage usage(componentName, setSize);
         CMemoryUsage::TMemoryUsagePtr ptr = mem->addChild();
@@ -921,7 +970,7 @@ public:
         componentName += "_list";
 
         std::size_t listSize = (memory_detail::EXTRA_NODES + t.size()) *
-                               (sizeof(T) + 2 * sizeof(std::size_t));
+                               (sizeof(T) + CMemory::storageNodeOverhead(t));
 
         CMemoryUsage::SMemoryUsage usage(componentName, listSize);
         CMemoryUsage::TMemoryUsagePtr ptr = mem->addChild();
@@ -961,23 +1010,12 @@ public:
     static void dynamicSize(const char* name,
                             const boost::multi_index::multi_index_container<T, I, A>& t,
                             const CMemoryUsage::TMemoryUsagePtr& mem) {
-        // It's tricky to determine the container overhead of a multi-index
-        // container.  It can have an arbitrary number of indices, each of which
-        // can be of a different type.  To accurately determine the overhead
-        // would require some serious template metaprogramming to interpret the
-        // "typename I" template argument, and it's just not worth it given the
-        // infrequent and relatively simple usage (generally just two indices
-        // in our current codebase).  Therefore there's an approximation here
-        // that the overhead is 2 pointers per entry per index.
-        using TMultiIndex = boost::multi_index::multi_index_container<T, I, A>;
-        constexpr std::size_t indexCount{
-            boost::mpl::size<typename TMultiIndex::index_type_list>::value};
         std::string componentName(name);
 
         std::size_t items = t.size();
         CMemoryUsage::SMemoryUsage usage(
             componentName + "::" + typeid(T).name(),
-            items * (sizeof(T) + 2 * indexCount * sizeof(std::size_t)));
+            items * (sizeof(T) + CMemory::storageNodeOverhead(t)));
         CMemoryUsage::TMemoryUsagePtr ptr = mem->addChild();
         ptr->setName(usage);
 

--- a/lib/core/unittest/CCompressedLfuCacheTest.cc
+++ b/lib/core/unittest/CCompressedLfuCacheTest.cc
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(testMemoryUsage) {
                      });
         BOOST_REQUIRE_EQUAL(0.0, cache.hitFraction());
         BOOST_TEST_REQUIRE(cache.size() <= i + 1);
-        BOOST_TEST_REQUIRE(cache.memoryUsage() < 64 * core::constants::BYTES_IN_KILOBYTES);
+        BOOST_TEST_REQUIRE(cache.memoryUsage() <= 64 * core::constants::BYTES_IN_KILOBYTES);
     }
     // This is sensitive to the exact memory limit and the item size because memory
     // is consumed in chunks by the hash map.
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(testResize) {
     }
     BOOST_TEST_REQUIRE(cache.memoryUsage() >
                        static_cast<std::size_t>(0.98 * 64 * core::constants::BYTES_IN_KILOBYTES));
-    BOOST_TEST_REQUIRE(cache.memoryUsage() < 64 * core::constants::BYTES_IN_KILOBYTES);
+    BOOST_TEST_REQUIRE(cache.memoryUsage() <= 64 * core::constants::BYTES_IN_KILOBYTES);
     BOOST_TEST_REQUIRE(cache.size() < 500);
 
     LOG_DEBUG(<< "64KB size = " << cache.size());
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(testResize) {
     // Check the cache is around twice as large.
     BOOST_TEST_REQUIRE(cache.memoryUsage() >
                        static_cast<std::size_t>(0.98 * 128 * core::constants::BYTES_IN_KILOBYTES));
-    BOOST_TEST_REQUIRE(cache.memoryUsage() < 128 * core::constants::BYTES_IN_KILOBYTES);
+    BOOST_TEST_REQUIRE(cache.memoryUsage() <= 128 * core::constants::BYTES_IN_KILOBYTES);
     BOOST_TEST_REQUIRE(cache.size() > static_cast<std::size_t>(1.95 * size64KB));
     BOOST_TEST_REQUIRE(cache.size() < static_cast<std::size_t>(2.05 * size64KB));
 
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(testResize) {
 
     BOOST_TEST_REQUIRE(cache.memoryUsage() >
                        static_cast<std::size_t>(0.98 * 64 * core::constants::BYTES_IN_KILOBYTES));
-    BOOST_TEST_REQUIRE(cache.memoryUsage() < 64 * core::constants::BYTES_IN_KILOBYTES);
+    BOOST_TEST_REQUIRE(cache.memoryUsage() <= 64 * core::constants::BYTES_IN_KILOBYTES);
     BOOST_TEST_REQUIRE(cache.size() > static_cast<std::size_t>(0.95 * size64KB));
     BOOST_TEST_REQUIRE(cache.size() < static_cast<std::size_t>(1.05 * size64KB));
 

--- a/lib/core/unittest/CCompressedLfuCacheTest.cc
+++ b/lib/core/unittest/CCompressedLfuCacheTest.cc
@@ -353,7 +353,7 @@ BOOST_AUTO_TEST_CASE(testEvictionStrategyMemory) {
     for (std::size_t i = 0; i < 200; ++i) {
         if (i < 100) {
             cache.lookup("large_key_" + std::to_string(i),
-                         [i](std::string) { return CTestValue{5 + i}; },
+                         [i](std::string) { return CTestValue{10 + i}; },
                          [&](const CTestValue&) {});
             auto stats = cache.stats("large_key_" + std::to_string(i));
             BOOST_TEST_REQUIRE(stats.first > 0);


### PR DESCRIPTION
The LFU cache was assuming that if a new item wouldn't
fit into it then there must already be a cached item
in it. This wasn't true in the case of a very tiny
cache size.

The code now accounts for the possibility of an item
not fitting into an empty cache.

This scenario was always very unlikely in production,
but more likely for test scenarios.

Fixes #2370