### PR TITLE
[ML] Improve quantile estimation performance for train

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -33,7 +33,7 @@
 === Enhancements
 
 * Improve classification and regression model train runtimes for data sets with many
-  numeric features. (See {ml-pull}2380[#2380] and {ml-pull}2388[#2388].)
+  numeric features. (See {ml-pull}2380[#2380], {ml-pull}2388[#2388] and {ml-pull}2388[#2390].)
 
 == {es} version 8.4.0
 

--- a/include/core/CFloatStorage.h
+++ b/include/core/CFloatStorage.h
@@ -73,10 +73,11 @@ public:
 
 public:
     //! Default construction of the floating point value.
-    CFloatStorage() : m_Value() {}
+    constexpr CFloatStorage() : m_Value() {}
 
     //! Integer promotion. So one can write things like CFloatStorage(1).
-    CFloatStorage(int value) : m_Value(float(value)) {
+    constexpr CFloatStorage(int value) noexcept
+        : m_Value(static_cast<float>(value)) {
 #ifdef CFLOATSTORAGE_BOUNDS_CHECK
         if (value > MAX_PRECISE_INTEGER_FLOAT || -value < MAX_PRECISE_INTEGER_FLOAT) {
             LOG_WARN(<< "Loss of precision assigning int " << value << " to float");
@@ -85,42 +86,66 @@ public:
     }
 
     //! Implicit construction from a float.
-    CFloatStorage(float value) : m_Value(value) {}
+    constexpr CFloatStorage(float value) noexcept : m_Value(value) {}
 
     //! Implicit construction from a double.
-    CFloatStorage(double value) : m_Value() { this->set(value); }
+    constexpr CFloatStorage(double value) noexcept : m_Value() {
+        this->set(value);
+    }
 
     //! \name Operators
     //@{
-    CFloatStorage operator-() const { return CFloatStorage{-m_Value}; }
-    bool operator==(CFloatStorage rhs) const { return m_Value == rhs.m_Value; }
-    bool operator==(float rhs) const { return m_Value == rhs; }
-    bool operator==(double rhs) const {
+    constexpr CFloatStorage operator-() const noexcept {
+        return CFloatStorage{-m_Value};
+    }
+    constexpr bool operator==(CFloatStorage rhs) const noexcept {
+        return m_Value == rhs.m_Value;
+    }
+    constexpr bool operator==(float rhs) const noexcept {
+        return m_Value == rhs;
+    }
+    constexpr bool operator==(double rhs) const noexcept {
         return static_cast<double>(m_Value) == rhs;
     }
-    bool operator!=(CFloatStorage rhs) const { return m_Value != rhs.m_Value; }
-    bool operator!=(float rhs) const { return m_Value != rhs; }
-    bool operator!=(double rhs) const {
+    constexpr bool operator!=(CFloatStorage rhs) const noexcept {
+        return m_Value != rhs.m_Value;
+    }
+    constexpr bool operator!=(float rhs) const noexcept {
+        return m_Value != rhs;
+    }
+    constexpr bool operator!=(double rhs) const noexcept {
         return static_cast<double>(m_Value) != rhs;
     }
-    bool operator<(CFloatStorage rhs) const { return m_Value < rhs.m_Value; }
-    bool operator<(float rhs) const { return m_Value < rhs; }
-    bool operator<(double rhs) const {
+    constexpr bool operator<(CFloatStorage rhs) const noexcept {
+        return m_Value < rhs.m_Value;
+    }
+    constexpr bool operator<(float rhs) const noexcept { return m_Value < rhs; }
+    constexpr bool operator<(double rhs) const noexcept {
         return static_cast<double>(m_Value) < rhs;
     }
-    bool operator<=(CFloatStorage rhs) const { return m_Value <= rhs.m_Value; }
-    bool operator<=(float rhs) const { return m_Value <= rhs; }
-    bool operator<=(double rhs) const {
+    constexpr bool operator<=(CFloatStorage rhs) const noexcept {
+        return m_Value <= rhs.m_Value;
+    }
+    constexpr bool operator<=(float rhs) const noexcept {
+        return m_Value <= rhs;
+    }
+    constexpr bool operator<=(double rhs) const noexcept {
         return static_cast<double>(m_Value) <= rhs;
     }
-    bool operator>(CFloatStorage rhs) const { return m_Value > rhs.m_Value; }
-    bool operator>(float rhs) const { return m_Value > rhs; }
-    bool operator>(double rhs) const {
+    constexpr bool operator>(CFloatStorage rhs) const noexcept {
+        return m_Value > rhs.m_Value;
+    }
+    constexpr bool operator>(float rhs) const noexcept { return m_Value > rhs; }
+    constexpr bool operator>(double rhs) const noexcept {
         return static_cast<double>(m_Value) > rhs;
     }
-    bool operator>=(CFloatStorage rhs) const { return m_Value >= rhs.m_Value; }
-    bool operator>=(float rhs) const { return m_Value >= rhs; }
-    bool operator>=(double rhs) const {
+    constexpr bool operator>=(CFloatStorage rhs) const noexcept {
+        return m_Value >= rhs.m_Value;
+    }
+    constexpr bool operator>=(float rhs) const noexcept {
+        return m_Value >= rhs;
+    }
+    constexpr bool operator>=(double rhs) const noexcept {
         return static_cast<double>(m_Value) >= rhs;
     }
     //@}
@@ -144,44 +169,45 @@ public:
     //! \name Double Assignment
     //@{
     //! Assign from a double.
-    CFloatStorage& operator=(double value) {
+    constexpr CFloatStorage& operator=(double value) noexcept {
         this->set(value);
         return *this;
     }
     //! Plus assign from double.
-    CFloatStorage& operator+=(double value) {
+    constexpr CFloatStorage& operator+=(double value) noexcept {
         this->set(static_cast<double>(m_Value) + value);
         return *this;
     }
     //! Minus assign from double.
-    CFloatStorage& operator-=(double value) {
+    constexpr CFloatStorage& operator-=(double value) noexcept {
         this->set(static_cast<double>(m_Value) - value);
         return *this;
     }
     //! Multiply assign from double.
-    CFloatStorage& operator*=(double value) {
+    constexpr CFloatStorage& operator*=(double value) noexcept {
         this->set(static_cast<double>(m_Value) * value);
         return *this;
     }
     //! Divide assign from double.
-    CFloatStorage& operator/=(double value) {
+    constexpr CFloatStorage& operator/=(double value) noexcept {
         this->set(static_cast<double>(m_Value) / value);
         return *this;
     }
     //@}
 
     //! Implicit conversion to a double.
-    operator double() const { return static_cast<double>(m_Value); }
+    constexpr operator double() const noexcept {
+        return static_cast<double>(m_Value);
+    }
 
     //! Constant reference access to the underlying storage.
-    const float& cstorage() const { return m_Value; }
-
-protected:
-    float& storage() { return m_Value; }
+    constexpr const float& cstorage() const noexcept { return m_Value; }
+    //! Writeable reference access to the underlying storage.
+    constexpr float& storage() noexcept { return m_Value; }
 
 private:
     //! Utility to actually set the floating point value.
-    void set(double value) {
+    constexpr void set(double value) noexcept {
 #ifdef CFLOATSTORAGE_BOUNDS_CHECK
         if (value > std::numeric_limits<float>::max() ||
             -value > std::numeric_limits<float>::max()) {

--- a/include/core/CMemoryDef.h
+++ b/include/core/CMemoryDef.h
@@ -277,7 +277,7 @@ std::size_t elementDynamicSize(const CONTAINER& t) {
 //! compute their memory usage. It will warn if a type is visited which is
 //! not registered. Example usage:
 //! \code{.cpp}
-//!   CMemory::anyVisitor().insertCallback<std::vector<double>>();
+//!   memory::anyVisitor().insertCallback<std::vector<double>>();
 //!   std::vector<std::any> variables;
 //!   variables.push_back(TDoubleVec(10));
 //!   std::size_t size{memory::dynamicSize(variables, visitor)};
@@ -634,7 +634,7 @@ void elementDynamicSize(std::string name,
 //! stored in std::any.
 //!
 //! DESCRIPTION:\n
-//! See CMemory::CAnyVisitor for details.
+//! See memory::CAnyVisitor for details.
 class CORE_EXPORT CAnyVisitor {
 public:
     using TDynamicSizeFunc = void (*)(const char*,

--- a/include/maths/analytics/CBoostedTreeImpl.h
+++ b/include/maths/analytics/CBoostedTreeImpl.h
@@ -312,7 +312,8 @@ private:
                                     core::CLoopProgress& trainingProgress) const;
 
     //! Randomly downsamples the training row mask by the downsample factor.
-    core::CPackedBitVector downsample(const core::CPackedBitVector& trainingRowMask) const;
+    core::CPackedBitVector downsample(const core::CPackedBitVector& trainingRowMask,
+                                      TOptionalDouble downsampleFactor = std::nullopt) const;
 
     //! Set the candidate splits for low cardinality features which remain
     //! fixed for the duration of training.

--- a/include/maths/analytics/CBoostedTreeUtils.h
+++ b/include/maths/analytics/CBoostedTreeUtils.h
@@ -23,7 +23,7 @@
 #include <cmath>
 #include <cstddef>
 
-#if defined(__SSE4_2__)
+#if defined(__SSE__)
 
 #include <xmmintrin.h>
 

--- a/include/model/CDetectorEqualizer.h
+++ b/include/model/CDetectorEqualizer.h
@@ -71,8 +71,6 @@ private:
     maths::common::CQuantileSketch& sketch(int detector);
 
 private:
-    //! The style of interpolation to use for the sketch.
-    static const maths::common::CQuantileSketch::EInterpolation SKETCH_INTERPOLATION;
     //! The maximum size of the quantile sketch.
     static const std::size_t SKETCH_SIZE;
     //! The minimum count in a detector's sketch for which we'll

--- a/include/model/CGathererTools.h
+++ b/include/model/CGathererTools.h
@@ -62,8 +62,7 @@ public:
     using TOptionalDouble = std::optional<double>;
     using TSampleVec = std::vector<CSample>;
     using TMeanAccumulator = maths::common::CBasicStatistics::SSampleMean<double>::TAccumulator;
-    using TMedianAccumulator =
-        maths::common::CFixedQuantileSketch<maths::common::CQuantileSketch::E_Linear, 30>;
+    using TMedianAccumulator = maths::common::CFixedQuantileSketch<30>;
     using TMinAccumulator = maths::common::CBasicStatistics::SMin<double>::TAccumulator;
     using TMaxAccumulator = maths::common::CBasicStatistics::SMax<double>::TAccumulator;
     using TVarianceAccumulator =

--- a/include/model/CMetricStatisticWrappers.h
+++ b/include/model/CMetricStatisticWrappers.h
@@ -62,8 +62,7 @@ struct MODEL_EXPORT CMetricStatisticWrappers {
     using TMeanAccumulator = maths::common::CBasicStatistics::SSampleMean<double>::TAccumulator;
     using TVarianceAccumulator =
         maths::common::CBasicStatistics::SSampleMeanVar<double>::TAccumulator;
-    using TMedianAccumulator =
-        maths::common::CFixedQuantileSketch<maths::common::CQuantileSketch::E_Linear, 30>;
+    using TMedianAccumulator = maths::common::CFixedQuantileSketch<30>;
 
     //! Make a statistic.
     template<typename STATISTIC>

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -1197,7 +1197,7 @@ void CBoostedTreeFactory::initializeUnsetTreeTopologyPenalty(core::CDataFrame& f
                                              m_TreeImpl->m_TestingRowMasks[0],
                                              m_TreeImpl->m_TrainingProgress)
                               .s_Forest;
-            common::CFastQuantileSketch quantiles{common::CQuantileSketch::E_Linear, 50};
+            common::CFastQuantileSketch quantiles{50};
             for (const auto& tree : forest) {
                 for (const auto& node : tree) {
                     if (node.isLeaf() == false) {

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -72,7 +72,7 @@ const std::string HYPERPARAMETER_OPTIMIZATION_ROUND{"hyperparameter_optimization
 const std::string TRAIN_FINAL_FOREST{"train_final_forest"};
 const double BYTES_IN_MB{static_cast<double>(core::constants::BYTES_IN_MEGABYTES)};
 const double MAXIMUM_SAMPLE_SIZE_FOR_QUANTILES{50000.0};
-const std::size_t LOSS_ESTIMATION_BOOTSTRAP_SIZE{7};
+const std::size_t LOSS_ESTIMATION_BOOTSTRAP_SIZE{5};
 CDataFrameTrainBoostedTreeInstrumentationStub INSTRUMENTATION_STUB;
 
 //! \brief Record the memory used by a supplied object using the RAII idiom.
@@ -1679,7 +1679,7 @@ void CBoostedTreeImpl::refreshSplitsCache(core::CDataFrame& frame,
                         if (featureMask[i]) {
                             double feature{encodedRow[i]};
                             packedSplits[j] =
-                                CDataFrameUtils::isMissing(feature)
+                                core::CDataFrame::isMissing(feature)
                                     ? static_cast<std::uint8_t>(
                                           missingSplit(candidateSplitsTrees[i]))
                                     : static_cast<std::uint8_t>(

--- a/lib/maths/analytics/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
@@ -390,7 +390,7 @@ BOOST_AUTO_TEST_CASE(testGainBoundComputation) {
     std::size_t numberThreads{1};
 
     for (std::size_t seed = 0; seed < 1000; ++seed) {
-        maths::common::CQuantileSketch sketch(maths::common::CQuantileSketch::E_Linear, rows);
+        maths::common::CQuantileSketch sketch{rows};
         test::CRandomNumbers rng;
         rng.seed(seed);
         auto frame = core::makeMainStorageDataFrame(cols, rows).first;

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -857,7 +857,7 @@ BOOST_AUTO_TEST_CASE(testLowCardinalityFeatures) {
     std::size_t trainRows{500};
     std::size_t testRows{200};
     std::size_t rows{trainRows + testRows};
-    double noiseVariance{9.0};
+    double noiseVariance{4.0};
     std::size_t cols{6};
 
     test::CRandomNumbers rng;
@@ -878,7 +878,7 @@ BOOST_AUTO_TEST_CASE(testLowCardinalityFeatures) {
     TDoubleVec noise;
     rng.generateNormalSamples(0.0, noiseVariance, rows, noise);
     for (auto& ni : noise) {
-        ni = std::floor(ni + 0.5);
+        ni = std::round(ni);
     }
 
     TDoubleVecVec x(cols - 1);
@@ -887,7 +887,7 @@ BOOST_AUTO_TEST_CASE(testLowCardinalityFeatures) {
     }
     for (std::size_t i = 0; i < (cols - 1) / 2 + 1; ++i) {
         for (auto& xj : x[i]) {
-            xj = std::floor(xj + 0.5);
+            xj = std::round(xj);
         }
     }
 

--- a/lib/maths/analytics/unittest/CDataFrameUtilsTest.cc
+++ b/lib/maths/analytics/unittest/CDataFrameUtilsTest.cc
@@ -306,8 +306,7 @@ BOOST_AUTO_TEST_CASE(testColumnQuantiles) {
     std::size_t capacity{500};
 
     TDoubleVecVec values(4);
-    TQuantileSketchVec expectedQuantiles(
-        4, {maths::common::CFastQuantileSketch::E_Linear, rows});
+    TQuantileSketchVec expectedQuantiles(4, maths::common::CFastQuantileSketch{rows});
     {
         std::size_t i = 0;
         for (auto a : {-10.0, 0.0}) {
@@ -350,12 +349,9 @@ BOOST_AUTO_TEST_CASE(testColumnQuantiles) {
             }
             frame->finishWritingRows();
 
-            TQuantileSketchVec actualQuantiles;
-            bool successful;
-            std::tie(actualQuantiles, successful) =
-                maths::analytics::CDataFrameUtils::columnQuantiles(
-                    threads, *frame, maskAll(rows), columnMask,
-                    {maths::common::CFastQuantileSketch::E_Linear, 100});
+            auto[actualQuantiles, successful] = maths::analytics::CDataFrameUtils::columnQuantiles(
+                threads, *frame, maskAll(rows), columnMask,
+                maths::common::CFastQuantileSketch{100});
             BOOST_TEST_REQUIRE(successful);
 
             // Check the quantile sketches match.
@@ -444,8 +440,8 @@ BOOST_AUTO_TEST_CASE(testColumnQuantilesWithEncoding) {
     TSizeVec columnMask(encoder.numberEncodedColumns());
     std::iota(columnMask.begin(), columnMask.end(), 0);
 
-    TQuantileSketchVec expectedQuantiles{
-        columnMask.size(), {maths::common::CFastQuantileSketch::E_Linear, 100}};
+    TQuantileSketchVec expectedQuantiles{columnMask.size(),
+                                         maths::common::CFastQuantileSketch{100}};
     frame->readRows(1, [&](const core::CDataFrame::TRowItr& beginRows,
                            const core::CDataFrame::TRowItr& endRows) {
         for (auto row = beginRows; row != endRows; ++row) {
@@ -456,11 +452,9 @@ BOOST_AUTO_TEST_CASE(testColumnQuantilesWithEncoding) {
         }
     });
 
-    TQuantileSketchVec actualQuantiles;
-    bool successful;
-    std::tie(actualQuantiles, successful) = maths::analytics::CDataFrameUtils::columnQuantiles(
+    auto[actualQuantiles, successful] = maths::analytics::CDataFrameUtils::columnQuantiles(
         1, *frame, maskAll(rows), columnMask,
-        {maths::common::CFastQuantileSketch::E_Linear, 100}, &encoder);
+        maths::common::CFastQuantileSketch{100}, &encoder);
     BOOST_TEST_REQUIRE(successful);
 
     for (std::size_t i = 5; i < 100; i += 5) {
@@ -777,10 +771,8 @@ BOOST_AUTO_TEST_CASE(testStratifiedSamplingRowMasks) {
                             samplingRowMask.manhattan(), 1.0);
 
         // Ensure that the target's distribution is similar.
-        maths::common::CQuantileSketch expectedQuantiles(
-            maths::common::CQuantileSketch::E_Linear, numberRows);
-        maths::common::CQuantileSketch actualQuantiles(
-            maths::common::CQuantileSketch::E_Linear, numberRows);
+        maths::common::CQuantileSketch expectedQuantiles{numberRows};
+        maths::common::CQuantileSketch actualQuantiles{numberRows};
         for (std::size_t i = 0; i < numberRows; ++i) {
             expectedQuantiles.add(value[i]);
             if (samplingRowMask[i]) {
@@ -891,10 +883,8 @@ BOOST_AUTO_TEST_CASE(testDistributionPreservingSamplingRowMasks) {
                             sampledRowMask.manhattan(), 1.0);
 
         // Ensure that the target's distribution is similar.
-        maths::common::CQuantileSketch expectedQuantiles(
-            maths::common::CQuantileSketch::E_Linear, numberRows);
-        maths::common::CQuantileSketch actualQuantiles(
-            maths::common::CQuantileSketch::E_Linear, numberRows);
+        maths::common::CQuantileSketch expectedQuantiles{numberRows};
+        maths::common::CQuantileSketch actualQuantiles{numberRows};
         for (std::size_t i = 0; i < numberRows; ++i) {
             if (distributionSourceRowMask[i]) {
                 expectedQuantiles.add(value[i]);

--- a/lib/maths/common/CQuantileSketch.cc
+++ b/lib/maths/common/CQuantileSketch.cc
@@ -68,7 +68,7 @@ ml_shuffle_128(float32x4_t a, float32x4_t b, MASK) {
     return result;
 }
 
-inline __attribute__((always_inline)) auto ml_rotate_128(x) {
+inline __attribute__((always_inline)) auto ml_rotate_128(float32x4_t x) {
     float32x2_t x21{vget_high_f32(vextq_f32(x, x), 3)};
     float32x2_t x03{vget_low_f32(vextq_f32(x, x), 3)};
     return vcombine_f32(x21, x03);

--- a/lib/maths/common/CQuantileSketch.cc
+++ b/lib/maths/common/CQuantileSketch.cc
@@ -49,7 +49,7 @@
 
 // clang-format off
 #define ml_unaligned_load_128(x) vld1q_f32(x)
-#define ml_unaligned_store_128(x) vst1q_f32(x)
+#define ml_unaligned_store_128(x, y) vst1q_f32(x, y)
 #define ml_minimum_128(x, y) vminq_f32(x, y)
 #define ml_subtract_128(x, y) vsubq_f32(x, y)
 #define ml_multiply_128(x, y) vmulq_f32(x, y)
@@ -69,8 +69,8 @@ ml_shuffle_128(float32x4_t a, float32x4_t b, MASK) {
 }
 
 inline __attribute__((always_inline)) auto ml_rotate_128(float32x4_t x) {
-    float32x2_t x21{vget_high_f32(vextq_f32(x, x), 3)};
-    float32x2_t x03{vget_low_f32(vextq_f32(x, x), 3)};
+    float32x2_t x21{vget_high_f32(vextq_f32(x, x, 3))};
+    float32x2_t x03{vget_low_f32(vextq_f32(x, x, 3))};
     return vcombine_f32(x21, x03);
 }
 

--- a/lib/maths/common/CQuantileSketch.cc
+++ b/lib/maths/common/CQuantileSketch.cc
@@ -47,22 +47,24 @@
 
 #include <arm_neon.h>
 
+// clang-format off
 #define ml_unaligned_load_128(x) vld1q_f32(x)
 #define ml_unaligned_store_128(x) vst1q_f32(x)
 #define ml_minimum_128(x, y) vminq_f32(x, y)
 #define ml_subtract_128(x, y) vsubq_f32(x, y)
 #define ml_multiply_128(x, y) vmulq_f32(x, y)
-#define ml_shuffle_mask(w, x, y, z)                                            \
-    std::integral_constant<int, (((w) << 6) | ((x) << 4) | ((y) << 2) | (z))> {}
+#define ml_shuffle_mask(w, x, y, z)                                             \
+    std::integral_constant<int, (((w) << 6) | ((x) << 4) | ((y) << 2) | (z))>{}
+// clang-format on
 
-template<typename T>
+template<typename MASK>
 inline __attribute__((always_inline)) auto
-ml_shuffle_128(float32x4_t a, float32x4_t b, T mask) {
+ml_shuffle_128(float32x4_t a, float32x4_t b, MASK) {
     float32x4_t result;
-    result = vmovq_n_f32(vgetq_lane_f32(a, mask::value() & 0x3));
-    result = vsetq_lane_f32(vgetq_lane_f32(a, (mask::value() >> 2) & 0x3), result, 1);
-    result = vsetq_lane_f32(vgetq_lane_f32(b, (mask::value() >> 4) & 0x3), result, 2);
-    result = vsetq_lane_f32(vgetq_lane_f32(b, (mask::value() >> 6) & 0x3), result, 3);
+    result = vmovq_n_f32(vgetq_lane_f32(a, MASK::value & 0x3));
+    result = vsetq_lane_f32(vgetq_lane_f32(a, (MASK::value >> 2) & 0x3), result, 1);
+    result = vsetq_lane_f32(vgetq_lane_f32(b, (MASK::value >> 4) & 0x3), result, 2);
+    result = vsetq_lane_f32(vgetq_lane_f32(b, (MASK::value >> 6) & 0x3), result, 3);
     return result;
 }
 

--- a/lib/maths/common/CQuantileSketch.cc
+++ b/lib/maths/common/CQuantileSketch.cc
@@ -43,6 +43,7 @@
 
 #elif defined(__ARM_NEON__)
 
+#include <type_traits>
 #include <arm_neon.h>
 
 #define ml_unaligned_load_128(x) vld1q_f32(x)
@@ -50,15 +51,17 @@
 #define ml_minimum_128(x, y) vminq_f32(x, y)
 #define ml_subtract_128(x, y) vsubq_f32(x, y)
 #define ml_multiply_128(x, y) vmulq_f32(x, y)
-#define ml_shuffle_mask(w, x, y, z) (((w) << 6) | ((x) << 4) | ((y) << 2) | (z))
+#define ml_shuffle_mask(w, x, y, z)                                            \
+    std::integral_constant<int, (((w) << 6) | ((x) << 4) | ((y) << 2) | (z))> {}
 
+template<typename T>
 inline __attribute__((always_inline)) auto
-ml_shuffle_128(float32x4_ta, float32x4_t b, int mask) {
+ml_shuffle_128(float32x4_t a, float32x4_t b, T mask) {
     float32x4_t result;
-    result = vmovq_n_f32(vgetq_lane_f32(a, mask & 0x3));
-    result = vsetq_lane_f32(vgetq_lane_f32(a, (mask >> 2) & 0x3), result, 1);
-    result = vsetq_lane_f32(vgetq_lane_f32(b, (mask >> 4) & 0x3), result, 2);
-    result = vsetq_lane_f32(vgetq_lane_f32(b, (mask >> 6) & 0x3), result, 3);
+    result = vmovq_n_f32(vgetq_lane_f32(a, mask::value() & 0x3));
+    result = vsetq_lane_f32(vgetq_lane_f32(a, (mask::value() >> 2) & 0x3), result, 1);
+    result = vsetq_lane_f32(vgetq_lane_f32(b, (mask::value() >> 4) & 0x3), result, 2);
+    result = vsetq_lane_f32(vgetq_lane_f32(b, (mask::value() >> 6) & 0x3), result, 3);
     return result;
 }
 

--- a/lib/maths/common/CQuantileSketch.cc
+++ b/lib/maths/common/CQuantileSketch.cc
@@ -28,7 +28,7 @@
 #include <optional>
 #include <random>
 
-#if defined(__SSE4_2__)
+#if defined(__SSE__)
 
 #include <xmmintrin.h>
 
@@ -44,6 +44,7 @@
 #elif defined(__ARM_NEON__)
 
 #include <type_traits>
+
 #include <arm_neon.h>
 
 #define ml_unaligned_load_128(x) vld1q_f32(x)

--- a/lib/maths/common/unittest/CQuantileSketchTest.cc
+++ b/lib/maths/common/unittest/CQuantileSketchTest.cc
@@ -673,7 +673,7 @@ BOOST_AUTO_TEST_CASE(testFastSketchComputeMergeCosts) {
 
     for (std::size_t i = 0; i < samples.size(); /**/) {
         maths::common::CFastQuantileSketch fastSketch{100};
-        for (std::size_t j = 0; j < 599; ++i, ++j) {
+        for (std::size_t j = 0; i < samples.size() && j < 599; ++i, ++j) {
             fastSketch.add(samples[i]);
         }
         fastSketch.order();

--- a/lib/maths/common/unittest/CQuantileSketchTest.cc
+++ b/lib/maths/common/unittest/CQuantileSketchTest.cc
@@ -17,6 +17,7 @@
 #include <core/CStopWatch.h>
 
 #include <maths/common/CBasicStatistics.h>
+#include <maths/common/CBasicStatisticsPersist.h>
 #include <maths/common/CQuantileSketch.h>
 
 #include <test/BoostTestCloseAbsolute.h>
@@ -25,6 +26,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
+#include <numeric>
 
 BOOST_AUTO_TEST_SUITE(CQuantileSketchTest)
 
@@ -80,8 +82,44 @@ void testSketch(SKETCH sketch,
 }
 }
 
+BOOST_AUTO_TEST_CASE(testOrderAndDeduplicate) {
+
+    maths::common::CQuantileSketch sketch{15};
+    sketch.add(1.0);
+    sketch.add(3.0);
+    sketch.add(1.0);
+    sketch.add(1.0);
+    sketch.add(5.0);
+    sketch.add(4.0);
+    sketch.add(5.0);
+    sketch.add(4.0);
+    sketch.order();
+    sketch.deduplicate(sketch.m_Knots.begin(), sketch.m_Knots.end());
+    LOG_DEBUG(<< "sketch = " << sketch);
+    BOOST_REQUIRE_EQUAL("[(1, 3), (3, 1), (4, 2), (5, 2)]", sketch.print());
+
+    sketch.add(3.0);
+    sketch.add(1.0);
+    sketch.add(0.0);
+    sketch.add(9.0);
+    sketch.order();
+    sketch.deduplicate(sketch.m_Knots.begin(), sketch.m_Knots.end());
+    LOG_DEBUG(<< "sketch = " << sketch);
+    BOOST_REQUIRE_EQUAL("[(0, 1), (1, 4), (3, 2), (4, 2), (5, 2), (9, 1)]",
+                        sketch.print());
+
+    sketch.add(9.0);
+    sketch.add(9.0);
+    sketch.add(9.0);
+    sketch.order();
+    sketch.deduplicate(sketch.m_Knots.begin(), sketch.m_Knots.end());
+    LOG_DEBUG(<< "sketch = " << sketch);
+    BOOST_REQUIRE_EQUAL("[(0, 1), (1, 4), (3, 2), (4, 2), (5, 2), (9, 4)]",
+                        sketch.print());
+}
+
 BOOST_AUTO_TEST_CASE(testAdd) {
-    maths::common::CQuantileSketch sketch(maths::common::CQuantileSketch::E_Linear, 5);
+    maths::common::CQuantileSketch sketch{5};
 
     // Test adding a point.
     sketch.add(1.2);
@@ -96,17 +134,14 @@ BOOST_AUTO_TEST_CASE(testAdd) {
     sketch = std::for_each(x.begin(), x.end(), sketch);
     BOOST_TEST_REQUIRE(sketch.checkInvariants());
 
-    LOG_DEBUG(<< "sketch = " << sketch.knots());
+    LOG_DEBUG(<< "sketch = " << sketch);
     BOOST_REQUIRE_EQUAL(6.0, sketch.count());
-    BOOST_REQUIRE_EQUAL("[(1.2, 1), (0.9, 3), (1.8, 1), (2.1, 1)]",
-                        core::CContainerPrinter::print(sketch.knots()));
+    BOOST_REQUIRE_EQUAL("[(1.2, 1), (0.9, 3), (1.8, 1), (2.1, 1)]", sketch.print());
 }
 
 BOOST_AUTO_TEST_CASE(testReduce) {
-
-    LOG_DEBUG(<< "**** Linear ****");
     {
-        maths::common::CQuantileSketch sketch(maths::common::CQuantileSketch::E_Linear, 6);
+        maths::common::CQuantileSketch sketch{6};
 
         // Test duplicate points.
 
@@ -117,36 +152,35 @@ BOOST_AUTO_TEST_CASE(testReduce) {
             BOOST_TEST_REQUIRE(sketch.checkInvariants());
         }
 
-        LOG_DEBUG(<< "sketch = " << sketch.knots());
-        BOOST_REQUIRE_EQUAL("[(0.4, 3), (1, 1), (1.2, 3.5), (5, 2)]",
-                            core::CContainerPrinter::print(sketch.knots()));
+        LOG_DEBUG(<< "sketch = " << sketch);
+        BOOST_REQUIRE_EQUAL("[(0.4, 3), (1, 1), (1.2, 3.5), (5, 2)]", sketch.print());
 
         // Regular compress (merging two point).
 
         sketch.add(0.1);
         sketch.add(0.2);
         sketch.add(0.0);
-        LOG_DEBUG(<< "sketch = " << sketch.knots());
+        LOG_DEBUG(<< "sketch = " << sketch);
         BOOST_REQUIRE_EQUAL("[(0, 1), (0.15, 2), (0.4, 3), (1, 1), (1.2, 3.5), (5, 2)]",
-                            core::CContainerPrinter::print(sketch.knots()));
+                            sketch.print());
     }
     {
         // Multiple points compressed at once.
 
-        maths::common::CQuantileSketch sketch(maths::common::CQuantileSketch::E_Linear, 30);
+        maths::common::CQuantileSketch sketch{30};
 
         for (std::size_t i = 0; i <= 30; ++i) {
             sketch.add(static_cast<double>(i));
             BOOST_TEST_REQUIRE(sketch.checkInvariants());
         }
-        LOG_DEBUG(<< "sketch = " << sketch.knots());
+        LOG_DEBUG(<< "sketch = " << sketch);
         BOOST_REQUIRE_EQUAL("[(0, 1), (1, 1), (2, 1), (3, 1), (4, 1),"
                             " (5.5, 2), (7, 1), (8, 1), (9, 1), (10, 1),"
                             " (11, 1), (12, 1), (13.5, 2), (15, 1), (16, 1),"
                             " (17, 1), (18, 1), (19, 1), (20, 1), (21, 1),"
                             " (22.5, 2), (24, 1), (25, 1), (26, 1), (27, 1),"
                             " (28, 1), (29, 1), (30, 1)]",
-                            core::CContainerPrinter::print(sketch.knots()));
+                            sketch.print());
     }
     {
         // Test the quantiles are reasonable at a compression ratio of 2:1.
@@ -158,12 +192,12 @@ BOOST_AUTO_TEST_CASE(testReduce) {
                        40.0, 45.0, 50.0, 55.0, 60.0, 65.0, 70.0,
                        75.0, 80.0, 85.0, 90.0, 95.0, 100.0};
 
-        maths::common::CQuantileSketch sketch(maths::common::CQuantileSketch::E_Linear, 10);
+        maths::common::CQuantileSketch sketch{10};
         for (std::size_t i = 0; i < points.size(); ++i) {
             sketch.add(points[i]);
             BOOST_TEST_REQUIRE(sketch.checkInvariants());
             if ((i + 1) % 5 == 0) {
-                LOG_DEBUG(<< "sketch = " << sketch.knots());
+                LOG_DEBUG(<< "sketch = " << sketch);
             }
         }
 
@@ -179,90 +213,14 @@ BOOST_AUTO_TEST_CASE(testReduce) {
         LOG_DEBUG(<< "error = " << maths::common::CBasicStatistics::mean(error));
         BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(error) < 1.5);
     }
-
-    LOG_DEBUG(<< "**** Piecewise Constant ****");
-    {
-        maths::common::CQuantileSketch sketch(
-            maths::common::CQuantileSketch::E_PiecewiseConstant, 6);
-
-        // Test duplicate points.
-
-        TDoubleVecVec points{{5.0, 1.0}, {0.4, 2.0}, {0.4, 1.0}, {1.0, 1.0},
-                             {1.2, 2.0}, {1.2, 1.5}, {5.0, 1.0}};
-        for (const auto& point : points) {
-            sketch.add(point[0], point[1]);
-            BOOST_TEST_REQUIRE(sketch.checkInvariants());
-        }
-
-        LOG_DEBUG(<< "sketch = " << sketch.knots());
-        BOOST_REQUIRE_EQUAL("[(0.4, 3), (1, 1), (1.2, 3.5), (5, 2)]",
-                            core::CContainerPrinter::print(sketch.knots()));
-
-        // Regular compress (merging two point).
-
-        sketch.add(0.1);
-        sketch.add(0.2);
-        sketch.add(0.0);
-        LOG_DEBUG(<< "sketch = " << sketch.knots());
-        BOOST_REQUIRE_EQUAL("[(0, 1), (0.2, 2), (0.4, 3), (1, 1), (1.2, 3.5), (5, 2)]",
-                            core::CContainerPrinter::print(sketch.knots()));
-    }
-    {
-        // Multiple points compressed at once.
-
-        maths::common::CQuantileSketch sketch(
-            maths::common::CQuantileSketch::E_PiecewiseConstant, 30);
-
-        for (std::size_t i = 0; i <= 30; ++i) {
-            sketch.add(static_cast<double>(i));
-            BOOST_TEST_REQUIRE(sketch.checkInvariants());
-        }
-        LOG_DEBUG(<< "sketch = " << sketch.knots());
-        BOOST_REQUIRE_EQUAL("[(0, 1), (1, 1), (2, 1), (3, 1), (4, 1),"
-                            " (6, 2), (7, 1), (8, 1), (9, 1), (10, 1),"
-                            " (11, 1), (12, 1), (13, 1), (14, 1), (15, 1),"
-                            " (16, 1), (17, 1), (18, 1), (19, 1), (20, 1),"
-                            " (21, 1), (23, 3), (25, 1), (26, 1), (27, 1),"
-                            " (28, 1), (29, 1), (30, 1)]",
-                            core::CContainerPrinter::print(sketch.knots()));
-    }
-    {
-        // Test the quantiles are reasonable at a compression ratio of 2:1.
-
-        TDoubleVec points{1.0,  2.0,  40.0, 13.0, 5.0,  6.0,  4.0,
-                          7.0,  15.0, 17.0, 19.0, 44.0, 42.0, 3.0,
-                          46.0, 48.0, 50.0, 21.0, 23.0, 52.0};
-        TDoubleVec cdf{5.0,  10.0, 15.0, 20.0, 25.0, 30.0, 35.0,
-                       40.0, 45.0, 50.0, 55.0, 60.0, 65.0, 70.0,
-                       75.0, 80.0, 85.0, 90.0, 95.0, 100.0};
-
-        maths::common::CQuantileSketch sketch(
-            maths::common::CQuantileSketch::E_PiecewiseConstant, 10);
-        for (const auto& point : points) {
-            sketch.add(point);
-            BOOST_TEST_REQUIRE(sketch.checkInvariants());
-        }
-
-        std::sort(points.begin(), points.end());
-        TMeanAccumulator error;
-        for (std::size_t i = 0; i < cdf.size(); ++i) {
-            double x;
-            BOOST_TEST_REQUIRE(sketch.quantile(cdf[i], x));
-            LOG_DEBUG(<< "expected quantile = " << points[i] << ", actual quantile = " << x);
-            BOOST_REQUIRE_CLOSE_ABSOLUTE(points[i], x, 10.0);
-            error.add(std::fabs(points[i] - x));
-        }
-        LOG_DEBUG(<< "error = " << maths::common::CBasicStatistics::mean(error));
-        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(error) < 1.8);
-    }
 }
 
 BOOST_AUTO_TEST_CASE(testMerge) {
     {
         // Simple merge no reduction.
 
-        maths::common::CQuantileSketch sketch1(maths::common::CQuantileSketch::E_Linear, 20);
-        maths::common::CQuantileSketch sketch2(maths::common::CQuantileSketch::E_Linear, 10);
+        maths::common::CQuantileSketch sketch1{20};
+        maths::common::CQuantileSketch sketch2{10};
 
         sketch1.add(2.0);
         sketch1.add(1.0);
@@ -275,9 +233,9 @@ BOOST_AUTO_TEST_CASE(testMerge) {
         sketch2.add(5.1);
 
         sketch1 += sketch2;
-        LOG_DEBUG(<< "merged sketch = " << sketch1.knots());
+        LOG_DEBUG(<< "merged sketch = " << sketch1);
         BOOST_REQUIRE_EQUAL("[(1, 3.6), (1.1, 1), (2, 1), (3, 1), (3.1, 2), (5.1, 2)]",
-                            core::CContainerPrinter::print(sketch1.knots()));
+                            sketch1.print());
     }
 
     {
@@ -290,17 +248,17 @@ BOOST_AUTO_TEST_CASE(testMerge) {
                        40.0, 45.0, 50.0, 55.0, 60.0, 65.0, 70.0,
                        75.0, 80.0, 85.0, 90.0, 95.0, 100.0};
 
-        maths::common::CQuantileSketch sketch1(maths::common::CQuantileSketch::E_Linear, 10);
-        maths::common::CQuantileSketch sketch2(maths::common::CQuantileSketch::E_Linear, 10);
+        maths::common::CQuantileSketch sketch1{10};
+        maths::common::CQuantileSketch sketch2{10};
         for (std::size_t i = 0; i < points.size(); i += 2) {
             sketch1.add(points[i]);
             sketch2.add(points[i + 1]);
         }
-        LOG_DEBUG(<< "sketch 1 = " << sketch1.knots());
-        LOG_DEBUG(<< "sketch 2 = " << sketch2.knots());
+        LOG_DEBUG(<< "sketch 1 = " << sketch1);
+        LOG_DEBUG(<< "sketch 2 = " << sketch2);
 
         maths::common::CQuantileSketch sketch3 = sketch1 + sketch2;
-        LOG_DEBUG(<< "merged sketch = " << sketch3.knots());
+        LOG_DEBUG(<< "merged sketch = " << sketch3);
 
         std::sort(points.begin(), points.end());
         TMeanAccumulator error;
@@ -316,6 +274,32 @@ BOOST_AUTO_TEST_CASE(testMerge) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testDuplicates) {
+
+    // Test we never have duplicate values in the sketch even for a data set
+    // with many duplicates.
+
+    test::CRandomNumbers rng;
+
+    TDoubleVec samples;
+    rng.generateUniformSamples(0.0, 30.0, 100000, samples);
+
+    auto testSketch = [&](auto& sketch) {
+        for (auto sample : samples) {
+            sketch.add(std::floor(sample));
+            BOOST_TEST_REQUIRE(sketch.checkInvariants());
+        }
+    };
+
+    LOG_DEBUG(<< "sketch");
+    maths::common::CQuantileSketch sketch{40};
+    testSketch(sketch);
+
+    LOG_DEBUG(<< "fast sketch");
+    maths::common::CFastQuantileSketch fastSketch{40};
+    testSketch(sketch);
+}
+
 BOOST_AUTO_TEST_CASE(testMedian) {
 
     LOG_DEBUG(<< "**** Exact ****");
@@ -324,8 +308,7 @@ BOOST_AUTO_TEST_CASE(testMedian) {
     // values is less than the sketch size.
 
     {
-        maths::common::CQuantileSketch sketch(
-            maths::common::CQuantileSketch::E_PiecewiseConstant, 10);
+        maths::common::CQuantileSketch sketch{10};
 
         double median;
         BOOST_TEST_REQUIRE(!sketch.quantile(50.0, median));
@@ -360,7 +343,7 @@ BOOST_AUTO_TEST_CASE(testMedian) {
     TDoubleVec samples;
 
     for (std::size_t n = 1; n <= 200; ++n) {
-        maths::common::CQuantileSketch sketch(maths::common::CQuantileSketch::E_Linear, 220);
+        maths::common::CQuantileSketch sketch{220};
 
         rng.generateLogNormalSamples(0.0, 3.0, n, samples);
 
@@ -380,21 +363,12 @@ BOOST_AUTO_TEST_CASE(testMedian) {
     }
 
     LOG_DEBUG(<< "**** Approximate ****");
-
-    TDoubleVec maximumBias(2);
-    TDoubleVec maximumError(2);
-    maximumBias[maths::common::CQuantileSketch::E_PiecewiseConstant] = 0.2;
-    maximumError[maths::common::CQuantileSketch::E_PiecewiseConstant] = 1.1;
-    maximumBias[maths::common::CQuantileSketch::E_Linear] = 0.02;
-    maximumError[maths::common::CQuantileSketch::E_Linear] = 0.3;
-
-    for (auto interpolation : {maths::common::CQuantileSketch::E_PiecewiseConstant,
-                               maths::common::CQuantileSketch::E_Linear}) {
+    {
         TMeanAccumulator bias;
         TMeanAccumulator error;
         for (std::size_t t = 0; t < 500; ++t) {
             rng.generateUniformSamples(0.0, 100.0, 501, samples);
-            maths::common::CQuantileSketch sketch(interpolation, 30);
+            maths::common::CQuantileSketch sketch{30};
             sketch = std::for_each(samples.begin(), samples.end(), sketch);
             std::sort(samples.begin(), samples.end());
             double expectedMedian = samples[250];
@@ -407,10 +381,8 @@ BOOST_AUTO_TEST_CASE(testMedian) {
 
         LOG_DEBUG(<< "bias  = " << maths::common::CBasicStatistics::mean(bias));
         LOG_DEBUG(<< "error = " << maths::common::CBasicStatistics::mean(error));
-        BOOST_TEST_REQUIRE(std::fabs(maths::common::CBasicStatistics::mean(bias)) <
-                           maximumBias[interpolation]);
-        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(error) <
-                           maximumError[interpolation]);
+        BOOST_TEST_REQUIRE(std::fabs(maths::common::CBasicStatistics::mean(bias)) < 0.025);
+        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(error) < 0.25);
     }
 }
 
@@ -423,9 +395,8 @@ BOOST_AUTO_TEST_CASE(testMad) {
 
     double mad = 0.0;
 
-    for (auto interpolation : {maths::common::CQuantileSketch::E_PiecewiseConstant,
-                               maths::common::CQuantileSketch::E_Linear}) {
-        maths::common::CQuantileSketch sketch(interpolation, 10);
+    {
+        maths::common::CQuantileSketch sketch{10};
 
         BOOST_TEST_REQUIRE(!sketch.mad(mad));
 
@@ -439,16 +410,14 @@ BOOST_AUTO_TEST_CASE(testMad) {
         LOG_DEBUG(<< "MAD = " << mad);
         BOOST_REQUIRE_EQUAL(0.5, mad);
     }
-
-    TDoubleVec samples;
-    for (auto interpolation : {maths::common::CQuantileSketch::E_PiecewiseConstant,
-                               maths::common::CQuantileSketch::E_Linear}) {
+    {
+        TDoubleVec samples;
         TMeanAccumulator error;
 
         for (std::size_t t = 0; t < 500; ++t) {
             rng.generateNormalSamples(10.0, 10.0, 101, samples);
 
-            maths::common::CQuantileSketch sketch(interpolation, 20);
+            maths::common::CQuantileSketch sketch{20};
 
             for (auto sample : samples) {
                 sketch.add(sample);
@@ -485,8 +454,7 @@ BOOST_AUTO_TEST_CASE(testPropagateForwardByTime) {
     TDoubleVec samples;
     rng.generateUniformSamples(0.0, 20.0, 100, samples);
 
-    maths::common::CQuantileSketch sketch(
-        maths::common::CQuantileSketch::E_PiecewiseConstant, 20);
+    maths::common::CQuantileSketch sketch{20};
     sketch = std::for_each(samples.begin(), samples.end(), sketch);
 
     sketch.age(0.9);
@@ -503,86 +471,88 @@ BOOST_AUTO_TEST_CASE(testQuantileAccuracy) {
 
     LOG_DEBUG(<< "**** Uniform ****");
     {
-        auto testUniform = [rng](const maths::common::CQuantileSketch& sketch) mutable {
+        auto testUniform = [rng](const auto& sketch, double maxMaxBias, double maxMeanBias,
+                                 double maxMaxError, double maxMeanError) mutable {
             TMeanAccumulator meanBias;
             TMeanAccumulator meanError;
             for (double t = 1.0; t <= 50.0; t += 1.0) {
                 TDoubleVec samples;
                 rng.generateUniformSamples(0.0, 20.0 * t, 1000, samples);
-                testSketch(sketch, samples, 0.10 * t, 0.12 * t, meanBias, meanError);
+                testSketch(sketch, samples, maxMaxBias * t, maxMaxError * t,
+                           meanBias, meanError);
             }
             LOG_DEBUG(<< "mean bias = " << maths::common::CBasicStatistics::mean(meanBias)
                       << ", mean error = " << maths::common::CBasicStatistics::mean(meanError));
-            BOOST_TEST_REQUIRE(
-                std::fabs(maths::common::CBasicStatistics::mean(meanBias)) < 0.0005);
-            BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.003);
+            BOOST_TEST_REQUIRE(std::fabs(maths::common::CBasicStatistics::mean(meanBias)) <
+                               maxMeanBias);
+            BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < maxMeanError);
         };
 
-        maths::common::CQuantileSketch sketch{maths::common::CQuantileSketch::E_Linear, 20};
-        maths::common::CFastQuantileSketch fastSketch{
-            maths::common::CQuantileSketch::E_Linear, 20};
+        maths::common::CQuantileSketch sketch{20};
+        maths::common::CFastQuantileSketch fastSketch{20};
         LOG_DEBUG(<< "** sketch **");
-        testUniform(sketch);
+        testUniform(sketch, 0.1, 0.0005, 0.12, 0.003);
         LOG_DEBUG(<< "** fast sketch **");
-        testUniform(fastSketch);
+        testUniform(fastSketch, 0.1, 0.0005, 0.4, 0.01);
     }
 
     LOG_DEBUG(<< "**** Normal ****");
     {
-        auto testNormal = [rng](const maths::common::CQuantileSketch& sketch) mutable {
+        auto testNormal = [rng](const auto& sketch, double maxMaxBias, double maxMeanBias,
+                                double maxMaxError, double maxMeanError) mutable {
             TMeanAccumulator meanBias;
             TMeanAccumulator meanError;
             for (double t = 1.0; t <= 50.0; t += 1.0) {
                 TDoubleVec samples;
                 rng.generateNormalSamples(20.0 * (t - 1.0), 20.0 * t, 1000, samples);
-                testSketch(sketch, samples, 0.03 * t, 0.1 * t, meanBias, meanError);
+                testSketch(sketch, samples, maxMaxBias * t, maxMaxError * t,
+                           meanBias, meanError);
             }
             LOG_DEBUG(<< "mean bias = " << maths::common::CBasicStatistics::mean(meanBias)
                       << ", mean error = " << maths::common::CBasicStatistics::mean(meanError));
-            BOOST_TEST_REQUIRE(
-                std::fabs(maths::common::CBasicStatistics::mean(meanBias)) < 0.0005);
-            BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.002);
+            BOOST_TEST_REQUIRE(std::fabs(maths::common::CBasicStatistics::mean(meanBias)) <
+                               maxMeanBias);
+            BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < maxMeanError);
         };
 
-        maths::common::CQuantileSketch sketch{maths::common::CQuantileSketch::E_Linear, 20};
-        maths::common::CFastQuantileSketch fastSketch{
-            maths::common::CQuantileSketch::E_Linear, 20};
+        maths::common::CQuantileSketch sketch{20};
+        maths::common::CFastQuantileSketch fastSketch{20};
         LOG_DEBUG(<< "** sketch **");
-        testNormal(sketch);
+        testNormal(sketch, 0.06, 0.0005, 0.1, 0.002);
         LOG_DEBUG(<< "** fast sketch **");
-        testNormal(fastSketch);
+        testNormal(fastSketch, 0.07, 0.0005, 0.4, 0.012);
     }
 
     LOG_DEBUG(<< "**** Log-Normal ****");
     {
-        auto testLogNormal = [&](const maths::common::CQuantileSketch& sketch) {
+        auto testLogNormal = [rng](const auto& sketch, double maxMaxBias, double maxMeanBias,
+                                   double maxMaxError, double maxMeanError) mutable {
             TMeanAccumulator meanBias;
             TMeanAccumulator meanError;
             for (double t = 1.0; t <= 50.0; t += 1.0) {
                 TDoubleVec samples;
                 rng.generateLogNormalSamples(0.03 * (t - 1.0), 0.12 * t, 1000, samples);
-                testSketch(sketch, samples, 0.05 * t, 0.1 * t, meanBias, meanError);
+                testSketch(sketch, samples, maxMaxBias * t, maxMaxError * t,
+                           meanBias, meanError);
             }
             LOG_DEBUG(<< "mean bias = " << maths::common::CBasicStatistics::mean(meanBias)
                       << ", mean error = " << maths::common::CBasicStatistics::mean(meanError));
-            BOOST_TEST_REQUIRE(
-                std::fabs(maths::common::CBasicStatistics::mean(meanBias)) < 0.0002);
-            BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.0004);
+            BOOST_TEST_REQUIRE(std::fabs(maths::common::CBasicStatistics::mean(meanBias)) <
+                               maxMeanBias);
+            BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < maxMeanError);
         };
 
-        maths::common::CQuantileSketch sketch{maths::common::CQuantileSketch::E_Linear, 20};
-        maths::common::CFastQuantileSketch fastSketch{
-            maths::common::CQuantileSketch::E_Linear, 20};
+        maths::common::CQuantileSketch sketch{20};
+        maths::common::CFastQuantileSketch fastSketch{20};
         LOG_DEBUG(<< "** sketch **");
-        testLogNormal(sketch);
+        testLogNormal(sketch, 0.05, 0.0002, 0.1, 0.0004);
         LOG_DEBUG(<< "** fast sketch **");
-        testLogNormal(fastSketch);
+        testLogNormal(fastSketch, 1.0, 0.002, 1.1, 0.005);
     }
 
     LOG_DEBUG(<< "**** Mixture ****");
     {
-        auto testMixture = [rng](const maths::common::CQuantileSketch& sketch,
-                                 double maxBias, double maxError,
+        auto testMixture = [rng](const auto& sketch, double maxBias, double maxError,
                                  double maxMeanBias, double maxMeanError) mutable {
             TMeanAccumulator meanBias;
             TMeanAccumulator meanError;
@@ -607,29 +577,19 @@ BOOST_AUTO_TEST_CASE(testQuantileAccuracy) {
             BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < maxMeanError);
         };
 
-        maths::common::CQuantileSketch linearSketch{
-            maths::common::CQuantileSketch::E_Linear, 40};
-        maths::common::CFastQuantileSketch fastLinearSketch{
-            maths::common::CQuantileSketch::E_Linear, 40};
-        maths::common::CQuantileSketch piecewiseSketch{
-            maths::common::CQuantileSketch::E_PiecewiseConstant, 40};
-        maths::common::CFastQuantileSketch fastPiecewiseSketch{
-            maths::common::CQuantileSketch::E_PiecewiseConstant, 40};
+        maths::common::CQuantileSketch sketch{40};
+        maths::common::CFastQuantileSketch fastSketch{40};
 
-        LOG_DEBUG(<< "** linear sketch **");
-        testMixture(linearSketch, 60, 62, 0.021, 0.021);
+        LOG_DEBUG(<< "** sketch **");
+        testMixture(sketch, 60, 62, 0.021, 0.021);
         LOG_DEBUG(<< "** fast linear sketch **");
-        testMixture(fastLinearSketch, 60, 62, 0.021, 0.021);
-        LOG_DEBUG(<< "** piecewise sketch **");
-        testMixture(linearSketch, 55, 56, 0.021, 0.021);
-        LOG_DEBUG(<< "** fast piecewise sketch **");
-        testMixture(fastLinearSketch, 55, 56, 0.021, 0.021);
+        testMixture(fastSketch, 60, 62, 0.021, 0.026);
     }
 }
 
 BOOST_AUTO_TEST_CASE(testCdf) {
 
-    // Test that quantile and c.d.f. are mutual inverses.
+    // Test the quantile and c.d.f. functions are mutual inverses.
 
     test::CRandomNumbers rng;
 
@@ -638,22 +598,7 @@ BOOST_AUTO_TEST_CASE(testCdf) {
         TDoubleVec values{1.3, 5.2, 0.3, 0.7, 6.9, 10.3, 0.1, -2.9, 9.3, 0.0};
 
         {
-            maths::common::CQuantileSketch sketch(
-                maths::common::CQuantileSketch::E_PiecewiseConstant, 10);
-            sketch = std::for_each(values.begin(), values.end(), sketch);
-            for (std::size_t i = 0; i < 10; ++i) {
-                double x;
-                sketch.quantile(10.0 * static_cast<double>(i) + 5.0, x);
-                double f;
-                sketch.cdf(x, f);
-                LOG_DEBUG(<< "x = " << x
-                          << ", f(exact) = " << static_cast<double>(i) / 10.0 + 0.05
-                          << ", f(actual) = " << f);
-                BOOST_REQUIRE_CLOSE_ABSOLUTE(static_cast<double>(i) / 10.0 + 0.05, f, 1e-6);
-            }
-        }
-        {
-            maths::common::CQuantileSketch sketch(maths::common::CQuantileSketch::E_Linear, 10);
+            maths::common::CQuantileSketch sketch{10};
             sketch = std::for_each(values.begin(), values.end(), sketch);
             for (std::size_t i = 0; i < 10; ++i) {
                 double x;
@@ -675,7 +620,9 @@ BOOST_AUTO_TEST_CASE(testCdf) {
         }
     }
 
-    LOG_DEBUG(<< "**** Uniform ****");
+    // Test the estimation error vs the generating distribution.
+
+    LOG_DEBUG(<< "**** Error vs Generating Distribution ****");
     auto exactCdf = [](const TDoubleVec& samples, double x) {
         return static_cast<double>((std::upper_bound(samples.begin(), samples.end(), x) -
                                     samples.begin())) /
@@ -687,7 +634,7 @@ BOOST_AUTO_TEST_CASE(testCdf) {
         LOG_DEBUG(<< "test " << t + 1);
         TDoubleVec samples;
         rng.generateUniformSamples(0.0, 20.0 * static_cast<double>(t + 1), 1000, samples);
-        maths::common::CQuantileSketch sketch(maths::common::CQuantileSketch::E_Linear, 20);
+        maths::common::CQuantileSketch sketch{20};
         sketch = std::for_each(samples.begin(), samples.end(), sketch);
         std::sort(samples.begin(), samples.end());
         for (std::size_t i = 0; i <= 100; ++i) {
@@ -713,28 +660,115 @@ BOOST_AUTO_TEST_CASE(testCdf) {
     BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanError) < 0.0025);
 }
 
-BOOST_AUTO_TEST_CASE(testFastSketchPerformance) {
+BOOST_AUTO_TEST_CASE(testFastSketchComputeMergeCosts) {
 
-    // Check that the fast sketch with the same reduction factor produces
-    // identical results.
+    // Test the fast sketch calculation of all merge costs produces the
+    // same results as the standard sketch.
 
     test::CRandomNumbers generator;
     TDoubleVec samples;
-    generator.generateUniformSamples(0.0, 5000.0, 1500000, samples);
-    maths::common::CQuantileSketch sketch{maths::common::CQuantileSketch::E_Linear, 75};
-    maths::common::CFastQuantileSketch fastSketch{maths::common::CQuantileSketch::E_Linear, 75};
+    generator.generateUniformSamples(0.0, 5000.0, 10000, samples);
+
+    TDoubleVec expectedCosts;
+
+    for (std::size_t i = 0; i < samples.size(); /**/) {
+        maths::common::CFastQuantileSketch fastSketch{100};
+        for (std::size_t j = 0; j < 599; ++i, ++j) {
+            fastSketch.add(samples[i]);
+        }
+        fastSketch.order();
+
+        auto knots = fastSketch.knots();
+
+        expectedCosts.clear();
+        for (std::size_t j = 0; j + 3 < knots.size(); ++j) {
+            expectedCosts.push_back(maths::common::CFastQuantileSketch::mergeCost(
+                knots[j + 1], knots[j + 2]));
+        }
+
+        fastSketch.computeMergeCosts(knots);
+
+        BOOST_REQUIRE_EQUAL(expectedCosts.size(), fastSketch.m_MergeCosts.size());
+        for (std::size_t j = 0; j + 3 < expectedCosts.size(); ++j) {
+            BOOST_REQUIRE_CLOSE(expectedCosts[j], fastSketch.m_MergeCosts[j], 1e-3);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testFastSketchFastReduce) {
+
+    // Check that we hit the target size, every non-merged knot is preserved,
+    // and the count and average of merged knots and class invariants are
+    // preserved by fastReduce.
+
+    test::CRandomNumbers rng;
+    TDoubleVec samples;
+    rng.generateUniformSamples(0.0, 5000.0, 10000, samples);
+
+    for (std::size_t i = 0; i < 1; /**/) {
+        maths::common::CFastQuantileSketch fastSketch{100};
+        for (std::size_t j = 0; j < 119; ++i, ++j) {
+            fastSketch.add(samples[i]);
+        }
+
+        auto knots = fastSketch.knots();
+        std::sort(knots.begin(), knots.end());
+
+        fastSketch.fastReduce();
+
+        BOOST_TEST_REQUIRE(fastSketch.fastReduceTargetSize(), fastSketch.knots().size());
+
+        double actualMergeMean{0.0};
+        double actualMergeCount{0.0};
+        for (const auto& knot : fastSketch.knots()) {
+            if (knot.second == 1.0) {
+                bool found{*std::lower_bound(knots.begin(), knots.end(), knot) == knot};
+                BOOST_TEST_REQUIRE(found);
+            } else {
+                actualMergeMean += knot.second * knot.first;
+                actualMergeCount += knot.second;
+            }
+        }
+        actualMergeMean /= actualMergeCount;
+
+        double expectedMergeMean{0.0};
+        double expectedMergeCount{0.0};
+        for (const auto& knot : knots) {
+            if (*std::lower_bound(fastSketch.knots().begin(),
+                                  fastSketch.knots().end(), knot) != knot) {
+                expectedMergeMean += knot.second * knot.first;
+                expectedMergeCount += knot.second;
+            }
+        }
+        expectedMergeMean /= expectedMergeCount;
+
+        BOOST_REQUIRE_CLOSE(expectedMergeMean, actualMergeMean, 1e-3);
+        BOOST_REQUIRE_CLOSE(expectedMergeCount, actualMergeCount, 1e-3);
+        BOOST_TEST_REQUIRE(fastSketch.checkInvariants());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testFastSketchPerformance) {
+
+    // Check the fast sketch relative size.
+
+    test::CRandomNumbers rng;
+    TDoubleVec samples;
+    rng.generateUniformSamples(0.0, 5000.0, 1500000, samples);
+
+    maths::common::CQuantileSketch sketch{75};
+    maths::common::CFastQuantileSketch fastSketch{75};
 
     core::CStopWatch watch{true};
     std::for_each(samples.begin(), samples.end(), sketch);
     auto lap = watch.lap();
     LOG_DEBUG(<< "sketch duration = " << lap);
-
     std::for_each(samples.begin(), samples.end(), fastSketch);
     LOG_DEBUG(<< "fast sketch duration = " << watch.lap() - lap);
 
     LOG_DEBUG(<< "sketch memory usage = " << core::memory::dynamicSize(&sketch));
     LOG_DEBUG(<< "fast sketch memory usage = " << core::memory::dynamicSize(&fastSketch));
-    BOOST_TEST_REQUIRE(2 * core::memory::dynamicSize(&sketch) >
+    BOOST_TEST_REQUIRE(4 * core::memory::dynamicSize(&sketch) >
                        core::memory::dynamicSize(&fastSketch));
 }
 
@@ -746,7 +780,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
     TDoubleVec samples;
     generator.generateUniformSamples(0.0, 5000.0, 500, samples);
 
-    maths::common::CQuantileSketch origSketch{maths::common::CQuantileSketch::E_Linear, 100};
+    maths::common::CQuantileSketch origSketch{100};
     for (const auto& sample : samples) {
         origSketch.add(sample);
     }
@@ -760,8 +794,7 @@ BOOST_AUTO_TEST_CASE(testPersist) {
 
     LOG_DEBUG(<< "quantile sketch XML representation:\n" << origXml);
 
-    maths::common::CQuantileSketch restoredSketch{
-        maths::common::CQuantileSketch::E_Linear, 100};
+    maths::common::CQuantileSketch restoredSketch{100};
     {
         core::CRapidXmlParser parser;
         BOOST_TEST_REQUIRE(parser.parseStringIgnoreCdata(origXml));

--- a/lib/maths/time_series/CCalendarCyclicTest.cc
+++ b/lib/maths/time_series/CCalendarCyclicTest.cc
@@ -85,8 +85,7 @@ std::once_flag setTimeZone;
 }
 
 CCalendarCyclicTest::CCalendarCyclicTest(double decayRate)
-    : m_DecayRate{decayRate}, m_ErrorQuantiles{common::CQuantileSketch::E_Linear, 20},
-      m_CurrentBucketTime{0}, m_CurrentBucketIndex{0} {
+    : m_DecayRate{decayRate}, m_ErrorQuantiles{20}, m_CurrentBucketTime{0}, m_CurrentBucketIndex{0} {
     std::call_once(setTimeZone,
                    [] { core::CTimezone::instance().timezoneName("GMT"); });
     TErrorStatsVec stats(SIZE);
@@ -142,7 +141,7 @@ void CCalendarCyclicTest::acceptPersistInserter(core::CStatePersistInserter& ins
 }
 
 void CCalendarCyclicTest::forgetErrorDistribution() {
-    m_ErrorQuantiles = common::CQuantileSketch{common::CQuantileSketch::E_Linear, 20};
+    m_ErrorQuantiles = common::CQuantileSketch{20};
 }
 
 void CCalendarCyclicTest::propagateForwardsByTime(double time) {

--- a/lib/model/CDetectorEqualizer.cc
+++ b/lib/model/CDetectorEqualizer.cc
@@ -36,16 +36,16 @@ void CDetectorEqualizer::acceptPersistInserter(core::CStatePersistInserter& inse
     }
     for (const auto& sketch : m_Sketches) {
         inserter.insertValue(DETECTOR_TAG, sketch.first);
-        inserter.insertLevel(
-            SKETCH_TAG, std::bind(&maths::common::CQuantileSketch::acceptPersistInserter,
-                                  std::cref(sketch.second), std::placeholders::_1));
+        inserter.insertLevel(SKETCH_TAG, [& sketch = sketch.second](auto& inserter_) {
+            sketch.acceptPersistInserter(inserter_);
+        });
     }
 }
 
 bool CDetectorEqualizer::acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) {
     std::optional<int> detector;
     do {
-        const std::string& name = traverser.name();
+        const std::string& name{traverser.name()};
         RESTORE_SETUP_TEARDOWN(DETECTOR_TAG, detector.emplace(0),
                                core::CStringUtils::stringToType(traverser.value(), *detector),
                                /**/)
@@ -53,11 +53,10 @@ bool CDetectorEqualizer::acceptRestoreTraverser(core::CStateRestoreTraverser& tr
             if (detector == std::nullopt) {
                 LOG_ABORT(<< "Expected the detector label first");
             }
-            m_Sketches.emplace_back(*detector, maths::common::CQuantileSketch(
-                                                   SKETCH_INTERPOLATION, SKETCH_SIZE));
-            if (traverser.traverseSubLevel(std::bind(
-                    &maths::common::CQuantileSketch::acceptRestoreTraverser,
-                    std::ref(m_Sketches.back().second), std::placeholders::_1)) == false) {
+            m_Sketches.emplace_back(*detector, maths::common::CQuantileSketch{SKETCH_SIZE});
+            if (traverser.traverseSubLevel([& sketch = m_Sketches.back().second](auto& traverser_) {
+                    return sketch.acceptRestoreTraverser(traverser_);
+                }) == false) {
                 LOG_ERROR(<< "Failed to restore SKETCH_TAG, got " << traverser.value());
                 m_Sketches.pop_back();
                 return false;
@@ -144,14 +143,11 @@ maths::common::CQuantileSketch& CDetectorEqualizer::sketch(int detector) {
     auto i = std::lower_bound(m_Sketches.begin(), m_Sketches.end(), detector,
                               maths::common::COrderings::SFirstLess());
     if (i == m_Sketches.end() || i->first != detector) {
-        i = m_Sketches.insert(i, {detector, maths::common::CQuantileSketch(
-                                                SKETCH_INTERPOLATION, SKETCH_SIZE)});
+        i = m_Sketches.insert(i, {detector, maths::common::CQuantileSketch{SKETCH_SIZE}});
     }
     return i->second;
 }
 
-const maths::common::CQuantileSketch::EInterpolation
-    CDetectorEqualizer::SKETCH_INTERPOLATION(maths::common::CQuantileSketch::E_Linear);
 const std::size_t CDetectorEqualizer::SKETCH_SIZE(100);
 const double CDetectorEqualizer::MINIMUM_COUNT_FOR_CORRECTION(1.5);
 }


### PR DESCRIPTION
This is the second part of #2380.

Quantile estimation during training is expensive for data sets with many numeric features. This change makes various speed ups in this area:
1. Batch computes merge costs using explicit vectorisation,
2. Use a larger reduce factor when merging buckets. I've held the reduced size fixed to maintain roughly similar accuracy, the upshot being more memory but less work per bucket,
3. Improve handling of duplicate values: we should deduplicate new values before merging because it reduces the cost of `inplace_merge`,
4. Be a bit more careful with how random numbers for tiebreaks are generated.

Together these drop the amortised add cost from around 100ns to 50ns per item on my i9. The remaining costs are 50% `std::nth_element` and 30% `std::sort` + `std::inplace_merge`. Short of dropping the requirement we extract the smallest k merge costs it is unlikely we'd be able to make big inroads on these costs. Doing this it was useful to extend `CFloatStorage` to be useable in constexprs. I also mark all methods noexcept which they are and always will be, it might in theory allow some extra optimisations, although the compiler should be able to deduce these are no throw.

Separately, I cap the maximum number of values we'll use to estimate quantiles. The accuracy of the quantiles we care about converges quickly with sample size. For example, the count of values less (greater) than the _sample_ 1st (99th) percentile would be ~ Binomial(n, 0.01), for sample size n, so relative error in count would be O(10.0 / n^(1/2)). I therefore cap the maximum sample size to 50000 for which this error is around 4%.

Finally, following on from #2364 we don't really need to expose interpolation outside the class (all uses were linear and that would be unlikely to change). I took the opportunity to remove the option from the constructor.