### PR TITLE
[ML] Add a "clear cache" control message to pytorch_inference

### DIFF
--- a/bin/pytorch_inference/CCommandParser.cc
+++ b/bin/pytorch_inference/CCommandParser.cc
@@ -101,7 +101,7 @@ bool CCommandParser::ioLoop(const TRequestHandlerFunc& requestHandler,
             }
             break;
         case EMessageType::E_ControlMessage:
-            controlHandler(jsonToControlMessage(doc));
+            controlHandler(*m_RequestCache, jsonToControlMessage(doc));
             break;
         case EMessageType::E_MalformedMessage:
             continue;
@@ -136,22 +136,32 @@ CCommandParser::validateControlMessageJson(const rapidjson::Document& doc,
                                            const TErrorHandlerFunc& errorHandler) {
 
     const rapidjson::Value& control = doc[CONTROL];
-    if (control.IsInt() == false || control.GetInt() < 0 ||
-        control.GetInt() >= EControlMessageType::E_Unknown) {
+    EControlMessageType controlMessageType =
+        (control.IsInt() && control.GetInt() >= 0 &&
+         control.GetInt() < EControlMessageType::E_Unknown)
+            ? static_cast<EControlMessageType>(control.GetInt())
+            : EControlMessageType::E_Unknown;
+
+    switch (controlMessageType) {
+    case E_NumberOfAllocations: {
+        if (doc.HasMember(NUM_ALLOCATIONS) == false) {
+            errorHandler(UNKNOWN_ID, "Invalid control message: missing field [" +
+                                         NUM_ALLOCATIONS + "]");
+            return EMessageType::E_MalformedMessage;
+        }
+        const rapidjson::Value& numAllocations = doc[NUM_ALLOCATIONS];
+        if (numAllocations.IsInt() == false) {
+            errorHandler(UNKNOWN_ID, "Invalid control message: field [" +
+                                         NUM_ALLOCATIONS + "] is not an integer");
+            return EMessageType::E_MalformedMessage;
+        }
+        break;
+    }
+    case E_ClearCache:
+        // No extra arguments needed
+        break;
+    case E_Unknown:
         errorHandler(UNKNOWN_ID, "Invalid control message: unknown control message type");
-        return EMessageType::E_MalformedMessage;
-    }
-
-    if (doc.HasMember(NUM_ALLOCATIONS) == false) {
-        errorHandler(UNKNOWN_ID, "Invalid control message: missing field [" +
-                                     NUM_ALLOCATIONS + "]");
-        return EMessageType::E_MalformedMessage;
-    }
-
-    const rapidjson::Value& numThreads = doc[NUM_ALLOCATIONS];
-    if (numThreads.IsInt() == false) {
-        errorHandler(UNKNOWN_ID, "Invalid control message: field [" +
-                                     NUM_ALLOCATIONS + "] is not an integer");
         return EMessageType::E_MalformedMessage;
     }
 
@@ -281,8 +291,18 @@ CCommandParser::jsonToInferenceRequest(const rapidjson::Document& doc) {
 
 CCommandParser::SControlMessage
 CCommandParser::jsonToControlMessage(const rapidjson::Document& doc) {
-    return {static_cast<EControlMessageType>(doc[CONTROL].GetInt()),
-            doc[NUM_ALLOCATIONS].GetInt(), doc[REQUEST_ID].GetString()};
+    auto controlMessageType = static_cast<EControlMessageType>(doc[CONTROL].GetInt());
+    switch (controlMessageType) {
+    case E_NumberOfAllocations:
+        return {controlMessageType, doc[NUM_ALLOCATIONS].GetInt(),
+                doc[REQUEST_ID].GetString()};
+    case E_ClearCache:
+        return {controlMessageType, 0, doc[REQUEST_ID].GetString()};
+    case E_Unknown:
+        break;
+    }
+
+    LOG_ABORT(<< "Programmatic error - incorrect validation of control message");
 }
 
 CCommandParser::CRequestCache::CRequestCache(std::size_t memoryLimitBytes)

--- a/bin/pytorch_inference/CCommandParser.h
+++ b/bin/pytorch_inference/CCommandParser.h
@@ -67,6 +67,7 @@ public:
         virtual bool lookup(SRequest request,
                             const TComputeResponse& computeResponse,
                             const TReadResponse& readResponse) = 0;
+        virtual void clear() = 0;
     };
 
     //! \brief Memory limited inference request LFU cache.
@@ -77,11 +78,14 @@ public:
         void resize(std::size_t memoryLimitBytes) override {
             m_Impl.resize(memoryLimitBytes);
         }
+
         bool lookup(SRequest request,
                     const TComputeResponse& computeResponse,
                     const TReadResponse& readResponse) override {
             return m_Impl.lookup(std::move(request), computeResponse, readResponse);
         }
+
+        void clear() override { m_Impl.clear(); }
 
     private:
         using TConcurrentLfuCache = core::CConcurrentCompressedLfuCache<SRequest, std::string>;
@@ -94,12 +98,15 @@ public:
     class CRequestCacheStub : public CRequestCacheInterface {
     public:
         void resize(std::size_t) override {}
+
         bool lookup(SRequest request,
                     const TComputeResponse& computeResponse,
                     const TReadResponse& readResponse) override {
             readResponse(computeResponse(std::move(request)));
             return false;
         }
+
+        void clear() override {}
     };
 
     using TRequestCachePtr = std::unique_ptr<CRequestCacheInterface>;
@@ -109,7 +116,7 @@ public:
         E_ControlMessage,
         E_MalformedMessage
     };
-    enum EControlMessageType { E_NumberOfAllocations, E_Unknown };
+    enum EControlMessageType { E_NumberOfAllocations, E_ClearCache, E_Unknown };
 
     //! The incoming JSON requests contain a 2D array of tokens representing
     //! a batch of inference calls. To avoid copying, the input tensor
@@ -132,7 +139,8 @@ public:
         std::string s_RequestId;
     };
 
-    using TControlHandlerFunc = std::function<void(const SControlMessage&)>;
+    using TControlHandlerFunc =
+        std::function<void(CRequestCacheInterface&, const SControlMessage&)>;
     using TRequestHandlerFunc = std::function<bool(CRequestCacheInterface&, SRequest)>;
     using TErrorHandlerFunc =
         std::function<void(const std::string& requestId, const std::string& message)>;

--- a/lib/core/unittest/CCompressedLfuCacheTest.cc
+++ b/lib/core/unittest/CCompressedLfuCacheTest.cc
@@ -550,4 +550,58 @@ BOOST_AUTO_TEST_CASE(testPersist) {
     BOOST_TEST_REQUIRE(restoredCache.checkInvariants());
 }
 
+BOOST_AUTO_TEST_CASE(testClear) {
+
+    TStrStrCache cache{32 * core::constants::BYTES_IN_KILOBYTES,
+                       [](const TStrStrCache::TDictionary& dictionary, const std::string& key) {
+                           return dictionary.word(key);
+                       }};
+
+    BOOST_REQUIRE_EQUAL(
+        false, cache.lookup("key_1", [](std::string key_) { return key_; },
+                            [&](const std::string& value) {
+                                BOOST_REQUIRE_EQUAL("key_1", value);
+                            }));
+    BOOST_REQUIRE_EQUAL(1, cache.size());
+    BOOST_REQUIRE_EQUAL(0.0, cache.hitFraction());
+
+    BOOST_REQUIRE_EQUAL(true, cache.lookup("key_1",
+                                           [](std::string key_) { return key_; },
+                                           [&](const std::string& value) {
+                                               BOOST_REQUIRE_EQUAL("key_1", value);
+                                           }));
+    BOOST_REQUIRE_EQUAL(1, cache.size());
+    BOOST_REQUIRE_EQUAL(1.0 / 2.0, cache.hitFraction());
+
+    BOOST_REQUIRE_EQUAL(
+        false, cache.lookup("key_2", [](std::string key_) { return key_; },
+                            [&](const std::string& value) {
+                                BOOST_REQUIRE_EQUAL("key_2", value);
+                            }));
+    BOOST_REQUIRE_EQUAL(2, cache.size());
+    BOOST_REQUIRE_EQUAL(1.0 / 3.0, cache.hitFraction());
+
+    BOOST_TEST_REQUIRE(cache.checkInvariants());
+    cache.clear();
+    BOOST_TEST_REQUIRE(cache.checkInvariants());
+
+    BOOST_REQUIRE_EQUAL(
+        false, cache.lookup("key_1", [](std::string key_) { return key_; },
+                            [&](const std::string& value) {
+                                BOOST_REQUIRE_EQUAL("key_1", value);
+                            }));
+    BOOST_REQUIRE_EQUAL(1, cache.size());
+    BOOST_REQUIRE_EQUAL(0.0, cache.hitFraction());
+
+    BOOST_REQUIRE_EQUAL(
+        false, cache.lookup("key_2", [](std::string key_) { return key_; },
+                            [&](const std::string& value) {
+                                BOOST_REQUIRE_EQUAL("key_2", value);
+                            }));
+    BOOST_REQUIRE_EQUAL(2, cache.size());
+    BOOST_REQUIRE_EQUAL(0.0, cache.hitFraction());
+
+    BOOST_TEST_REQUIRE(cache.checkInvariants());
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is likely to be useful for QA performance tests once
it's exposed on the Java side.