### PR TITLE
[ML] Adding a cache_hit indicator to inference results

### DIFF
--- a/bin/pytorch_inference/CCommandParser.cc
+++ b/bin/pytorch_inference/CCommandParser.cc
@@ -11,9 +11,7 @@
 
 #include "CCommandParser.h"
 
-#include <core/CCompressedLfuCache.h>
 #include <core/CLogger.h>
-#include <core/CMemory.h>
 #include <core/CRapidJsonUnbufferedIStreamWrapper.h>
 
 #include <rapidjson/error/en.h>


### PR DESCRIPTION
This is a companion to https://github.com/elastic/elasticsearch/pull/88287.

In addition to adding a `cache_hit` indicator, the meaning of `time_ms` is
changed from "original inference time" to "cache lookup plus inference time
if necessary".