### PR TITLE
[ML] Fix main() functions for test suites

### DIFF
--- a/bin/controller/unittest/Main.cc
+++ b/bin/controller/unittest/Main.cc
@@ -23,6 +23,8 @@
 int main(int argc, char** argv) {
     ml::test::CTestObserver observer;
     boost::unit_test::framework::register_observer(observer);
-    return boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init, argc, argv);
+    int result{boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init,
+                                                argc, argv)};
     boost::unit_test::framework::deregister_observer(observer);
+    return result;
 }

--- a/bin/pytorch_inference/unittest/Main.cc
+++ b/bin/pytorch_inference/unittest/Main.cc
@@ -23,6 +23,8 @@
 int main(int argc, char** argv) {
     ml::test::CTestObserver observer;
     boost::unit_test::framework::register_observer(observer);
-    return boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init, argc, argv);
+    int result{boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init,
+                                                argc, argv)};
     boost::unit_test::framework::deregister_observer(observer);
+    return result;
 }

--- a/lib/api/unittest/Main.cc
+++ b/lib/api/unittest/Main.cc
@@ -23,6 +23,8 @@
 int main(int argc, char** argv) {
     ml::test::CTestObserver observer;
     boost::unit_test::framework::register_observer(observer);
-    return boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init, argc, argv);
+    int result{boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init,
+                                                argc, argv)};
     boost::unit_test::framework::deregister_observer(observer);
+    return result;
 }

--- a/lib/core/unittest/Main.cc
+++ b/lib/core/unittest/Main.cc
@@ -23,6 +23,8 @@
 int main(int argc, char** argv) {
     ml::test::CTestObserver observer;
     boost::unit_test::framework::register_observer(observer);
-    return boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init, argc, argv);
+    int result{boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init,
+                                                argc, argv)};
     boost::unit_test::framework::deregister_observer(observer);
+    return result;
 }

--- a/lib/maths/analytics/unittest/Main.cc
+++ b/lib/maths/analytics/unittest/Main.cc
@@ -23,6 +23,8 @@
 int main(int argc, char** argv) {
     ml::test::CTestObserver observer;
     boost::unit_test::framework::register_observer(observer);
-    return boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init, argc, argv);
+    int result{boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init,
+                                                argc, argv)};
     boost::unit_test::framework::deregister_observer(observer);
+    return result;
 }

--- a/lib/maths/common/unittest/Main.cc
+++ b/lib/maths/common/unittest/Main.cc
@@ -23,6 +23,8 @@
 int main(int argc, char** argv) {
     ml::test::CTestObserver observer;
     boost::unit_test::framework::register_observer(observer);
-    return boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init, argc, argv);
+    int result{boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init,
+                                                argc, argv)};
     boost::unit_test::framework::deregister_observer(observer);
+    return result;
 }

--- a/lib/maths/time_series/unittest/Main.cc
+++ b/lib/maths/time_series/unittest/Main.cc
@@ -23,6 +23,8 @@
 int main(int argc, char** argv) {
     ml::test::CTestObserver observer;
     boost::unit_test::framework::register_observer(observer);
-    return boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init, argc, argv);
+    int result{boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init,
+                                                argc, argv)};
     boost::unit_test::framework::deregister_observer(observer);
+    return result;
 }

--- a/lib/model/unittest/Main.cc
+++ b/lib/model/unittest/Main.cc
@@ -23,6 +23,8 @@
 int main(int argc, char** argv) {
     ml::test::CTestObserver observer;
     boost::unit_test::framework::register_observer(observer);
-    return boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init, argc, argv);
+    int result{boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init,
+                                                argc, argv)};
     boost::unit_test::framework::deregister_observer(observer);
+    return result;
 }

--- a/lib/seccomp/unittest/Main.cc
+++ b/lib/seccomp/unittest/Main.cc
@@ -23,6 +23,8 @@
 int main(int argc, char** argv) {
     ml::test::CTestObserver observer;
     boost::unit_test::framework::register_observer(observer);
-    return boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init, argc, argv);
+    int result{boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init,
+                                                argc, argv)};
     boost::unit_test::framework::deregister_observer(observer);
+    return result;
 }

--- a/lib/ver/unittest/Main.cc
+++ b/lib/ver/unittest/Main.cc
@@ -23,6 +23,8 @@
 int main(int argc, char** argv) {
     ml::test::CTestObserver observer;
     boost::unit_test::framework::register_observer(observer);
-    return boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init, argc, argv);
+    int result{boost::unit_test::unit_test_main(&ml::test::CBoostTestXmlOutput::init,
+                                                argc, argv)};
     boost::unit_test::framework::deregister_observer(observer);
+    return result;
 }


### PR DESCRIPTION
These have had a silly mistake ever since they were written.
The observer was unregistered after main() returned. Clearly
it didn't matter, as the program was about to exit anyway,
but it's nice to tidy up the code.