### PR TITLE
[ML] Improve memory management for training on large data sets

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -33,7 +33,7 @@
 === Enhancements
 
 * Improve classification and regression model train runtimes for data sets with many
-  numeric features. (See {ml-pull}2380[#2380].)
+  numeric features. (See {ml-pull}2380[#2380] and {ml-pull}2388[#2388].)
 
 == {es} version 8.4.0
 

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -1582,7 +1582,7 @@ CBoostedTreeImpl::candidateSplits(const core::CDataFrame& frame,
             [this](const TRowRef& row) {
                 std::size_t numberLossParameters{m_Loss->numberParameters()};
                 return trace(numberLossParameters,
-                                      readLossCurvature(row, m_ExtraColumns, numberLossParameters));
+                             readLossCurvature(row, m_ExtraColumns, numberLossParameters));
             })
             .first;
 

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -1581,8 +1581,7 @@ CBoostedTreeImpl::candidateSplits(const core::CDataFrame& frame,
             m_Encoder.get(),
             [this](const TRowRef& row) {
                 std::size_t numberLossParameters{m_Loss->numberParameters()};
-                double weight{readExampleWeight(row, m_ExtraColumns)};
-                return weight * trace(numberLossParameters,
+                return trace(numberLossParameters,
                                       readLossCurvature(row, m_ExtraColumns, numberLossParameters));
             })
             .first;

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -1672,10 +1672,11 @@ CBoostedTreeImpl::trainTree(core::CDataFrame& frame,
                                   static_cast<std::ptrdiff_t>(maximumNumberInternalNodes);
         auto smallestCurrentCandidateGainIndex =
             std::min(lastPotentialSplit, numberSplittableLeaves - 1);
-        double smallestCandidateGain{
+        double smallestCandidateGain{std::max(
+            workspace.minimumGain(),
             smallestCurrentCandidateGainIndex < 0
                 ? 0.0
-                : splittableLeaves[smallestCurrentCandidateGainIndex]->gain()};
+                : splittableLeaves[smallestCurrentCandidateGainIndex]->gain())};
 
         TLeafNodeStatisticsPtr leftChild;
         TLeafNodeStatisticsPtr rightChild;

--- a/lib/maths/analytics/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/analytics/CBoostedTreeLeafNodeStatistics.cc
@@ -351,8 +351,11 @@ CBoostedTreeLeafNodeStatistics::CWorkspace::featuresToInclude() const {
 }
 
 std::size_t CBoostedTreeLeafNodeStatistics::CWorkspace::memoryUsage() const {
-    return core::memory::dynamicSize(m_Masks) + core::memory::dynamicSize(m_Derivatives) +
-           core::memory::dynamicSize(m_FreeDerivativesList);
+    // We purposely don't account for the free list memory usage because we
+    // account for them as we recycle them during training. This means our
+    // instantaneous memory estimate might be off but not the peak memory
+    // usage which is what we care about.
+    return core::memory::dynamicSize(m_Masks) + core::memory::dynamicSize(m_Derivatives);
 }
 }
 }

--- a/lib/maths/analytics/CBoostedTreeLeafNodeStatistics.cc
+++ b/lib/maths/analytics/CBoostedTreeLeafNodeStatistics.cc
@@ -13,7 +13,7 @@
 
 #include <core/CDataFrame.h>
 #include <core/CLogger.h>
-#include <core/CMemoryDef.h>
+#include <core/CMemoryDefStd.h>
 
 #include <maths/analytics/CBoostedTree.h>
 #include <maths/analytics/CDataFrameCategoryEncoder.h>
@@ -107,11 +107,11 @@ std::string CBoostedTreeLeafNodeStatistics::print() const {
 
 CBoostedTreeLeafNodeStatistics::CBoostedTreeLeafNodeStatistics(std::size_t id,
                                                                std::size_t depth,
-                                                               TSizeVecCRef extraColumns,
+                                                               const TSizeVec& extraColumns,
                                                                std::size_t numberLossParameters,
                                                                const TFloatVecVec& candidateSplits,
                                                                CSplitsDerivatives derivatives)
-    : m_Id{id}, m_Depth{depth}, m_ExtraColumns{extraColumns}, m_NumberLossParameters{numberLossParameters},
+    : m_Id{id}, m_Depth{depth}, m_NumberLossParameters{numberLossParameters}, m_ExtraColumns{extraColumns},
       m_CandidateSplits{candidateSplits}, m_Derivatives{std::move(derivatives)} {
 }
 
@@ -180,7 +180,7 @@ void CBoostedTreeLeafNodeStatistics::computeAggregateLossDerivativesWith(
     for (std::size_t i = 0; i < numberThreads; ++i) {
         auto& splitsDerivatives = workspace.derivatives()[i];
         splitsDerivatives.zero();
-        aggregators.push_back([&](const TRowItr& beginRows, const TRowItr& endRows) {
+        aggregators.emplace_back([&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
                 this->addRowDerivatives(bound, featureBag, *row, splitsDerivatives);
             }
@@ -211,7 +211,7 @@ void CBoostedTreeLeafNodeStatistics::computeRowMaskAndAggregateLossDerivativesWi
         auto& splitsDerivatives = workspace.derivatives()[i];
         mask.clear();
         splitsDerivatives.zero();
-        aggregators.push_back([&](const TRowItr& beginRows, const TRowItr& endRows) {
+        aggregators.emplace_back([&](const TRowItr& beginRows, const TRowItr& endRows) {
             for (auto row_ = beginRows; row_ != endRows; ++row_) {
                 auto row = *row_;
                 if (split.assignToLeft(row, m_ExtraColumns) == isLeftChild) {
@@ -284,7 +284,7 @@ std::size_t CBoostedTreeLeafNodeStatistics::depth() const {
     return m_Depth;
 }
 
-CBoostedTreeLeafNodeStatistics::TSizeVecCRef
+const CBoostedTreeLeafNodeStatistics::TSizeVec&
 CBoostedTreeLeafNodeStatistics::extraColumns() const {
     return m_ExtraColumns;
 }
@@ -351,7 +351,8 @@ CBoostedTreeLeafNodeStatistics::CWorkspace::featuresToInclude() const {
 }
 
 std::size_t CBoostedTreeLeafNodeStatistics::CWorkspace::memoryUsage() const {
-    return core::memory::dynamicSize(m_Masks) + core::memory::dynamicSize(m_Derivatives);
+    return core::memory::dynamicSize(m_Masks) + core::memory::dynamicSize(m_Derivatives) +
+           core::memory::dynamicSize(m_FreeDerivativesList);
 }
 }
 }

--- a/lib/maths/analytics/CBoostedTreeLeafNodeStatisticsIncremental.cc
+++ b/lib/maths/analytics/CBoostedTreeLeafNodeStatisticsIncremental.cc
@@ -64,7 +64,7 @@ CBoostedTreeLeafNodeStatisticsIncremental::CBoostedTreeLeafNodeStatisticsIncreme
 
     if (this->gain() >= workspace.minimumGain()) {
         this->rowMask() = rowMask;
-        CSplitsDerivatives tmp{workspace.derivatives()[0]};
+        CSplitsDerivatives tmp{workspace.copy(workspace.derivatives()[0])};
         this->derivatives() = std::move(tmp);
     }
 }
@@ -102,7 +102,7 @@ CBoostedTreeLeafNodeStatisticsIncremental::CBoostedTreeLeafNodeStatisticsIncreme
 
     // Lazily copy the mask and derivatives to avoid unnecessary allocations.
     if (this->gain() >= workspace.minimumGain()) {
-        CSplitsDerivatives tmp{workspace.reducedDerivatives(treeFeatureBag)};
+        CSplitsDerivatives tmp{workspace.copy(workspace.reducedDerivatives(treeFeatureBag))};
         this->rowMask() = workspace.reducedMask(parent.rowMask().size());
         this->derivatives() = std::move(tmp);
     }
@@ -137,10 +137,13 @@ CBoostedTreeLeafNodeStatisticsIncremental::CBoostedTreeLeafNodeStatisticsIncreme
     this->bestSplitStatistics() = this->computeBestSplitStatistics(
         workspace.numberThreads(), regularization, nodeFeatureBag);
 
-    // Lazily compute the row mask to avoid unnecessary work.
     if (this->gain() >= workspace.minimumGain()) {
+        // Lazily compute the row mask to avoid unnecessary work.
         this->rowMask() = std::move(parent.rowMask());
         this->rowMask() ^= workspace.reducedMask(this->rowMask().size());
+    } else {
+        // We're going to discard this node so recycle its derivatives.
+        workspace.recycle(std::move(this->derivatives()));
     }
 }
 
@@ -170,19 +173,19 @@ CBoostedTreeLeafNodeStatisticsIncremental::split(std::size_t leftChildId,
     TPtr leftChild;
     TPtr rightChild;
     if (this->leftChildHasFewerRows()) {
-        leftChild = std::make_shared<CBoostedTreeLeafNodeStatisticsIncremental>(
+        leftChild = std::make_unique<CBoostedTreeLeafNodeStatisticsIncremental>(
             leftChildId, *this, frame, regularization, treeFeatureBag,
             nodeFeatureBag, true /*is left child*/, split, workspace);
-        rightChild = std::make_shared<CBoostedTreeLeafNodeStatisticsIncremental>(
+        rightChild = std::make_unique<CBoostedTreeLeafNodeStatisticsIncremental>(
             rightChildId, std::move(*this), regularization, treeFeatureBag,
             nodeFeatureBag, false /*is left child*/, workspace);
         return {std::move(leftChild), std::move(rightChild)};
     }
 
-    rightChild = std::make_shared<CBoostedTreeLeafNodeStatisticsIncremental>(
+    rightChild = std::make_unique<CBoostedTreeLeafNodeStatisticsIncremental>(
         rightChildId, *this, frame, regularization, treeFeatureBag,
         nodeFeatureBag, false /*is left child*/, split, workspace);
-    leftChild = std::make_shared<CBoostedTreeLeafNodeStatisticsIncremental>(
+    leftChild = std::make_unique<CBoostedTreeLeafNodeStatisticsIncremental>(
         leftChildId, std::move(*this), regularization, treeFeatureBag,
         nodeFeatureBag, true /*is left child*/, workspace);
     return {std::move(leftChild), std::move(rightChild)};

--- a/lib/maths/analytics/CBoostedTreeLeafNodeStatisticsScratch.cc
+++ b/lib/maths/analytics/CBoostedTreeLeafNodeStatisticsScratch.cc
@@ -59,7 +59,7 @@ CBoostedTreeLeafNodeStatisticsScratch::CBoostedTreeLeafNodeStatisticsScratch(
 
     if (this->gain() >= workspace.minimumGain()) {
         this->rowMask() = rowMask;
-        CSplitsDerivatives tmp{workspace.derivatives()[0]};
+        CSplitsDerivatives tmp{workspace.copy(workspace.derivatives()[0])};
         this->derivatives() = std::move(tmp);
     }
 }
@@ -92,7 +92,7 @@ CBoostedTreeLeafNodeStatisticsScratch::CBoostedTreeLeafNodeStatisticsScratch(
     workspace.reducedDerivatives(treeFeatureBag).swap(this->derivatives());
 
     if (this->gain() >= workspace.minimumGain()) {
-        CSplitsDerivatives tmp{workspace.reducedDerivatives(treeFeatureBag)};
+        CSplitsDerivatives tmp{workspace.copy(workspace.reducedDerivatives(treeFeatureBag))};
         this->rowMask() = workspace.reducedMask(parent.rowMask().size());
         this->derivatives() = std::move(tmp);
     }
@@ -120,10 +120,13 @@ CBoostedTreeLeafNodeStatisticsScratch::CBoostedTreeLeafNodeStatisticsScratch(
     this->bestSplitStatistics() = this->computeBestSplitStatistics(
         workspace.numberThreads(), regularization, nodeFeatureBag);
 
-    // Lazily compute the row mask to avoid unnecessary work.
     if (this->gain() >= workspace.minimumGain()) {
+        // Lazily compute the row mask to avoid unnecessary work.
         this->rowMask() = std::move(parent.rowMask());
         this->rowMask() ^= workspace.reducedMask(this->rowMask().size());
+    } else {
+        // We're going to discard this node so recycle its derivatives.
+        workspace.recycle(std::move(this->derivatives()));
     }
 }
 
@@ -152,38 +155,46 @@ CBoostedTreeLeafNodeStatisticsScratch::split(std::size_t leftChildId,
                                              CWorkspace& workspace) {
     TPtr leftChild;
     TPtr rightChild;
+    bool recycle{true};
+
     if (this->leftChildHasFewerRows()) {
         if (this->bestSplitStatistics().s_LeftChildMaxGain > gainThreshold) {
-            leftChild = std::make_shared<CBoostedTreeLeafNodeStatisticsScratch>(
+            leftChild = std::make_unique<CBoostedTreeLeafNodeStatisticsScratch>(
                 leftChildId, *this, frame, regularization, treeFeatureBag,
                 nodeFeatureBag, true /*is left child*/, split, workspace);
             if (this->bestSplitStatistics().s_RightChildMaxGain > gainThreshold) {
-                rightChild = std::make_shared<CBoostedTreeLeafNodeStatisticsScratch>(
+                rightChild = std::make_unique<CBoostedTreeLeafNodeStatisticsScratch>(
                     rightChildId, std::move(*this), regularization,
                     treeFeatureBag, nodeFeatureBag, workspace);
+                recycle = false;
             }
         } else if (this->bestSplitStatistics().s_RightChildMaxGain > gainThreshold) {
-            rightChild = std::make_shared<CBoostedTreeLeafNodeStatisticsScratch>(
+            rightChild = std::make_unique<CBoostedTreeLeafNodeStatisticsScratch>(
                 rightChildId, *this, frame, regularization, treeFeatureBag,
                 nodeFeatureBag, false /*is left child*/, split, workspace);
         }
-        return {std::move(leftChild), std::move(rightChild)};
+    } else {
+        if (this->bestSplitStatistics().s_RightChildMaxGain > gainThreshold) {
+            rightChild = std::make_unique<CBoostedTreeLeafNodeStatisticsScratch>(
+                rightChildId, *this, frame, regularization, treeFeatureBag,
+                nodeFeatureBag, false /*is left child*/, split, workspace);
+            if (this->bestSplitStatistics().s_LeftChildMaxGain > gainThreshold) {
+                leftChild = std::make_unique<CBoostedTreeLeafNodeStatisticsScratch>(
+                    leftChildId, std::move(*this), regularization, treeFeatureBag,
+                    nodeFeatureBag, workspace);
+                recycle = false;
+            }
+        } else if (this->bestSplitStatistics().s_LeftChildMaxGain > gainThreshold) {
+            leftChild = std::make_unique<CBoostedTreeLeafNodeStatisticsScratch>(
+                leftChildId, *this, frame, regularization, treeFeatureBag,
+                nodeFeatureBag, true /*is left child*/, split, workspace);
+        }
     }
 
-    if (this->bestSplitStatistics().s_RightChildMaxGain > gainThreshold) {
-        rightChild = std::make_shared<CBoostedTreeLeafNodeStatisticsScratch>(
-            rightChildId, *this, frame, regularization, treeFeatureBag,
-            nodeFeatureBag, false /*is left child*/, split, workspace);
-        if (this->bestSplitStatistics().s_LeftChildMaxGain > gainThreshold) {
-            leftChild = std::make_shared<CBoostedTreeLeafNodeStatisticsScratch>(
-                leftChildId, std::move(*this), regularization, treeFeatureBag,
-                nodeFeatureBag, workspace);
-        }
-    } else if (this->bestSplitStatistics().s_LeftChildMaxGain > gainThreshold) {
-        leftChild = std::make_shared<CBoostedTreeLeafNodeStatisticsScratch>(
-            leftChildId, *this, frame, regularization, treeFeatureBag,
-            nodeFeatureBag, true /*is left child*/, split, workspace);
+    if (recycle) {
+        workspace.recycle(std::move(this->derivatives()));
     }
+
     return {std::move(leftChild), std::move(rightChild)};
 }
 

--- a/lib/maths/analytics/CBoostedTreeLeafNodeStatisticsScratch.cc
+++ b/lib/maths/analytics/CBoostedTreeLeafNodeStatisticsScratch.cc
@@ -180,8 +180,8 @@ CBoostedTreeLeafNodeStatisticsScratch::split(std::size_t leftChildId,
                 nodeFeatureBag, false /*is left child*/, split, workspace);
             if (this->bestSplitStatistics().s_LeftChildMaxGain > gainThreshold) {
                 leftChild = std::make_unique<CBoostedTreeLeafNodeStatisticsScratch>(
-                    leftChildId, std::move(*this), regularization, treeFeatureBag,
-                    nodeFeatureBag, workspace);
+                    leftChildId, std::move(*this), regularization,
+                    treeFeatureBag, nodeFeatureBag, workspace);
                 recycle = false;
             }
         } else if (this->bestSplitStatistics().s_LeftChildMaxGain > gainThreshold) {


### PR DESCRIPTION
Profiling showed we spend a surprising amount of time creating and destroying leaf statistics state training on large data sets. These objects are large O("number splits" * "number features" * ("gradient" + "hessian")) we also have to map out the memory of individual split vectors and this work has to be done each time we allocate a new object. In fact, we can just recycle the objects when we determine that no splits are useful at a leaf as long as the objects are "conformable", i.e. same dimensions, which they usually are.

This change saves up to 40% of the work on the main thread for some data sets, it should also lead to better LOR. It logically belongs with #2380 so I'll document together with that change.