### PR TITLE
[ML] Detect debug-only compile errors in PR builds

### DIFF
--- a/dev-tools/jenkins_cross_compile.sh
+++ b/dev-tools/jenkins_cross_compile.sh
@@ -87,10 +87,15 @@ fi
 # Cross compile macOS
 ./docker_build.sh macosx
 
-# If this isn't a PR build cross compile aarch64 too
-if [ -z "$PR_AUTHOR" ] ; then
-    ./docker_build.sh linux_aarch64_cross
+# If this is a PR build then it's redundant to cross compile aarch64 (as
+# we build and test aarch64 natively for PR builds) but there's a benefit
+# to building one platform with debug enabled to detect code that only
+# compiles with optimisation
+if [ -n "$PR_AUTHOR" ] ; then
+    export ML_DEBUG=1
 fi
+
+./docker_build.sh linux_aarch64_cross
 
 # If this isn't a PR build and isn't a debug build then upload the artifacts
 if [[ -z "$PR_AUTHOR" && -z "$ML_DEBUG" ]] ; then

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -947,7 +947,7 @@ CBoostedTreeImpl::retrainTreeSelectionProbabilities(const core::CDataFrame& fram
     using TDoubleVectorVecVec = std::vector<TDoubleVectorVec>;
 
     std::size_t numberLossParameters{m_Loss->numberParameters()};
-    LOG_TRACE(<< "dependent variable " << dependentVariable);
+    LOG_TRACE(<< "dependent variable " << m_DependentVariable);
     LOG_TRACE(<< "number loss parameters = " << numberLossParameters);
 
     auto makeComputeTotalLossGradient = [&]() {


### PR DESCRIPTION
People rarely build the code with debug enabled, so it's
possible for an error in the code that only affects debug
builds to get committed.

This change adds a step to build (but not unit test) the
code with debug enabled in every PR build. Doing this in
the cross compile sub-job should mean that it doesn't
increase the overall PR CI duration, as the cross compile
sub-job is faster than the sub-jobs that run unit tests.