### PR TITLE
[ML] Improve layout of aggregate derivatives for training

### DIFF
--- a/lib/maths/analytics/CBoostedTreeHyperparameters.cc
+++ b/lib/maths/analytics/CBoostedTreeHyperparameters.cc
@@ -14,6 +14,7 @@
 #include <core/CLogger.h>
 #include <core/CMemoryDef.h>
 #include <core/CPersistUtils.h>
+#include <core/CStopWatch.h>
 #include <core/RestoreMacros.h>
 
 #include <maths/analytics/CBoostedTreeImpl.h>
@@ -141,6 +142,7 @@ CBoostedTreeHyperparameters::initializeFineTuneSearchInterval(const CInitializeF
         double meanValue{(minValue + maxValue) / 2.0};
         LOG_TRACE(<< "mean value = " << meanValue);
 
+        core::CStopWatch watch{true};
         TVector3x1 fallback;
         fallback(MIN_VALUE_INDEX) = minValue;
         fallback(MID_VALUE_INDEX) = meanValue;
@@ -150,10 +152,12 @@ CBoostedTreeHyperparameters::initializeFineTuneSearchInterval(const CInitializeF
         auto interval = maybeNullInterval.value_or(fallback);
         args.truncateParameter()(interval);
         LOG_TRACE(<< "search interval = [" << interval.toDelimited() << "]");
+        LOG_TRACE(<< "search took = " << watch.lap() << "ms");
 
         parameter.fixToRange(parameter.fromSearchValue(interval(MIN_VALUE_INDEX)),
                              parameter.fromSearchValue(interval(MAX_VALUE_INDEX)));
         parameter.set(parameter.fromSearchValue(interval(MID_VALUE_INDEX)));
+
         return TOptionalDoubleSizePr{std::in_place, lossGap, forestSize};
     }
 

--- a/lib/maths/analytics/CBoostedTreeLeafNodeStatisticsIncremental.cc
+++ b/lib/maths/analytics/CBoostedTreeLeafNodeStatisticsIncremental.cc
@@ -64,9 +64,8 @@ CBoostedTreeLeafNodeStatisticsIncremental::CBoostedTreeLeafNodeStatisticsIncreme
     workspace.reducedDerivatives(treeFeatureBag).swap(this->derivatives());
 
     if (this->gain() >= workspace.minimumGain()) {
+        this->derivatives() = workspace.copy(workspace.derivatives()[0]);
         this->rowMask() = rowMask;
-        CSplitsDerivatives tmp{workspace.copy(workspace.derivatives()[0])};
-        this->derivatives() = std::move(tmp);
     }
 }
 
@@ -103,9 +102,8 @@ CBoostedTreeLeafNodeStatisticsIncremental::CBoostedTreeLeafNodeStatisticsIncreme
 
     // Lazily copy the mask and derivatives to avoid unnecessary allocations.
     if (this->gain() >= workspace.minimumGain()) {
-        CSplitsDerivatives tmp{workspace.copy(workspace.reducedDerivatives(treeFeatureBag))};
+        this->derivatives() = workspace.copy(workspace.reducedDerivatives(treeFeatureBag));
         this->rowMask() = workspace.reducedMask(parent.rowMask().size());
-        this->derivatives() = std::move(tmp);
     }
 }
 

--- a/lib/maths/analytics/CBoostedTreeLeafNodeStatisticsScratch.cc
+++ b/lib/maths/analytics/CBoostedTreeLeafNodeStatisticsScratch.cc
@@ -56,9 +56,8 @@ CBoostedTreeLeafNodeStatisticsScratch::CBoostedTreeLeafNodeStatisticsScratch(
     workspace.reducedDerivatives(treeFeatureBag).swap(this->derivatives());
 
     if (this->gain() >= workspace.minimumGain()) {
+        this->derivatives() = workspace.copy(workspace.derivatives()[0]);
         this->rowMask() = rowMask;
-        CSplitsDerivatives tmp{workspace.copy(workspace.derivatives()[0])};
-        this->derivatives() = std::move(tmp);
     }
 }
 
@@ -90,9 +89,8 @@ CBoostedTreeLeafNodeStatisticsScratch::CBoostedTreeLeafNodeStatisticsScratch(
     workspace.reducedDerivatives(treeFeatureBag).swap(this->derivatives());
 
     if (this->gain() >= workspace.minimumGain()) {
-        CSplitsDerivatives tmp{workspace.copy(workspace.reducedDerivatives(treeFeatureBag))};
+        this->derivatives() = workspace.copy(workspace.reducedDerivatives(treeFeatureBag));
         this->rowMask() = workspace.reducedMask(parent.rowMask().size());
-        this->derivatives() = std::move(tmp);
     }
 }
 

--- a/lib/maths/common/CBayesianOptimisation.cc
+++ b/lib/maths/common/CBayesianOptimisation.cc
@@ -25,6 +25,7 @@
 #include <maths/common/CLinearAlgebraEigen.h>
 #include <maths/common/CLinearAlgebraShims.h>
 #include <maths/common/CMathsFuncs.h>
+#include <maths/common/COrderings.h>
 #include <maths/common/CSampling.h>
 #include <maths/common/CTools.h>
 

--- a/lib/maths/common/CChecksum.cc
+++ b/lib/maths/common/CChecksum.cc
@@ -11,11 +11,59 @@
 
 #include <maths/common/CChecksum.h>
 
+#include <core/CIEEE754.h>
+#include <core/CStoredStringPtr.h>
+
+#include <cstdio>
+#include <cstring>
+#include <functional>
+
 namespace ml {
 namespace maths {
 namespace common {
 namespace checksum_detail {
-const std::hash<std::vector<bool>> CChecksumImpl<ContainerChecksum>::ms_VectorBoolHasher{};
+namespace {
+const std::hash<std::vector<bool>> vectorBoolHasher;
+}
+
+std::uint64_t CChecksumImpl<BasicChecksum>::dispatch(std::uint64_t seed, double target) {
+    // A fuzzy checksum implementation is useful for floating point values
+    // so we know we're close to a reasonable precision. This checksums the
+    // printed value so that it's stable over persist and restore.
+    target = core::CIEEE754::round(target, core::CIEEE754::E_SinglePrecision);
+    char buf[4 * sizeof(double)];
+    std::memset(buf, 0, sizeof(buf));
+    std::sprintf(buf, "%.7g", target);
+    return core::CHashing::safeMurmurHash64(&buf[0], 4 * sizeof(double), seed);
+}
+
+std::uint64_t CChecksumImpl<BasicChecksum>::dispatch(
+    std::uint64_t seed,
+    const core::CHashing::CUniversalHash::CUInt32UnrestrictedHash& target) {
+    seed = core::CHashing::hashCombine(seed, static_cast<std::uint64_t>(target.a()));
+    return core::CHashing::hashCombine(seed, static_cast<std::uint64_t>(target.b()));
+}
+
+std::uint64_t CChecksumImpl<BasicChecksum>::dispatch(std::uint64_t seed,
+                                                     const std::string& target) {
+    return core::CHashing::safeMurmurHash64(target.data(),
+                                            static_cast<int>(target.size()), seed);
+}
+
+std::uint64_t CChecksumImpl<BasicChecksum>::dispatch(std::uint64_t seed,
+                                                     const core::CStoredStringPtr& target) {
+    return target == nullptr ? seed : dispatch(seed, *target);
+}
+
+std::uint64_t CChecksumImpl<ContainerChecksum>::dispatch(std::uint64_t seed,
+                                                         const std::vector<bool>& target) {
+    return core::CHashing::hashCombine(seed, vectorBoolHasher(target));
+}
+
+std::uint64_t CChecksumImpl<ContainerChecksum>::dispatch(std::uint64_t seed,
+                                                         const std::string& target) {
+    return CChecksumImpl<BasicChecksum>::dispatch(seed, target);
+}
 }
 }
 }

--- a/lib/maths/common/CNaiveBayes.cc
+++ b/lib/maths/common/CNaiveBayes.cc
@@ -20,6 +20,7 @@
 
 #include <maths/common/CBasicStatistics.h>
 #include <maths/common/CChecksum.h>
+#include <maths/common/COrderings.h>
 #include <maths/common/CPrior.h>
 #include <maths/common/CPriorStateSerialiser.h>
 #include <maths/common/CRestoreParams.h>

--- a/lib/maths/time_series/CCalendarFeature.cc
+++ b/lib/maths/time_series/CCalendarFeature.cc
@@ -18,6 +18,7 @@
 
 #include <maths/common/CChecksum.h>
 #include <maths/common/CIntegerTools.h>
+#include <maths/common/COrderings.h>
 
 #include <limits>
 #include <ostream>


### PR DESCRIPTION
This migrates the count of values we maintain for splits into the buffer we use for storing accumulated derivatives. This has the advantage that we can reset and copy it in the same operations we use for derivates rather than separately iterating over the collection to update counts. Furthermore, we often get these operations for free since we pad buffers to maintain alignment.

This change showed up some deficiencies in `CChecksum` particularly for pointers. I fixed these and pulled non template implementations out of the header since it is widely included. This logically belongs with #2388. I don't think we need to document it separately, so I'm marking this as a non-issue. 