### PR TITLE
[ML] Fix debug build for raw JSON splicing

### DIFF
--- a/bin/pytorch_inference/CResultWriter.cc
+++ b/bin/pytorch_inference/CResultWriter.cc
@@ -64,7 +64,7 @@ void CResultWriter::wrapAndWriteInnerResponse(const std::string& innerResponse,
     jsonWriter.Bool(isCacheHit);
     jsonWriter.Key(TIME_MS);
     jsonWriter.Uint64(timeMs);
-    jsonWriter.RawValue(innerResponse.c_str(), innerResponse.length(), rapidjson::kObjectType);
+    jsonWriter.rawKeyAndValue(innerResponse);
     jsonWriter.EndObject();
 }
 

--- a/include/core/CRapidJsonLineWriter.h
+++ b/include/core/CRapidJsonLineWriter.h
@@ -58,6 +58,24 @@ public:
         return baseReturnCode;
     }
 
+    //! Add a pre-formatted key and value to the output.
+    bool rawKeyAndValue(const std::string& keyAndValue) {
+        // We achieve this by pretending we're just adding the key, i.e.
+        // a string, but since it's written raw it can contain both key
+        // and value.
+        if (this->RawValue(keyAndValue.c_str(), keyAndValue.length(), rapidjson::kStringType)) {
+            // However, to avoiding tripping assertions we need to increment
+            // the count of values within the level by an extra 1 so that it
+            // includes the value that was bundled with the key. (The
+            // RawValue() call above will have added 1 for the key.)
+            TRapidJsonWriterBase::level_stack_
+                .template Top<typename TRapidJsonWriterBase::Level>()
+                ->valueCount++;
+            return true;
+        }
+        return false;
+    }
+
     //! Write JSON document to outputstream
     //! \note This overwrite is needed because the members of rapidjson::Writer
     //! are not virtual and we need to avoid "slicing" the writer to ensure that


### PR DESCRIPTION
In #2376 the results writer for inference was changed
to splice a preformatted cached section of the final result
document into an outer wrapper that varies per request.

The approach used worked when assertions were disabled but
tripped assertions in RapidJSON due to its internal counters
thinking that the spliced portion was a single value instead
of a key and value together.

This PR fixes the code when assertions are enabled by
taking advantage of the fact that the internal value
count of the RapidJSON writer is accessible to derived
classes, so we can add a method that adds a key and
value together and increments the counter twice.