### PR TITLE
[ML] Fix potential out-of-bounds read

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -42,6 +42,10 @@
 * Improve accuracy of anomaly detection median estimation. (See {ml-pull}2367[#2367],
   issue: {ml-issue}2364[#2364].)
 
+=== Bug Fixes
+
+* Fix potential cause of classification and regression job failures. (See {ml-pull}2385[#2385].)
+
 == {es} version 8.3.0
 
 === Enhancements

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -1666,9 +1666,8 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
         auto numberSplittableLeaves =
             static_cast<std::ptrdiff_t>(splittableLeaves.size());
         auto currentNumberInternalNodes = static_cast<std::ptrdiff_t>(tree.size() - 1) / 2;
-        auto lastPotentialSplit =
-            numberSplittableLeaves + currentNumberInternalNodes -
-            static_cast<std::ptrdiff_t>(maximumNumberInternalNodes);
+        auto lastPotentialSplit = numberSplittableLeaves + currentNumberInternalNodes -
+                                  static_cast<std::ptrdiff_t>(maximumNumberInternalNodes);
         auto smallestCurrentCandidateGainIndex =
             std::min(lastPotentialSplit, numberSplittableLeaves - 1);
         double smallestCandidateGain{

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -1663,16 +1663,18 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
         this->nodeFeatureBag(treeFeatureBag, featureSampleProbabilities, nodeFeatureBag);
         nodeFeatureBag = merge(featuresToInclude, std::move(nodeFeatureBag));
 
-        std::size_t numberSplittableLeaves{splittableLeaves.size()};
-        std::size_t currentNumberInternalNodes{(tree.size() - 1) / 2};
+        auto numberSplittableLeaves =
+            static_cast<std::ptrdiff_t>(splittableLeaves.size());
+        auto currentNumberInternalNodes = static_cast<std::ptrdiff_t>(tree.size() - 1) / 2;
+        auto lastPotentialSplit =
+            numberSplittableLeaves + currentNumberInternalNodes -
+            static_cast<std::ptrdiff_t>(maximumNumberInternalNodes);
         auto smallestCurrentCandidateGainIndex =
-            static_cast<std::ptrdiff_t>(numberSplittableLeaves) -
-            static_cast<std::ptrdiff_t>(maximumNumberInternalNodes - currentNumberInternalNodes);
+            std::min(lastPotentialSplit, numberSplittableLeaves - 1);
         double smallestCandidateGain{
-            smallestCurrentCandidateGainIndex >= 0
-                ? splittableLeaves[static_cast<std::size_t>(smallestCurrentCandidateGainIndex)]
-                      ->gain()
-                : 0.0};
+            smallestCurrentCandidateGainIndex < 0
+                ? 0.0
+                : splittableLeaves[smallestCurrentCandidateGainIndex]->gain()};
 
         TLeafNodeStatisticsPtr leftChild;
         TLeafNodeStatisticsPtr rightChild;


### PR DESCRIPTION
Debugging an intermittent SIGSEGV triggered by another change I'm working on showed up this potential out-of-bounds read. It would happen very infrequently. It was introduced by #1537.