### PR TITLE
[ML] Rename CMemory and CMemoryDebug according to repo conventions

### DIFF
--- a/include/core/CCompressedLfuCache.h
+++ b/include/core/CCompressedLfuCache.h
@@ -138,7 +138,7 @@ public:
 
         auto value = computeValue(std::move(key));
 
-        std::size_t itemMemoryUsage{CMemory::dynamicSize(value)};
+        std::size_t itemMemoryUsage{memory::dynamicSize(value)};
 
         if (this->guardWrite(TIME_OUT, [&] {
                 // It is possible that two values with the same key check the cache
@@ -382,7 +382,7 @@ private:
     class CCacheItem {
     public:
         //! We purposely disable direct memory estimation for cache items because
-        //! we want to avoid quadratic complexity using core::CMemory::dynamicSize.
+        //! we want to avoid quadratic complexity using core::memory::dynamicSize.
         //! Instead we estimate memory usage for each item we add and remove from
         //! the cache and maintain a running total.
         static constexpr bool dynamicSizeAlwaysZero() { return true; }
@@ -483,15 +483,15 @@ private:
     bool full(std::size_t itemMemoryUsage) const {
         std::size_t memory{this->unguardedMemoryUsage() + itemMemoryUsage +
                            sizeof(typename TCompressedKeyCacheItemUMap::value_type) +
-                           CMemory::storageNodeOverhead(m_ItemCache) +
+                           memory::storageNodeOverhead(m_ItemCache) +
                            sizeof(typename TCacheItemStatsSet::value_type) +
-                           CMemory::storageNodeOverhead(m_ItemStats)};
+                           memory::storageNodeOverhead(m_ItemStats)};
         if (this->needToResizeItemCache()) {
             memory += static_cast<std::size_t>(
                 (static_cast<double>(this->nextItemCacheBucketCount()) /
                      static_cast<double>(m_ItemCache.bucket_count()) -
                  1.0) *
-                static_cast<double>(CMemory::dynamicSize(m_ItemCache) -
+                static_cast<double>(memory::dynamicSize(m_ItemCache) -
                                     m_ItemCache.size() *
                                         sizeof(typename TCompressedKeyCacheItemUMap::value_type)));
         }
@@ -500,8 +500,8 @@ private:
 
     std::size_t unguardedMemoryUsage() const {
         return m_ItemsMemoryUsage + // overheads
-               CMemory::dynamicSize(m_ItemCache) + CMemory::dynamicSize(m_ItemStats) +
-               CMemory::dynamicSize(m_BucketCountSequence);
+               memory::dynamicSize(m_ItemCache) + memory::dynamicSize(m_ItemStats) +
+               memory::dynamicSize(m_BucketCountSequence);
     }
 
     bool needToResizeItemCache() const {

--- a/include/core/CConcurrentQueue.h
+++ b/include/core/CConcurrentQueue.h
@@ -123,11 +123,11 @@ public:
     //! Debug the memory used by this component.
     void debugMemoryUsage(const CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CConcurrentQueue");
-        CMemoryDebug::dynamicSize("m_Queue", m_Queue, mem);
+        memory_debug::dynamicSize("m_Queue", m_Queue, mem);
     }
 
     //! Get the memory used by this component.
-    std::size_t memoryUsage() const { return CMemory::dynamicSize(m_Queue); }
+    std::size_t memoryUsage() const { return memory::dynamicSize(m_Queue); }
 
     //! Return the number of items currently in the queue
     size_t size() {

--- a/include/core/CMemoryDec.h
+++ b/include/core/CMemoryDec.h
@@ -62,7 +62,7 @@ struct SMemoryStaticSize<T, std::enable_if_t<
 //! \code{.cpp}
 //!     std::size_t memoryUsage() const;
 //! \endcode
-//! which should call CMemory::dynamicSize(t); on all its dynamic members.
+//! which should call memory::dynamicSize(t); on all its dynamic members.
 //!
 //! For virtual hierarchies, the compiler can not determine the size
 //! of derived classes from the base pointer, so wherever the afore-
@@ -71,7 +71,7 @@ struct SMemoryStaticSize<T, std::enable_if_t<
 //!     std::size_t staticSize() const;
 //! \endcode
 //! should be declared, returning sizeof(*this).
-namespace CMemory {
+namespace memory {
 
 //! Default implementation.
 template<typename T>
@@ -167,9 +167,9 @@ std::size_t elementDynamicSize(const CONTAINER& t);
 //! \code{.cpp}
 //!     void debugMemoryUsage(const CMemoryUsage::TMemoryUsagePtr&) const;
 //! \endcode
-//! which should call CMemoryDebug::dynamicSize("t_name", t, memUsagePtr)
+//! which should call memory_debug::dynamicSize("t_name", t, memUsagePtr)
 //! on all its dynamic members.
-namespace CMemoryDebug {
+namespace memory_debug {
 
 //! Default implementation for non-pointer types.
 template<typename T>

--- a/include/core/CMemoryDecStd.h
+++ b/include/core/CMemoryDecStd.h
@@ -21,7 +21,7 @@
 
 namespace ml {
 namespace core {
-namespace CMemory {
+namespace memory {
 
 template<typename T, typename A>
 constexpr std::size_t storageNodeOverhead(const std::list<T, A>&) {
@@ -76,7 +76,7 @@ template<typename T, typename C, typename A>
 std::size_t dynamicSize(const std::multiset<T, C, A>& t);
 }
 
-namespace CMemoryDebug {
+namespace memory_debug {
 
 template<typename T, typename A>
 void dynamicSize(const char* name,

--- a/include/core/CMemoryDefMultiIndex.h
+++ b/include/core/CMemoryDefMultiIndex.h
@@ -20,7 +20,7 @@
 
 namespace ml {
 namespace core {
-namespace CMemory {
+namespace memory {
 template<typename T, typename I, typename A>
 std::size_t
 storageNodeOverhead(const boost::multi_index::multi_index_container<T, I, A>&) {
@@ -40,12 +40,12 @@ storageNodeOverhead(const boost::multi_index::multi_index_container<T, I, A>&) {
 
 template<typename T, typename I, typename A>
 std::size_t dynamicSize(const boost::multi_index::multi_index_container<T, I, A>& t) {
-    return CMemory::elementDynamicSize(t) +
-           t.size() * (sizeof(T) + CMemory::storageNodeOverhead(t));
+    return memory::elementDynamicSize(t) +
+           t.size() * (sizeof(T) + memory::storageNodeOverhead(t));
 }
 }
 
-namespace CMemoryDebug {
+namespace memory_debug {
 template<typename T, typename I, typename A>
 void dynamicSize(const char* name,
                  const boost::multi_index::multi_index_container<T, I, A>& t,
@@ -54,11 +54,11 @@ void dynamicSize(const char* name,
 
     std::size_t items = t.size();
     CMemoryUsage::SMemoryUsage usage(componentName + "::" + typeid(T).name(),
-                                     items * (sizeof(T) + CMemory::storageNodeOverhead(t)));
+                                     items * (sizeof(T) + memory::storageNodeOverhead(t)));
     CMemoryUsage::TMemoryUsagePtr ptr = mem->addChild();
     ptr->setName(usage);
 
-    CMemoryDebug::elementDynamicSize(std::move(componentName), t, mem);
+    memory_debug::elementDynamicSize(std::move(componentName), t, mem);
 }
 }
 }

--- a/include/core/CMemoryDefStd.h
+++ b/include/core/CMemoryDefStd.h
@@ -39,13 +39,13 @@ constexpr std::size_t MIN_DEQUE_PAGE_VEC_ENTRIES{8};
 #endif
 }
 
-namespace CMemory {
+namespace memory {
 
 template<typename T, typename A>
 std::size_t dynamicSize(const std::list<T, A>& t) {
-    return CMemory::elementDynamicSize(t) +
+    return memory::elementDynamicSize(t) +
            (memory_detail::EXTRA_NODES + t.size()) *
-               (sizeof(T) + CMemory::storageNodeOverhead(t));
+               (sizeof(T) + memory::storageNodeOverhead(t));
 }
 
 template<typename T, typename A>
@@ -58,44 +58,44 @@ std::size_t dynamicSize(const std::deque<T, A>& t) {
     // This could also be an underestimate if items have been removed
     std::size_t pageVecEntries = std::max(numPages, memory_detail::MIN_DEQUE_PAGE_VEC_ENTRIES);
 
-    return CMemory::elementDynamicSize(t) +
+    return memory::elementDynamicSize(t) +
            pageVecEntries * sizeof(std::size_t) + numPages * pageSize;
 }
 
 template<typename K, typename V, typename C, typename A>
 std::size_t dynamicSize(const std::map<K, V, C, A>& t) {
-    return CMemory::elementDynamicSize(t) +
+    return memory::elementDynamicSize(t) +
            (memory_detail::EXTRA_NODES + t.size()) *
-               (sizeof(K) + sizeof(V) + CMemory::storageNodeOverhead(t));
+               (sizeof(K) + sizeof(V) + memory::storageNodeOverhead(t));
 }
 
 template<typename K, typename V, typename C, typename A>
 std::size_t dynamicSize(const std::multimap<K, V, C, A>& t) {
     // In practice, both std::multimap and std::map use the same
     // rb tree implementation.
-    return CMemory::elementDynamicSize(t) +
+    return memory::elementDynamicSize(t) +
            (memory_detail::EXTRA_NODES + t.size()) *
-               (sizeof(K) + sizeof(V) + CMemory::storageNodeOverhead(t));
+               (sizeof(K) + sizeof(V) + memory::storageNodeOverhead(t));
 }
 
 template<typename T, typename C, typename A>
 std::size_t dynamicSize(const std::set<T, C, A>& t) {
-    return CMemory::elementDynamicSize(t) +
+    return memory::elementDynamicSize(t) +
            (memory_detail::EXTRA_NODES + t.size()) *
-               (sizeof(T) + CMemory::storageNodeOverhead(t));
+               (sizeof(T) + memory::storageNodeOverhead(t));
 }
 
 template<typename T, typename C, typename A>
 std::size_t dynamicSize(const std::multiset<T, C, A>& t) {
     // In practice, both std::multiset and std::set use the same
     // rb tree implementation.
-    return CMemory::elementDynamicSize(t) +
+    return memory::elementDynamicSize(t) +
            (memory_detail::EXTRA_NODES + t.size()) *
-               (sizeof(T) + CMemory::storageNodeOverhead(t));
+               (sizeof(T) + memory::storageNodeOverhead(t));
 }
 }
 
-namespace CMemoryDebug {
+namespace memory_debug {
 
 template<typename T, typename A>
 void dynamicSize(const char* name,
@@ -107,13 +107,13 @@ void dynamicSize(const char* name,
     componentName += "_list";
 
     std::size_t listSize = (memory_detail::EXTRA_NODES + t.size()) *
-                           (sizeof(T) + CMemory::storageNodeOverhead(t));
+                           (sizeof(T) + memory::storageNodeOverhead(t));
 
     CMemoryUsage::SMemoryUsage usage(componentName, listSize);
     CMemoryUsage::TMemoryUsagePtr ptr = mem->addChild();
     ptr->setName(usage);
 
-    CMemoryDebug::elementDynamicSize(std::move(componentName), t, mem);
+    memory_debug::elementDynamicSize(std::move(componentName), t, mem);
 }
 
 template<typename T, typename C, typename A>
@@ -138,7 +138,7 @@ void dynamicSize(const char* name,
     CMemoryUsage::TMemoryUsagePtr ptr = mem->addChild();
     ptr->setName(usage);
 
-    CMemoryDebug::elementDynamicSize(std::move(componentName), t, mem);
+    memory_debug::elementDynamicSize(std::move(componentName), t, mem);
 }
 
 template<typename K, typename V, typename C, typename A>
@@ -151,13 +151,13 @@ void dynamicSize(const char* name,
     componentName += "_map";
 
     std::size_t mapSize = (memory_detail::EXTRA_NODES + t.size()) *
-                          (sizeof(K) + sizeof(V) + CMemory::storageNodeOverhead(t));
+                          (sizeof(K) + sizeof(V) + memory::storageNodeOverhead(t));
 
     CMemoryUsage::SMemoryUsage usage(componentName, mapSize);
     CMemoryUsage::TMemoryUsagePtr ptr = mem->addChild();
     ptr->setName(usage);
 
-    CMemoryDebug::associativeElementDynamicSize(std::move(componentName), t, mem);
+    memory_debug::associativeElementDynamicSize(std::move(componentName), t, mem);
 }
 
 template<typename K, typename V, typename C, typename A>
@@ -170,13 +170,13 @@ void dynamicSize(const char* name,
     componentName += "_map";
 
     std::size_t mapSize = (memory_detail::EXTRA_NODES + t.size()) *
-                          (sizeof(K) + sizeof(V) + CMemory::storageNodeOverhead(t));
+                          (sizeof(K) + sizeof(V) + memory::storageNodeOverhead(t));
 
     CMemoryUsage::SMemoryUsage usage(componentName, mapSize);
     CMemoryUsage::TMemoryUsagePtr ptr = mem->addChild();
     ptr->setName(usage);
 
-    CMemoryDebug::associativeElementDynamicSize(std::move(componentName), t, mem);
+    memory_debug::associativeElementDynamicSize(std::move(componentName), t, mem);
 }
 
 template<typename T, typename C, typename A>
@@ -189,13 +189,13 @@ void dynamicSize(const char* name,
     componentName += "_set";
 
     std::size_t setSize = (memory_detail::EXTRA_NODES + t.size()) *
-                          (sizeof(T) + CMemory::storageNodeOverhead(t));
+                          (sizeof(T) + memory::storageNodeOverhead(t));
 
     CMemoryUsage::SMemoryUsage usage(componentName, setSize);
     CMemoryUsage::TMemoryUsagePtr ptr = mem->addChild();
     ptr->setName(usage);
 
-    CMemoryDebug::elementDynamicSize(std::move(componentName), t, mem);
+    memory_debug::elementDynamicSize(std::move(componentName), t, mem);
 }
 
 template<typename T, typename C, typename A>
@@ -208,13 +208,13 @@ void dynamicSize(const char* name,
     componentName += "_set";
 
     std::size_t setSize = (memory_detail::EXTRA_NODES + t.size()) *
-                          (sizeof(T) + CMemory::storageNodeOverhead(t));
+                          (sizeof(T) + memory::storageNodeOverhead(t));
 
     CMemoryUsage::SMemoryUsage usage(componentName, setSize);
     CMemoryUsage::TMemoryUsagePtr ptr = mem->addChild();
     ptr->setName(usage);
 
-    CMemoryDebug::elementDynamicSize(std::move(componentName), t, mem);
+    memory_debug::elementDynamicSize(std::move(componentName), t, mem);
 }
 }
 }

--- a/include/core/CTriple.h
+++ b/include/core/CTriple.h
@@ -71,16 +71,16 @@ public:
 
     void debugMemoryUsage(const CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CTriple");
-        CMemoryDebug::dynamicSize("first", first, mem);
-        CMemoryDebug::dynamicSize("second", second, mem);
-        CMemoryDebug::dynamicSize("third", third, mem);
+        memory_debug::dynamicSize("first", first, mem);
+        memory_debug::dynamicSize("second", second, mem);
+        memory_debug::dynamicSize("third", third, mem);
     }
 
     std::size_t memoryUsage() const {
         std::size_t mem = 0;
-        mem += CMemory::dynamicSize(first);
-        mem += CMemory::dynamicSize(second);
-        mem += CMemory::dynamicSize(third);
+        mem += memory::dynamicSize(first);
+        mem += memory::dynamicSize(second);
+        mem += memory::dynamicSize(third);
         return mem;
     }
 

--- a/include/maths/analytics/COutliers.h
+++ b/include/maths/analytics/COutliers.h
@@ -191,9 +191,9 @@ public:
     std::size_t staticSize() const override { return sizeof(*this); }
 
     std::size_t memoryUsage() const override {
-        return core::CMemory::dynamicSize(m_KDistances) +
-               core::CMemory::dynamicSize(m_Lrd) +
-               core::CMemory::dynamicSize(m_CoordinateLrd);
+        return core::memory::dynamicSize(m_KDistances) +
+               core::memory::dynamicSize(m_Lrd) +
+               core::memory::dynamicSize(m_CoordinateLrd);
     }
 
     static std::size_t estimateOwnMemoryOverhead(bool computeFeatureInfluence,
@@ -618,7 +618,7 @@ public:
     std::size_t staticSize() const override { return sizeof(*this); }
 
     std::size_t memoryUsage() const override {
-        return core::CMemory::dynamicSize(m_Methods);
+        return core::memory::dynamicSize(m_Methods);
     }
 
     std::string print() const override {

--- a/include/maths/common/CAnnotatedVector.h
+++ b/include/maths/common/CAnnotatedVector.h
@@ -58,13 +58,13 @@ public:
     //! Debug the memory usage of this object.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CAnnotatedVector");
-        mem->addItem("vector", core::CMemory::dynamicSize(static_cast<VECTOR>(*this)));
-        mem->addItem("annotation", core::CMemory::dynamicSize(m_Annotation));
+        mem->addItem("vector", core::memory::dynamicSize(static_cast<VECTOR>(*this)));
+        mem->addItem("annotation", core::memory::dynamicSize(m_Annotation));
     }
     //! Get the memory used by this object.
     std::size_t memoryUsage() const {
-        return core::CMemory::dynamicSize(static_cast<VECTOR>(*this)) +
-               core::CMemory::dynamicSize(m_Annotation);
+        return core::memory::dynamicSize(static_cast<VECTOR>(*this)) +
+               core::memory::dynamicSize(m_Annotation);
     }
 
 private:

--- a/include/maths/common/CKMeansOnline.h
+++ b/include/maths/common/CKMeansOnline.h
@@ -496,12 +496,12 @@ public:
     //! Get the memory used by this component
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CKMeansOnline");
-        core::CMemoryDebug::dynamicSize("m_Clusters", m_Clusters, mem);
+        core::memory_debug::dynamicSize("m_Clusters", m_Clusters, mem);
     }
 
     //! Get the memory used by this component
     std::size_t memoryUsage() const {
-        return core::CMemory::dynamicSize(m_Clusters);
+        return core::memory::dynamicSize(m_Clusters);
     }
 
 protected:

--- a/include/maths/common/CKdTree.h
+++ b/include/maths/common/CKdTree.h
@@ -145,7 +145,7 @@ public:
 
         //! Get the memory used by this object.
         std::size_t memoryUsage() const {
-            return core::CMemory::dynamicSize(s_Point);
+            return core::memory::dynamicSize(s_Point);
         }
 
         //! Estimate the amount of memory this node will use.
@@ -368,7 +368,7 @@ public:
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const {
-        return core::CMemory::dynamicSize(m_Nodes);
+        return core::memory::dynamicSize(m_Nodes);
     }
 
     //! Estimate the amount of memory the k-d tree will use.

--- a/include/maths/common/CMultimodalPriorMode.h
+++ b/include/maths/common/CMultimodalPriorMode.h
@@ -57,12 +57,12 @@ struct SMultimodalPriorMode {
     //! Get the memory used by this component
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CMultimodalPrior::SMode");
-        core::CMemoryDebug::dynamicSize("s_Prior", s_Prior, mem);
+        core::memory_debug::dynamicSize("s_Prior", s_Prior, mem);
     }
 
     //! Get the memory used by this component
     std::size_t memoryUsage() const {
-        return core::CMemory::dynamicSize(s_Prior);
+        return core::memory::dynamicSize(s_Prior);
     }
 
     //! Create from part of a state document.

--- a/include/maths/common/CMultivariateMultimodalPrior.h
+++ b/include/maths/common/CMultivariateMultimodalPrior.h
@@ -807,16 +807,16 @@ public:
     //! Get the memory used by this component
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
         mem->setName("CMultivariateMultimodalPrior");
-        core::CMemoryDebug::dynamicSize("m_Clusterer", m_Clusterer, mem);
-        core::CMemoryDebug::dynamicSize("m_SeedPrior", m_SeedPrior, mem);
-        core::CMemoryDebug::dynamicSize("m_Modes", m_Modes, mem);
+        core::memory_debug::dynamicSize("m_Clusterer", m_Clusterer, mem);
+        core::memory_debug::dynamicSize("m_SeedPrior", m_SeedPrior, mem);
+        core::memory_debug::dynamicSize("m_Modes", m_Modes, mem);
     }
 
     //! Get the memory used by this component
     std::size_t memoryUsage() const override {
-        std::size_t mem = core::CMemory::dynamicSize(m_Clusterer);
-        mem += core::CMemory::dynamicSize(m_SeedPrior);
-        mem += core::CMemory::dynamicSize(m_Modes);
+        std::size_t mem = core::memory::dynamicSize(m_Clusterer);
+        mem += core::memory::dynamicSize(m_SeedPrior);
+        mem += core::memory::dynamicSize(m_Modes);
         return mem;
     }
 

--- a/include/maths/common/CQuantileSketch.h
+++ b/include/maths/common/CQuantileSketch.h
@@ -198,7 +198,7 @@ public:
 
     //! Debug the memory used by this object.
     //!
-    //! \note Needs to be redeclared to work with CMemoryDebug.
+    //! \note Needs to be redeclared to work with memory_debug.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
         this->CQuantileSketch::debugMemoryUsage(mem);
     }

--- a/include/maths/common/CSpline.h
+++ b/include/maths/common/CSpline.h
@@ -620,16 +620,16 @@ public:
     //! Debug the memory used by this object.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CSpline");
-        core::CMemoryDebug::dynamicSize("m_Knots", m_Knots, mem);
-        core::CMemoryDebug::dynamicSize("m_Values", m_Values, mem);
-        core::CMemoryDebug::dynamicSize("m_Curvatures", m_Curvatures, mem);
+        core::memory_debug::dynamicSize("m_Knots", m_Knots, mem);
+        core::memory_debug::dynamicSize("m_Values", m_Values, mem);
+        core::memory_debug::dynamicSize("m_Curvatures", m_Curvatures, mem);
     }
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const {
-        std::size_t mem = core::CMemory::dynamicSize(m_Knots);
-        mem += core::CMemory::dynamicSize(m_Values);
-        mem += core::CMemory::dynamicSize(m_Curvatures);
+        std::size_t mem = core::memory::dynamicSize(m_Knots);
+        mem += core::memory::dynamicSize(m_Values);
+        mem += core::memory::dynamicSize(m_Curvatures);
         return mem;
     }
 

--- a/include/maths/common/CXMeansOnline.h
+++ b/include/maths/common/CXMeansOnline.h
@@ -337,12 +337,12 @@ public:
         //! Debug the memory used by this component.
         void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
             mem->setName("CXMeansOnline");
-            core::CMemoryDebug::dynamicSize("m_Structure", m_Structure, mem);
+            core::memory_debug::dynamicSize("m_Structure", m_Structure, mem);
         }
 
         //! Get the memory used by this component.
         std::size_t memoryUsage() const {
-            return core::CMemory::dynamicSize(m_Structure);
+            return core::memory::dynamicSize(m_Structure);
         }
 
         //! Get Bayes Information Criterion decrease in going from one
@@ -967,15 +967,15 @@ public:
     //! Debug the memory used by the object.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
         mem->setName("CXMeansOnline");
-        core::CMemoryDebug::dynamicSize("m_ClusterIndexGenerator",
+        core::memory_debug::dynamicSize("m_ClusterIndexGenerator",
                                         m_ClusterIndexGenerator, mem);
-        core::CMemoryDebug::dynamicSize("m_Clusters", m_Clusters, mem);
+        core::memory_debug::dynamicSize("m_Clusters", m_Clusters, mem);
     }
 
     //! Get the memory used by the object.
     std::size_t memoryUsage() const override {
-        std::size_t mem = core::CMemory::dynamicSize(m_ClusterIndexGenerator);
-        mem += core::CMemory::dynamicSize(m_Clusters);
+        std::size_t mem = core::memory::dynamicSize(m_ClusterIndexGenerator);
+        mem += core::memory::dynamicSize(m_Clusters);
         return mem;
     }
 

--- a/include/maths/time_series/CTimeSeriesMultibucketFeatures.h
+++ b/include/maths/time_series/CTimeSeriesMultibucketFeatures.h
@@ -219,7 +219,7 @@ public:
     //! Debug the memory used by this object.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
         mem->setName("CTimeSeriesMultibucketMean");
-        core::CMemoryDebug::dynamicSize("m_SlidingWindow", m_SlidingWindow, mem);
+        core::memory_debug::dynamicSize("m_SlidingWindow", m_SlidingWindow, mem);
     }
 
     //! Get the static size of object.
@@ -227,7 +227,7 @@ public:
 
     //! Get the memory used by this object.
     std::size_t memoryUsage() const override {
-        return core::CMemory::dynamicSize(m_SlidingWindow);
+        return core::memory::dynamicSize(m_SlidingWindow);
     }
 
     //! Initialize reading state from \p traverser.

--- a/include/model/CBucketQueue.h
+++ b/include/model/CBucketQueue.h
@@ -164,12 +164,12 @@ public:
     //! Debug the memory used by this component.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CBucketQueue");
-        core::CMemoryDebug::dynamicSize("m_Queue", m_Queue, mem);
+        core::memory_debug::dynamicSize("m_Queue", m_Queue, mem);
     }
 
     //! Get the memory used by this component.
     std::size_t memoryUsage() const {
-        return core::CMemory::dynamicSize(m_Queue);
+        return core::memory::dynamicSize(m_Queue);
     }
 
     //! Prints the contents of the queue.

--- a/include/model/CMetricMultivariateStatistic.h
+++ b/include/model/CMetricMultivariateStatistic.h
@@ -41,8 +41,8 @@ namespace model {
 //!   -# Implementations for every function in CMetricStatisticsWrapper
 //!   -# Member operator +=
 //!   -# Supported by maths::common::CChecksum::calculate
-//!   -# Supported by core::CMemoryDebug::dynamicSize
-//!   -# Supported by core::CMemory::dynamicSize
+//!   -# Supported by core::memory_debug::dynamicSize
+//!   -# Supported by core::memory::dynamicSize
 //!   -# Have overload of operator<<
 template<class STATISTIC>
 class CMetricMultivariateStatistic {
@@ -147,12 +147,12 @@ public:
     //! Debug the memory used by the statistic.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CMetricPartialStatistic", sizeof(*this));
-        core::CMemoryDebug::dynamicSize("m_Value", m_Values, mem);
+        core::memory_debug::dynamicSize("m_Value", m_Values, mem);
     }
 
     //! Get the memory used by the statistic.
     std::size_t memoryUsage() const {
-        return sizeof(*this) + core::CMemory::dynamicSize(m_Values);
+        return sizeof(*this) + core::memory::dynamicSize(m_Values);
     }
 
 private:

--- a/include/model/CMetricPartialStatistic.h
+++ b/include/model/CMetricPartialStatistic.h
@@ -46,8 +46,8 @@ namespace model {
 //!   -# Implementations for every function in CMetricStatisticsWrapper
 //!   -# Member operator +=
 //!   -# Supported by maths::common::CChecksum::calculate
-//!   -# Supported by core::CMemoryDebug::dynamicSize
-//!   -# Supported by core::CMemory::dynamicSize
+//!   -# Supported by core::memory_debug::dynamicSize
+//!   -# Supported by core::memory::dynamicSize
 //!   -# Have overload of operator<<
 template<class STATISTIC>
 class CMetricPartialStatistic {
@@ -130,14 +130,14 @@ public:
     //! Debug the memory used by the statistic.
     inline void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CMetricPartialStatistic", sizeof(*this));
-        core::CMemoryDebug::dynamicSize("m_Value", m_Value, mem);
-        core::CMemoryDebug::dynamicSize("m_Time", m_Time, mem);
+        core::memory_debug::dynamicSize("m_Value", m_Value, mem);
+        core::memory_debug::dynamicSize("m_Time", m_Time, mem);
     }
 
     //! Get the memory used by the statistic.
     inline std::size_t memoryUsage() const {
-        return sizeof(*this) + core::CMemory::dynamicSize(m_Value) +
-               core::CMemory::dynamicSize(m_Time);
+        return sizeof(*this) + core::memory::dynamicSize(m_Value) +
+               core::memory::dynamicSize(m_Time);
     }
 
     //! Print partial statistic

--- a/include/model/CSampleGatherer.h
+++ b/include/model/CSampleGatherer.h
@@ -316,19 +316,19 @@ public:
     //! Debug the memory used by this gatherer.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CSampleGatherer", sizeof(*this));
-        core::CMemoryDebug::dynamicSize("m_SampleStats", m_SampleStats, mem);
-        core::CMemoryDebug::dynamicSize("m_BucketStats", m_BucketStats, mem);
-        core::CMemoryDebug::dynamicSize("m_InfluencerBucketStats",
+        core::memory_debug::dynamicSize("m_SampleStats", m_SampleStats, mem);
+        core::memory_debug::dynamicSize("m_BucketStats", m_BucketStats, mem);
+        core::memory_debug::dynamicSize("m_InfluencerBucketStats",
                                         m_InfluencerBucketStats, mem);
-        core::CMemoryDebug::dynamicSize("m_Samples", m_Samples, mem);
+        core::memory_debug::dynamicSize("m_Samples", m_Samples, mem);
     }
 
     //! Get the memory used by this gatherer.
     std::size_t memoryUsage() const {
-        return sizeof(*this) + core::CMemory::dynamicSize(m_SampleStats) +
-               core::CMemory::dynamicSize(m_BucketStats) +
-               core::CMemory::dynamicSize(m_InfluencerBucketStats) +
-               core::CMemory::dynamicSize(m_Samples);
+        return sizeof(*this) + core::memory::dynamicSize(m_SampleStats) +
+               core::memory::dynamicSize(m_BucketStats) +
+               core::memory::dynamicSize(m_InfluencerBucketStats) +
+               core::memory::dynamicSize(m_Samples);
     }
 
     //! Print this gatherer for debug.

--- a/include/model/CSampleQueue.h
+++ b/include/model/CSampleQueue.h
@@ -156,12 +156,12 @@ private:
         //! Debug the memory used by the sub-sample.
         void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
             mem->setName("SSubSample", sizeof(*this));
-            core::CMemoryDebug::dynamicSize("s_Statistic", s_Statistic, mem);
+            core::memory_debug::dynamicSize("s_Statistic", s_Statistic, mem);
         }
 
         //! Get the memory used by the sub-sample.
         std::size_t memoryUsage() const {
-            return sizeof(*this) + core::CMemory::dynamicSize(s_Statistic);
+            return sizeof(*this) + core::memory::dynamicSize(s_Statistic);
         }
 
         //! Print the sub-sample for debug.
@@ -344,12 +344,12 @@ public:
     //! Debug the memory used by the queue.
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CSampleQueue", sizeof(*this));
-        core::CMemoryDebug::dynamicSize("m_Queue", m_Queue, mem);
+        core::memory_debug::dynamicSize("m_Queue", m_Queue, mem);
     }
 
     //! Get the memory used by the queue.
     std::size_t memoryUsage() const {
-        return sizeof(*this) + core::CMemory::dynamicSize(m_Queue);
+        return sizeof(*this) + core::memory::dynamicSize(m_Queue);
     }
 
     //! Prints the contents of the queue.

--- a/include/model/CTokenListDataCategorizer.h
+++ b/include/model/CTokenListDataCategorizer.h
@@ -74,14 +74,14 @@ public:
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
         mem->setName("CTokenListDataCategorizer");
         this->CTokenListDataCategorizerBase::debugMemoryUsage(mem->addChild());
-        core::CMemoryDebug::dynamicSize("m_SimilarityTester", m_SimilarityTester, mem);
+        core::memory_debug::dynamicSize("m_SimilarityTester", m_SimilarityTester, mem);
     }
 
     //! Get the memory used by this categorizer.
     std::size_t memoryUsage() const override {
         std::size_t mem = 0;
         mem += this->CTokenListDataCategorizerBase::memoryUsage();
-        mem += core::CMemory::dynamicSize(m_SimilarityTester);
+        mem += core::memory::dynamicSize(m_SimilarityTester);
         return mem;
     }
 

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -350,7 +350,7 @@ CDataFrameTrainBoostedTreeClassifierRunner::inferenceModelMetadata() const {
     m_InferenceModelMetadata.numDataSummarizationRows(static_cast<std::size_t>(
         this->boostedTree().dataSummarization().manhattan()));
     m_InferenceModelMetadata.trainedModelMemoryUsage(
-        core::CMemory::dynamicSize(this->boostedTree().trainedModel()));
+        core::memory::dynamicSize(this->boostedTree().trainedModel()));
     return &m_InferenceModelMetadata;
 }
 

--- a/lib/core/CDataFrame.cc
+++ b/lib/core/CDataFrame.cc
@@ -468,13 +468,13 @@ const CDataFrame::TBoolVec& CDataFrame::columnIsCategorical() const {
 }
 
 std::size_t CDataFrame::memoryUsage() const {
-    std::size_t memory{CMemory::dynamicSize(m_ColumnNames)};
-    memory += CMemory::dynamicSize(m_CategoricalColumnValues);
-    memory += CMemory::dynamicSize(m_CategoricalColumnValueLookup);
-    memory += CMemory::dynamicSize(m_MissingString);
-    memory += CMemory::dynamicSize(m_ColumnIsCategorical);
-    memory += CMemory::dynamicSize(m_Slices);
-    memory += CMemory::dynamicSize(m_Writer);
+    std::size_t memory{memory::dynamicSize(m_ColumnNames)};
+    memory += memory::dynamicSize(m_CategoricalColumnValues);
+    memory += memory::dynamicSize(m_CategoricalColumnValueLookup);
+    memory += memory::dynamicSize(m_MissingString);
+    memory += memory::dynamicSize(m_ColumnIsCategorical);
+    memory += memory::dynamicSize(m_Slices);
+    memory += memory::dynamicSize(m_Writer);
     return memory;
 }
 
@@ -495,10 +495,10 @@ std::size_t CDataFrame::estimateMemoryUsage(bool inMainMemory,
                                             std::size_t numberRows,
                                             std::size_t numberColumns,
                                             CAlignment::EType alignment) {
-    return sizeof(CDataFrame) + core::CMemory::dynamicSize(TStrVec(numberColumns)) +
-           core::CMemory::dynamicSize(TStrVecVec(numberColumns)) +
-           core::CMemory::dynamicSize(TStrSizeUMapVec(numberColumns)) +
-           core::CMemory::dynamicSize(TBoolVec(numberColumns)) +
+    return sizeof(CDataFrame) + core::memory::dynamicSize(TStrVec(numberColumns)) +
+           core::memory::dynamicSize(TStrVecVec(numberColumns)) +
+           core::memory::dynamicSize(TStrSizeUMapVec(numberColumns)) +
+           core::memory::dynamicSize(TBoolVec(numberColumns)) +
            (inMainMemory ? numberRows * CAlignment::roundupSizeof<CFloatStorage>(alignment, numberColumns)
                          : 0);
     ;

--- a/lib/core/CDataFrameRowSlice.cc
+++ b/lib/core/CDataFrameRowSlice.cc
@@ -233,7 +233,7 @@ std::size_t CMainMemoryDataFrameRowSlice::staticSize() const {
 }
 
 std::size_t CMainMemoryDataFrameRowSlice::memoryUsage() const {
-    return CMemory::dynamicSize(m_Rows) + CMemory::dynamicSize(m_DocHashes);
+    return memory::dynamicSize(m_Rows) + memory::dynamicSize(m_DocHashes);
 }
 
 std::uint64_t CMainMemoryDataFrameRowSlice::checksum() const {
@@ -381,7 +381,7 @@ std::size_t COnDiskDataFrameRowSlice::staticSize() const {
 }
 
 std::size_t COnDiskDataFrameRowSlice::memoryUsage() const {
-    return CMemory::dynamicSize(m_Directory) + CMemory::dynamicSize(m_FileName.string());
+    return memory::dynamicSize(m_Directory) + memory::dynamicSize(m_FileName.string());
 }
 
 void COnDiskDataFrameRowSlice::writeToDisk(const TFloatVec& rows, const TInt32Vec& docHashes) {

--- a/lib/core/CMemoryDef.cc
+++ b/lib/core/CMemoryDef.cc
@@ -14,7 +14,7 @@
 
 namespace ml {
 namespace core {
-namespace CMemory {
+namespace memory {
 std::size_t dynamicSize(const std::string& t) {
     std::size_t capacity = t.capacity();
     // The different STLs we use on various platforms all have different
@@ -46,7 +46,7 @@ std::size_t dynamicSize(const std::any& t) {
 }
 }
 
-namespace CMemoryDebug {
+namespace memory_debug {
 
 void dynamicSize(const char* name, const std::string& t, const CMemoryUsage::TMemoryUsagePtr& mem) {
     std::string componentName(name);

--- a/lib/core/CPackedBitVector.cc
+++ b/lib/core/CPackedBitVector.cc
@@ -299,11 +299,11 @@ std::uint64_t CPackedBitVector::checksum() const {
 
 void CPackedBitVector::debugMemoryUsage(const CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CPackedBitVector");
-    CMemoryDebug::dynamicSize("m_RunLengths", m_RunLengthBytes, mem);
+    memory_debug::dynamicSize("m_RunLengths", m_RunLengthBytes, mem);
 }
 
 std::size_t CPackedBitVector::memoryUsage() const {
-    return CMemory::dynamicSize(m_RunLengthBytes);
+    return memory::dynamicSize(m_RunLengthBytes);
 }
 
 template<typename RUN_OP>

--- a/lib/core/CStoredStringPtr.cc
+++ b/lib/core/CStoredStringPtr.cc
@@ -85,7 +85,7 @@ bool CStoredStringPtr::operator<(const CStoredStringPtr& rhs) const noexcept {
 std::size_t CStoredStringPtr::actualMemoryUsage() const {
     // We convert to a raw pointer here to avoid the "divide by use count"
     // feature of CMemory's shared_ptr handling
-    return CMemory::dynamicSize(m_String.get());
+    return memory::dynamicSize(m_String.get());
 }
 
 void CStoredStringPtr::debugActualMemoryUsage(const CMemoryUsage::TMemoryUsagePtr& mem) const {

--- a/lib/core/CStringSimilarityTester.cc
+++ b/lib/core/CStringSimilarityTester.cc
@@ -141,12 +141,12 @@ int** CStringSimilarityTester::setupBerghelRoachMatrix(int maxDist,
 
 void CStringSimilarityTester::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CStringSimilarityTester");
-    core::CMemoryDebug::dynamicSize("m_Compressor", m_Compressor, mem);
+    core::memory_debug::dynamicSize("m_Compressor", m_Compressor, mem);
 }
 
 std::size_t CStringSimilarityTester::memoryUsage() const {
     std::size_t mem = 0;
-    mem += core::CMemory::dynamicSize(m_Compressor);
+    mem += core::memory::dynamicSize(m_Compressor);
     return mem;
 }
 }

--- a/lib/core/CompressUtils.cc
+++ b/lib/core/CompressUtils.cc
@@ -143,7 +143,7 @@ bool CCompressUtil::prepareToReturnData(bool finish) {
 
 void CCompressUtil::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCompressUtil");
-    core::CMemoryDebug::dynamicSize("m_FullResult", m_FullResult, mem);
+    core::memory_debug::dynamicSize("m_FullResult", m_FullResult, mem);
     if (m_ZlibStrm.state != nullptr) {
         mem->addItem("m_ZlibStrm", ZLIB_INTERNAL_STATE_SIZE);
     }
@@ -151,7 +151,7 @@ void CCompressUtil::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& 
 
 std::size_t CCompressUtil::memoryUsage() const {
     std::size_t mem = 0;
-    mem += core::CMemory::dynamicSize(m_FullResult);
+    mem += core::memory::dynamicSize(m_FullResult);
     if (m_ZlibStrm.state != nullptr) {
         mem += ZLIB_INTERNAL_STATE_SIZE;
     }

--- a/lib/core/unittest/CCompressedLfuCacheTest.cc
+++ b/lib/core/unittest/CCompressedLfuCacheTest.cc
@@ -42,7 +42,7 @@ public:
     explicit CTestValue(std::size_t size) { m_Buffer.reserve(size); }
 
     std::size_t memoryUsage() const {
-        return core::CMemory::dynamicSize(m_Buffer);
+        return core::memory::dynamicSize(m_Buffer);
     }
 
 private:

--- a/lib/core/unittest/CMemoryUsageTest.cc
+++ b/lib/core/unittest/CMemoryUsageTest.cc
@@ -88,7 +88,7 @@ struct SFooWithMemoryUsage {
 
 struct SFooWrapper {
     std::size_t memoryUsage() const {
-        std::size_t mem = core::CMemory::dynamicSize(s_Foo);
+        std::size_t mem = core::memory::dynamicSize(s_Foo);
         return mem;
     }
     SFooWithMemoryUsage s_Foo;
@@ -120,7 +120,7 @@ struct SBarDebug {
 
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("SBarDebug", 0);
-        core::CMemoryDebug::dynamicSize("s_State", s_State, mem);
+        core::memory_debug::dynamicSize("s_State", s_State, mem);
     }
 
     std::size_t s_Key;
@@ -138,12 +138,12 @@ struct SBarVectorDebug {
         return s_Key == rhs.s_Key;
     }
     std::size_t memoryUsage() const {
-        return core::CMemory::dynamicSize(s_State);
+        return core::memory::dynamicSize(s_State);
     }
 
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("SBarVectorDebug", 0);
-        core::CMemoryDebug::dynamicSize("s_State", s_State, mem);
+        core::memory_debug::dynamicSize("s_State", s_State, mem);
     }
 
     std::size_t s_Key;
@@ -165,12 +165,12 @@ public:
     virtual ~CBase() = default;
 
     virtual std::size_t memoryUsage() const {
-        return core::CMemory::dynamicSize(m_Vec);
+        return core::memory::dynamicSize(m_Vec);
     }
 
     virtual void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
         mem->setName("CBase", 0);
-        core::CMemoryDebug::dynamicSize("m_Vec", m_Vec, mem);
+        core::memory_debug::dynamicSize("m_Vec", m_Vec, mem);
     }
 
     virtual std::size_t staticSize() const { return sizeof(*this); }
@@ -190,14 +190,14 @@ public:
     ~CDerived() override = default;
 
     std::size_t memoryUsage() const override {
-        std::size_t mem = core::CMemory::dynamicSize(m_Strings);
+        std::size_t mem = core::memory::dynamicSize(m_Strings);
         mem += this->CBase::memoryUsage();
         return mem;
     }
 
     void debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const override {
         mem->setName("CDerived", 0);
-        core::CMemoryDebug::dynamicSize("m_Strings", m_Strings, mem);
+        core::memory_debug::dynamicSize("m_Strings", m_Strings, mem);
         this->CBase::debugMemoryUsage(mem->addChild());
     }
 
@@ -314,9 +314,9 @@ BOOST_AUTO_TEST_CASE(testUsage) {
     // Check std::unique_ptr behaves as expected.
 
     {
-        BOOST_REQUIRE_EQUAL(0, core::CMemory::dynamicSize(TDoubleUPtr{}));
+        BOOST_REQUIRE_EQUAL(0, core::memory::dynamicSize(TDoubleUPtr{}));
         BOOST_REQUIRE_EQUAL(sizeof(double),
-                            core::CMemory::dynamicSize(std::make_unique<double>(1.0)));
+                            core::memory::dynamicSize(std::make_unique<double>(1.0)));
     }
 
     // Check that containers of containers work as expected.
@@ -325,10 +325,10 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         TDoubleVecVec v1{{}, {}, {}};
         TDoubleVecVec v2{{1.0}, {2.0, 2.0}, {3.0, 3.0, 3.0}};
 
-        std::size_t actualMemoryUsage{core::CMemory::dynamicSize(v2)};
+        std::size_t actualMemoryUsage{core::memory::dynamicSize(v2)};
         std::size_t expectedMemoryUsage{
-            core::CMemory::dynamicSize(v1) + core::CMemory::dynamicSize(v2[0]) +
-            core::CMemory::dynamicSize(v2[1]) + core::CMemory::dynamicSize(v2[2])};
+            core::memory::dynamicSize(v1) + core::memory::dynamicSize(v2[0]) +
+            core::memory::dynamicSize(v2[1]) + core::memory::dynamicSize(v2[2])};
 
         LOG_DEBUG(<< "*** TDoubleVecVec ***");
         LOG_DEBUG(<< "expected = " << expectedMemoryUsage);
@@ -343,10 +343,10 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         TDoubleVec v3{3.0, 3.0, 3.0};
         TDoubleVecMultiset s2{v1, v2, v3};
 
-        std::size_t actualMemoryUsage{core::CMemory::dynamicSize(s2)};
+        std::size_t actualMemoryUsage{core::memory::dynamicSize(s2)};
         std::size_t expectedMemoryUsage{
-            core::CMemory::dynamicSize(s1) + core::CMemory::dynamicSize(v1) +
-            core::CMemory::dynamicSize(v2) + core::CMemory::dynamicSize(v3)};
+            core::memory::dynamicSize(s1) + core::memory::dynamicSize(v1) +
+            core::memory::dynamicSize(v2) + core::memory::dynamicSize(v3)};
 
         LOG_DEBUG(<< "*** TDoubleVecMultiset ***");
         LOG_DEBUG(<< "expected = " << expectedMemoryUsage);
@@ -361,10 +361,10 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         TDoubleVec v3{3.0, 3.0, 3.0};
         TDoubleDoubleVecMap m2{{1.0, v1}, {2.0, v2}, {3.0, v3}};
 
-        std::size_t actualMemoryUsage{core::CMemory::dynamicSize(m2)};
+        std::size_t actualMemoryUsage{core::memory::dynamicSize(m2)};
         std::size_t expectedMemoryUsage{
-            core::CMemory::dynamicSize(m1) + core::CMemory::dynamicSize(v1) +
-            core::CMemory::dynamicSize(v2) + core::CMemory::dynamicSize(v3)};
+            core::memory::dynamicSize(m1) + core::memory::dynamicSize(v1) +
+            core::memory::dynamicSize(v2) + core::memory::dynamicSize(v3)};
 
         LOG_DEBUG(<< "*** TDoubleDoubleVecMap ***");
         LOG_DEBUG(<< "expected = " << expectedMemoryUsage);
@@ -379,10 +379,10 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         TDoubleVec v3{3.0, 3.0, 3.0};
         TDoubleDoubleVecMultimap m2{{1.0, v1}, {2.0, v2}, {3.0, v3}};
 
-        std::size_t actualMemoryUsage{core::CMemory::dynamicSize(m2)};
+        std::size_t actualMemoryUsage{core::memory::dynamicSize(m2)};
         std::size_t expectedMemoryUsage{
-            core::CMemory::dynamicSize(m1) + core::CMemory::dynamicSize(v1) +
-            core::CMemory::dynamicSize(v2) + core::CMemory::dynamicSize(v3)};
+            core::memory::dynamicSize(m1) + core::memory::dynamicSize(v1) +
+            core::memory::dynamicSize(v2) + core::memory::dynamicSize(v3)};
 
         LOG_DEBUG(<< "*** TDoubleDoubleVecMap ***");
         LOG_DEBUG(<< "expected = " << expectedMemoryUsage);
@@ -404,33 +404,33 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         TFooWithMemoryVec foosWithMemory(10);
 
         LOG_DEBUG(<< "*** TFooVec ***");
-        LOG_DEBUG(<< "dynamicSize(foos)           = " << core::CMemory::dynamicSize(foos));
+        LOG_DEBUG(<< "dynamicSize(foos)           = " << core::memory::dynamicSize(foos));
         LOG_DEBUG(<< "dynamicSize(foosWithMemory) = "
-                  << core::CMemory::dynamicSize(foosWithMemory));
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(foos),
-                            core::CMemory::dynamicSize(foosWithMemory));
+                  << core::memory::dynamicSize(foosWithMemory));
+        BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(foos),
+                            core::memory::dynamicSize(foosWithMemory));
     }
     {
         TFooList foos(10);
         TFooWithMemoryList foosWithMemory(10);
 
         LOG_DEBUG(<< "*** TFooList ***");
-        LOG_DEBUG(<< "dynamicSize(foos)           = " << core::CMemory::dynamicSize(foos));
+        LOG_DEBUG(<< "dynamicSize(foos)           = " << core::memory::dynamicSize(foos));
         LOG_DEBUG(<< "dynamicSize(foosWithMemory) = "
-                  << core::CMemory::dynamicSize(foosWithMemory));
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(foos),
-                            core::CMemory::dynamicSize(foosWithMemory));
+                  << core::memory::dynamicSize(foosWithMemory));
+        BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(foos),
+                            core::memory::dynamicSize(foosWithMemory));
     }
     {
         TFooDeque foos(10);
         TFooWithMemoryDeque foosWithMemory(10);
 
         LOG_DEBUG(<< "*** TFooDeque ***");
-        LOG_DEBUG(<< "dynamicSize(foos)           = " << core::CMemory::dynamicSize(foos));
+        LOG_DEBUG(<< "dynamicSize(foos)           = " << core::memory::dynamicSize(foos));
         LOG_DEBUG(<< "dynamicSize(foosWithMemory) = "
-                  << core::CMemory::dynamicSize(foosWithMemory));
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(foos),
-                            core::CMemory::dynamicSize(foosWithMemory));
+                  << core::memory::dynamicSize(foosWithMemory));
+        BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(foos),
+                            core::memory::dynamicSize(foosWithMemory));
     }
     {
         TFooCircBuf foos(10);
@@ -439,11 +439,11 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         foosWithMemory.resize(5);
 
         LOG_DEBUG(<< "*** TFooCircBuf ***");
-        LOG_DEBUG(<< "dynamicSize(foos)           = " << core::CMemory::dynamicSize(foos));
+        LOG_DEBUG(<< "dynamicSize(foos)           = " << core::memory::dynamicSize(foos));
         LOG_DEBUG(<< "dynamicSize(foosWithMemory) = "
-                  << core::CMemory::dynamicSize(foosWithMemory));
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(foos),
-                            core::CMemory::dynamicSize(foosWithMemory));
+                  << core::memory::dynamicSize(foosWithMemory));
+        BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(foos),
+                            core::memory::dynamicSize(foosWithMemory));
     }
     {
         TFooFooMap foos;
@@ -455,11 +455,11 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         }
 
         LOG_DEBUG(<< "*** TFooFooMap ***");
-        LOG_DEBUG(<< "dynamicSize(foos)           = " << core::CMemory::dynamicSize(foos));
+        LOG_DEBUG(<< "dynamicSize(foos)           = " << core::memory::dynamicSize(foos));
         LOG_DEBUG(<< "dynamicSize(foosWithMemory) = "
-                  << core::CMemory::dynamicSize(foosWithMemory));
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(foos),
-                            core::CMemory::dynamicSize(foosWithMemory));
+                  << core::memory::dynamicSize(foosWithMemory));
+        BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(foos),
+                            core::memory::dynamicSize(foosWithMemory));
     }
     {
         TFooFooUMap foos;
@@ -471,11 +471,11 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         }
 
         LOG_DEBUG(<< "*** TFooFooUMap ***");
-        LOG_DEBUG(<< "dynamicSize(foos)           = " << core::CMemory::dynamicSize(foos));
+        LOG_DEBUG(<< "dynamicSize(foos)           = " << core::memory::dynamicSize(foos));
         LOG_DEBUG(<< "dynamicSize(foosWithMemory) = "
-                  << core::CMemory::dynamicSize(foosWithMemory));
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(foos),
-                            core::CMemory::dynamicSize(foosWithMemory));
+                  << core::memory::dynamicSize(foosWithMemory));
+        BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(foos),
+                            core::memory::dynamicSize(foosWithMemory));
     }
     {
         TFooFSet foos;
@@ -485,8 +485,8 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         }
 
         LOG_DEBUG(<< "*** TFooFSet ***");
-        LOG_DEBUG(<< "dynamicSize(foos)           = " << core::CMemory::dynamicSize(foos));
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(foos),
+        LOG_DEBUG(<< "dynamicSize(foos)           = " << core::memory::dynamicSize(foos));
+        BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(foos),
                             foos.capacity() * sizeof(SFoo));
     }
 
@@ -517,14 +517,14 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         state22.resize(2);
 
         LOG_DEBUG(<< "*** TBarVec ***");
-        LOG_DEBUG(<< "dynamic size = " << core::CMemory::dynamicSize(bars1));
+        LOG_DEBUG(<< "dynamic size = " << core::memory::dynamicSize(bars1));
         LOG_DEBUG(<< "expected dynamic size = "
-                  << core::CMemory::dynamicSize(bars2) + core::CMemory::dynamicSize(state21) +
-                         core::CMemory::dynamicSize(state22));
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(bars1),
-                            core::CMemory::dynamicSize(bars2) +
-                                core::CMemory::dynamicSize(state21) +
-                                core::CMemory::dynamicSize(state22));
+                  << core::memory::dynamicSize(bars2) + core::memory::dynamicSize(state21) +
+                         core::memory::dynamicSize(state22));
+        BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(bars1),
+                            core::memory::dynamicSize(bars2) +
+                                core::memory::dynamicSize(state21) +
+                                core::memory::dynamicSize(state22));
     }
     {
         SBar key;
@@ -539,14 +539,14 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         bars2[SBar()] = SBar();
 
         LOG_DEBUG(<< "*** TBarBarMap ***");
-        LOG_DEBUG(<< "dynamic size = " << core::CMemory::dynamicSize(bars1));
+        LOG_DEBUG(<< "dynamic size = " << core::memory::dynamicSize(bars1));
         LOG_DEBUG(<< "expected dynamic size = "
-                  << core::CMemory::dynamicSize(bars2) + core::CMemory::dynamicSize(key) +
-                         core::CMemory::dynamicSize(value));
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(bars1),
-                            core::CMemory::dynamicSize(bars2) +
-                                core::CMemory::dynamicSize(key) +
-                                core::CMemory::dynamicSize(value));
+                  << core::memory::dynamicSize(bars2) + core::memory::dynamicSize(key) +
+                         core::memory::dynamicSize(value));
+        BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(bars1),
+                            core::memory::dynamicSize(bars2) +
+                                core::memory::dynamicSize(key) +
+                                core::memory::dynamicSize(value));
     }
     {
         SBar key;
@@ -561,14 +561,14 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         bars2[SBar()] = SBar();
 
         LOG_DEBUG(<< "*** TBarBarUMap ***");
-        LOG_DEBUG(<< "dynamic size = " << core::CMemory::dynamicSize(bars1));
+        LOG_DEBUG(<< "dynamic size = " << core::memory::dynamicSize(bars1));
         LOG_DEBUG(<< "expected dynamic size = "
-                  << core::CMemory::dynamicSize(bars2) + core::CMemory::dynamicSize(key) +
-                         core::CMemory::dynamicSize(value));
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(bars1),
-                            core::CMemory::dynamicSize(bars2) +
-                                core::CMemory::dynamicSize(key) +
-                                core::CMemory::dynamicSize(value));
+                  << core::memory::dynamicSize(bars2) + core::memory::dynamicSize(key) +
+                         core::memory::dynamicSize(value));
+        BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(bars1),
+                            core::memory::dynamicSize(bars2) +
+                                core::memory::dynamicSize(key) +
+                                core::memory::dynamicSize(value));
     }
     {
         SBar key;
@@ -578,7 +578,7 @@ BOOST_AUTO_TEST_CASE(testUsage) {
 
         TBarBarFMap bars1;
         bars1.reserve(4);
-        BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(bars1) > 4 * sizeof(SBar));
+        BOOST_TEST_REQUIRE(core::memory::dynamicSize(bars1) > 4 * sizeof(SBar));
 
         bars1[key] = value;
 
@@ -587,14 +587,14 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         bars2[SBar()] = SBar();
 
         LOG_DEBUG(<< "*** TBarBarFMap ***");
-        LOG_DEBUG(<< "dynamic size = " << core::CMemory::dynamicSize(bars1));
+        LOG_DEBUG(<< "dynamic size = " << core::memory::dynamicSize(bars1));
         LOG_DEBUG(<< "expected dynamic size = "
-                  << core::CMemory::dynamicSize(bars2) + core::CMemory::dynamicSize(key) +
-                         core::CMemory::dynamicSize(value));
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(bars1),
-                            core::CMemory::dynamicSize(bars2) +
-                                core::CMemory::dynamicSize(key) +
-                                core::CMemory::dynamicSize(value));
+                  << core::memory::dynamicSize(bars2) + core::memory::dynamicSize(key) +
+                         core::memory::dynamicSize(value));
+        BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(bars1),
+                            core::memory::dynamicSize(bars2) +
+                                core::memory::dynamicSize(key) +
+                                core::memory::dynamicSize(value));
     }
     {
         SBar value;
@@ -603,10 +603,10 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         TBarPtr pointer(new SBar(value));
 
         LOG_DEBUG(<< "*** TBarPtr ***");
-        LOG_DEBUG(<< "dynamic size = " << core::CMemory::dynamicSize(pointer));
+        LOG_DEBUG(<< "dynamic size = " << core::memory::dynamicSize(pointer));
         LOG_DEBUG(<< "expected dynamic size = "
                   << sizeof(SBar) + sizeof(SFoo) * value.s_State.capacity());
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(pointer),
+        BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(pointer),
                             sizeof(long) + sizeof(SBar) +
                                 sizeof(SFoo) * value.s_State.capacity());
     }
@@ -620,31 +620,31 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         variables.push_back(a);
         variables.push_back(b);
 
-        LOG_DEBUG(<< "wrong dynamic size = " << core::CMemory::dynamicSize(variables));
+        LOG_DEBUG(<< "wrong dynamic size = " << core::memory::dynamicSize(variables));
         BOOST_REQUIRE_EQUAL(variables.capacity() * sizeof(std::any),
-                            core::CMemory::dynamicSize(variables));
+                            core::memory::dynamicSize(variables));
 
-        auto& visitor = core::CMemory::anyVisitor();
+        auto& visitor = core::memory::anyVisitor();
         visitor.registerCallback<TDoubleVec>();
         visitor.registerCallback<TFooVec>();
 
-        LOG_DEBUG(<< "dynamic size = " << core::CMemory::dynamicSize(variables));
+        LOG_DEBUG(<< "dynamic size = " << core::memory::dynamicSize(variables));
         LOG_DEBUG(<< "expected dynamic size = "
                   << variables.capacity() * sizeof(std::any) + sizeof(a) +
-                         core::CMemory::dynamicSize(a) + sizeof(b) +
-                         core::CMemory::dynamicSize(b));
+                         core::memory::dynamicSize(a) + sizeof(b) +
+                         core::memory::dynamicSize(b));
         BOOST_REQUIRE_EQUAL(variables.capacity() * sizeof(std::any) +
-                                sizeof(a) + core::CMemory::dynamicSize(a) +
-                                sizeof(b) + core::CMemory::dynamicSize(b),
-                            core::CMemory::dynamicSize(variables));
+                                sizeof(a) + core::memory::dynamicSize(a) +
+                                sizeof(b) + core::memory::dynamicSize(b),
+                            core::memory::dynamicSize(variables));
 
-        auto& debugVisitor = core::CMemoryDebug::anyVisitor();
+        auto& debugVisitor = core::memory_debug::anyVisitor();
         debugVisitor.registerCallback<TDoubleVec>();
         debugVisitor.registerCallback<TFooVec>();
 
         auto mem = std::make_shared<core::CMemoryUsage>();
-        core::CMemoryDebug::dynamicSize("", variables, mem);
-        BOOST_REQUIRE_EQUAL(mem->usage(), core::CMemory::dynamicSize(variables));
+        core::memory_debug::dynamicSize("", variables, mem);
+        BOOST_REQUIRE_EQUAL(mem->usage(), core::memory::dynamicSize(variables));
         std::ostringstream ss;
         mem->print(ss);
         LOG_DEBUG(<< ss.str());
@@ -654,48 +654,48 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         CBase* derived = new CDerived(10);
         {
             auto mem = std::make_shared<core::CMemoryUsage>();
-            core::CMemoryDebug::dynamicSize("", *base, mem);
-            BOOST_REQUIRE_EQUAL(mem->usage(), core::CMemory::dynamicSize(*base));
+            core::memory_debug::dynamicSize("", *base, mem);
+            BOOST_REQUIRE_EQUAL(mem->usage(), core::memory::dynamicSize(*base));
             std::ostringstream ss;
             mem->print(ss);
             LOG_TRACE(<< ss.str());
         }
         {
             auto mem = std::make_shared<core::CMemoryUsage>();
-            core::CMemoryDebug::dynamicSize("", *derived, mem);
-            BOOST_REQUIRE_EQUAL(mem->usage(), core::CMemory::dynamicSize(*derived));
+            core::memory_debug::dynamicSize("", *derived, mem);
+            BOOST_REQUIRE_EQUAL(mem->usage(), core::memory::dynamicSize(*derived));
             std::ostringstream ss;
             mem->print(ss);
             LOG_TRACE(<< ss.str());
         }
-        BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(*base) <
-                           core::CMemory::dynamicSize(*derived));
+        BOOST_TEST_REQUIRE(core::memory::dynamicSize(*base) <
+                           core::memory::dynamicSize(*derived));
 
         TBasePtr sharedBase(new CBase(10));
         TBasePtr sharedDerived(new CDerived(10));
         {
             auto mem = std::make_shared<core::CMemoryUsage>();
-            core::CMemoryDebug::dynamicSize("", sharedBase, mem);
-            BOOST_REQUIRE_EQUAL(mem->usage(), core::CMemory::dynamicSize(sharedBase));
+            core::memory_debug::dynamicSize("", sharedBase, mem);
+            BOOST_REQUIRE_EQUAL(mem->usage(), core::memory::dynamicSize(sharedBase));
             std::ostringstream ss;
             mem->print(ss);
             LOG_TRACE(<< ss.str());
         }
         {
             auto mem = std::make_shared<core::CMemoryUsage>();
-            core::CMemoryDebug::dynamicSize("", sharedDerived, mem);
-            BOOST_REQUIRE_EQUAL(mem->usage(), core::CMemory::dynamicSize(sharedDerived));
+            core::memory_debug::dynamicSize("", sharedDerived, mem);
+            BOOST_REQUIRE_EQUAL(mem->usage(), core::memory::dynamicSize(sharedDerived));
             std::ostringstream ss;
             mem->print(ss);
             LOG_TRACE(<< ss.str());
         }
         // boost:reference_wrapper should give zero
         std::reference_wrapper<CBase> baseRef(std::ref(*base));
-        BOOST_REQUIRE_EQUAL(0, core::CMemory::dynamicSize(baseRef));
+        BOOST_REQUIRE_EQUAL(0, core::memory::dynamicSize(baseRef));
         {
             auto mem = std::make_shared<core::CMemoryUsage>();
-            core::CMemoryDebug::dynamicSize("", baseRef, mem);
-            BOOST_REQUIRE_EQUAL(mem->usage(), core::CMemory::dynamicSize(baseRef));
+            core::memory_debug::dynamicSize("", baseRef, mem);
+            BOOST_REQUIRE_EQUAL(mem->usage(), core::memory::dynamicSize(baseRef));
             std::ostringstream ss;
             mem->print(ss);
             LOG_TRACE(<< ss.str());
@@ -703,26 +703,26 @@ BOOST_AUTO_TEST_CASE(testUsage) {
     }
     {
         CBase base(5);
-        BOOST_REQUIRE_EQUAL(base.memoryUsage(), core::CMemory::dynamicSize(base));
+        BOOST_REQUIRE_EQUAL(base.memoryUsage(), core::memory::dynamicSize(base));
 
         CBase* basePtr = new CBase(5);
         BOOST_REQUIRE_EQUAL(basePtr->memoryUsage() + sizeof(*basePtr),
-                            core::CMemory::dynamicSize(basePtr));
+                            core::memory::dynamicSize(basePtr));
 
         CDerived derived(6);
-        BOOST_REQUIRE_EQUAL(derived.memoryUsage(), core::CMemory::dynamicSize(derived));
+        BOOST_REQUIRE_EQUAL(derived.memoryUsage(), core::memory::dynamicSize(derived));
 
         CDerived* derivedPtr = new CDerived(5);
         BOOST_REQUIRE_EQUAL(derivedPtr->memoryUsage() + sizeof(*derivedPtr),
-                            core::CMemory::dynamicSize(derivedPtr));
+                            core::memory::dynamicSize(derivedPtr));
 
         CBase* basederivedPtr = new CDerived(5);
         BOOST_REQUIRE_EQUAL(basederivedPtr->memoryUsage() + sizeof(CDerived),
-                            core::CMemory::dynamicSize(basederivedPtr));
+                            core::memory::dynamicSize(basederivedPtr));
 
         TBasePtr sPtr(new CDerived(6));
         BOOST_REQUIRE_EQUAL(sPtr->memoryUsage() + sizeof(long) + sizeof(CDerived),
-                            core::CMemory::dynamicSize(sPtr));
+                            core::memory::dynamicSize(sPtr));
     }
     {
         TDerivedVec vec;
@@ -733,7 +733,7 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         vec.push_back(CDerived(7));
         vec.push_back(CDerived(9));
         vec.push_back(CDerived(12));
-        std::size_t total = core::CMemory::dynamicSize(vec);
+        std::size_t total = core::memory::dynamicSize(vec);
         std::size_t calc = vec.capacity() * sizeof(CDerived);
         for (std::size_t i = 0; i < vec.size(); ++i) {
             calc += vec[i].memoryUsage();
@@ -750,7 +750,7 @@ BOOST_AUTO_TEST_CASE(testUsage) {
         vec.push_back(TBasePtr(new CBase(2)));
         vec.push_back(TBasePtr(new CDerived(44)));
 
-        std::size_t total = core::CMemory::dynamicSize(vec);
+        std::size_t total = core::memory::dynamicSize(vec);
         std::size_t calc = vec.capacity() * sizeof(TBasePtr);
         for (std::size_t i = 0; i < 6; ++i) {
             calc += sizeof(long);
@@ -812,13 +812,13 @@ BOOST_AUTO_TEST_CASE(testDebug) {
 
         core::CMemoryUsage memoryUsage;
         memoryUsage.setName("test", 0);
-        core::CMemoryDebug::dynamicSize("TBarVecPtr", t, memoryUsage.addChild());
+        core::memory_debug::dynamicSize("TBarVecPtr", t, memoryUsage.addChild());
         std::ostringstream ss;
         memoryUsage.print(ss);
-        LOG_TRACE(<< "TBarVecPtr usage: " << core::CMemory::dynamicSize(t)
+        LOG_TRACE(<< "TBarVecPtr usage: " << core::memory::dynamicSize(t)
                   << ", debug: " << memoryUsage.usage());
         LOG_TRACE(<< ss.str());
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(t), memoryUsage.usage());
+        BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(t), memoryUsage.usage());
     }
     {
         using TFeatureBarVecPtrPr = std::pair<EFeature, TBarVecPtr>;
@@ -842,13 +842,13 @@ BOOST_AUTO_TEST_CASE(testDebug) {
                                         TBarVecPtr()));
         core::CMemoryUsage memoryUsage;
         memoryUsage.setName("test", 0);
-        core::CMemoryDebug::dynamicSize("TFeatureBarVecPtrPrVec", t, memoryUsage.addChild());
+        core::memory_debug::dynamicSize("TFeatureBarVecPtrPrVec", t, memoryUsage.addChild());
         std::ostringstream ss;
         memoryUsage.print(ss);
-        LOG_TRACE(<< "TFeatureBarVecPtrPrVec usage: " << core::CMemory::dynamicSize(t)
+        LOG_TRACE(<< "TFeatureBarVecPtrPrVec usage: " << core::memory::dynamicSize(t)
                   << ", debug: " << memoryUsage.usage());
         LOG_TRACE(<< ss.str());
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(t), memoryUsage.usage());
+        BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(t), memoryUsage.usage());
     }
 }
 
@@ -1121,9 +1121,9 @@ BOOST_AUTO_TEST_CASE(testStringMemory) {
             trackingString.push_back(static_cast<char>('a' + j));
             normalString.push_back(static_cast<char>('a' + j));
         }
-        LOG_TRACE(<< "String size " << core::CMemory::dynamicSize(normalString)
+        LOG_TRACE(<< "String size " << core::memory::dynamicSize(normalString)
                   << ", allocated " << TAllocator::usage());
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(normalString), TAllocator::usage());
+        BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(normalString), TAllocator::usage());
     }
 }
 
@@ -1172,8 +1172,8 @@ BOOST_AUTO_TEST_CASE(testSharedPointer) {
     LOG_DEBUG(<< "IntVec size: " << sizeof(TIntVec));
     LOG_DEBUG(<< "int size: " << sizeof(int));
 
-    LOG_DEBUG(<< "vec1 size: " << core::CMemory::dynamicSize(vec1));
-    LOG_DEBUG(<< "vec2 size: " << core::CMemory::dynamicSize(vec2));
+    LOG_DEBUG(<< "vec1 size: " << core::memory::dynamicSize(vec1));
+    LOG_DEBUG(<< "vec2 size: " << core::memory::dynamicSize(vec2));
 
     // shared_ptr size is 16
     // intvec size is 24
@@ -1194,10 +1194,10 @@ BOOST_AUTO_TEST_CASE(testSharedPointer) {
         (vec1[0]->capacity() + vec1[1]->capacity() + vec1[3]->capacity()) * sizeof(int);
 
     LOG_DEBUG(<< "Expected: " << expectedSize << ", actual: "
-              << (core::CMemory::dynamicSize(vec1) + core::CMemory::dynamicSize(vec2)));
+              << (core::memory::dynamicSize(vec1) + core::memory::dynamicSize(vec2)));
 
-    BOOST_REQUIRE_EQUAL(expectedSize, core::CMemory::dynamicSize(vec1) +
-                                          core::CMemory::dynamicSize(vec2));
+    BOOST_REQUIRE_EQUAL(expectedSize, core::memory::dynamicSize(vec1) +
+                                          core::memory::dynamicSize(vec2));
 
     TStrPtrVec svec1;
     svec1.push_back(TStrPtr(new std::string("This is a string")));
@@ -1210,33 +1210,32 @@ BOOST_AUTO_TEST_CASE(testSharedPointer) {
     svec2.push_back(TStrPtr());
     svec2.push_back(TStrPtr());
 
-    long stringSizeBefore = core::CMemory::dynamicSize(svec1) +
-                            core::CMemory::dynamicSize(svec2);
+    long stringSizeBefore = core::memory::dynamicSize(svec1) +
+                            core::memory::dynamicSize(svec2);
 
     svec2[0] = svec1[2];
     svec2[1] = svec1[0];
     svec2[2] = svec1[1];
 
-    long stringSizeAfter = core::CMemory::dynamicSize(svec1) +
-                           core::CMemory::dynamicSize(svec2);
+    long stringSizeAfter = core::memory::dynamicSize(svec1) +
+                           core::memory::dynamicSize(svec2);
 
-    BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(svec1),
-                        core::CMemory::dynamicSize(svec2));
+    BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(svec1), core::memory::dynamicSize(svec2));
     // Allow for integer rounding off by 1 for each string
     BOOST_TEST_REQUIRE(std::abs(stringSizeBefore - stringSizeAfter) < 4);
 }
 
 BOOST_AUTO_TEST_CASE(testRawPointer) {
     std::string* strPtr = nullptr;
-    BOOST_REQUIRE_EQUAL(0, core::CMemory::dynamicSize(strPtr));
+    BOOST_REQUIRE_EQUAL(0, core::memory::dynamicSize(strPtr));
 
     std::string foo = "abcdefghijklmnopqrstuvwxyz";
-    std::size_t fooMem = core::CMemory::dynamicSize(foo);
+    std::size_t fooMem = core::memory::dynamicSize(foo);
     // We will not normally have a raw pointer on stack memory,
     // but we do so here for testing purposes.
     strPtr = &foo;
 
-    BOOST_REQUIRE_EQUAL(fooMem + sizeof(std::string), core::CMemory::dynamicSize(strPtr));
+    BOOST_REQUIRE_EQUAL(fooMem + sizeof(std::string), core::memory::dynamicSize(strPtr));
 }
 
 BOOST_AUTO_TEST_CASE(testSmallVector) {
@@ -1253,8 +1252,8 @@ BOOST_AUTO_TEST_CASE(testSmallVector) {
         TDouble1Vec vec1(size);
         TDouble6Vec vec2(size);
         TDouble9Vec vec3(size);
-        TSizeVec memory{core::CMemory::dynamicSize(vec1), core::CMemory::dynamicSize(vec2),
-                        core::CMemory::dynamicSize(vec3)};
+        TSizeVec memory{core::memory::dynamicSize(vec1), core::memory::dynamicSize(vec2),
+                        core::memory::dynamicSize(vec3)};
         // These assertions hold because the vectors never shrink
         if (size <= 2) {
             BOOST_TEST_REQUIRE(memory[0] == 0);
@@ -1272,22 +1271,22 @@ BOOST_AUTO_TEST_CASE(testSmallVector) {
 
     // Test growing and shrinking
     TDouble6Vec growShrink;
-    std::size_t extraMem{core::CMemory::dynamicSize(growShrink)};
+    std::size_t extraMem{core::memory::dynamicSize(growShrink)};
     BOOST_REQUIRE_EQUAL(0, extraMem);
     growShrink.resize(6);
-    extraMem = core::CMemory::dynamicSize(growShrink);
+    extraMem = core::memory::dynamicSize(growShrink);
     BOOST_REQUIRE_EQUAL(0, extraMem);
     growShrink.resize(10);
-    extraMem = core::CMemory::dynamicSize(growShrink);
+    extraMem = core::memory::dynamicSize(growShrink);
     BOOST_TEST_REQUIRE(extraMem > 0);
     growShrink.clear();
-    extraMem = core::CMemory::dynamicSize(growShrink);
+    extraMem = core::memory::dynamicSize(growShrink);
     BOOST_TEST_REQUIRE(extraMem > 0);
     growShrink.shrink_to_fit();
-    extraMem = core::CMemory::dynamicSize(growShrink);
+    extraMem = core::memory::dynamicSize(growShrink);
     BOOST_REQUIRE_EQUAL(0, extraMem);
     growShrink.push_back(1.7);
-    extraMem = core::CMemory::dynamicSize(growShrink);
+    extraMem = core::memory::dynamicSize(growShrink);
     // Interesting (shocking?) result: once a boost::small_vector has switched
     // off of internal storage it will NEVER go back to internal storage.
     // Arguably this is a bug, and this assertion might start failing after a
@@ -1305,18 +1304,18 @@ BOOST_AUTO_TEST_CASE(testAlignedVector) {
     TAlignedDoubleVec alignedVector{10.0, 11.0, 12.0, 13.0, 14.0,
                                     15.0, 16.0, 17.0, 18.0, 19.0};
 
-    LOG_DEBUG(<< "TDoubleVec usage = " << core::CMemory::dynamicSize(vector));
-    LOG_DEBUG(<< "TAlignedDoubleVec usage = " << core::CMemory::dynamicSize(alignedVector));
-    BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(vector),
-                        core::CMemory::dynamicSize(alignedVector));
+    LOG_DEBUG(<< "TDoubleVec usage = " << core::memory::dynamicSize(vector));
+    LOG_DEBUG(<< "TAlignedDoubleVec usage = " << core::memory::dynamicSize(alignedVector));
+    BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(vector),
+                        core::memory::dynamicSize(alignedVector));
 
     core::CMemoryUsage memoryUsage;
     memoryUsage.setName("test", 0);
-    core::CMemoryDebug::dynamicSize("TAlignedDoubleVec", vector, memoryUsage.addChild());
+    core::memory_debug::dynamicSize("TAlignedDoubleVec", vector, memoryUsage.addChild());
     std::ostringstream ss;
     memoryUsage.print(ss);
     LOG_DEBUG(<< "TAlignedDoubleVec usage debug = " << ss.str());
-    BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(vector), memoryUsage.usage());
+    BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(vector), memoryUsage.usage());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/core/unittest/CStoredStringPtrTest.cc
+++ b/lib/core/unittest/CStoredStringPtrTest.cc
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(testMemoryUsage) {
     {
         ml::core::CStoredStringPtr null;
 
-        BOOST_REQUIRE_EQUAL(0, ml::core::CMemory::dynamicSize(null));
+        BOOST_REQUIRE_EQUAL(0, ml::core::memory::dynamicSize(null));
         BOOST_REQUIRE_EQUAL(0, null.actualMemoryUsage());
     }
     {
@@ -95,16 +95,16 @@ BOOST_AUTO_TEST_CASE(testMemoryUsage) {
 
         ml::core::CStoredStringPtr ptr1 = ml::core::CStoredStringPtr::makeStoredString(str1);
 
-        BOOST_REQUIRE_EQUAL(0, ml::core::CMemory::dynamicSize(ptr1));
-        BOOST_REQUIRE_EQUAL(ml::core::CMemory::dynamicSize(&str1), ptr1.actualMemoryUsage());
+        BOOST_REQUIRE_EQUAL(0, ml::core::memory::dynamicSize(ptr1));
+        BOOST_REQUIRE_EQUAL(ml::core::memory::dynamicSize(&str1), ptr1.actualMemoryUsage());
     }
     {
         std::string str2("much longer - YUGE in fact!");
 
         ml::core::CStoredStringPtr ptr2 = ml::core::CStoredStringPtr::makeStoredString(str2);
 
-        BOOST_REQUIRE_EQUAL(0, ml::core::CMemory::dynamicSize(ptr2));
-        BOOST_REQUIRE_EQUAL(ml::core::CMemory::dynamicSize(&str2), ptr2.actualMemoryUsage());
+        BOOST_REQUIRE_EQUAL(0, ml::core::memory::dynamicSize(ptr2));
+        BOOST_REQUIRE_EQUAL(ml::core::memory::dynamicSize(&str2), ptr2.actualMemoryUsage());
     }
 }
 

--- a/lib/maths/analytics/CBoostedTree.cc
+++ b/lib/maths/analytics/CBoostedTree.cc
@@ -125,7 +125,7 @@ CBoostedTreeNode::split(const TFloatVecVec& candidateSplits,
 }
 
 std::size_t CBoostedTreeNode::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_NodeValue);
+    return core::memory::dynamicSize(m_NodeValue);
 }
 
 std::size_t CBoostedTreeNode::estimateMemoryUsage(std::size_t numberLossParameters) {

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -151,7 +151,7 @@ CBoostedTreeFactory::buildForEncode(core::CDataFrame& frame, std::size_t depende
         this->initializeFeatureSampleDistribution();
     });
 
-    m_TreeImpl->m_Instrumentation->updateMemoryUsage(core::CMemory::dynamicSize(m_TreeImpl));
+    m_TreeImpl->m_Instrumentation->updateMemoryUsage(core::memory::dynamicSize(m_TreeImpl));
     m_TreeImpl->m_Instrumentation->lossType(m_TreeImpl->m_Loss->name());
     m_TreeImpl->m_Instrumentation->flush();
 
@@ -199,7 +199,7 @@ CBoostedTreeFactory::buildForTrain(core::CDataFrame& frame, std::size_t dependen
 
     this->initializeSplitsCache(frame);
 
-    m_TreeImpl->m_Instrumentation->updateMemoryUsage(core::CMemory::dynamicSize(m_TreeImpl));
+    m_TreeImpl->m_Instrumentation->updateMemoryUsage(core::memory::dynamicSize(m_TreeImpl));
     m_TreeImpl->m_Instrumentation->lossType(m_TreeImpl->m_Loss->name());
     m_TreeImpl->m_Instrumentation->flush();
 
@@ -247,7 +247,7 @@ CBoostedTreeFactory::buildForTrainIncremental(core::CDataFrame& frame,
 
     this->initializeSplitsCache(frame);
 
-    m_TreeImpl->m_Instrumentation->updateMemoryUsage(core::CMemory::dynamicSize(m_TreeImpl));
+    m_TreeImpl->m_Instrumentation->updateMemoryUsage(core::memory::dynamicSize(m_TreeImpl));
     m_TreeImpl->m_Instrumentation->lossType(m_TreeImpl->m_Loss->name());
     m_TreeImpl->m_Instrumentation->flush();
 
@@ -290,7 +290,7 @@ CBoostedTreeFactory::buildForPredict(core::CDataFrame& frame, std::size_t depend
     m_TreeImpl->predict(frame);
     m_TreeImpl->computeClassificationWeights(frame);
 
-    m_TreeImpl->m_Instrumentation->updateMemoryUsage(core::CMemory::dynamicSize(m_TreeImpl));
+    m_TreeImpl->m_Instrumentation->updateMemoryUsage(core::memory::dynamicSize(m_TreeImpl));
 
     auto treeImpl = std::make_unique<CBoostedTreeImpl>(m_NumberThreads,
                                                        m_TreeImpl->m_Loss->clone());
@@ -335,7 +335,7 @@ CBoostedTreeFactory::restoreFor(core::CDataFrame& frame, std::size_t dependentVa
     }
     this->initializeSplitsCache(frame);
 
-    m_TreeImpl->m_Instrumentation->updateMemoryUsage(core::CMemory::dynamicSize(m_TreeImpl));
+    m_TreeImpl->m_Instrumentation->updateMemoryUsage(core::memory::dynamicSize(m_TreeImpl));
     m_TreeImpl->m_Instrumentation->lossType(m_TreeImpl->m_Loss->name());
     m_TreeImpl->m_Instrumentation->flush();
 
@@ -472,7 +472,7 @@ void CBoostedTreeFactory::prepareDataFrameForTrain(core::CDataFrame& frame) cons
     }
 
     // Extend the frame with the bookkeeping columns used in train.
-    std::size_t oldFrameMemory{core::CMemory::dynamicSize(frame)};
+    std::size_t oldFrameMemory{core::memory::dynamicSize(frame)};
     TSizeVec extraColumns;
     std::size_t paddedExtraColumns;
     std::size_t numberLossParameters{m_TreeImpl->m_Loss->numberParameters()};
@@ -486,7 +486,7 @@ void CBoostedTreeFactory::prepareDataFrameForTrain(core::CDataFrame& frame) cons
     m_TreeImpl->m_ExtraColumns[E_Weight] = rowWeightColumn;
     m_PaddedExtraColumns += paddedExtraColumns;
 
-    std::size_t newFrameMemory{core::CMemory::dynamicSize(frame)};
+    std::size_t newFrameMemory{core::memory::dynamicSize(frame)};
     m_TreeImpl->m_Instrumentation->updateMemoryUsage(newFrameMemory - oldFrameMemory);
     m_TreeImpl->m_Instrumentation->flush();
 }
@@ -496,7 +496,7 @@ void CBoostedTreeFactory::prepareDataFrameForIncrementalTrain(core::CDataFrame& 
     this->prepareDataFrameForTrain(frame);
 
     // Extend the frame with the bookkeeping columns used in incremental train.
-    std::size_t oldFrameMemory{core::CMemory::dynamicSize(frame)};
+    std::size_t oldFrameMemory{core::memory::dynamicSize(frame)};
     TSizeVec extraColumns;
     std::size_t paddedExtraColumns;
     std::size_t numberLossParameters{m_TreeImpl->m_Loss->numberParameters()};
@@ -507,7 +507,7 @@ void CBoostedTreeFactory::prepareDataFrameForIncrementalTrain(core::CDataFrame& 
         m_TreeImpl->m_ExtraColumns[extraColumnTags[i]] = extraColumns[i];
     }
     m_PaddedExtraColumns += paddedExtraColumns;
-    std::size_t newFrameMemory{core::CMemory::dynamicSize(frame)};
+    std::size_t newFrameMemory{core::memory::dynamicSize(frame)};
     m_TreeImpl->m_Instrumentation->updateMemoryUsage(newFrameMemory - oldFrameMemory);
     m_TreeImpl->m_Instrumentation->flush();
 
@@ -530,7 +530,7 @@ void CBoostedTreeFactory::prepareDataFrameForPredict(core::CDataFrame& frame) co
     std::size_t rowWeightColumn{UNIT_ROW_WEIGHT_COLUMN};
 
     // Extend the frame with the bookkeeping columns used in predict.
-    std::size_t oldFrameMemory{core::CMemory::dynamicSize(frame)};
+    std::size_t oldFrameMemory{core::memory::dynamicSize(frame)};
     TSizeVec extraColumns;
     std::size_t paddedExtraColumns;
     std::size_t numberLossParameters{m_TreeImpl->m_Loss->numberParameters()};
@@ -544,7 +544,7 @@ void CBoostedTreeFactory::prepareDataFrameForPredict(core::CDataFrame& frame) co
     m_TreeImpl->m_ExtraColumns[E_Weight] = rowWeightColumn;
     m_PaddedExtraColumns += paddedExtraColumns;
 
-    std::size_t newFrameMemory{core::CMemory::dynamicSize(frame)};
+    std::size_t newFrameMemory{core::memory::dynamicSize(frame)};
     m_TreeImpl->m_Instrumentation->updateMemoryUsage(newFrameMemory - oldFrameMemory);
     m_TreeImpl->m_Instrumentation->flush();
 }
@@ -640,13 +640,13 @@ void CBoostedTreeFactory::selectFeaturesAndEncodeCategories(core::CDataFrame& fr
 }
 
 void CBoostedTreeFactory::initializeSplitsCache(core::CDataFrame& frame) const {
-    std::size_t oldFrameMemory{core::CMemory::dynamicSize(frame)};
+    std::size_t oldFrameMemory{core::memory::dynamicSize(frame)};
     std::size_t beginSplits{frame.numberColumns()};
     frame.resizeColumns(m_TreeImpl->m_NumberThreads,
                         beginSplits + (m_TreeImpl->numberFeatures() + 3) / 4);
     m_PaddedExtraColumns += frame.numberColumns() - beginSplits;
     m_TreeImpl->m_ExtraColumns[E_BeginSplits] = beginSplits;
-    std::size_t newFrameMemory{core::CMemory::dynamicSize(frame)};
+    std::size_t newFrameMemory{core::memory::dynamicSize(frame)};
     m_TreeImpl->m_Instrumentation->updateMemoryUsage(newFrameMemory - oldFrameMemory);
     m_TreeImpl->m_Instrumentation->flush();
     m_TreeImpl->initializeFixedCandidateSplits(frame);

--- a/lib/maths/analytics/CBoostedTreeHyperparameters.cc
+++ b/lib/maths/analytics/CBoostedTreeHyperparameters.cc
@@ -681,11 +681,11 @@ std::size_t CBoostedTreeHyperparameters::estimateMemoryUsage() const {
 }
 
 std::size_t CBoostedTreeHyperparameters::memoryUsage() const {
-    std::size_t mem{core::CMemory::dynamicSize(m_TunableHyperparameters)};
-    mem += core::CMemory::dynamicSize(m_HyperparameterSamples);
-    mem += core::CMemory::dynamicSize(m_BayesianOptimization);
-    mem += core::CMemory::dynamicSize(m_LineSearchRelevantParameters);
-    mem += core::CMemory::dynamicSize(m_LineSearchHyperparameterLosses);
+    std::size_t mem{core::memory::dynamicSize(m_TunableHyperparameters)};
+    mem += core::memory::dynamicSize(m_HyperparameterSamples);
+    mem += core::memory::dynamicSize(m_BayesianOptimization);
+    mem += core::memory::dynamicSize(m_LineSearchRelevantParameters);
+    mem += core::memory::dynamicSize(m_LineSearchHyperparameterLosses);
     return mem;
 }
 

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -77,7 +77,7 @@ public:
     template<typename T>
     CScopeRecordMemoryUsage(const T& object, TMemoryUsageCallback&& recordMemoryUsage)
         : m_RecordMemoryUsage{std::move(recordMemoryUsage)},
-          m_MemoryUsage(core::CMemory::dynamicSize(object)) {
+          m_MemoryUsage(core::memory::dynamicSize(object)) {
         m_RecordMemoryUsage(m_MemoryUsage);
     }
 
@@ -88,14 +88,14 @@ public:
 
     template<typename T>
     void add(const T& object) {
-        std::int64_t memoryUsage(core::CMemory::dynamicSize(object));
+        std::int64_t memoryUsage(core::memory::dynamicSize(object));
         m_MemoryUsage += memoryUsage;
         m_RecordMemoryUsage(memoryUsage);
     }
 
     template<typename T>
     void remove(const T& object) {
-        std::int64_t memoryUsage(core::CMemory::dynamicSize(object));
+        std::int64_t memoryUsage(core::memory::dynamicSize(object));
         m_MemoryUsage -= memoryUsage;
         m_RecordMemoryUsage(-memoryUsage);
     }
@@ -670,7 +670,7 @@ std::size_t CBoostedTreeImpl::estimateMemoryUsageForTraining(std::size_t numberR
         numberTrees *
         (sizeof(TNodeVec) + maximumNumberNodes * CBoostedTreeNode::estimateMemoryUsage(
                                                      m_Loss->numberParameters()))};
-    std::size_t foldRoundLossMemoryUsage{core::CMemory::dynamicSize(TOptionalDoubleVecVec(
+    std::size_t foldRoundLossMemoryUsage{core::memory::dynamicSize(TOptionalDoubleVecVec(
         m_NumberFolds.value(), TOptionalDoubleVec(m_Hyperparameters.numberRounds())))};
     // The leaves' row masks memory is accounted for here because it's proportional
     // to the log2(number of nodes). The compressed bit vector representation uses
@@ -693,11 +693,11 @@ std::size_t CBoostedTreeImpl::estimateMemoryUsageForTraining(std::size_t numberR
                                  2};
     std::size_t categoryEncoderMemoryUsage{sizeof(CDataFrameCategoryEncoder)};
     std::size_t dataTypeMemoryUsage{
-        core::CMemory::dynamicSize(TDataTypeVec(maximumNumberFeatures))};
+        core::memory::dynamicSize(TDataTypeVec(maximumNumberFeatures))};
     std::size_t featureSampleProbabilitiesMemoryUsage{
-        core::CMemory::dynamicSize(TDoubleVec(maximumNumberFeatures))};
+        core::memory::dynamicSize(TDoubleVec(maximumNumberFeatures))};
     std::size_t fixedCandidateSplitsMemoryUsage{
-        core::CMemory::dynamicSize(TFloatVecVec(maximumNumberFeatures))};
+        core::memory::dynamicSize(TFloatVecVec(maximumNumberFeatures))};
     // Assuming either many or few missing rows, we get good compression of the bit
     // vector. Specifically, we'll assume the average run length is 64 for which
     // we get a constant 8 / 64.
@@ -726,7 +726,7 @@ std::size_t CBoostedTreeImpl::estimateMemoryUsageForPredict(std::size_t numberRo
         std::min(numberColumns - 1, numberRows / this->rowsPerFeature(numberRows))};
     std::size_t categoryEncoderMemoryUsage{sizeof(CDataFrameCategoryEncoder)};
     std::size_t dataTypeMemoryUsage{
-        core::CMemory::dynamicSize(TDataTypeVec(maximumNumberFeatures))};
+        core::memory::dynamicSize(TDataTypeVec(maximumNumberFeatures))};
     std::size_t missingFeatureMaskMemoryUsage{8 * numberColumns * numberRows / 64};
     std::size_t newTrainingRowMaskMemoryUsage{8 * numberRows / 64};
     return sizeof(*this) + categoryEncoderMemoryUsage + dataTypeMemoryUsage +
@@ -2591,24 +2591,24 @@ void CBoostedTreeImpl::checkIncrementalTrainInvariants(const core::CDataFrame& f
 }
 
 std::size_t CBoostedTreeImpl::memoryUsage() const {
-    std::size_t mem{core::CMemory::dynamicSize(m_Loss)};
-    mem += core::CMemory::dynamicSize(m_ExtraColumns);
-    mem += core::CMemory::dynamicSize(m_Encoder);
-    mem += core::CMemory::dynamicSize(m_FeatureDataTypes);
-    mem += core::CMemory::dynamicSize(m_FeatureSampleProbabilities);
-    mem += core::CMemory::dynamicSize(m_MissingFeatureRowMasks);
-    mem += core::CMemory::dynamicSize(m_FixedCandidateSplits);
-    mem += core::CMemory::dynamicSize(m_TrainingRowMasks);
-    mem += core::CMemory::dynamicSize(m_TestingRowMasks);
-    mem += core::CMemory::dynamicSize(m_NewTrainingRowMask);
-    mem += core::CMemory::dynamicSize(m_FoldRoundTestLosses);
-    mem += core::CMemory::dynamicSize(m_ClassificationWeightsOverride);
-    mem += core::CMemory::dynamicSize(m_ClassificationWeights);
-    mem += core::CMemory::dynamicSize(m_BestForest);
-    mem += core::CMemory::dynamicSize(m_Hyperparameters);
-    mem += core::CMemory::dynamicSize(m_TreeShap);
-    mem += core::CMemory::dynamicSize(m_Instrumentation);
-    mem += core::CMemory::dynamicSize(m_TreesToRetrain);
+    std::size_t mem{core::memory::dynamicSize(m_Loss)};
+    mem += core::memory::dynamicSize(m_ExtraColumns);
+    mem += core::memory::dynamicSize(m_Encoder);
+    mem += core::memory::dynamicSize(m_FeatureDataTypes);
+    mem += core::memory::dynamicSize(m_FeatureSampleProbabilities);
+    mem += core::memory::dynamicSize(m_MissingFeatureRowMasks);
+    mem += core::memory::dynamicSize(m_FixedCandidateSplits);
+    mem += core::memory::dynamicSize(m_TrainingRowMasks);
+    mem += core::memory::dynamicSize(m_TestingRowMasks);
+    mem += core::memory::dynamicSize(m_NewTrainingRowMask);
+    mem += core::memory::dynamicSize(m_FoldRoundTestLosses);
+    mem += core::memory::dynamicSize(m_ClassificationWeightsOverride);
+    mem += core::memory::dynamicSize(m_ClassificationWeights);
+    mem += core::memory::dynamicSize(m_BestForest);
+    mem += core::memory::dynamicSize(m_Hyperparameters);
+    mem += core::memory::dynamicSize(m_TreeShap);
+    mem += core::memory::dynamicSize(m_Instrumentation);
+    mem += core::memory::dynamicSize(m_TreesToRetrain);
     return mem;
 }
 

--- a/lib/maths/analytics/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/analytics/CBoostedTreeLeafNodeStatistics.cc
@@ -87,7 +87,7 @@ core::CPackedBitVector& CBoostedTreeLeafNodeStatistics::rowMask() {
 }
 
 std::size_t CBoostedTreeLeafNodeStatistics::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_RowMask) + core::CMemory::dynamicSize(m_Derivatives);
+    return core::memory::dynamicSize(m_RowMask) + core::memory::dynamicSize(m_Derivatives);
 }
 
 std::size_t
@@ -305,7 +305,7 @@ std::uint64_t CBoostedTreeLeafNodeStatistics::CDerivatives::checksum(std::uint64
 }
 
 std::size_t CBoostedTreeLeafNodeStatistics::CSplitsDerivatives::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Derivatives) + core::CMemory::dynamicSize(m_Storage);
+    return core::memory::dynamicSize(m_Derivatives) + core::memory::dynamicSize(m_Storage);
 }
 
 //! Estimate the split derivatives' memory usage for a data frame with
@@ -351,7 +351,7 @@ CBoostedTreeLeafNodeStatistics::CWorkspace::featuresToInclude() const {
 }
 
 std::size_t CBoostedTreeLeafNodeStatistics::CWorkspace::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Masks) + core::CMemory::dynamicSize(m_Derivatives);
+    return core::memory::dynamicSize(m_Masks) + core::memory::dynamicSize(m_Derivatives);
 }
 }
 }

--- a/lib/maths/analytics/CDataFrameCategoryEncoder.cc
+++ b/lib/maths/analytics/CDataFrameCategoryEncoder.cc
@@ -670,18 +670,17 @@ CMakeDataFrameCategoryEncoder::TEncodingUPtrVec CMakeDataFrameCategoryEncoder::m
 }
 
 std::size_t CMakeDataFrameCategoryEncoder::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_RowMask) +
-           core::CMemory::dynamicSize(m_ColumnMask) +
-           core::CMemory::dynamicSize(m_InputColumnUsesFrequencyEncoding) +
-           core::CMemory::dynamicSize(m_OneHotEncodedCategories) +
-           core::CMemory::dynamicSize(m_RareCategories) +
-           core::CMemory::dynamicSize(m_CategoryFrequencies) +
-           core::CMemory::dynamicSize(m_MeanCategoryFrequencies) +
-           core::CMemory::dynamicSize(m_CategoryTargetMeanValues) +
-           core::CMemory::dynamicSize(m_MeanCategoryTargetMeanValues) +
-           core::CMemory::dynamicSize(m_EncodedColumnMics) +
-           core::CMemory::dynamicSize(m_EncodedColumnInputColumnMap) +
-           core::CMemory::dynamicSize(m_EncodedColumnEncodingMap);
+    return core::memory::dynamicSize(m_RowMask) + core::memory::dynamicSize(m_ColumnMask) +
+           core::memory::dynamicSize(m_InputColumnUsesFrequencyEncoding) +
+           core::memory::dynamicSize(m_OneHotEncodedCategories) +
+           core::memory::dynamicSize(m_RareCategories) +
+           core::memory::dynamicSize(m_CategoryFrequencies) +
+           core::memory::dynamicSize(m_MeanCategoryFrequencies) +
+           core::memory::dynamicSize(m_CategoryTargetMeanValues) +
+           core::memory::dynamicSize(m_MeanCategoryTargetMeanValues) +
+           core::memory::dynamicSize(m_EncodedColumnMics) +
+           core::memory::dynamicSize(m_EncodedColumnInputColumnMap) +
+           core::memory::dynamicSize(m_EncodedColumnEncodingMap);
 }
 
 std::size_t CMakeDataFrameCategoryEncoder::estimateMemoryUsage(std::size_t numberRows,
@@ -698,20 +697,18 @@ std::size_t CMakeDataFrameCategoryEncoder::estimateMemoryUsage(std::size_t numbe
     std::size_t columnMaskMemoryUsage{numberColumns * sizeof(std::size_t)};
     std::size_t frequencyEncodingMemoryUsage{numberColumns / 8};
     std::size_t oneHotMemoryUsage{
-        numberCategoricalColumns *
-            core::CMemory::dynamicSize(TSizeVec(static_cast<std::size_t>(
-                1.0 / MINIMUM_FREQUENCY_TO_ONE_HOT_ENCODE))) +
-        (numberColumns - numberCategoricalColumns) * core::CMemory::dynamicSize(TSizeVec())};
+        numberCategoricalColumns * core::memory::dynamicSize(TSizeVec(static_cast<std::size_t>(
+                                       1.0 / MINIMUM_FREQUENCY_TO_ONE_HOT_ENCODE))) +
+        (numberColumns - numberCategoricalColumns) * core::memory::dynamicSize(TSizeVec())};
     std::size_t rareCategoriesMemoryUsage{
-        numberCategoricalColumns * core::CMemory::dynamicSize(TSizeUSet(maximumNumberCategories)) +
-        (numberColumns - numberCategoricalColumns) *
-            core::CMemory::dynamicSize(TSizeUSet())};
+        numberCategoricalColumns * core::memory::dynamicSize(TSizeUSet(maximumNumberCategories)) +
+        (numberColumns - numberCategoricalColumns) * core::memory::dynamicSize(TSizeUSet())};
     std::size_t meanFrequencyMemoryUsage{numberColumns * sizeof(double)};
     std::size_t meanValuesMemoryUsage{
         numberColumns * sizeof(double) +
-        numberCategoricalColumns * core::CMemory::dynamicSize(TDoubleVec(1000)) +
+        numberCategoricalColumns * core::memory::dynamicSize(TDoubleVec(1000)) +
         (numberColumns - numberCategoricalColumns) *
-            core::CMemory::dynamicSize(TDoubleVec())};
+            core::memory::dynamicSize(TDoubleVec())};
     std::size_t micsMemoryUsage{numberColumns * sizeof(double)};
     std::size_t encodingMapMemoryUsage{2 * numberColumns * sizeof(std::size_t)};
     return sizeof(CMakeDataFrameCategoryEncoder) + missingFeatureMaskMemoryUsage +

--- a/lib/maths/analytics/COutliers.cc
+++ b/lib/maths/analytics/COutliers.cc
@@ -55,7 +55,7 @@ double shift(double score) {
 
 template<typename T>
 std::int64_t signedMemoryUsage(const T& obj) {
-    return static_cast<std::int64_t>(core::CMemory::dynamicSize(obj));
+    return static_cast<std::int64_t>(core::memory::dynamicSize(obj));
 }
 
 //! \brief This encapsulates creating a collection of models used for outlier
@@ -139,7 +139,7 @@ public:
         TDouble1Vec compute(double pOutlier) const;
 
         std::size_t memoryUsage() const {
-            return core::CMemory::dynamicSize(m_State);
+            return core::memory::dynamicSize(m_State);
         }
 
         static std::size_t estimateMemoryUsage(std::size_t numberInfluences) {
@@ -226,11 +226,11 @@ private:
                               const TMemoryUsageCallback& recordMemoryUsage) const;
 
         std::size_t memoryUsage() const {
-            return core::CMemory::dynamicSize(m_Lookup) +
-                   core::CMemory::dynamicSize(m_Projection) +
-                   core::CMemory::dynamicSize(m_RowNormalizedProjection) +
-                   core::CMemory::dynamicSize(m_Method) +
-                   core::CMemory::dynamicSize(m_LogScoreMoments);
+            return core::memory::dynamicSize(m_Lookup) +
+                   core::memory::dynamicSize(m_Projection) +
+                   core::memory::dynamicSize(m_RowNormalizedProjection) +
+                   core::memory::dynamicSize(m_Method) +
+                   core::memory::dynamicSize(m_LogScoreMoments);
         }
 
         static std::size_t estimateMemoryUsage(TMethodSize methodSize,
@@ -331,7 +331,7 @@ CEnsemble<POINT>::CEnsemble(const TMethodFactoryVec& methodFactories,
         model.proportionOfRuntimePerMethod(1.0 / static_cast<double>(m_Models.size()));
     }
 
-    m_RecordMemoryUsage(core::CMemory::dynamicSize(m_Models));
+    m_RecordMemoryUsage(core::memory::dynamicSize(m_Models));
 }
 
 template<typename POINT>
@@ -395,7 +395,7 @@ CEnsemble<POINT>::computeOutlierScores(const std::vector<POINT>& points) const {
     LOG_TRACE(<< "Computing outlier scores for\n" << this->print());
 
     TScorerVec scores(points.size());
-    m_RecordMemoryUsage(core::CMemory::dynamicSize(scores));
+    m_RecordMemoryUsage(core::memory::dynamicSize(scores));
 
     for (const auto& model : m_Models) {
         model.addOutlierScores(points, scores, m_RecordMemoryUsage);

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -2969,7 +2969,7 @@ BOOST_AUTO_TEST_CASE(testEstimateMemory) {
         estimatedMemory =
             core::CDataFrame::estimateMemoryUsage(true, rows, cols + extraCols,
                                                   core::CAlignment::E_Aligned16) +
-            core::CMemory::dynamicSize(regression->trainedModel()) +
+            core::memory::dynamicSize(regression->trainedModel()) +
             maths::analytics::CBoostedTreeFactory::constructFromParameters(
                 1, std::make_unique<maths::analytics::boosted_tree::CMse>())
                 .estimateMemoryUsageForTrainIncremental(rows, cols);
@@ -2995,7 +2995,7 @@ BOOST_AUTO_TEST_CASE(testEstimateMemory) {
         estimatedMemory =
             core::CDataFrame::estimateMemoryUsage(true, rows, cols + extraCols,
                                                   core::CAlignment::E_Aligned16) +
-            core::CMemory::dynamicSize(&regression->impl()) +
+            core::memory::dynamicSize(&regression->impl()) +
             maths::analytics::CBoostedTreeFactory::constructFromParameters(
                 1, std::make_unique<maths::analytics::boosted_tree::CMse>())
                 .estimateMemoryUsageForPredict(rows, cols);

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -936,12 +936,12 @@ void CBayesianOptimisation::checkRestoredInvariants() const {
 }
 
 std::size_t CBayesianOptimisation::memoryUsage() const {
-    std::size_t mem{core::CMemory::dynamicSize(m_MinBoundary)};
-    mem += core::CMemory::dynamicSize(m_MaxBoundary);
-    mem += core::CMemory::dynamicSize(m_FunctionMeanValues);
-    mem += core::CMemory::dynamicSize(m_ErrorVariances);
-    mem += core::CMemory::dynamicSize(m_KernelParameters);
-    mem += core::CMemory::dynamicSize(m_MinimumKernelCoordinateDistanceScale);
+    std::size_t mem{core::memory::dynamicSize(m_MinBoundary)};
+    mem += core::memory::dynamicSize(m_MaxBoundary);
+    mem += core::memory::dynamicSize(m_FunctionMeanValues);
+    mem += core::memory::dynamicSize(m_ErrorVariances);
+    mem += core::memory::dynamicSize(m_KernelParameters);
+    mem += core::memory::dynamicSize(m_MinimumKernelCoordinateDistanceScale);
     return mem;
 }
 

--- a/lib/maths/common/CBjkstUniqueValues.cc
+++ b/lib/maths/common/CBjkstUniqueValues.cc
@@ -444,15 +444,15 @@ void CBjkstUniqueValues::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsage
     mem->setName("CBjkstUniqueValues");
     const TUInt32Vec* values = std::get_if<TUInt32Vec>(&m_Sketch);
     if (values != nullptr) {
-        core::CMemoryDebug::dynamicSize("values", *values, mem);
+        core::memory_debug::dynamicSize("values", *values, mem);
     } else {
         try {
             const auto& sketch = std::get<SSketch>(m_Sketch);
             mem->addItem("SSketch", sizeof(SSketch));
-            core::CMemoryDebug::dynamicSize("sketch.s_G", sketch.s_G, mem);
-            core::CMemoryDebug::dynamicSize("sketch.s_H", sketch.s_H, mem);
-            core::CMemoryDebug::dynamicSize("sketch.s_Z", sketch.s_Z, mem);
-            core::CMemoryDebug::dynamicSize("sketch.s_B", sketch.s_B, mem);
+            core::memory_debug::dynamicSize("sketch.s_G", sketch.s_G, mem);
+            core::memory_debug::dynamicSize("sketch.s_H", sketch.s_H, mem);
+            core::memory_debug::dynamicSize("sketch.s_Z", sketch.s_Z, mem);
+            core::memory_debug::dynamicSize("sketch.s_B", sketch.s_B, mem);
         } catch (const std::exception& e) {
             LOG_ABORT(<< "Unexpected exception: " << e.what());
         }
@@ -463,15 +463,15 @@ std::size_t CBjkstUniqueValues::memoryUsage() const {
     std::size_t mem = 0;
     const TUInt32Vec* values = std::get_if<TUInt32Vec>(&m_Sketch);
     if (values != nullptr) {
-        mem += core::CMemory::dynamicSize(*values);
+        mem += core::memory::dynamicSize(*values);
     } else {
         try {
             const auto& sketch = std::get<SSketch>(m_Sketch);
             mem += sizeof(SSketch);
-            mem += core::CMemory::dynamicSize(sketch.s_G);
-            mem += core::CMemory::dynamicSize(sketch.s_H);
-            mem += core::CMemory::dynamicSize(sketch.s_Z);
-            mem += core::CMemory::dynamicSize(sketch.s_B);
+            mem += core::memory::dynamicSize(sketch.s_G);
+            mem += core::memory::dynamicSize(sketch.s_H);
+            mem += core::memory::dynamicSize(sketch.s_Z);
+            mem += core::memory::dynamicSize(sketch.s_B);
         } catch (const std::exception& e) {
             LOG_ABORT(<< "Unexpected exception: " << e.what());
         }

--- a/lib/maths/common/CClusterer.cc
+++ b/lib/maths/common/CClusterer.cc
@@ -65,11 +65,11 @@ void CClustererTypes::CIndexGenerator::recycle(std::size_t index) {
 
 void CClustererTypes::CIndexGenerator::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CClusterer::CIndexGenerator");
-    core::CMemoryDebug::dynamicSize("m_IndexHeap", m_IndexHeap, mem);
+    core::memory_debug::dynamicSize("m_IndexHeap", m_IndexHeap, mem);
 }
 
 std::size_t CClustererTypes::CIndexGenerator::memoryUsage() const {
-    std::size_t mem = core::CMemory::dynamicSize(m_IndexHeap);
+    std::size_t mem = core::memory::dynamicSize(m_IndexHeap);
     return mem;
 }
 

--- a/lib/maths/common/CKMeansOnline1d.cc
+++ b/lib/maths/common/CKMeansOnline1d.cc
@@ -267,11 +267,11 @@ double CKMeansOnline1d::probability(std::size_t index) const {
 
 void CKMeansOnline1d::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CKMeansOnline1d");
-    core::CMemoryDebug::dynamicSize("m_Clusters", m_Clusters, mem);
+    core::memory_debug::dynamicSize("m_Clusters", m_Clusters, mem);
 }
 
 std::size_t CKMeansOnline1d::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Clusters);
+    return core::memory::dynamicSize(m_Clusters);
 }
 
 std::size_t CKMeansOnline1d::staticSize() const {

--- a/lib/maths/common/CKMostCorrelated.cc
+++ b/lib/maths/common/CKMostCorrelated.cc
@@ -362,19 +362,19 @@ std::uint64_t CKMostCorrelated::checksum(std::uint64_t seed) const {
 
 void CKMostCorrelated::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CKMostCorrelated");
-    core::CMemoryDebug::dynamicSize("m_Projections", m_Projections, mem);
-    core::CMemoryDebug::dynamicSize("m_CurrentProjected", m_CurrentProjected, mem);
-    core::CMemoryDebug::dynamicSize("m_Projected", m_Projected, mem);
-    core::CMemoryDebug::dynamicSize("m_Moments", m_Moments, mem);
-    core::CMemoryDebug::dynamicSize("m_MostCorrelated", m_MostCorrelated, mem);
+    core::memory_debug::dynamicSize("m_Projections", m_Projections, mem);
+    core::memory_debug::dynamicSize("m_CurrentProjected", m_CurrentProjected, mem);
+    core::memory_debug::dynamicSize("m_Projected", m_Projected, mem);
+    core::memory_debug::dynamicSize("m_Moments", m_Moments, mem);
+    core::memory_debug::dynamicSize("m_MostCorrelated", m_MostCorrelated, mem);
 }
 
 std::size_t CKMostCorrelated::memoryUsage() const {
-    std::size_t mem = core::CMemory::dynamicSize(m_Projections);
-    mem += core::CMemory::dynamicSize(m_CurrentProjected);
-    mem += core::CMemory::dynamicSize(m_Projected);
-    mem += core::CMemory::dynamicSize(m_Moments);
-    mem += core::CMemory::dynamicSize(m_MostCorrelated);
+    std::size_t mem = core::memory::dynamicSize(m_Projections);
+    mem += core::memory::dynamicSize(m_CurrentProjected);
+    mem += core::memory::dynamicSize(m_Projected);
+    mem += core::memory::dynamicSize(m_Moments);
+    mem += core::memory::dynamicSize(m_MostCorrelated);
     return mem;
 }
 

--- a/lib/maths/common/CMultimodalPrior.cc
+++ b/lib/maths/common/CMultimodalPrior.cc
@@ -1173,15 +1173,15 @@ std::uint64_t CMultimodalPrior::checksum(std::uint64_t seed) const {
 
 void CMultimodalPrior::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CMultimodalPrior");
-    core::CMemoryDebug::dynamicSize("m_Clusterer", m_Clusterer, mem);
-    core::CMemoryDebug::dynamicSize("m_SeedPrior", m_SeedPrior, mem);
-    core::CMemoryDebug::dynamicSize("m_Modes", m_Modes, mem);
+    core::memory_debug::dynamicSize("m_Clusterer", m_Clusterer, mem);
+    core::memory_debug::dynamicSize("m_SeedPrior", m_SeedPrior, mem);
+    core::memory_debug::dynamicSize("m_Modes", m_Modes, mem);
 }
 
 std::size_t CMultimodalPrior::memoryUsage() const {
-    std::size_t mem = core::CMemory::dynamicSize(m_Clusterer);
-    mem += core::CMemory::dynamicSize(m_SeedPrior);
-    mem += core::CMemory::dynamicSize(m_Modes);
+    std::size_t mem = core::memory::dynamicSize(m_Clusterer);
+    mem += core::memory::dynamicSize(m_SeedPrior);
+    mem += core::memory::dynamicSize(m_Modes);
     return mem;
 }
 

--- a/lib/maths/common/CMultinomialConjugate.cc
+++ b/lib/maths/common/CMultinomialConjugate.cc
@@ -1250,13 +1250,13 @@ std::uint64_t CMultinomialConjugate::checksum(std::uint64_t seed) const {
 
 void CMultinomialConjugate::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CMultinomialConjugate");
-    core::CMemoryDebug::dynamicSize("m_Categories", m_Categories, mem);
-    core::CMemoryDebug::dynamicSize("m_Concentrations", m_Concentrations, mem);
+    core::memory_debug::dynamicSize("m_Categories", m_Categories, mem);
+    core::memory_debug::dynamicSize("m_Concentrations", m_Concentrations, mem);
 }
 
 std::size_t CMultinomialConjugate::memoryUsage() const {
-    std::size_t mem = core::CMemory::dynamicSize(m_Categories);
-    mem += core::CMemory::dynamicSize(m_Concentrations);
+    std::size_t mem = core::memory::dynamicSize(m_Categories);
+    mem += core::memory::dynamicSize(m_Concentrations);
     return mem;
 }
 

--- a/lib/maths/common/CMultivariateConstantPrior.cc
+++ b/lib/maths/common/CMultivariateConstantPrior.cc
@@ -288,11 +288,11 @@ std::uint64_t CMultivariateConstantPrior::checksum(std::uint64_t seed) const {
 
 void CMultivariateConstantPrior::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CMultivariateConstantPrior");
-    core::CMemoryDebug::dynamicSize("m_Constant", m_Constant, mem);
+    core::memory_debug::dynamicSize("m_Constant", m_Constant, mem);
 }
 
 std::size_t CMultivariateConstantPrior::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Constant);
+    return core::memory::dynamicSize(m_Constant);
 }
 
 std::size_t CMultivariateConstantPrior::staticSize() const {

--- a/lib/maths/common/CMultivariateOneOfNPrior.cc
+++ b/lib/maths/common/CMultivariateOneOfNPrior.cc
@@ -751,11 +751,11 @@ std::uint64_t CMultivariateOneOfNPrior::checksum(std::uint64_t seed) const {
 
 void CMultivariateOneOfNPrior::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CMultivariateOneOfNPrior");
-    core::CMemoryDebug::dynamicSize("m_Models", m_Models, mem);
+    core::memory_debug::dynamicSize("m_Models", m_Models, mem);
 }
 
 std::size_t CMultivariateOneOfNPrior::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Models);
+    return core::memory::dynamicSize(m_Models);
 }
 
 std::size_t CMultivariateOneOfNPrior::staticSize() const {

--- a/lib/maths/common/CNaiveBayes.cc
+++ b/lib/maths/common/CNaiveBayes.cc
@@ -119,7 +119,7 @@ void CNaiveBayesFeatureDensityFromPrior::propagateForwardsByTime(double time) {
 
 void CNaiveBayesFeatureDensityFromPrior::debugMemoryUsage(
     const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
-    return core::CMemoryDebug::dynamicSize("m_Prior", m_Prior, mem);
+    return core::memory_debug::dynamicSize("m_Prior", m_Prior, mem);
 }
 
 std::size_t CNaiveBayesFeatureDensityFromPrior::staticSize() const {
@@ -127,7 +127,7 @@ std::size_t CNaiveBayesFeatureDensityFromPrior::staticSize() const {
 }
 
 std::size_t CNaiveBayesFeatureDensityFromPrior::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Prior);
+    return core::memory::dynamicSize(m_Prior);
 }
 
 std::uint64_t CNaiveBayesFeatureDensityFromPrior::checksum(std::uint64_t seed) const {
@@ -360,14 +360,14 @@ CNaiveBayes::TDoubleSizePrVec CNaiveBayes::classProbabilities(const TDouble1VecV
 }
 
 void CNaiveBayes::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
-    core::CMemoryDebug::dynamicSize("m_Exemplar", m_Exemplar, mem);
-    core::CMemoryDebug::dynamicSize("m_ClassConditionalDensities",
+    core::memory_debug::dynamicSize("m_Exemplar", m_Exemplar, mem);
+    core::memory_debug::dynamicSize("m_ClassConditionalDensities",
                                     m_ClassConditionalDensities, mem);
 }
 
 std::size_t CNaiveBayes::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Exemplar) +
-           core::CMemory::dynamicSize(m_ClassConditionalDensities);
+    return core::memory::dynamicSize(m_Exemplar) +
+           core::memory::dynamicSize(m_ClassConditionalDensities);
 }
 
 std::uint64_t CNaiveBayes::checksum(std::uint64_t seed) const {
@@ -464,11 +464,11 @@ CNaiveBayes::TFeatureDensityPtrVec& CNaiveBayes::CClass::conditionalDensities() 
 }
 
 void CNaiveBayes::CClass::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
-    core::CMemoryDebug::dynamicSize("s_ConditionalDensities", m_ConditionalDensities, mem);
+    core::memory_debug::dynamicSize("s_ConditionalDensities", m_ConditionalDensities, mem);
 }
 
 std::size_t CNaiveBayes::CClass::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_ConditionalDensities);
+    return core::memory::dynamicSize(m_ConditionalDensities);
 }
 
 std::uint64_t CNaiveBayes::CClass::checksum(std::uint64_t seed) const {

--- a/lib/maths/common/CNaturalBreaksClassifier.cc
+++ b/lib/maths/common/CNaturalBreaksClassifier.cc
@@ -482,13 +482,13 @@ std::uint64_t CNaturalBreaksClassifier::checksum(std::uint64_t seed) const {
 
 void CNaturalBreaksClassifier::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CNaturalBreaksClassifier");
-    core::CMemoryDebug::dynamicSize("m_Categories", m_Categories, mem);
-    core::CMemoryDebug::dynamicSize("m_PointsBuffer", m_PointsBuffer, mem);
+    core::memory_debug::dynamicSize("m_Categories", m_Categories, mem);
+    core::memory_debug::dynamicSize("m_PointsBuffer", m_PointsBuffer, mem);
 }
 
 std::size_t CNaturalBreaksClassifier::memoryUsage() const {
-    std::size_t mem = core::CMemory::dynamicSize(m_Categories);
-    mem += core::CMemory::dynamicSize(m_PointsBuffer);
+    std::size_t mem = core::memory::dynamicSize(m_Categories);
+    mem += core::memory::dynamicSize(m_PointsBuffer);
     return mem;
 }
 

--- a/lib/maths/common/COneOfNPrior.cc
+++ b/lib/maths/common/COneOfNPrior.cc
@@ -1009,11 +1009,11 @@ std::uint64_t COneOfNPrior::checksum(std::uint64_t seed) const {
 
 void COneOfNPrior::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("COneOfNPrior");
-    core::CMemoryDebug::dynamicSize("m_Models", m_Models, mem);
+    core::memory_debug::dynamicSize("m_Models", m_Models, mem);
 }
 
 std::size_t COneOfNPrior::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Models);
+    return core::memory::dynamicSize(m_Models);
 }
 
 std::size_t COneOfNPrior::staticSize() const {

--- a/lib/maths/common/CQuantileSketch.cc
+++ b/lib/maths/common/CQuantileSketch.cc
@@ -331,11 +331,11 @@ std::uint64_t CQuantileSketch::checksum(std::uint64_t seed) const {
 
 void CQuantileSketch::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CQuantileSketch");
-    core::CMemoryDebug::dynamicSize("m_Knots", m_Knots, mem);
+    core::memory_debug::dynamicSize("m_Knots", m_Knots, mem);
 }
 
 std::size_t CQuantileSketch::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Knots);
+    return core::memory::dynamicSize(m_Knots);
 }
 
 std::size_t CQuantileSketch::staticSize() const {
@@ -603,15 +603,15 @@ std::uint64_t CFastQuantileSketch::checksum(std::uint64_t seed) const {
 
 void CFastQuantileSketch::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CFastQuantileSketch");
-    core::CMemoryDebug::dynamicSize("m_Knots", this->knots(), mem);
-    core::CMemoryDebug::dynamicSize("m_MergeCosts", m_MergeCosts, mem);
-    core::CMemoryDebug::dynamicSize("m_MergeCandidates", m_MergeCandidates, mem);
+    core::memory_debug::dynamicSize("m_Knots", this->knots(), mem);
+    core::memory_debug::dynamicSize("m_MergeCosts", m_MergeCosts, mem);
+    core::memory_debug::dynamicSize("m_MergeCandidates", m_MergeCandidates, mem);
 }
 
 std::size_t CFastQuantileSketch::memoryUsage() const {
     std::size_t mem{this->CQuantileSketch::memoryUsage()};
-    mem += core::CMemory::dynamicSize(m_MergeCosts);
-    mem += core::CMemory::dynamicSize(m_MergeCandidates);
+    mem += core::memory::dynamicSize(m_MergeCosts);
+    mem += core::memory::dynamicSize(m_MergeCandidates);
     return mem;
 }
 

--- a/lib/maths/common/CXMeansOnline1d.cc
+++ b/lib/maths/common/CXMeansOnline1d.cc
@@ -1016,13 +1016,13 @@ double CXMeansOnline1d::probability(std::size_t index) const {
 
 void CXMeansOnline1d::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CXMeansOnline1d");
-    core::CMemoryDebug::dynamicSize("m_ClusterIndexGenerator", m_ClusterIndexGenerator, mem);
-    core::CMemoryDebug::dynamicSize("m_Clusters", m_Clusters, mem);
+    core::memory_debug::dynamicSize("m_ClusterIndexGenerator", m_ClusterIndexGenerator, mem);
+    core::memory_debug::dynamicSize("m_Clusters", m_Clusters, mem);
 }
 
 std::size_t CXMeansOnline1d::memoryUsage() const {
-    std::size_t mem = core::CMemory::dynamicSize(m_ClusterIndexGenerator);
-    mem += core::CMemory::dynamicSize(m_Clusters);
+    std::size_t mem = core::memory::dynamicSize(m_ClusterIndexGenerator);
+    mem += core::memory::dynamicSize(m_Clusters);
     return mem;
 }
 
@@ -1561,13 +1561,13 @@ std::uint64_t CXMeansOnline1d::CCluster::checksum(std::uint64_t seed) const {
 
 void CXMeansOnline1d::CCluster::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CXMeansOnline1d::CCluster");
-    core::CMemoryDebug::dynamicSize("m_Prior", m_Prior, mem);
-    core::CMemoryDebug::dynamicSize("m_Structure", m_Structure, mem);
+    core::memory_debug::dynamicSize("m_Prior", m_Prior, mem);
+    core::memory_debug::dynamicSize("m_Structure", m_Structure, mem);
 }
 
 std::size_t CXMeansOnline1d::CCluster::memoryUsage() const {
-    std::size_t mem = core::CMemory::dynamicSize(m_Prior);
-    mem += core::CMemory::dynamicSize(m_Structure);
+    std::size_t mem = core::memory::dynamicSize(m_Prior);
+    mem += core::memory::dynamicSize(m_Structure);
     return mem;
 }
 

--- a/lib/maths/common/unittest/CNaiveBayesTest.cc
+++ b/lib/maths/common/unittest/CNaiveBayesTest.cc
@@ -305,9 +305,9 @@ BOOST_AUTO_TEST_CASE(testMemoryUsage) {
     LOG_DEBUG(<< "Memory = " << memoryUsage);
     BOOST_REQUIRE_EQUAL(memoryUsage, mem->usage());
 
-    LOG_DEBUG(<< "Memory = " << core::CMemory::dynamicSize(nb));
+    LOG_DEBUG(<< "Memory = " << core::memory::dynamicSize(nb));
     BOOST_REQUIRE_EQUAL(memoryUsage + sizeof(maths::common::CNaiveBayes),
-                        core::CMemory::dynamicSize(nb));
+                        core::memory::dynamicSize(nb));
 }
 
 BOOST_AUTO_TEST_CASE(testPersist) {

--- a/lib/maths/common/unittest/CQuantileSketchTest.cc
+++ b/lib/maths/common/unittest/CQuantileSketchTest.cc
@@ -732,10 +732,10 @@ BOOST_AUTO_TEST_CASE(testFastSketchPerformance) {
     std::for_each(samples.begin(), samples.end(), fastSketch);
     LOG_DEBUG(<< "fast sketch duration = " << watch.lap() - lap);
 
-    LOG_DEBUG(<< "sketch memory usage = " << core::CMemory::dynamicSize(&sketch));
-    LOG_DEBUG(<< "fast sketch memory usage = " << core::CMemory::dynamicSize(&fastSketch));
-    BOOST_TEST_REQUIRE(2 * core::CMemory::dynamicSize(&sketch) >
-                       core::CMemory::dynamicSize(&fastSketch));
+    LOG_DEBUG(<< "sketch memory usage = " << core::memory::dynamicSize(&sketch));
+    LOG_DEBUG(<< "fast sketch memory usage = " << core::memory::dynamicSize(&fastSketch));
+    BOOST_TEST_REQUIRE(2 * core::memory::dynamicSize(&sketch) >
+                       core::memory::dynamicSize(&fastSketch));
 }
 
 BOOST_AUTO_TEST_CASE(testPersist) {

--- a/lib/maths/time_series/CAdaptiveBucketing.cc
+++ b/lib/maths/time_series/CAdaptiveBucketing.cc
@@ -848,9 +848,9 @@ std::uint64_t CAdaptiveBucketing::checksum(std::uint64_t seed) const {
 }
 
 std::size_t CAdaptiveBucketing::memoryUsage() const {
-    std::size_t mem{core::CMemory::dynamicSize(m_Endpoints)};
-    mem += core::CMemory::dynamicSize(m_Centres);
-    mem += core::CMemory::dynamicSize(m_LargeErrorCounts);
+    std::size_t mem{core::memory::dynamicSize(m_Endpoints)};
+    mem += core::memory::dynamicSize(m_Centres);
+    mem += core::memory::dynamicSize(m_LargeErrorCounts);
     return mem;
 }
 

--- a/lib/maths/time_series/CCalendarComponent.cc
+++ b/lib/maths/time_series/CCalendarComponent.cc
@@ -194,13 +194,13 @@ std::uint64_t CCalendarComponent::checksum(std::uint64_t seed) const {
 
 void CCalendarComponent::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCalendarComponent");
-    core::CMemoryDebug::dynamicSize("m_Bucketing", m_Bucketing, mem);
-    core::CMemoryDebug::dynamicSize("m_Splines", this->splines(), mem);
+    core::memory_debug::dynamicSize("m_Bucketing", m_Bucketing, mem);
+    core::memory_debug::dynamicSize("m_Splines", this->splines(), mem);
 }
 
 std::size_t CCalendarComponent::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Bucketing) +
-           core::CMemory::dynamicSize(this->splines());
+    return core::memory::dynamicSize(m_Bucketing) +
+           core::memory::dynamicSize(this->splines());
 }
 
 bool CCalendarComponent::isBad() const {

--- a/lib/maths/time_series/CCalendarComponentAdaptiveBucketing.cc
+++ b/lib/maths/time_series/CCalendarComponentAdaptiveBucketing.cc
@@ -165,14 +165,14 @@ std::uint64_t CCalendarComponentAdaptiveBucketing::checksum(std::uint64_t seed) 
 void CCalendarComponentAdaptiveBucketing::debugMemoryUsage(
     const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCalendarComponentAdaptiveBucketing");
-    core::CMemoryDebug::dynamicSize("m_Endpoints", this->endpoints(), mem);
-    core::CMemoryDebug::dynamicSize("m_Centres", this->centres(), mem);
-    core::CMemoryDebug::dynamicSize("m_LargeErrorCounts", this->largeErrorCounts(), mem);
-    core::CMemoryDebug::dynamicSize("m_Values", m_Values, mem);
+    core::memory_debug::dynamicSize("m_Endpoints", this->endpoints(), mem);
+    core::memory_debug::dynamicSize("m_Centres", this->centres(), mem);
+    core::memory_debug::dynamicSize("m_LargeErrorCounts", this->largeErrorCounts(), mem);
+    core::memory_debug::dynamicSize("m_Values", m_Values, mem);
 }
 
 std::size_t CCalendarComponentAdaptiveBucketing::memoryUsage() const {
-    return this->CAdaptiveBucketing::memoryUsage() + core::CMemory::dynamicSize(m_Values);
+    return this->CAdaptiveBucketing::memoryUsage() + core::memory::dynamicSize(m_Values);
 }
 
 bool CCalendarComponentAdaptiveBucketing::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {

--- a/lib/maths/time_series/CCalendarCyclicTest.cc
+++ b/lib/maths/time_series/CCalendarCyclicTest.cc
@@ -278,14 +278,14 @@ std::uint64_t CCalendarCyclicTest::checksum(std::uint64_t seed) const {
 
 void CCalendarCyclicTest::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCalendarCyclicTest");
-    core::CMemoryDebug::dynamicSize("m_ErrorQuantiles", m_ErrorQuantiles, mem);
-    core::CMemoryDebug::dynamicSize("m_CompressedBucketErrorStats",
+    core::memory_debug::dynamicSize("m_ErrorQuantiles", m_ErrorQuantiles, mem);
+    core::memory_debug::dynamicSize("m_CompressedBucketErrorStats",
                                     m_CompressedBucketErrorStats, mem);
 }
 
 std::size_t CCalendarCyclicTest::memoryUsage() const {
-    std::size_t mem{core::CMemory::dynamicSize(m_ErrorQuantiles)};
-    mem += core::CMemory::dynamicSize(m_CompressedBucketErrorStats);
+    std::size_t mem{core::memory::dynamicSize(m_ErrorQuantiles)};
+    mem += core::memory::dynamicSize(m_CompressedBucketErrorStats);
     return mem;
 }
 

--- a/lib/maths/time_series/CCountMinSketch.cc
+++ b/lib/maths/time_series/CCountMinSketch.cc
@@ -322,14 +322,14 @@ void CCountMinSketch::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr
     mem->setName("CCountMinSketch");
     const auto* counts = std::get_if<TUInt32FloatPrVec>(&m_Sketch);
     if (counts != nullptr) {
-        core::CMemoryDebug::dynamicSize("m_Counts", *counts, mem);
+        core::memory_debug::dynamicSize("m_Counts", *counts, mem);
     } else {
         try {
             const auto& sketch = std::get<SSketch>(m_Sketch);
             mem->addItem("SSketch", sizeof(SSketch));
-            core::CMemoryDebug::dynamicSize("sketch", sketch, mem);
-            core::CMemoryDebug::dynamicSize("s_Hashes", sketch.s_Hashes, mem);
-            core::CMemoryDebug::dynamicSize("s_Counts", sketch.s_Counts, mem);
+            core::memory_debug::dynamicSize("sketch", sketch, mem);
+            core::memory_debug::dynamicSize("s_Hashes", sketch.s_Hashes, mem);
+            core::memory_debug::dynamicSize("s_Counts", sketch.s_Counts, mem);
         } catch (const std::exception& e) {
             LOG_ABORT(<< "Unexpected exception " << e.what());
         }
@@ -340,13 +340,13 @@ std::size_t CCountMinSketch::memoryUsage() const {
     std::size_t mem = 0;
     const auto* counts = std::get_if<TUInt32FloatPrVec>(&m_Sketch);
     if (counts != nullptr) {
-        mem += core::CMemory::dynamicSize(*counts);
+        mem += core::memory::dynamicSize(*counts);
     } else {
         try {
             const auto& sketch = std::get<SSketch>(m_Sketch);
             mem += sizeof(SSketch);
-            mem += core::CMemory::dynamicSize(sketch.s_Hashes);
-            mem += core::CMemory::dynamicSize(sketch.s_Counts);
+            mem += core::memory::dynamicSize(sketch.s_Hashes);
+            mem += core::memory::dynamicSize(sketch.s_Counts);
         } catch (const std::exception& e) {
             LOG_ABORT(<< "Unexpected exception " << e.what());
         }

--- a/lib/maths/time_series/CDecayRateController.cc
+++ b/lib/maths/time_series/CDecayRateController.cc
@@ -293,17 +293,17 @@ std::size_t CDecayRateController::dimension() const {
 
 void CDecayRateController::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CDecayRateController");
-    core::CMemoryDebug::dynamicSize("m_PredictionMean", m_PredictionMean, mem);
-    core::CMemoryDebug::dynamicSize("m_Bias", m_Bias, mem);
-    core::CMemoryDebug::dynamicSize("m_RecentAbsError", m_RecentAbsError, mem);
-    core::CMemoryDebug::dynamicSize("m_HistoricalAbsError", m_HistoricalAbsError, mem);
+    core::memory_debug::dynamicSize("m_PredictionMean", m_PredictionMean, mem);
+    core::memory_debug::dynamicSize("m_Bias", m_Bias, mem);
+    core::memory_debug::dynamicSize("m_RecentAbsError", m_RecentAbsError, mem);
+    core::memory_debug::dynamicSize("m_HistoricalAbsError", m_HistoricalAbsError, mem);
 }
 
 std::size_t CDecayRateController::memoryUsage() const {
-    std::size_t mem{core::CMemory::dynamicSize(m_PredictionMean)};
-    mem += core::CMemory::dynamicSize(m_Bias);
-    mem += core::CMemory::dynamicSize(m_RecentAbsError);
-    mem += core::CMemory::dynamicSize(m_HistoricalAbsError);
+    std::size_t mem{core::memory::dynamicSize(m_PredictionMean)};
+    mem += core::memory::dynamicSize(m_Bias);
+    mem += core::memory::dynamicSize(m_RecentAbsError);
+    mem += core::memory::dynamicSize(m_HistoricalAbsError);
     return mem;
 }
 

--- a/lib/maths/time_series/CDecompositionComponent.cc
+++ b/lib/maths/time_series/CDecompositionComponent.cc
@@ -346,19 +346,19 @@ std::uint64_t CDecompositionComponent::CPackedSplines::checksum(std::uint64_t se
 void CDecompositionComponent::CPackedSplines::debugMemoryUsage(
     const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CPackedSplines");
-    core::CMemoryDebug::dynamicSize("m_Knots", m_Knots, mem);
-    core::CMemoryDebug::dynamicSize("m_Values[0]", m_Values[0], mem);
-    core::CMemoryDebug::dynamicSize("m_Values[1]", m_Values[1], mem);
-    core::CMemoryDebug::dynamicSize("m_Curvatures[0]", m_Curvatures[0], mem);
-    core::CMemoryDebug::dynamicSize("m_Curvatures[1]", m_Curvatures[1], mem);
+    core::memory_debug::dynamicSize("m_Knots", m_Knots, mem);
+    core::memory_debug::dynamicSize("m_Values[0]", m_Values[0], mem);
+    core::memory_debug::dynamicSize("m_Values[1]", m_Values[1], mem);
+    core::memory_debug::dynamicSize("m_Curvatures[0]", m_Curvatures[0], mem);
+    core::memory_debug::dynamicSize("m_Curvatures[1]", m_Curvatures[1], mem);
 }
 
 std::size_t CDecompositionComponent::CPackedSplines::memoryUsage() const {
-    std::size_t mem{core::CMemory::dynamicSize(m_Knots)};
-    mem += core::CMemory::dynamicSize(m_Values[0]);
-    mem += core::CMemory::dynamicSize(m_Values[1]);
-    mem += core::CMemory::dynamicSize(m_Curvatures[0]);
-    mem += core::CMemory::dynamicSize(m_Curvatures[1]);
+    std::size_t mem{core::memory::dynamicSize(m_Knots)};
+    mem += core::memory::dynamicSize(m_Values[0]);
+    mem += core::memory::dynamicSize(m_Values[1]);
+    mem += core::memory::dynamicSize(m_Curvatures[0]);
+    mem += core::memory::dynamicSize(m_Curvatures[1]);
     return mem;
 }
 }

--- a/lib/maths/time_series/CExpandingWindow.cc
+++ b/lib/maths/time_series/CExpandingWindow.cc
@@ -261,13 +261,13 @@ std::uint64_t CExpandingWindow::checksum(std::uint64_t seed) const {
 
 void CExpandingWindow::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CExpandingWindow");
-    core::CMemoryDebug::dynamicSize("m_BucketValues", m_BucketValues, mem);
-    core::CMemoryDebug::dynamicSize("m_DeflatedBucketValues", m_DeflatedBucketValues, mem);
+    core::memory_debug::dynamicSize("m_BucketValues", m_BucketValues, mem);
+    core::memory_debug::dynamicSize("m_DeflatedBucketValues", m_DeflatedBucketValues, mem);
 }
 
 std::size_t CExpandingWindow::memoryUsage() const {
-    std::size_t mem{core::CMemory::dynamicSize(m_BucketValues)};
-    mem += core::CMemory::dynamicSize(m_DeflatedBucketValues);
+    std::size_t mem{core::memory::dynamicSize(m_BucketValues)};
+    mem += core::memory::dynamicSize(m_DeflatedBucketValues);
     return mem;
 }
 

--- a/lib/maths/time_series/CSeasonalComponent.cc
+++ b/lib/maths/time_series/CSeasonalComponent.cc
@@ -363,13 +363,13 @@ std::uint64_t CSeasonalComponent::checksum(std::uint64_t seed) const {
 
 void CSeasonalComponent::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CSeasonalComponent");
-    core::CMemoryDebug::dynamicSize("m_Bucketing", m_Bucketing, mem);
-    core::CMemoryDebug::dynamicSize("m_Splines", this->splines(), mem);
+    core::memory_debug::dynamicSize("m_Bucketing", m_Bucketing, mem);
+    core::memory_debug::dynamicSize("m_Splines", this->splines(), mem);
 }
 
 std::size_t CSeasonalComponent::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Bucketing) +
-           core::CMemory::dynamicSize(this->splines());
+    return core::memory::dynamicSize(m_Bucketing) +
+           core::memory::dynamicSize(this->splines());
 }
 
 CSeasonalComponent::TTimeDoublePr CSeasonalComponent::likelyShift(core_t::TTime maxTimeShift,

--- a/lib/maths/time_series/CSeasonalComponentAdaptiveBucketing.cc
+++ b/lib/maths/time_series/CSeasonalComponentAdaptiveBucketing.cc
@@ -315,14 +315,14 @@ std::uint64_t CSeasonalComponentAdaptiveBucketing::checksum(std::uint64_t seed) 
 void CSeasonalComponentAdaptiveBucketing::debugMemoryUsage(
     const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CSeasonalComponentAdaptiveBucketing");
-    core::CMemoryDebug::dynamicSize("m_Endpoints", this->endpoints(), mem);
-    core::CMemoryDebug::dynamicSize("m_Centres", this->centres(), mem);
-    core::CMemoryDebug::dynamicSize("m_LargeErrorCounts", this->largeErrorCounts(), mem);
-    core::CMemoryDebug::dynamicSize("m_Buckets", m_Buckets, mem);
+    core::memory_debug::dynamicSize("m_Endpoints", this->endpoints(), mem);
+    core::memory_debug::dynamicSize("m_Centres", this->centres(), mem);
+    core::memory_debug::dynamicSize("m_LargeErrorCounts", this->largeErrorCounts(), mem);
+    core::memory_debug::dynamicSize("m_Buckets", m_Buckets, mem);
 }
 
 std::size_t CSeasonalComponentAdaptiveBucketing::memoryUsage() const {
-    return this->CAdaptiveBucketing::memoryUsage() + core::CMemory::dynamicSize(m_Buckets);
+    return this->CAdaptiveBucketing::memoryUsage() + core::memory::dynamicSize(m_Buckets);
 }
 
 bool CSeasonalComponentAdaptiveBucketing::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {

--- a/lib/maths/time_series/CTimeSeriesDecomposition.cc
+++ b/lib/maths/time_series/CTimeSeriesDecomposition.cc
@@ -576,19 +576,19 @@ std::uint64_t CTimeSeriesDecomposition::checksum(std::uint64_t seed) const {
 
 void CTimeSeriesDecomposition::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CTimeSeriesDecomposition");
-    core::CMemoryDebug::dynamicSize("m_Mediator", m_Mediator, mem);
-    core::CMemoryDebug::dynamicSize("m_ChangePointTest", m_ChangePointTest, mem);
-    core::CMemoryDebug::dynamicSize("m_SeasonalityTest", m_SeasonalityTest, mem);
-    core::CMemoryDebug::dynamicSize("m_CalendarCyclicTest", m_CalendarCyclicTest, mem);
-    core::CMemoryDebug::dynamicSize("m_Components", m_Components, mem);
+    core::memory_debug::dynamicSize("m_Mediator", m_Mediator, mem);
+    core::memory_debug::dynamicSize("m_ChangePointTest", m_ChangePointTest, mem);
+    core::memory_debug::dynamicSize("m_SeasonalityTest", m_SeasonalityTest, mem);
+    core::memory_debug::dynamicSize("m_CalendarCyclicTest", m_CalendarCyclicTest, mem);
+    core::memory_debug::dynamicSize("m_Components", m_Components, mem);
 }
 
 std::size_t CTimeSeriesDecomposition::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Mediator) +
-           core::CMemory::dynamicSize(m_ChangePointTest) +
-           core::CMemory::dynamicSize(m_SeasonalityTest) +
-           core::CMemory::dynamicSize(m_CalendarCyclicTest) +
-           core::CMemory::dynamicSize(m_Components);
+    return core::memory::dynamicSize(m_Mediator) +
+           core::memory::dynamicSize(m_ChangePointTest) +
+           core::memory::dynamicSize(m_SeasonalityTest) +
+           core::memory::dynamicSize(m_CalendarCyclicTest) +
+           core::memory::dynamicSize(m_Components);
 }
 
 std::size_t CTimeSeriesDecomposition::staticSize() const {

--- a/lib/maths/time_series/CTimeSeriesDecompositionDetail.cc
+++ b/lib/maths/time_series/CTimeSeriesDecompositionDetail.cc
@@ -482,11 +482,11 @@ void CTimeSeriesDecompositionDetail::CMediator::registerHandler(CHandler& handle
 void CTimeSeriesDecompositionDetail::CMediator::debugMemoryUsage(
     const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CMediator");
-    core::CMemoryDebug::dynamicSize("m_Handlers", m_Handlers, mem);
+    core::memory_debug::dynamicSize("m_Handlers", m_Handlers, mem);
 }
 
 std::size_t CTimeSeriesDecompositionDetail::CMediator::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Handlers);
+    return core::memory::dynamicSize(m_Handlers);
 }
 
 //////// CChangePointTest ////////
@@ -694,13 +694,13 @@ std::uint64_t CTimeSeriesDecompositionDetail::CChangePointTest::checksum(std::ui
 void CTimeSeriesDecompositionDetail::CChangePointTest::debugMemoryUsage(
     const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CChangePointTest");
-    core::CMemoryDebug::dynamicSize("m_Window", m_Window, mem);
-    core::CMemoryDebug::dynamicSize("m_UndoableLastChange", m_UndoableLastChange, mem);
+    core::memory_debug::dynamicSize("m_Window", m_Window, mem);
+    core::memory_debug::dynamicSize("m_UndoableLastChange", m_UndoableLastChange, mem);
 }
 
 std::size_t CTimeSeriesDecompositionDetail::CChangePointTest::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Window) +
-           core::CMemory::dynamicSize(m_UndoableLastChange);
+    return core::memory::dynamicSize(m_Window) +
+           core::memory::dynamicSize(m_UndoableLastChange);
 }
 
 void CTimeSeriesDecompositionDetail::CChangePointTest::apply(std::size_t symbol) {
@@ -1288,11 +1288,11 @@ std::uint64_t CTimeSeriesDecompositionDetail::CSeasonalityTest::checksum(std::ui
 void CTimeSeriesDecompositionDetail::CSeasonalityTest::debugMemoryUsage(
     const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CSeasonalityTest");
-    core::CMemoryDebug::dynamicSize("m_Windows", m_Windows, mem);
+    core::memory_debug::dynamicSize("m_Windows", m_Windows, mem);
 }
 
 std::size_t CTimeSeriesDecompositionDetail::CSeasonalityTest::memoryUsage() const {
-    std::size_t usage{core::CMemory::dynamicSize(m_Windows)};
+    std::size_t usage{core::memory::dynamicSize(m_Windows)};
     if (m_Machine.state() == PT_INITIAL) {
         usage += this->extraMemoryOnInitialization();
     }
@@ -1307,7 +1307,7 @@ std::size_t CTimeSeriesDecompositionDetail::CSeasonalityTest::extraMemoryOnIniti
             // The 0.3 is a rule-of-thumb estimate of the worst case
             // compression ratio we achieve on the test state.
             result += static_cast<std::size_t>(
-                0.3 * static_cast<double>(core::CMemory::dynamicSize(window)));
+                0.3 * static_cast<double>(core::memory::dynamicSize(window)));
         }
     }
     return result;
@@ -1534,11 +1534,11 @@ std::uint64_t CTimeSeriesDecompositionDetail::CCalendarTest::checksum(std::uint6
 void CTimeSeriesDecompositionDetail::CCalendarTest::debugMemoryUsage(
     const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCalendarTest");
-    core::CMemoryDebug::dynamicSize("m_Test", m_Test, mem);
+    core::memory_debug::dynamicSize("m_Test", m_Test, mem);
 }
 
 std::size_t CTimeSeriesDecompositionDetail::CCalendarTest::memoryUsage() const {
-    std::size_t usage{core::CMemory::dynamicSize(m_Test)};
+    std::size_t usage{core::memory::dynamicSize(m_Test)};
     if (m_Machine.state() == CC_INITIAL) {
         usage += this->extraMemoryOnInitialization();
     }
@@ -1549,7 +1549,7 @@ std::size_t CTimeSeriesDecompositionDetail::CCalendarTest::extraMemoryOnInitiali
     static std::size_t result{0};
     if (result == 0) {
         TCalendarCyclicTestPtr test = std::make_unique<CCalendarCyclicTest>(m_DecayRate);
-        result = core::CMemory::dynamicSize(test);
+        result = core::memory::dynamicSize(test);
     }
     return result;
 }
@@ -2052,14 +2052,14 @@ std::uint64_t CTimeSeriesDecompositionDetail::CComponents::checksum(std::uint64_
 void CTimeSeriesDecompositionDetail::CComponents::debugMemoryUsage(
     const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CComponents");
-    core::CMemoryDebug::dynamicSize("m_Trend", m_Trend, mem);
-    core::CMemoryDebug::dynamicSize("m_Seasonal", m_Seasonal, mem);
-    core::CMemoryDebug::dynamicSize("m_Calendar", m_Calendar, mem);
+    core::memory_debug::dynamicSize("m_Trend", m_Trend, mem);
+    core::memory_debug::dynamicSize("m_Seasonal", m_Seasonal, mem);
+    core::memory_debug::dynamicSize("m_Calendar", m_Calendar, mem);
 }
 
 std::size_t CTimeSeriesDecompositionDetail::CComponents::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Trend) + core::CMemory::dynamicSize(m_Seasonal) +
-           core::CMemory::dynamicSize(m_Calendar);
+    return core::memory::dynamicSize(m_Trend) + core::memory::dynamicSize(m_Seasonal) +
+           core::memory::dynamicSize(m_Calendar);
 }
 
 std::size_t CTimeSeriesDecompositionDetail::CComponents::size() const {
@@ -2856,13 +2856,13 @@ CTimeSeriesDecompositionDetail::CComponents::CSeasonal::checksum(std::uint64_t s
 void CTimeSeriesDecompositionDetail::CComponents::CSeasonal::debugMemoryUsage(
     const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CSeasonal");
-    core::CMemoryDebug::dynamicSize("m_Components", m_Components, mem);
-    core::CMemoryDebug::dynamicSize("m_PredictionErrors", m_PredictionErrors, mem);
+    core::memory_debug::dynamicSize("m_Components", m_Components, mem);
+    core::memory_debug::dynamicSize("m_PredictionErrors", m_PredictionErrors, mem);
 }
 
 std::size_t CTimeSeriesDecompositionDetail::CComponents::CSeasonal::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Components) +
-           core::CMemory::dynamicSize(m_PredictionErrors);
+    return core::memory::dynamicSize(m_Components) +
+           core::memory::dynamicSize(m_PredictionErrors);
 }
 
 bool CTimeSeriesDecompositionDetail::CComponents::CCalendar::acceptRestoreTraverser(
@@ -3060,13 +3060,13 @@ CTimeSeriesDecompositionDetail::CComponents::CCalendar::checksum(std::uint64_t s
 void CTimeSeriesDecompositionDetail::CComponents::CCalendar::debugMemoryUsage(
     const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCalendar");
-    core::CMemoryDebug::dynamicSize("m_Components", m_Components, mem);
-    core::CMemoryDebug::dynamicSize("m_PredictionErrors", m_PredictionErrors, mem);
+    core::memory_debug::dynamicSize("m_Components", m_Components, mem);
+    core::memory_debug::dynamicSize("m_PredictionErrors", m_PredictionErrors, mem);
 }
 
 std::size_t CTimeSeriesDecompositionDetail::CComponents::CCalendar::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Components) +
-           core::CMemory::dynamicSize(m_PredictionErrors);
+    return core::memory::dynamicSize(m_Components) +
+           core::memory::dynamicSize(m_PredictionErrors);
 }
 }
 }

--- a/lib/maths/time_series/CTimeSeriesModel.cc
+++ b/lib/maths/time_series/CTimeSeriesModel.cc
@@ -535,13 +535,13 @@ std::uint64_t CTimeSeriesAnomalyModel::checksum(std::uint64_t seed) const {
 
 void CTimeSeriesAnomalyModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CTimeSeriesAnomalyModel");
-    core::CMemoryDebug::dynamicSize("m_Anomalies", m_Anomaly, mem);
-    core::CMemoryDebug::dynamicSize("m_AnomalyFeatureModels", m_AnomalyFeatureModels, mem);
+    core::memory_debug::dynamicSize("m_Anomalies", m_Anomaly, mem);
+    core::memory_debug::dynamicSize("m_AnomalyFeatureModels", m_AnomalyFeatureModels, mem);
 }
 
 std::size_t CTimeSeriesAnomalyModel::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Anomaly) +
-           core::CMemory::dynamicSize(m_AnomalyFeatureModels);
+    return core::memory::dynamicSize(m_Anomaly) +
+           core::memory::dynamicSize(m_AnomalyFeatureModels);
 }
 
 bool CTimeSeriesAnomalyModel::acceptRestoreTraverser(const common::SModelRestoreParams& params,
@@ -1235,22 +1235,22 @@ std::uint64_t CUnivariateTimeSeriesModel::checksum(std::uint64_t seed) const {
 
 void CUnivariateTimeSeriesModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CUnivariateTimeSeriesModel");
-    core::CMemoryDebug::dynamicSize("m_Controllers", m_Controllers, mem);
-    core::CMemoryDebug::dynamicSize("m_TrendModel", m_TrendModel, mem);
-    core::CMemoryDebug::dynamicSize("m_ResidualModel", m_ResidualModel, mem);
-    core::CMemoryDebug::dynamicSize("m_MultibucketFeature", m_MultibucketFeature, mem);
-    core::CMemoryDebug::dynamicSize("m_MultibucketFeatureModel",
+    core::memory_debug::dynamicSize("m_Controllers", m_Controllers, mem);
+    core::memory_debug::dynamicSize("m_TrendModel", m_TrendModel, mem);
+    core::memory_debug::dynamicSize("m_ResidualModel", m_ResidualModel, mem);
+    core::memory_debug::dynamicSize("m_MultibucketFeature", m_MultibucketFeature, mem);
+    core::memory_debug::dynamicSize("m_MultibucketFeatureModel",
                                     m_MultibucketFeatureModel, mem);
-    core::CMemoryDebug::dynamicSize("m_AnomalyModel", m_AnomalyModel, mem);
+    core::memory_debug::dynamicSize("m_AnomalyModel", m_AnomalyModel, mem);
 }
 
 std::size_t CUnivariateTimeSeriesModel::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Controllers) +
-           core::CMemory::dynamicSize(m_TrendModel) +
-           core::CMemory::dynamicSize(m_ResidualModel) +
-           core::CMemory::dynamicSize(m_MultibucketFeature) +
-           core::CMemory::dynamicSize(m_MultibucketFeatureModel) +
-           core::CMemory::dynamicSize(m_AnomalyModel);
+    return core::memory::dynamicSize(m_Controllers) +
+           core::memory::dynamicSize(m_TrendModel) +
+           core::memory::dynamicSize(m_ResidualModel) +
+           core::memory::dynamicSize(m_MultibucketFeature) +
+           core::memory::dynamicSize(m_MultibucketFeatureModel) +
+           core::memory::dynamicSize(m_AnomalyModel);
 }
 
 bool CUnivariateTimeSeriesModel::acceptRestoreTraverser(const common::SModelRestoreParams& params,
@@ -1913,18 +1913,18 @@ CTimeSeriesCorrelations::correlationModels() const {
 
 void CTimeSeriesCorrelations::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CTimeSeriesCorrelations");
-    core::CMemoryDebug::dynamicSize("m_SampleData", m_SampleData, mem);
-    core::CMemoryDebug::dynamicSize("m_Correlations", m_Correlations, mem);
-    core::CMemoryDebug::dynamicSize("m_CorrelatedLookup", m_CorrelatedLookup, mem);
-    core::CMemoryDebug::dynamicSize("m_CorrelationDistributionModels",
+    core::memory_debug::dynamicSize("m_SampleData", m_SampleData, mem);
+    core::memory_debug::dynamicSize("m_Correlations", m_Correlations, mem);
+    core::memory_debug::dynamicSize("m_CorrelatedLookup", m_CorrelatedLookup, mem);
+    core::memory_debug::dynamicSize("m_CorrelationDistributionModels",
                                     m_CorrelationDistributionModels, mem);
 }
 
 std::size_t CTimeSeriesCorrelations::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_SampleData) +
-           core::CMemory::dynamicSize(m_Correlations) +
-           core::CMemory::dynamicSize(m_CorrelatedLookup) +
-           core::CMemory::dynamicSize(m_CorrelationDistributionModels);
+    return core::memory::dynamicSize(m_SampleData) +
+           core::memory::dynamicSize(m_Correlations) +
+           core::memory::dynamicSize(m_CorrelatedLookup) +
+           core::memory::dynamicSize(m_CorrelationDistributionModels);
 }
 
 bool CTimeSeriesCorrelations::acceptRestoreTraverser(const common::SDistributionRestoreParams& params,
@@ -2644,22 +2644,22 @@ std::uint64_t CMultivariateTimeSeriesModel::checksum(std::uint64_t seed) const {
 
 void CMultivariateTimeSeriesModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CMultivariateTimeSeriesModel");
-    core::CMemoryDebug::dynamicSize("m_Controllers", m_Controllers, mem);
-    core::CMemoryDebug::dynamicSize("m_TrendModel", m_TrendModel, mem);
-    core::CMemoryDebug::dynamicSize("m_ResidualModel", m_ResidualModel, mem);
-    core::CMemoryDebug::dynamicSize("m_MultibucketFeature", m_MultibucketFeature, mem);
-    core::CMemoryDebug::dynamicSize("m_MultibucketFeatureModel",
+    core::memory_debug::dynamicSize("m_Controllers", m_Controllers, mem);
+    core::memory_debug::dynamicSize("m_TrendModel", m_TrendModel, mem);
+    core::memory_debug::dynamicSize("m_ResidualModel", m_ResidualModel, mem);
+    core::memory_debug::dynamicSize("m_MultibucketFeature", m_MultibucketFeature, mem);
+    core::memory_debug::dynamicSize("m_MultibucketFeatureModel",
                                     m_MultibucketFeatureModel, mem);
-    core::CMemoryDebug::dynamicSize("m_AnomalyModel", m_AnomalyModel, mem);
+    core::memory_debug::dynamicSize("m_AnomalyModel", m_AnomalyModel, mem);
 }
 
 std::size_t CMultivariateTimeSeriesModel::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Controllers) +
-           core::CMemory::dynamicSize(m_TrendModel) +
-           core::CMemory::dynamicSize(m_ResidualModel) +
-           core::CMemory::dynamicSize(m_MultibucketFeature) +
-           core::CMemory::dynamicSize(m_MultibucketFeatureModel) +
-           core::CMemory::dynamicSize(m_AnomalyModel);
+    return core::memory::dynamicSize(m_Controllers) +
+           core::memory::dynamicSize(m_TrendModel) +
+           core::memory::dynamicSize(m_ResidualModel) +
+           core::memory::dynamicSize(m_MultibucketFeature) +
+           core::memory::dynamicSize(m_MultibucketFeatureModel) +
+           core::memory::dynamicSize(m_AnomalyModel);
 }
 
 bool CMultivariateTimeSeriesModel::acceptRestoreTraverser(const common::SModelRestoreParams& params,

--- a/lib/maths/time_series/unittest/CCalendarCyclicTestTest.cc
+++ b/lib/maths/time_series/unittest/CCalendarCyclicTestTest.cc
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
                                                                   : falsePositive) += 1.0;
                 }
             }
-            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 790);
+            BOOST_TEST_REQUIRE(core::memory::dynamicSize(&cyclic) < 790);
         }
     }
     LOG_DEBUG(<< "true positive = " << truePositive);
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
                          : falsePositive) += 1.0;
                 }
             }
-            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 790);
+            BOOST_TEST_REQUIRE(core::memory::dynamicSize(&cyclic) < 790);
         }
     }
     LOG_DEBUG(<< "true positive = " << truePositive);
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
                          : falsePositive) += 1.0;
                 }
             }
-            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 790);
+            BOOST_TEST_REQUIRE(core::memory::dynamicSize(&cyclic) < 790);
         }
     }
     LOG_DEBUG(<< "true positive = " << truePositive);
@@ -226,7 +226,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
                          : falsePositive) += 1.0;
                 }
             }
-            BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 790);
+            BOOST_TEST_REQUIRE(core::memory::dynamicSize(&cyclic) < 790);
         }
     }
     LOG_DEBUG(<< "true positive = " << truePositive);
@@ -426,7 +426,7 @@ BOOST_AUTO_TEST_CASE(testFalsePositives) {
                 if (feature != std::nullopt) {
                     LOG_DEBUG(<< "Detected = " << feature->first.print());
                 }
-                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 880);
+                BOOST_TEST_REQUIRE(core::memory::dynamicSize(&cyclic) < 880);
             }
         }
     }
@@ -450,7 +450,7 @@ BOOST_AUTO_TEST_CASE(testFalsePositives) {
                 if (feature != std::nullopt) {
                     LOG_DEBUG(<< "Detected = " << feature->first.print());
                 }
-                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 880);
+                BOOST_TEST_REQUIRE(core::memory::dynamicSize(&cyclic) < 880);
             }
         }
     }
@@ -476,7 +476,7 @@ BOOST_AUTO_TEST_CASE(testFalsePositives) {
                 if (feature != std::nullopt) {
                     LOG_DEBUG(<< "Detected = " << feature->first.print());
                 }
-                BOOST_TEST_REQUIRE(core::CMemory::dynamicSize(&cyclic) < 880);
+                BOOST_TEST_REQUIRE(core::memory::dynamicSize(&cyclic) < 880);
             }
         }
     }

--- a/lib/maths/time_series/unittest/CMathsMemoryTest.cc
+++ b/lib/maths/time_series/unittest/CMathsMemoryTest.cc
@@ -121,8 +121,8 @@ BOOST_AUTO_TEST_CASE(testBjkstVec) {
         TBjkstValuesVec values;
         auto mem = std::make_shared<core::CMemoryUsage>();
         mem->setName("root", 0);
-        core::CMemoryDebug::dynamicSize("values", values, mem);
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(values), mem->usage());
+        core::memory_debug::dynamicSize("values", values, mem);
+        BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(values), mem->usage());
     }
     {
         // Test adding values to the vector part
@@ -136,8 +136,8 @@ BOOST_AUTO_TEST_CASE(testBjkstVec) {
         }
         auto mem = std::make_shared<core::CMemoryUsage>();
         mem->setName("root", 0);
-        core::CMemoryDebug::dynamicSize("values", values, mem);
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(values), mem->usage());
+        core::memory_debug::dynamicSize("values", values, mem);
+        BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(values), mem->usage());
     }
     {
         // Test adding values to the sketch part
@@ -151,8 +151,8 @@ BOOST_AUTO_TEST_CASE(testBjkstVec) {
         }
         auto mem = std::make_shared<core::CMemoryUsage>();
         mem->setName("root", 0);
-        core::CMemoryDebug::dynamicSize("values", values, mem);
-        BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(values), mem->usage());
+        core::memory_debug::dynamicSize("values", values, mem);
+        BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(values), mem->usage());
     }
 }
 

--- a/lib/maths/time_series/unittest/CTimeSeriesMultibucketFeaturesTest.cc
+++ b/lib/maths/time_series/unittest/CTimeSeriesMultibucketFeaturesTest.cc
@@ -100,10 +100,10 @@ BOOST_AUTO_TEST_CASE(testUnivariateMean) {
     // Memory accounting through base pointer.
 
     maths::time_series::CTimeSeriesMultibucketScalarMean* base = &feature;
-    LOG_DEBUG(<< "size = " << core::CMemory::dynamicSize(&feature));
+    LOG_DEBUG(<< "size = " << core::memory::dynamicSize(&feature));
 
-    BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(base),
-                        core::CMemory::dynamicSize(&feature));
+    BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(base),
+                        core::memory::dynamicSize(&feature));
 
     // Check clearing the feature.
 
@@ -288,10 +288,10 @@ BOOST_AUTO_TEST_CASE(testMultivariateMean) {
     // Memory accounting through base pointer.
 
     maths::time_series::CTimeSeriesMultibucketVectorMean* base = &feature;
-    LOG_DEBUG(<< "size = " << core::CMemory::dynamicSize(&feature));
+    LOG_DEBUG(<< "size = " << core::memory::dynamicSize(&feature));
 
-    BOOST_REQUIRE_EQUAL(core::CMemory::dynamicSize(base),
-                        core::CMemory::dynamicSize(&feature));
+    BOOST_REQUIRE_EQUAL(core::memory::dynamicSize(base),
+                        core::memory::dynamicSize(&feature));
 
     // Check clearing the feature.
 

--- a/lib/model/CAnomalyDetector.cc
+++ b/lib/model/CAnomalyDetector.cc
@@ -632,12 +632,12 @@ void CAnomalyDetector::showMemoryUsage(std::ostream& stream) const {
 
 void CAnomalyDetector::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("Anomaly Detector Memory Usage");
-    core::CMemoryDebug::dynamicSize("m_DataGatherer", m_DataGatherer, mem);
-    core::CMemoryDebug::dynamicSize("m_Model", m_Model, mem);
+    core::memory_debug::dynamicSize("m_DataGatherer", m_DataGatherer, mem);
+    core::memory_debug::dynamicSize("m_Model", m_Model, mem);
 }
 
 std::size_t CAnomalyDetector::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_DataGatherer) + core::CMemory::dynamicSize(m_Model);
+    return core::memory::dynamicSize(m_DataGatherer) + core::memory::dynamicSize(m_Model);
 }
 
 std::size_t CAnomalyDetector::staticSize() const {

--- a/lib/model/CAnomalyDetectorModel.cc
+++ b/lib/model/CAnomalyDetectorModel.cc
@@ -311,17 +311,17 @@ std::uint64_t CAnomalyDetectorModel::checksum(bool /*includeCurrentBucketStats*/
 
 void CAnomalyDetectorModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CAnomalyDetectorModel");
-    core::CMemoryDebug::dynamicSize("m_DataGatherer", m_DataGatherer, mem);
-    core::CMemoryDebug::dynamicSize("m_Params", m_Params, mem);
-    core::CMemoryDebug::dynamicSize("m_PersonBucketCounts", m_PersonBucketCounts, mem);
-    core::CMemoryDebug::dynamicSize("m_InfluenceCalculators", m_InfluenceCalculators, mem);
+    core::memory_debug::dynamicSize("m_DataGatherer", m_DataGatherer, mem);
+    core::memory_debug::dynamicSize("m_Params", m_Params, mem);
+    core::memory_debug::dynamicSize("m_PersonBucketCounts", m_PersonBucketCounts, mem);
+    core::memory_debug::dynamicSize("m_InfluenceCalculators", m_InfluenceCalculators, mem);
 }
 
 std::size_t CAnomalyDetectorModel::memoryUsage() const {
-    std::size_t mem{core::CMemory::dynamicSize(m_Params)};
-    mem += core::CMemory::dynamicSize(m_DataGatherer);
-    mem += core::CMemory::dynamicSize(m_PersonBucketCounts);
-    mem += core::CMemory::dynamicSize(m_InfluenceCalculators);
+    std::size_t mem{core::memory::dynamicSize(m_Params)};
+    mem += core::memory::dynamicSize(m_DataGatherer);
+    mem += core::memory::dynamicSize(m_PersonBucketCounts);
+    mem += core::memory::dynamicSize(m_InfluenceCalculators);
     return mem;
 }
 
@@ -535,12 +535,12 @@ void CAnomalyDetectorModel::SFeatureModels::acceptPersistInserter(core::CStatePe
 void CAnomalyDetectorModel::SFeatureModels::debugMemoryUsage(
     const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("SFeatureModels");
-    core::CMemoryDebug::dynamicSize("s_NewModel", s_NewModel, mem);
-    core::CMemoryDebug::dynamicSize("s_Models", s_Models, mem);
+    core::memory_debug::dynamicSize("s_NewModel", s_NewModel, mem);
+    core::memory_debug::dynamicSize("s_Models", s_Models, mem);
 }
 
 std::size_t CAnomalyDetectorModel::SFeatureModels::memoryUsage() const {
-    return core::CMemory::dynamicSize(s_NewModel) + core::CMemory::dynamicSize(s_Models);
+    return core::memory::dynamicSize(s_NewModel) + core::memory::dynamicSize(s_Models);
 }
 
 bool CAnomalyDetectorModel::SFeatureModels::shouldPersist() const {
@@ -590,12 +590,12 @@ void CAnomalyDetectorModel::SFeatureCorrelateModels::acceptPersistInserter(
 void CAnomalyDetectorModel::SFeatureCorrelateModels::debugMemoryUsage(
     const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("SFeatureCorrelateModels");
-    core::CMemoryDebug::dynamicSize("s_ModelPrior", s_ModelPrior, mem);
-    core::CMemoryDebug::dynamicSize("s_Models", s_Models, mem);
+    core::memory_debug::dynamicSize("s_ModelPrior", s_ModelPrior, mem);
+    core::memory_debug::dynamicSize("s_Models", s_Models, mem);
 }
 
 std::size_t CAnomalyDetectorModel::SFeatureCorrelateModels::memoryUsage() const {
-    return core::CMemory::dynamicSize(s_ModelPrior) + core::CMemory::dynamicSize(s_Models);
+    return core::memory::dynamicSize(s_ModelPrior) + core::memory::dynamicSize(s_Models);
 }
 
 CAnomalyDetectorModel::CTimeSeriesCorrelateModelAllocator::CTimeSeriesCorrelateModelAllocator(

--- a/lib/model/CBucketGatherer.cc
+++ b/lib/model/CBucketGatherer.cc
@@ -552,16 +552,16 @@ std::uint64_t CBucketGatherer::checksum() const {
 
 void CBucketGatherer::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CBucketGatherer");
-    core::CMemoryDebug::dynamicSize("m_PersonAttributeCounts", m_PersonAttributeCounts, mem);
-    core::CMemoryDebug::dynamicSize("m_PersonAttributeExplicitNulls",
+    core::memory_debug::dynamicSize("m_PersonAttributeCounts", m_PersonAttributeCounts, mem);
+    core::memory_debug::dynamicSize("m_PersonAttributeExplicitNulls",
                                     m_PersonAttributeExplicitNulls, mem);
-    core::CMemoryDebug::dynamicSize("m_Influencers", m_InfluencerCounts, mem);
+    core::memory_debug::dynamicSize("m_Influencers", m_InfluencerCounts, mem);
 }
 
 std::size_t CBucketGatherer::memoryUsage() const {
-    std::size_t mem = core::CMemory::dynamicSize(m_PersonAttributeCounts);
-    mem += core::CMemory::dynamicSize(m_PersonAttributeExplicitNulls);
-    mem += core::CMemory::dynamicSize(m_InfluencerCounts);
+    std::size_t mem = core::memory::dynamicSize(m_PersonAttributeCounts);
+    mem += core::memory::dynamicSize(m_PersonAttributeExplicitNulls);
+    mem += core::memory::dynamicSize(m_InfluencerCounts);
     return mem;
 }
 

--- a/lib/model/CCategoryExamplesCollector.cc
+++ b/lib/model/CCategoryExamplesCollector.cc
@@ -153,12 +153,12 @@ void CCategoryExamplesCollector::clear() {
 
 void CCategoryExamplesCollector::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCategoryExamplesCollector");
-    core::CMemoryDebug::dynamicSize("m_ExamplesByCategory", m_ExamplesByCategory, mem);
+    core::memory_debug::dynamicSize("m_ExamplesByCategory", m_ExamplesByCategory, mem);
 }
 
 std::size_t CCategoryExamplesCollector::memoryUsage() const {
     std::size_t mem = 0;
-    mem += core::CMemory::dynamicSize(m_ExamplesByCategory);
+    mem += core::memory::dynamicSize(m_ExamplesByCategory);
     return mem;
 }
 

--- a/lib/model/CCountingModel.cc
+++ b/lib/model/CCountingModel.cc
@@ -321,17 +321,17 @@ std::uint64_t CCountingModel::checksum(bool includeCurrentBucketStats) const {
 void CCountingModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CCountingModel");
     this->CAnomalyDetectorModel::debugMemoryUsage(mem->addChild());
-    core::CMemoryDebug::dynamicSize("m_Counts", m_Counts, mem);
-    core::CMemoryDebug::dynamicSize("m_MeanCounts", m_MeanCounts, mem);
-    core::CMemoryDebug::dynamicSize("m_InterimBucketCorrector",
+    core::memory_debug::dynamicSize("m_Counts", m_Counts, mem);
+    core::memory_debug::dynamicSize("m_MeanCounts", m_MeanCounts, mem);
+    core::memory_debug::dynamicSize("m_InterimBucketCorrector",
                                     m_InterimBucketCorrector, mem);
 }
 
 std::size_t CCountingModel::memoryUsage() const {
     std::size_t mem = this->CAnomalyDetectorModel::memoryUsage();
-    mem += core::CMemory::dynamicSize(m_Counts);
-    mem += core::CMemory::dynamicSize(m_MeanCounts);
-    mem += core::CMemory::dynamicSize(m_InterimBucketCorrector);
+    mem += core::memory::dynamicSize(m_Counts);
+    mem += core::memory::dynamicSize(m_MeanCounts);
+    mem += core::memory::dynamicSize(m_InterimBucketCorrector);
     return mem;
 }
 

--- a/lib/model/CDataCategorizer.cc
+++ b/lib/model/CDataCategorizer.cc
@@ -42,14 +42,14 @@ const std::string& CDataCategorizer::fieldName() const {
 
 void CDataCategorizer::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CDataCategorizer");
-    core::CMemoryDebug::dynamicSize("m_FieldName", m_FieldName, mem);
-    core::CMemoryDebug::dynamicSize("m_ExamplesCollector", m_ExamplesCollector, mem);
+    core::memory_debug::dynamicSize("m_FieldName", m_FieldName, mem);
+    core::memory_debug::dynamicSize("m_ExamplesCollector", m_ExamplesCollector, mem);
 }
 
 std::size_t CDataCategorizer::memoryUsage() const {
     std::size_t mem = 0;
-    mem += core::CMemory::dynamicSize(m_FieldName);
-    mem += core::CMemory::dynamicSize(m_ExamplesCollector);
+    mem += core::memory::dynamicSize(m_FieldName);
+    mem += core::memory::dynamicSize(m_ExamplesCollector);
     return mem;
 }
 

--- a/lib/model/CDataGatherer.cc
+++ b/lib/model/CDataGatherer.cc
@@ -571,19 +571,19 @@ std::uint64_t CDataGatherer::checksum() const {
 
 void CDataGatherer::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CDataGatherer");
-    core::CMemoryDebug::dynamicSize("m_Features", m_Features, mem);
-    core::CMemoryDebug::dynamicSize("m_PeopleRegistry", m_PeopleRegistry, mem);
-    core::CMemoryDebug::dynamicSize("m_AttributesRegistry", m_AttributesRegistry, mem);
-    core::CMemoryDebug::dynamicSize("m_SampleCounts", m_SampleCounts, mem);
-    core::CMemoryDebug::dynamicSize("m_BucketGatherer", m_BucketGatherer, mem);
+    core::memory_debug::dynamicSize("m_Features", m_Features, mem);
+    core::memory_debug::dynamicSize("m_PeopleRegistry", m_PeopleRegistry, mem);
+    core::memory_debug::dynamicSize("m_AttributesRegistry", m_AttributesRegistry, mem);
+    core::memory_debug::dynamicSize("m_SampleCounts", m_SampleCounts, mem);
+    core::memory_debug::dynamicSize("m_BucketGatherer", m_BucketGatherer, mem);
 }
 
 std::size_t CDataGatherer::memoryUsage() const {
-    std::size_t mem = core::CMemory::dynamicSize(m_Features);
-    mem += core::CMemory::dynamicSize(m_PeopleRegistry);
-    mem += core::CMemory::dynamicSize(m_AttributesRegistry);
-    mem += core::CMemory::dynamicSize(m_SampleCounts);
-    mem += core::CMemory::dynamicSize(m_BucketGatherer);
+    std::size_t mem = core::memory::dynamicSize(m_Features);
+    mem += core::memory::dynamicSize(m_PeopleRegistry);
+    mem += core::memory::dynamicSize(m_AttributesRegistry);
+    mem += core::memory::dynamicSize(m_SampleCounts);
+    mem += core::memory::dynamicSize(m_BucketGatherer);
     return mem;
 }
 

--- a/lib/model/CDynamicStringIdRegistry.cc
+++ b/lib/model/CDynamicStringIdRegistry.cc
@@ -226,20 +226,20 @@ std::uint64_t CDynamicStringIdRegistry::checksum() const {
 
 void CDynamicStringIdRegistry::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CDynamicStringIdRegistry");
-    core::CMemoryDebug::dynamicSize("m_NameType", m_NameType, mem);
-    core::CMemoryDebug::dynamicSize("m_PersonUids", m_Uids, mem);
-    core::CMemoryDebug::dynamicSize("m_PersonNames", m_Names, mem);
-    core::CMemoryDebug::dynamicSize("m_FreePersonUids", m_FreeUids, mem);
-    core::CMemoryDebug::dynamicSize("m_RecycledPersonUids", m_RecycledUids, mem);
+    core::memory_debug::dynamicSize("m_NameType", m_NameType, mem);
+    core::memory_debug::dynamicSize("m_PersonUids", m_Uids, mem);
+    core::memory_debug::dynamicSize("m_PersonNames", m_Names, mem);
+    core::memory_debug::dynamicSize("m_FreePersonUids", m_FreeUids, mem);
+    core::memory_debug::dynamicSize("m_RecycledPersonUids", m_RecycledUids, mem);
 }
 
 std::size_t CDynamicStringIdRegistry::memoryUsage() const {
-    std::size_t mem = core::CMemory::dynamicSize(m_Uids);
-    mem += core::CMemory::dynamicSize(m_NameType);
-    mem += core::CMemory::dynamicSize(m_Uids);
-    mem += core::CMemory::dynamicSize(m_Names);
-    mem += core::CMemory::dynamicSize(m_FreeUids);
-    mem += core::CMemory::dynamicSize(m_RecycledUids);
+    std::size_t mem = core::memory::dynamicSize(m_Uids);
+    mem += core::memory::dynamicSize(m_NameType);
+    mem += core::memory::dynamicSize(m_Uids);
+    mem += core::memory::dynamicSize(m_Names);
+    mem += core::memory::dynamicSize(m_FreeUids);
+    mem += core::memory::dynamicSize(m_RecycledUids);
     return mem;
 }
 

--- a/lib/model/CEventRateBucketGatherer.cc
+++ b/lib/model/CEventRateBucketGatherer.cc
@@ -720,8 +720,8 @@ void registerMemoryCallbacks(VISITOR& visitor) {
 void registerMemoryCallbacks() {
     static std::atomic_flag once = ATOMIC_FLAG_INIT;
     if (once.test_and_set() == false) {
-        registerMemoryCallbacks(core::CMemory::anyVisitor());
-        registerMemoryCallbacks(core::CMemoryDebug::anyVisitor());
+        registerMemoryCallbacks(core::memory::anyVisitor());
+        registerMemoryCallbacks(core::memory_debug::anyVisitor());
     }
 }
 
@@ -1014,15 +1014,15 @@ void CEventRateBucketGatherer::debugMemoryUsage(const core::CMemoryUsage::TMemor
     registerMemoryCallbacks();
     mem->setName("CPopulationEventRateDataGatherer");
     CBucketGatherer::debugMemoryUsage(mem->addChild());
-    core::CMemoryDebug::dynamicSize("m_FieldNames", m_FieldNames, mem);
-    core::CMemoryDebug::dynamicSize("m_FeatureData", m_FeatureData, mem);
+    core::memory_debug::dynamicSize("m_FieldNames", m_FieldNames, mem);
+    core::memory_debug::dynamicSize("m_FeatureData", m_FeatureData, mem);
 }
 
 std::size_t CEventRateBucketGatherer::memoryUsage() const {
     registerMemoryCallbacks();
     std::size_t mem = CBucketGatherer::memoryUsage();
-    mem += core::CMemory::dynamicSize(m_FieldNames);
-    mem += core::CMemory::dynamicSize(m_FeatureData);
+    mem += core::memory::dynamicSize(m_FieldNames);
+    mem += core::memory::dynamicSize(m_FeatureData);
     return mem;
 }
 
@@ -1796,15 +1796,15 @@ std::uint64_t CUniqueStringFeatureData::checksum() const {
 
 void CUniqueStringFeatureData::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CUniqueStringFeatureData", sizeof(*this));
-    core::CMemoryDebug::dynamicSize("s_NoInfluenceUniqueStrings", m_UniqueStrings, mem);
-    core::CMemoryDebug::dynamicSize("s_InfluenceUniqueStrings",
+    core::memory_debug::dynamicSize("s_NoInfluenceUniqueStrings", m_UniqueStrings, mem);
+    core::memory_debug::dynamicSize("s_InfluenceUniqueStrings",
                                     m_InfluencerUniqueStrings, mem);
 }
 
 std::size_t CUniqueStringFeatureData::memoryUsage() const {
     std::size_t mem = sizeof(*this);
-    mem += core::CMemory::dynamicSize(m_UniqueStrings);
-    mem += core::CMemory::dynamicSize(m_InfluencerUniqueStrings);
+    mem += core::memory::dynamicSize(m_UniqueStrings);
+    mem += core::memory::dynamicSize(m_InfluencerUniqueStrings);
     return mem;
 }
 

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -522,17 +522,17 @@ std::uint64_t CEventRateModel::checksum(bool includeCurrentBucketStats) const {
 void CEventRateModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CEventRateModel");
     this->CIndividualModel::debugMemoryUsage(mem->addChild());
-    core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_PersonCounts",
+    core::memory_debug::dynamicSize("m_CurrentBucketStats.s_PersonCounts",
                                     m_CurrentBucketStats.s_PersonCounts, mem);
-    core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_FeatureData",
+    core::memory_debug::dynamicSize("m_CurrentBucketStats.s_FeatureData",
                                     m_CurrentBucketStats.s_FeatureData, mem);
-    core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_InterimCorrections",
+    core::memory_debug::dynamicSize("m_CurrentBucketStats.s_InterimCorrections",
                                     m_CurrentBucketStats.s_InterimCorrections, mem);
-    core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_Annotations",
+    core::memory_debug::dynamicSize("m_CurrentBucketStats.s_Annotations",
                                     m_CurrentBucketStats.s_Annotations, mem);
-    core::CMemoryDebug::dynamicSize("s_Probabilities", m_Probabilities, mem);
-    core::CMemoryDebug::dynamicSize("m_ProbabilityPrior", m_ProbabilityPrior, mem);
-    core::CMemoryDebug::dynamicSize("m_InterimBucketCorrector",
+    core::memory_debug::dynamicSize("s_Probabilities", m_Probabilities, mem);
+    core::memory_debug::dynamicSize("m_ProbabilityPrior", m_ProbabilityPrior, mem);
+    core::memory_debug::dynamicSize("m_InterimBucketCorrector",
                                     m_InterimBucketCorrector, mem);
 }
 
@@ -546,13 +546,13 @@ std::size_t CEventRateModel::staticSize() const {
 
 std::size_t CEventRateModel::computeMemoryUsage() const {
     std::size_t mem = this->CIndividualModel::computeMemoryUsage();
-    mem += core::CMemory::dynamicSize(m_CurrentBucketStats.s_PersonCounts);
-    mem += core::CMemory::dynamicSize(m_CurrentBucketStats.s_FeatureData);
-    mem += core::CMemory::dynamicSize(m_CurrentBucketStats.s_InterimCorrections);
-    mem += core::CMemory::dynamicSize(m_CurrentBucketStats.s_Annotations);
-    mem += core::CMemory::dynamicSize(m_Probabilities);
-    mem += core::CMemory::dynamicSize(m_ProbabilityPrior);
-    mem += core::CMemory::dynamicSize(m_InterimBucketCorrector);
+    mem += core::memory::dynamicSize(m_CurrentBucketStats.s_PersonCounts);
+    mem += core::memory::dynamicSize(m_CurrentBucketStats.s_FeatureData);
+    mem += core::memory::dynamicSize(m_CurrentBucketStats.s_InterimCorrections);
+    mem += core::memory::dynamicSize(m_CurrentBucketStats.s_Annotations);
+    mem += core::memory::dynamicSize(m_Probabilities);
+    mem += core::memory::dynamicSize(m_ProbabilityPrior);
+    mem += core::memory::dynamicSize(m_InterimBucketCorrector);
     return mem;
 }
 

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -863,26 +863,26 @@ std::uint64_t CEventRatePopulationModel::checksum(bool includeCurrentBucketStats
 void CEventRatePopulationModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CEventRatePopulationModel");
     this->CPopulationModel::debugMemoryUsage(mem->addChild());
-    core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_PersonCounts",
+    core::memory_debug::dynamicSize("m_CurrentBucketStats.s_PersonCounts",
                                     m_CurrentBucketStats.s_PersonCounts, mem);
-    core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_FeatureData",
+    core::memory_debug::dynamicSize("m_CurrentBucketStats.s_FeatureData",
                                     m_CurrentBucketStats.s_FeatureData, mem);
-    core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_InterimCorrections",
+    core::memory_debug::dynamicSize("m_CurrentBucketStats.s_InterimCorrections",
                                     m_CurrentBucketStats.s_InterimCorrections, mem);
-    core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_Annotations",
+    core::memory_debug::dynamicSize("m_CurrentBucketStats.s_Annotations",
                                     m_CurrentBucketStats.s_Annotations, mem);
-    core::CMemoryDebug::dynamicSize("m_AttributeProbabilities",
+    core::memory_debug::dynamicSize("m_AttributeProbabilities",
                                     m_AttributeProbabilities, mem);
-    core::CMemoryDebug::dynamicSize("m_NewPersonAttributePrior",
+    core::memory_debug::dynamicSize("m_NewPersonAttributePrior",
                                     m_NewAttributeProbabilityPrior, mem);
-    core::CMemoryDebug::dynamicSize("m_AttributeProbabilityPrior",
+    core::memory_debug::dynamicSize("m_AttributeProbabilityPrior",
                                     m_AttributeProbabilityPrior, mem);
-    core::CMemoryDebug::dynamicSize("m_FeatureModels", m_FeatureModels, mem);
-    core::CMemoryDebug::dynamicSize("m_FeatureCorrelatesModels",
+    core::memory_debug::dynamicSize("m_FeatureModels", m_FeatureModels, mem);
+    core::memory_debug::dynamicSize("m_FeatureCorrelatesModels",
                                     m_FeatureCorrelatesModels, mem);
-    core::CMemoryDebug::dynamicSize("m_InterimBucketCorrector",
+    core::memory_debug::dynamicSize("m_InterimBucketCorrector",
                                     m_InterimBucketCorrector, mem);
-    core::CMemoryDebug::dynamicSize("m_MemoryEstimator", m_MemoryEstimator, mem);
+    core::memory_debug::dynamicSize("m_MemoryEstimator", m_MemoryEstimator, mem);
 }
 
 std::size_t CEventRatePopulationModel::memoryUsage() const {
@@ -895,17 +895,17 @@ std::size_t CEventRatePopulationModel::memoryUsage() const {
 
 std::size_t CEventRatePopulationModel::computeMemoryUsage() const {
     std::size_t mem = this->CPopulationModel::memoryUsage();
-    mem += core::CMemory::dynamicSize(m_CurrentBucketStats.s_PersonCounts);
-    mem += core::CMemory::dynamicSize(m_CurrentBucketStats.s_FeatureData);
-    mem += core::CMemory::dynamicSize(m_CurrentBucketStats.s_InterimCorrections);
-    mem += core::CMemory::dynamicSize(m_CurrentBucketStats.s_Annotations);
-    mem += core::CMemory::dynamicSize(m_AttributeProbabilities);
-    mem += core::CMemory::dynamicSize(m_NewAttributeProbabilityPrior);
-    mem += core::CMemory::dynamicSize(m_AttributeProbabilityPrior);
-    mem += core::CMemory::dynamicSize(m_FeatureModels);
-    mem += core::CMemory::dynamicSize(m_FeatureCorrelatesModels);
-    mem += core::CMemory::dynamicSize(m_InterimBucketCorrector);
-    mem += core::CMemory::dynamicSize(m_MemoryEstimator);
+    mem += core::memory::dynamicSize(m_CurrentBucketStats.s_PersonCounts);
+    mem += core::memory::dynamicSize(m_CurrentBucketStats.s_FeatureData);
+    mem += core::memory::dynamicSize(m_CurrentBucketStats.s_InterimCorrections);
+    mem += core::memory::dynamicSize(m_CurrentBucketStats.s_Annotations);
+    mem += core::memory::dynamicSize(m_AttributeProbabilities);
+    mem += core::memory::dynamicSize(m_NewAttributeProbabilityPrior);
+    mem += core::memory::dynamicSize(m_AttributeProbabilityPrior);
+    mem += core::memory::dynamicSize(m_FeatureModels);
+    mem += core::memory::dynamicSize(m_FeatureCorrelatesModels);
+    mem += core::memory::dynamicSize(m_InterimBucketCorrector);
+    mem += core::memory::dynamicSize(m_MemoryEstimator);
     return mem;
 }
 

--- a/lib/model/CFeatureData.cc
+++ b/lib/model/CFeatureData.cc
@@ -88,13 +88,13 @@ std::string SEventRateFeatureData::print() const {
 
 std::size_t SEventRateFeatureData::memoryUsage() const {
     std::size_t mem = sizeof(*this);
-    mem += core::CMemory::dynamicSize(s_InfluenceValues);
+    mem += core::memory::dynamicSize(s_InfluenceValues);
     return mem;
 }
 
 void SEventRateFeatureData::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("SMetricFeatureData", sizeof(*this));
-    core::CMemoryDebug::dynamicSize("s_InfluenceValues", s_InfluenceValues, mem);
+    core::memory_debug::dynamicSize("s_InfluenceValues", s_InfluenceValues, mem);
 }
 
 ////// SMetricFeatureData //////
@@ -127,17 +127,17 @@ std::string SMetricFeatureData::print() const {
 }
 
 std::size_t SMetricFeatureData::memoryUsage() const {
-    std::size_t mem = core::CMemory::dynamicSize(s_BucketValue);
-    mem += core::CMemory::dynamicSize(s_InfluenceValues);
-    mem += core::CMemory::dynamicSize(s_Samples);
+    std::size_t mem = core::memory::dynamicSize(s_BucketValue);
+    mem += core::memory::dynamicSize(s_InfluenceValues);
+    mem += core::memory::dynamicSize(s_Samples);
     return mem;
 }
 
 void SMetricFeatureData::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("SMetricFeatureData");
-    core::CMemoryDebug::dynamicSize("s_BucketValue", s_BucketValue, mem);
-    core::CMemoryDebug::dynamicSize("s_InfluenceValues", s_InfluenceValues, mem);
-    core::CMemoryDebug::dynamicSize("s_Samples", s_Samples, mem);
+    core::memory_debug::dynamicSize("s_BucketValue", s_BucketValue, mem);
+    core::memory_debug::dynamicSize("s_InfluenceValues", s_InfluenceValues, mem);
+    core::memory_debug::dynamicSize("s_Samples", s_Samples, mem);
 }
 }
 }

--- a/lib/model/CGathererTools.cc
+++ b/lib/model/CGathererTools.cc
@@ -299,13 +299,13 @@ std::uint64_t CGathererTools::CSumGatherer::checksum() const {
 
 void CGathererTools::CSumGatherer::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CSumGatherer");
-    core::CMemoryDebug::dynamicSize("m_BucketSums", m_BucketSums, mem);
-    core::CMemoryDebug::dynamicSize("m_InfluencerBucketSums", m_InfluencerBucketSums, mem);
+    core::memory_debug::dynamicSize("m_BucketSums", m_BucketSums, mem);
+    core::memory_debug::dynamicSize("m_InfluencerBucketSums", m_InfluencerBucketSums, mem);
 }
 
 std::size_t CGathererTools::CSumGatherer::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_BucketSums) +
-           core::CMemory::dynamicSize(m_InfluencerBucketSums);
+    return core::memory::dynamicSize(m_BucketSums) +
+           core::memory::dynamicSize(m_InfluencerBucketSums);
 }
 
 std::string CGathererTools::CSumGatherer::print() const {

--- a/lib/model/CIndividualModel.cc
+++ b/lib/model/CIndividualModel.cc
@@ -283,12 +283,12 @@ std::uint64_t CIndividualModel::checksum(bool includeCurrentBucketStats) const {
 void CIndividualModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CIndividualModel");
     this->CAnomalyDetectorModel::debugMemoryUsage(mem->addChild());
-    core::CMemoryDebug::dynamicSize("m_FirstBucketTimes", m_FirstBucketTimes, mem);
-    core::CMemoryDebug::dynamicSize("m_LastBucketTimes", m_LastBucketTimes, mem);
-    core::CMemoryDebug::dynamicSize("m_FeatureModels", m_FeatureModels, mem);
-    core::CMemoryDebug::dynamicSize("m_FeatureCorrelatesModels",
+    core::memory_debug::dynamicSize("m_FirstBucketTimes", m_FirstBucketTimes, mem);
+    core::memory_debug::dynamicSize("m_LastBucketTimes", m_LastBucketTimes, mem);
+    core::memory_debug::dynamicSize("m_FeatureModels", m_FeatureModels, mem);
+    core::memory_debug::dynamicSize("m_FeatureCorrelatesModels",
                                     m_FeatureCorrelatesModels, mem);
-    core::CMemoryDebug::dynamicSize("m_MemoryEstimator", m_MemoryEstimator, mem);
+    core::memory_debug::dynamicSize("m_MemoryEstimator", m_MemoryEstimator, mem);
 }
 
 std::size_t CIndividualModel::memoryUsage() const {
@@ -301,11 +301,11 @@ std::size_t CIndividualModel::memoryUsage() const {
 
 std::size_t CIndividualModel::computeMemoryUsage() const {
     std::size_t mem = this->CAnomalyDetectorModel::memoryUsage();
-    mem += core::CMemory::dynamicSize(m_FirstBucketTimes);
-    mem += core::CMemory::dynamicSize(m_LastBucketTimes);
-    mem += core::CMemory::dynamicSize(m_FeatureModels);
-    mem += core::CMemory::dynamicSize(m_FeatureCorrelatesModels);
-    mem += core::CMemory::dynamicSize(m_MemoryEstimator);
+    mem += core::memory::dynamicSize(m_FirstBucketTimes);
+    mem += core::memory::dynamicSize(m_LastBucketTimes);
+    mem += core::memory::dynamicSize(m_FeatureModels);
+    mem += core::memory::dynamicSize(m_FeatureCorrelatesModels);
+    mem += core::memory::dynamicSize(m_MemoryEstimator);
     return mem;
 }
 

--- a/lib/model/CInterimBucketCorrector.cc
+++ b/lib/model/CInterimBucketCorrector.cc
@@ -86,11 +86,11 @@ CInterimBucketCorrector::corrections(const TDouble10Vec& modes,
 
 void CInterimBucketCorrector::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CInterimBucketCorrector");
-    core::CMemoryDebug::dynamicSize("m_CountTrend", m_FinalCountTrend, mem);
+    core::memory_debug::dynamicSize("m_CountTrend", m_FinalCountTrend, mem);
 }
 
 std::size_t CInterimBucketCorrector::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_FinalCountTrend);
+    return core::memory::dynamicSize(m_FinalCountTrend);
 }
 
 void CInterimBucketCorrector::acceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/model/CMemoryUsageEstimator.cc
+++ b/lib/model/CMemoryUsageEstimator.cc
@@ -124,11 +124,11 @@ void CMemoryUsageEstimator::addValue(const TSizeArray& predictors, std::size_t m
 
 void CMemoryUsageEstimator::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CMemoryUsageEstimator");
-    core::CMemoryDebug::dynamicSize("m_Values", m_Values, mem);
+    core::memory_debug::dynamicSize("m_Values", m_Values, mem);
 }
 
 std::size_t CMemoryUsageEstimator::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Values);
+    return core::memory::dynamicSize(m_Values);
 }
 
 void CMemoryUsageEstimator::acceptPersistInserter(core::CStatePersistInserter& inserter) const {

--- a/lib/model/CMetricBucketGatherer.cc
+++ b/lib/model/CMetricBucketGatherer.cc
@@ -193,8 +193,8 @@ void registerMemoryCallbacks(VISITOR& visitor) {
 void registerMemoryCallbacks() {
     static std::atomic_flag once = ATOMIC_FLAG_INIT;
     if (once.test_and_set() == false) {
-        registerMemoryCallbacks(core::CMemory::anyVisitor());
-        registerMemoryCallbacks(core::CMemoryDebug::anyVisitor());
+        registerMemoryCallbacks(core::memory::anyVisitor());
+        registerMemoryCallbacks(core::memory_debug::anyVisitor());
     }
 }
 
@@ -1337,19 +1337,19 @@ void CMetricBucketGatherer::debugMemoryUsage(const core::CMemoryUsage::TMemoryUs
     registerMemoryCallbacks();
     mem->setName("CMetricBucketGatherer");
     this->CBucketGatherer::debugMemoryUsage(mem->addChild());
-    core::CMemoryDebug::dynamicSize("m_ValueFieldName", m_ValueFieldName, mem);
-    core::CMemoryDebug::dynamicSize("m_FieldNames", m_FieldNames, mem);
-    core::CMemoryDebug::dynamicSize("m_FieldMetricCategories", m_FieldMetricCategories, mem);
-    core::CMemoryDebug::dynamicSize("m_FeatureData", m_FeatureData, mem);
+    core::memory_debug::dynamicSize("m_ValueFieldName", m_ValueFieldName, mem);
+    core::memory_debug::dynamicSize("m_FieldNames", m_FieldNames, mem);
+    core::memory_debug::dynamicSize("m_FieldMetricCategories", m_FieldMetricCategories, mem);
+    core::memory_debug::dynamicSize("m_FeatureData", m_FeatureData, mem);
 }
 
 std::size_t CMetricBucketGatherer::memoryUsage() const {
     registerMemoryCallbacks();
     std::size_t mem = this->CBucketGatherer::memoryUsage();
-    mem += core::CMemory::dynamicSize(m_ValueFieldName);
-    mem += core::CMemory::dynamicSize(m_FieldNames);
-    mem += core::CMemory::dynamicSize(m_FieldMetricCategories);
-    mem += core::CMemory::dynamicSize(m_FeatureData);
+    mem += core::memory::dynamicSize(m_ValueFieldName);
+    mem += core::memory::dynamicSize(m_FieldNames);
+    mem += core::memory::dynamicSize(m_FieldMetricCategories);
+    mem += core::memory::dynamicSize(m_FeatureData);
     return mem;
 }
 

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -474,15 +474,15 @@ std::uint64_t CMetricModel::checksum(bool includeCurrentBucketStats) const {
 void CMetricModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CMetricModel");
     this->CIndividualModel::debugMemoryUsage(mem->addChild());
-    core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_PersonCounts",
+    core::memory_debug::dynamicSize("m_CurrentBucketStats.s_PersonCounts",
                                     m_CurrentBucketStats.s_PersonCounts, mem);
-    core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_FeatureData",
+    core::memory_debug::dynamicSize("m_CurrentBucketStats.s_FeatureData",
                                     m_CurrentBucketStats.s_FeatureData, mem);
-    core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_InterimCorrections",
+    core::memory_debug::dynamicSize("m_CurrentBucketStats.s_InterimCorrections",
                                     m_CurrentBucketStats.s_InterimCorrections, mem);
-    core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_Annotations",
+    core::memory_debug::dynamicSize("m_CurrentBucketStats.s_Annotations",
                                     m_CurrentBucketStats.s_Annotations, mem);
-    core::CMemoryDebug::dynamicSize("m_InterimBucketCorrector",
+    core::memory_debug::dynamicSize("m_InterimBucketCorrector",
                                     m_InterimBucketCorrector, mem);
 }
 
@@ -492,11 +492,11 @@ std::size_t CMetricModel::memoryUsage() const {
 
 std::size_t CMetricModel::computeMemoryUsage() const {
     std::size_t mem = this->CIndividualModel::computeMemoryUsage();
-    mem += core::CMemory::dynamicSize(m_CurrentBucketStats.s_PersonCounts);
-    mem += core::CMemory::dynamicSize(m_CurrentBucketStats.s_FeatureData);
-    mem += core::CMemory::dynamicSize(m_CurrentBucketStats.s_InterimCorrections);
-    mem += core::CMemory::dynamicSize(m_CurrentBucketStats.s_Annotations);
-    mem += core::CMemory::dynamicSize(m_InterimBucketCorrector);
+    mem += core::memory::dynamicSize(m_CurrentBucketStats.s_PersonCounts);
+    mem += core::memory::dynamicSize(m_CurrentBucketStats.s_FeatureData);
+    mem += core::memory::dynamicSize(m_CurrentBucketStats.s_InterimCorrections);
+    mem += core::memory::dynamicSize(m_CurrentBucketStats.s_Annotations);
+    mem += core::memory::dynamicSize(m_InterimBucketCorrector);
     return mem;
 }
 

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -765,20 +765,20 @@ std::uint64_t CMetricPopulationModel::checksum(bool includeCurrentBucketStats) c
 void CMetricPopulationModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CMetricPopulationModel");
     this->CPopulationModel::debugMemoryUsage(mem->addChild());
-    core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_PersonCounts",
+    core::memory_debug::dynamicSize("m_CurrentBucketStats.s_PersonCounts",
                                     m_CurrentBucketStats.s_PersonCounts, mem);
-    core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_FeatureData",
+    core::memory_debug::dynamicSize("m_CurrentBucketStats.s_FeatureData",
                                     m_CurrentBucketStats.s_FeatureData, mem);
-    core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_InterimCorrections",
+    core::memory_debug::dynamicSize("m_CurrentBucketStats.s_InterimCorrections",
                                     m_CurrentBucketStats.s_InterimCorrections, mem);
-    core::CMemoryDebug::dynamicSize("m_CurrentBucketStats.s_Annotations",
+    core::memory_debug::dynamicSize("m_CurrentBucketStats.s_Annotations",
                                     m_CurrentBucketStats.s_Annotations, mem);
-    core::CMemoryDebug::dynamicSize("m_FeatureModels", m_FeatureModels, mem);
-    core::CMemoryDebug::dynamicSize("m_FeatureCorrelatesModels",
+    core::memory_debug::dynamicSize("m_FeatureModels", m_FeatureModels, mem);
+    core::memory_debug::dynamicSize("m_FeatureCorrelatesModels",
                                     m_FeatureCorrelatesModels, mem);
-    core::CMemoryDebug::dynamicSize("m_InterimBucketCorrector",
+    core::memory_debug::dynamicSize("m_InterimBucketCorrector",
                                     m_InterimBucketCorrector, mem);
-    core::CMemoryDebug::dynamicSize("m_MemoryEstimator", m_MemoryEstimator, mem);
+    core::memory_debug::dynamicSize("m_MemoryEstimator", m_MemoryEstimator, mem);
 }
 
 std::size_t CMetricPopulationModel::memoryUsage() const {
@@ -791,14 +791,14 @@ std::size_t CMetricPopulationModel::memoryUsage() const {
 
 std::size_t CMetricPopulationModel::computeMemoryUsage() const {
     std::size_t mem = this->CPopulationModel::memoryUsage();
-    mem += core::CMemory::dynamicSize(m_CurrentBucketStats.s_PersonCounts);
-    mem += core::CMemory::dynamicSize(m_CurrentBucketStats.s_FeatureData);
-    mem += core::CMemory::dynamicSize(m_CurrentBucketStats.s_InterimCorrections);
-    mem += core::CMemory::dynamicSize(m_CurrentBucketStats.s_Annotations);
-    mem += core::CMemory::dynamicSize(m_FeatureModels);
-    mem += core::CMemory::dynamicSize(m_FeatureCorrelatesModels);
-    mem += core::CMemory::dynamicSize(m_InterimBucketCorrector);
-    mem += core::CMemory::dynamicSize(m_MemoryEstimator);
+    mem += core::memory::dynamicSize(m_CurrentBucketStats.s_PersonCounts);
+    mem += core::memory::dynamicSize(m_CurrentBucketStats.s_FeatureData);
+    mem += core::memory::dynamicSize(m_CurrentBucketStats.s_InterimCorrections);
+    mem += core::memory::dynamicSize(m_CurrentBucketStats.s_Annotations);
+    mem += core::memory::dynamicSize(m_FeatureModels);
+    mem += core::memory::dynamicSize(m_FeatureCorrelatesModels);
+    mem += core::memory::dynamicSize(m_InterimBucketCorrector);
+    mem += core::memory::dynamicSize(m_MemoryEstimator);
     return mem;
 }
 

--- a/lib/model/CModelTools.cc
+++ b/lib/model/CModelTools.cc
@@ -304,14 +304,14 @@ bool CModelTools::CCategoryProbabilityCache::lookup(std::size_t attribute, doubl
 void CModelTools::CCategoryProbabilityCache::debugMemoryUsage(
     const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CTools::CLessLikelyProbability");
-    core::CMemoryDebug::dynamicSize("m_Cache", m_Cache, mem->addChild());
+    core::memory_debug::dynamicSize("m_Cache", m_Cache, mem->addChild());
     if (m_Prior) {
         m_Prior->debugMemoryUsage(mem->addChild());
     }
 }
 
 std::size_t CModelTools::CCategoryProbabilityCache::memoryUsage() const {
-    std::size_t mem{core::CMemory::dynamicSize(m_Cache)};
+    std::size_t mem{core::memory::dynamicSize(m_Cache)};
     if (m_Prior) {
         mem += m_Prior->memoryUsage();
     }

--- a/lib/model/CPopulationModel.cc
+++ b/lib/model/CPopulationModel.cc
@@ -205,28 +205,28 @@ std::uint64_t CPopulationModel::checksum(bool includeCurrentBucketStats) const {
 void CPopulationModel::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CPopulationModel");
     this->CAnomalyDetectorModel::debugMemoryUsage(mem->addChild());
-    core::CMemoryDebug::dynamicSize("m_PersonLastBucketTimes", m_PersonLastBucketTimes, mem);
-    core::CMemoryDebug::dynamicSize("m_AttributeFirstBucketTimes",
+    core::memory_debug::dynamicSize("m_PersonLastBucketTimes", m_PersonLastBucketTimes, mem);
+    core::memory_debug::dynamicSize("m_AttributeFirstBucketTimes",
                                     m_AttributeFirstBucketTimes, mem);
-    core::CMemoryDebug::dynamicSize("m_AttributeLastBucketTimes",
+    core::memory_debug::dynamicSize("m_AttributeLastBucketTimes",
                                     m_AttributeLastBucketTimes, mem);
-    core::CMemoryDebug::dynamicSize("m_NewDistinctPersonCounts",
+    core::memory_debug::dynamicSize("m_NewDistinctPersonCounts",
                                     m_NewDistinctPersonCounts, mem);
-    core::CMemoryDebug::dynamicSize("m_DistinctPersonCounts", m_DistinctPersonCounts, mem);
-    core::CMemoryDebug::dynamicSize("m_NewPersonBucketCounts", m_NewPersonBucketCounts, mem);
-    core::CMemoryDebug::dynamicSize("m_PersonAttributeBucketCounts",
+    core::memory_debug::dynamicSize("m_DistinctPersonCounts", m_DistinctPersonCounts, mem);
+    core::memory_debug::dynamicSize("m_NewPersonBucketCounts", m_NewPersonBucketCounts, mem);
+    core::memory_debug::dynamicSize("m_PersonAttributeBucketCounts",
                                     m_PersonAttributeBucketCounts, mem);
 }
 
 std::size_t CPopulationModel::memoryUsage() const {
     std::size_t mem = this->CAnomalyDetectorModel::memoryUsage();
-    mem += core::CMemory::dynamicSize(m_PersonLastBucketTimes);
-    mem += core::CMemory::dynamicSize(m_AttributeFirstBucketTimes);
-    mem += core::CMemory::dynamicSize(m_AttributeLastBucketTimes);
-    mem += core::CMemory::dynamicSize(m_NewDistinctPersonCounts);
-    mem += core::CMemory::dynamicSize(m_DistinctPersonCounts);
-    mem += core::CMemory::dynamicSize(m_NewPersonBucketCounts);
-    mem += core::CMemory::dynamicSize(m_PersonAttributeBucketCounts);
+    mem += core::memory::dynamicSize(m_PersonLastBucketTimes);
+    mem += core::memory::dynamicSize(m_AttributeFirstBucketTimes);
+    mem += core::memory::dynamicSize(m_AttributeLastBucketTimes);
+    mem += core::memory::dynamicSize(m_NewDistinctPersonCounts);
+    mem += core::memory::dynamicSize(m_DistinctPersonCounts);
+    mem += core::memory::dynamicSize(m_NewPersonBucketCounts);
+    mem += core::memory::dynamicSize(m_PersonAttributeBucketCounts);
     return mem;
 }
 

--- a/lib/model/CResourceMonitor.cc
+++ b/lib/model/CResourceMonitor.cc
@@ -202,7 +202,7 @@ bool CResourceMonitor::pruneIfRequired(core_t::TTime endTime) {
         for (auto& resource : m_Resources) {
             if (resource.first->supportsPruning()) {
                 resource.first->prune(m_PruneWindow);
-                resource.second = core::CMemory::dynamicSize(resource.first);
+                resource.second = core::memory::dynamicSize(resource.first);
             }
             usageAfter += resource.second;
         }
@@ -259,7 +259,7 @@ void CResourceMonitor::memUsage(CMonitoredResource* resource) {
         return;
     }
     std::size_t modelPreviousUsage = itr->second;
-    std::size_t modelCurrentUsage = core::CMemory::dynamicSize(itr->first);
+    std::size_t modelCurrentUsage = core::memory::dynamicSize(itr->first);
     itr->second = modelCurrentUsage;
     m_MonitoredResourceCurrentMemory += (modelCurrentUsage - modelPreviousUsage);
 }

--- a/lib/model/CSample.cc
+++ b/lib/model/CSample.cc
@@ -106,11 +106,11 @@ std::string CSample::print() const {
 
 void CSample::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CSample");
-    core::CMemoryDebug::dynamicSize("m_Value", m_Value, mem);
+    core::memory_debug::dynamicSize("m_Value", m_Value, mem);
 }
 
 std::size_t CSample::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Value);
+    return core::memory::dynamicSize(m_Value);
 }
 }
 }

--- a/lib/model/CSampleCounts.cc
+++ b/lib/model/CSampleCounts.cc
@@ -232,17 +232,17 @@ std::uint64_t CSampleCounts::checksum(const CDataGatherer& gatherer) const {
 
 void CSampleCounts::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CSampleCounts");
-    core::CMemoryDebug::dynamicSize("m_SampleCounts", m_SampleCounts, mem);
-    core::CMemoryDebug::dynamicSize("m_MeanNonZeroBucketCounts",
+    core::memory_debug::dynamicSize("m_SampleCounts", m_SampleCounts, mem);
+    core::memory_debug::dynamicSize("m_MeanNonZeroBucketCounts",
                                     m_MeanNonZeroBucketCounts, mem);
-    core::CMemoryDebug::dynamicSize("m_EffectiveSampleVariances",
+    core::memory_debug::dynamicSize("m_EffectiveSampleVariances",
                                     m_EffectiveSampleVariances, mem);
 }
 
 std::size_t CSampleCounts::memoryUsage() const {
-    std::size_t mem = core::CMemory::dynamicSize(m_SampleCounts);
-    mem += core::CMemory::dynamicSize(m_MeanNonZeroBucketCounts);
-    mem += core::CMemory::dynamicSize(m_EffectiveSampleVariances);
+    std::size_t mem = core::memory::dynamicSize(m_SampleCounts);
+    mem += core::memory::dynamicSize(m_MeanNonZeroBucketCounts);
+    mem += core::memory::dynamicSize(m_EffectiveSampleVariances);
     return mem;
 }
 

--- a/lib/model/CStringStore.cc
+++ b/lib/model/CStringStore.cc
@@ -157,8 +157,8 @@ void CStringStore::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& m
                                                              : "unknown StringStore"));
     mem->addItem("empty string ptr", m_EmptyString.actualMemoryUsage());
     core::CScopedFastLock lock(m_Mutex);
-    core::CMemoryDebug::dynamicSize("stored strings", m_Strings, mem);
-    core::CMemoryDebug::dynamicSize("removed strings", m_Removed, mem);
+    core::memory_debug::dynamicSize("stored strings", m_Strings, mem);
+    core::memory_debug::dynamicSize("removed strings", m_Removed, mem);
     mem->addItem("stored string ptr memory", m_StoredStringsMemUse);
 }
 
@@ -169,12 +169,12 @@ std::size_t CStringStore::memoryUsage() const {
     // core::CStoredStringPtr::dynamicSizeAlwaysZero() combined with dead code
     // elimination will make calculating the size of m_Strings boil down to a
     // couple of simple multiplications and additions
-    mem += core::CMemory::dynamicSize(m_Strings);
+    mem += core::memory::dynamicSize(m_Strings);
     // This one could be more expensive, but the assumption is that there won't
     // be many memory usage calculations while m_Removed is populated
-    mem += core::CMemory::dynamicSize(m_Removed);
+    mem += core::memory::dynamicSize(m_Removed);
     // This adds back the size that was excluded from
-    // core::CMemory::dynamicSize(m_Strings)
+    // core::memory::dynamicSize(m_Strings)
     mem += m_StoredStringsMemUse;
     return mem;
 }

--- a/lib/model/CTokenListCategory.cc
+++ b/lib/model/CTokenListCategory.cc
@@ -536,20 +536,20 @@ const std::string& CTokenListCategory::reverseSearchPart2() const {
 
 void CTokenListCategory::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CTokenListCategory");
-    core::CMemoryDebug::dynamicSize("m_BaseString", m_BaseString, mem);
-    core::CMemoryDebug::dynamicSize("m_BaseTokenIds", m_BaseTokenIds, mem);
-    core::CMemoryDebug::dynamicSize("m_CommonUniqueTokenIds", m_CommonUniqueTokenIds, mem);
-    core::CMemoryDebug::dynamicSize("m_ReverseSearchPart1", m_ReverseSearchPart1, mem);
-    core::CMemoryDebug::dynamicSize("m_ReverseSearchPart2", m_ReverseSearchPart2, mem);
+    core::memory_debug::dynamicSize("m_BaseString", m_BaseString, mem);
+    core::memory_debug::dynamicSize("m_BaseTokenIds", m_BaseTokenIds, mem);
+    core::memory_debug::dynamicSize("m_CommonUniqueTokenIds", m_CommonUniqueTokenIds, mem);
+    core::memory_debug::dynamicSize("m_ReverseSearchPart1", m_ReverseSearchPart1, mem);
+    core::memory_debug::dynamicSize("m_ReverseSearchPart2", m_ReverseSearchPart2, mem);
 }
 
 std::size_t CTokenListCategory::memoryUsage() const {
     std::size_t mem = 0;
-    mem += core::CMemory::dynamicSize(m_BaseString);
-    mem += core::CMemory::dynamicSize(m_BaseTokenIds);
-    mem += core::CMemory::dynamicSize(m_CommonUniqueTokenIds);
-    mem += core::CMemory::dynamicSize(m_ReverseSearchPart1);
-    mem += core::CMemory::dynamicSize(m_ReverseSearchPart2);
+    mem += core::memory::dynamicSize(m_BaseString);
+    mem += core::memory::dynamicSize(m_BaseTokenIds);
+    mem += core::memory::dynamicSize(m_CommonUniqueTokenIds);
+    mem += core::memory::dynamicSize(m_ReverseSearchPart1);
+    mem += core::memory::dynamicSize(m_ReverseSearchPart2);
     return mem;
 }
 

--- a/lib/model/CTokenListDataCategorizerBase.cc
+++ b/lib/model/CTokenListDataCategorizerBase.cc
@@ -551,24 +551,24 @@ model_t::ECategorizationStatus CTokenListDataCategorizerBase::categorizationStat
 void CTokenListDataCategorizerBase::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CTokenListDataCategorizerBase");
     this->CDataCategorizer::debugMemoryUsage(mem->addChild());
-    core::CMemoryDebug::dynamicSize("m_ReverseSearchCreator", m_ReverseSearchCreator, mem);
-    core::CMemoryDebug::dynamicSize("m_Categories", m_Categories, mem);
-    core::CMemoryDebug::dynamicSize("m_CategoriesByCount", m_CategoriesByCount, mem);
-    core::CMemoryDebug::dynamicSize("m_TokenIdLookup", m_TokenIdLookup, mem);
-    core::CMemoryDebug::dynamicSize("m_WorkTokenIds", m_WorkTokenIds, mem);
-    core::CMemoryDebug::dynamicSize("m_WorkTokenUniqueIds", m_WorkTokenUniqueIds, mem);
-    core::CMemoryDebug::dynamicSize("m_CsvLineParser", m_CsvLineParser, mem);
+    core::memory_debug::dynamicSize("m_ReverseSearchCreator", m_ReverseSearchCreator, mem);
+    core::memory_debug::dynamicSize("m_Categories", m_Categories, mem);
+    core::memory_debug::dynamicSize("m_CategoriesByCount", m_CategoriesByCount, mem);
+    core::memory_debug::dynamicSize("m_TokenIdLookup", m_TokenIdLookup, mem);
+    core::memory_debug::dynamicSize("m_WorkTokenIds", m_WorkTokenIds, mem);
+    core::memory_debug::dynamicSize("m_WorkTokenUniqueIds", m_WorkTokenUniqueIds, mem);
+    core::memory_debug::dynamicSize("m_CsvLineParser", m_CsvLineParser, mem);
 }
 
 std::size_t CTokenListDataCategorizerBase::memoryUsage() const {
     std::size_t mem = this->CDataCategorizer::memoryUsage();
-    mem += core::CMemory::dynamicSize(m_ReverseSearchCreator);
-    mem += core::CMemory::dynamicSize(m_Categories);
-    mem += core::CMemory::dynamicSize(m_CategoriesByCount);
-    mem += core::CMemory::dynamicSize(m_TokenIdLookup);
-    mem += core::CMemory::dynamicSize(m_WorkTokenIds);
-    mem += core::CMemory::dynamicSize(m_WorkTokenUniqueIds);
-    mem += core::CMemory::dynamicSize(m_CsvLineParser);
+    mem += core::memory::dynamicSize(m_ReverseSearchCreator);
+    mem += core::memory::dynamicSize(m_Categories);
+    mem += core::memory::dynamicSize(m_CategoriesByCount);
+    mem += core::memory::dynamicSize(m_TokenIdLookup);
+    mem += core::memory::dynamicSize(m_WorkTokenIds);
+    mem += core::memory::dynamicSize(m_WorkTokenUniqueIds);
+    mem += core::memory::dynamicSize(m_CsvLineParser);
     return mem;
 }
 
@@ -813,11 +813,11 @@ const std::string& CTokenListDataCategorizerBase::CTokenInfoItem::str() const {
 void CTokenListDataCategorizerBase::CTokenInfoItem::debugMemoryUsage(
     const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CTokenInfoItem");
-    core::CMemoryDebug::dynamicSize("m_Str", m_Str, mem);
+    core::memory_debug::dynamicSize("m_Str", m_Str, mem);
 }
 
 std::size_t CTokenListDataCategorizerBase::CTokenInfoItem::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_Str);
+    return core::memory::dynamicSize(m_Str);
 }
 
 std::size_t CTokenListDataCategorizerBase::CTokenInfoItem::index() const {

--- a/lib/model/CTokenListReverseSearchCreator.cc
+++ b/lib/model/CTokenListReverseSearchCreator.cc
@@ -90,11 +90,11 @@ const std::string& CTokenListReverseSearchCreator::fieldName() const {
 
 void CTokenListReverseSearchCreator::debugMemoryUsage(const core::CMemoryUsage::TMemoryUsagePtr& mem) const {
     mem->setName("CTokenListReverseSearchCreator");
-    core::CMemoryDebug::dynamicSize("m_FieldName", m_FieldName, mem);
+    core::memory_debug::dynamicSize("m_FieldName", m_FieldName, mem);
 }
 
 std::size_t CTokenListReverseSearchCreator::memoryUsage() const {
-    return core::CMemory::dynamicSize(m_FieldName);
+    return core::memory::dynamicSize(m_FieldName);
 }
 }
 }

--- a/lib/model/unittest/CBucketQueueTest.cc
+++ b/lib/model/unittest/CBucketQueueTest.cc
@@ -166,7 +166,7 @@ BOOST_AUTO_TEST_CASE(testBucketQueueUMap) {
                 queue.latest()[TSizeSizePr(i, j)] = 99 * i * j + 12;
             }
         }
-        usageBefore = core::CMemory::dynamicSize(queue);
+        usageBefore = core::memory::dynamicSize(queue);
         core::CJsonStatePersistInserter inserter(ss);
         core::CPersistUtils::persist(queueTag, queue, inserter);
     }
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE(testBucketQueueUMap) {
         TSizeSizePrUInt64UMapQueue queue(4, 1000, 5000);
         core::CJsonStateRestoreTraverser traverser(ss);
         core::CPersistUtils::restore(queueTag, queue, traverser);
-        std::size_t usageAfter = core::CMemory::dynamicSize(queue);
+        std::size_t usageAfter = core::memory::dynamicSize(queue);
         BOOST_REQUIRE_EQUAL(usageBefore, usageAfter);
     }
 }

--- a/lib/model/unittest/CModelMemoryTest.cc
+++ b/lib/model/unittest/CModelMemoryTest.cc
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(testOnlineMetricModel) {
     CResourceMonitor resourceMonitor;
 
     LOG_DEBUG(<< "Memory used by model: " << model.memoryUsage() << " / "
-              << core::CMemory::dynamicSize(model));
+              << core::memory::dynamicSize(model));
 
     test::CRandomNumbers rng;
 

--- a/lib/model/unittest/CResourceMonitorTest.cc
+++ b/lib/model/unittest/CResourceMonitorTest.cc
@@ -120,9 +120,9 @@ BOOST_FIXTURE_TEST_CASE(testMonitor, CTestFixture) {
     CAnomalyDetector detector2(limits, modelConfig, EMPTY_STRING, FIRST_TIME,
                                modelConfig.factory(key2));
 
-    std::size_t mem = core::CMemory::dynamicSize(&categorizer) +
-                      core::CMemory::dynamicSize(&detector1) +
-                      core::CMemory::dynamicSize(&detector2) +
+    std::size_t mem = core::memory::dynamicSize(&categorizer) +
+                      core::memory::dynamicSize(&detector1) +
+                      core::memory::dynamicSize(&detector2) +
                       CStringStore::names().memoryUsage() +
                       CStringStore::influencers().memoryUsage();
 

--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -61,9 +61,9 @@ void checkMemoryUsageInstrumentation(const TTokenListDataCategorizerKeepsFields&
     LOG_DEBUG(<< "Debug memory report = " << strm.str());
     BOOST_REQUIRE_EQUAL(memoryUsage, mem->usage());
 
-    LOG_TRACE(<< "Dynamic size = " << ml::core::CMemory::dynamicSize(&categorizer));
+    LOG_TRACE(<< "Dynamic size = " << ml::core::memory::dynamicSize(&categorizer));
     BOOST_REQUIRE_EQUAL(memoryUsage + sizeof(TTokenListDataCategorizerKeepsFields),
-                        ml::core::CMemory::dynamicSize(&categorizer));
+                        ml::core::memory::dynamicSize(&categorizer));
 }
 }
 


### PR DESCRIPTION
Follows on from refactoring in #2373.