### PR TITLE
[ML] Raise the limit on maximum number of classes for multi-class classification

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -34,6 +34,8 @@
 
 * Improve classification and regression model train runtimes for data sets with many
   numeric features. (See {ml-pull}2380[#2380], {ml-pull}2388[#2388] and {ml-pull}2388[#2390].)
+* Increase the limit on the maximum number of classes to 100 for training classification
+  models. (See {ml-pull}2395[#2395] issue: {ml-issue}2246[#2246].)
 
 == {es} version 8.4.0
 

--- a/include/api/CDataFrameTrainBoostedTreeRunner.h
+++ b/include/api/CDataFrameTrainBoostedTreeRunner.h
@@ -172,7 +172,8 @@ private:
     std::string m_DependentVariableFieldName;
     std::string m_PredictionFieldName;
     double m_TrainingPercent;
-    std::size_t m_NumberLossParameters{0};
+    std::size_t m_DimensionPrediction{0};
+    std::size_t m_DimensionGradient{0};
     std::size_t m_TrainedModelMemoryUsage{0};
     TBoostedTreeFactoryUPtr m_BoostedTreeFactory;
     TBoostedTreeUPtr m_BoostedTree;

--- a/include/maths/analytics/CBoostedTree.h
+++ b/include/maths/analytics/CBoostedTree.h
@@ -86,7 +86,7 @@ public:
 
 public:
     CBoostedTreeNode() = default;
-    explicit CBoostedTreeNode(std::size_t numberLossParameters);
+    explicit CBoostedTreeNode(std::size_t dimensionPrediction);
 
     //! Check if this is a leaf node.
     bool isLeaf() const { return m_LeftChild == std::nullopt; }
@@ -193,7 +193,7 @@ public:
     //! Get the memory used by this object.
     std::size_t memoryUsage() const;
 
-    //! Get the node's memory usage for a loss function with \p numberLossParameters
+    //! Get the node's memory usage for a loss function with \p dimensionPrediction
     //! parameters.
     static std::size_t estimateMemoryUsage(std::size_t dimensionPrediction);
 

--- a/include/maths/analytics/CBoostedTree.h
+++ b/include/maths/analytics/CBoostedTree.h
@@ -195,7 +195,7 @@ public:
 
     //! Get the node's memory usage for a loss function with \p numberLossParameters
     //! parameters.
-    static std::size_t estimateMemoryUsage(std::size_t numberLossParameters);
+    static std::size_t estimateMemoryUsage(std::size_t dimensionPrediction);
 
     //! Get the memory the node will will use in bytes when deployed.
     std::size_t deployedSize() const;

--- a/include/maths/analytics/CBoostedTreeFactory.h
+++ b/include/maths/analytics/CBoostedTreeFactory.h
@@ -223,12 +223,15 @@ public:
     static std::size_t estimateExtraColumnsForEncode();
     //! Estimate the number of columns training the model will add to the data frame.
     static std::size_t estimateExtraColumnsForTrain(std::size_t numberColumns,
-                                                    std::size_t numberLossParameters);
+                                                    std::size_t dimensionPrediction,
+                                                    std::size_t dimensionGradient);
     //! Estimate the number of columns updating the model will add to the data frame.
-    static std::size_t estimateExtraColumnsForTrainIncremental(std::size_t numberColumns,
-                                                               std::size_t numberLossParameters);
+    static std::size_t
+    estimateExtraColumnsForTrainIncremental(std::size_t numberColumns,
+                                            std::size_t dimensionPrediction,
+                                            std::size_t dimensionGradient);
     //! Estimate the number of columns predicting the model will add to the data frame.
-    static std::size_t estimateExtraColumnsForPredict(std::size_t numberLossParameters);
+    static std::size_t estimateExtraColumnsForPredict(std::size_t dimensionPrediction);
 
     //! Build a boosted tree object for encoding on \p frame.
     TBoostedTreeUPtr buildForEncode(core::CDataFrame& frame, std::size_t dependentVariable);

--- a/include/maths/analytics/CBoostedTreeLeafNodeStatistics.h
+++ b/include/maths/analytics/CBoostedTreeLeafNodeStatistics.h
@@ -202,14 +202,14 @@ public:
         using TLoopBodyVec = std::vector<std::function<void(std::size_t)>>;
 
     public:
-        explicit CSplitsDerivatives(std::size_t numberLossParameters = 0)
-            : m_NumberLossParameters{numberLossParameters} {}
-        CSplitsDerivatives(const TFloatVecVec& candidateSplits, std::size_t numberLossParameters)
-            : m_NumberLossParameters{numberLossParameters} {
+        explicit CSplitsDerivatives(std::size_t dimensionGradient = 0)
+            : m_DimensionGradient{dimensionGradient} {}
+        CSplitsDerivatives(const TFloatVecVec& candidateSplits, std::size_t dimensionGradient)
+            : m_DimensionGradient{dimensionGradient} {
             this->initializeAndMapStorage(candidateSplits);
         }
         CSplitsDerivatives(const CSplitsDerivatives& other)
-            : m_NumberLossParameters{other.m_NumberLossParameters},
+            : m_DimensionGradient{other.m_DimensionGradient},
               m_PositiveDerivativesSum{other.m_PositiveDerivativesSum},
               m_NegativeDerivativesSum{other.m_NegativeDerivativesSum},
               m_PositiveDerivativesMax{other.m_PositiveDerivativesMax},
@@ -223,8 +223,8 @@ public:
         CSplitsDerivatives& operator=(CSplitsDerivatives&&) = default;
 
         //! Re-initialize recycling the allocated memory.
-        void reinitialize(const TFloatVecVec& candidateSplits, std::size_t numberLossParameters) {
-            m_NumberLossParameters = numberLossParameters;
+        void reinitialize(const TFloatVecVec& candidateSplits, std::size_t dimensionGradient) {
+            m_DimensionGradient = dimensionGradient;
             for (auto& derivatives : m_Derivatives) {
                 derivatives.clear();
             }
@@ -234,7 +234,7 @@ public:
 
         //! Efficiently swap this and \p other.
         void swap(CSplitsDerivatives& other) {
-            std::swap(m_NumberLossParameters, other.m_NumberLossParameters);
+            std::swap(m_DimensionGradient, other.m_DimensionGradient);
             std::swap(m_PositiveDerivativesSum, other.m_PositiveDerivativesSum);
             std::swap(m_NegativeDerivativesSum, other.m_NegativeDerivativesSum);
             std::swap(m_PositiveDerivativesMax, other.m_PositiveDerivativesMax);
@@ -399,7 +399,7 @@ public:
             m_NegativeDerivativesMin =
                 m_NegativeDerivativesMin.cwiseMin(rhs.m_NegativeDerivativesMin);
             numberThreads = TThreading::numberThreadsForAddSplitsDerivatives(
-                numberThreads, featureBag.size(), m_NumberLossParameters,
+                numberThreads, featureBag.size(), m_DimensionGradient,
                 this->numberDerivatives(featureBag));
             TLoopBodyVec add(numberThreads, [&](std::size_t i) {
                 for (std::size_t j = 0; j < rhs.m_Derivatives[i].size(); ++j) {
@@ -416,7 +416,7 @@ public:
             m_PositiveDerivativesSum -= rhs.m_PositiveDerivativesSum;
             m_NegativeDerivativesSum -= rhs.m_NegativeDerivativesSum;
             numberThreads = TThreading::numberThreadsForSubtractSplitsDerivatives(
-                numberThreads, featureBag.size(), m_NumberLossParameters,
+                numberThreads, featureBag.size(), m_DimensionGradient,
                 this->numberDerivatives(featureBag));
             TLoopBodyVec subtract(numberThreads, [&](std::size_t i) {
                 for (std::size_t j = 0; j < m_Derivatives[i].size(); ++j) {
@@ -429,7 +429,7 @@ public:
         //! Remap the accumulated curvature to lower triangle row major format.
         void remapCurvature(std::size_t numberThreads, const TSizeVec& featureBag) {
             numberThreads = TThreading::numberThreadsForRemapSplitsDerivatives(
-                numberThreads, featureBag.size(), m_NumberLossParameters,
+                numberThreads, featureBag.size(), m_DimensionGradient,
                 this->numberDerivatives(featureBag));
             TLoopBodyVec remap(numberThreads, [this](std::size_t i) {
                 for (auto& derivatives : m_Derivatives[i]) {
@@ -444,18 +444,16 @@ public:
 
         //! Estimate the split derivatives' memory usage for a data frame with
         //! \p numberCols columns using \p numberSplitsPerFeature for a loss
-        //! function with \p numberLossParameters parameters.
+        //! function with \p dimensionGradient parameters.
         static std::size_t estimateMemoryUsage(std::size_t numberFeatures,
                                                std::size_t numberSplitsPerFeature,
-                                               std::size_t numberLossParameters);
+                                               std::size_t dimensionGradient);
 
         //! Get a checksum of this object.
         std::uint64_t checksum(std::uint64_t seed = 0) const;
 
         //! Get the number of loss function parameters.
-        std::size_t numberLossParameters() const {
-            return m_NumberLossParameters;
-        }
+        std::size_t dimensionGradient() const { return m_DimensionGradient; }
 
     private:
         using TDerivativesVecVec = std::vector<TDerivativesVec>;
@@ -497,7 +495,7 @@ public:
             // Note we ensure 16 byte alignment because we're using aligned memory
             // mapped vectors which have better performance.
 
-            auto numberLossParameters = static_cast<int>(m_NumberLossParameters);
+            auto dimensionGradient = static_cast<int>(m_DimensionGradient);
             std::size_t numberFeatures{splits.size()};
             std::size_t numberGradients{this->numberGradients()};
             std::size_t countOffset{this->countOffset()};
@@ -507,7 +505,7 @@ public:
                 std::size_t size{numberSplits(splits[i])};
                 m_Derivatives[i].reserve(size);
                 for (std::size_t j = 0; j < size; ++j, storage += splitSize) {
-                    m_Derivatives[i].emplace_back(numberLossParameters, storage,
+                    m_Derivatives[i].emplace_back(dimensionGradient, storage,
                                                   storage + numberGradients,
                                                   storage + countOffset);
                 }
@@ -528,16 +526,16 @@ public:
 
         std::size_t numberGradients() const {
             return core::CAlignment::roundup<double>(core::CAlignment::E_Aligned16,
-                                                     m_NumberLossParameters);
+                                                     m_DimensionGradient);
         }
 
         std::size_t numberCurvatures() const {
             return core::CAlignment::roundup<double>(
-                core::CAlignment::E_Aligned16, m_NumberLossParameters * m_NumberLossParameters);
+                core::CAlignment::E_Aligned16, m_DimensionGradient * m_DimensionGradient);
         }
 
         std::size_t curvaturesPad() const {
-            return this->numberCurvatures() - m_NumberLossParameters * m_NumberLossParameters;
+            return this->numberCurvatures() - m_DimensionGradient * m_DimensionGradient;
         }
 
         std::size_t countOffset() const {
@@ -561,7 +559,7 @@ public:
         }
 
     private:
-        std::size_t m_NumberLossParameters{0};
+        std::size_t m_DimensionGradient{0};
         TDerivativesVecVec m_Derivatives;
         TAlignedDoubleVec m_Storage;
         TDerivatives2x1 m_PositiveDerivativesSum{TDerivatives2x1::Zero()};
@@ -585,8 +583,8 @@ public:
         using TNodeVec = std::vector<CBoostedTreeNode>;
 
     public:
-        explicit CWorkspace(std::size_t numberLossParameters)
-            : m_NumberLossParameters{numberLossParameters} {}
+        explicit CWorkspace(std::size_t dimensionGradient)
+            : m_DimensionGradient{dimensionGradient} {}
         CWorkspace(CWorkspace&&) = default;
         CWorkspace& operator=(const CWorkspace& other) = delete;
         CWorkspace& operator=(CWorkspace&&) = default;
@@ -609,10 +607,10 @@ public:
                 mask.clear();
             }
             for (auto& derivatives : m_Derivatives) {
-                derivatives.reinitialize(candidateSplits, m_NumberLossParameters);
+                derivatives.reinitialize(candidateSplits, m_DimensionGradient);
             }
             for (std::size_t j = m_Derivatives.size(); j < numberThreads; ++j) {
-                m_Derivatives.emplace_back(candidateSplits, m_NumberLossParameters);
+                m_Derivatives.emplace_back(candidateSplits, m_DimensionGradient);
             }
         }
 
@@ -692,7 +690,7 @@ public:
 
     private:
         const TNodeVec* m_TreeToRetrain{nullptr};
-        std::size_t m_NumberLossParameters{1};
+        std::size_t m_DimensionGradient{1};
         std::size_t m_NumberToReduce{0};
         double m_MinimumGain{0.0};
         bool m_ReducedMasks{false};
@@ -774,10 +772,10 @@ public:
 
     //! Estimate the maximum leaf statistics' memory usage training on a data frame
     //! with \p numberFeatures columns using \p numberSplitsPerFeature for a loss function
-    //! with \p numberLossParameters parameters.
+    //! with \p dimensionGradient parameters.
     static std::size_t estimateMemoryUsage(std::size_t numberFeatures,
                                            std::size_t numberSplitsPerFeature,
-                                           std::size_t numberLossParameters);
+                                           std::size_t dimensionGradient);
 
     //! Get the best split info as a string.
     std::string print() const;
@@ -845,7 +843,7 @@ protected:
     CBoostedTreeLeafNodeStatistics(std::size_t id,
                                    std::size_t depth,
                                    const TSizeVec& extraColumns,
-                                   std::size_t numberLossParameters,
+                                   std::size_t dimensionGradient,
                                    const TFloatVecVec& candidateSplits,
                                    CSplitsDerivatives derivatives = CSplitsDerivatives{});
 
@@ -883,7 +881,7 @@ protected:
     const CSplitsDerivatives& derivatives() const;
     std::size_t depth() const;
     const TSizeVec& extraColumns() const;
-    std::size_t numberLossParameters() const;
+    std::size_t dimensionGradient() const;
     const TFloatVecVec& candidateSplits() const;
 
 private:
@@ -918,7 +916,7 @@ private:
 private:
     std::size_t m_Id;
     std::size_t m_Depth;
-    std::size_t m_NumberLossParameters;
+    std::size_t m_DimensionGradient;
     const TSizeVec& m_ExtraColumns;
     const TFloatVecVec& m_CandidateSplits;
     CSplitsDerivatives m_Derivatives;

--- a/include/maths/analytics/CBoostedTreeLeafNodeStatisticsIncremental.h
+++ b/include/maths/analytics/CBoostedTreeLeafNodeStatisticsIncremental.h
@@ -50,7 +50,7 @@ class MATHS_ANALYTICS_EXPORT CBoostedTreeLeafNodeStatisticsIncremental final
 public:
     CBoostedTreeLeafNodeStatisticsIncremental(std::size_t id,
                                               const TSizeVec& extraColumns,
-                                              std::size_t numberLossParameters,
+                                              std::size_t dimensionGradient,
                                               const core::CDataFrame& frame,
                                               const TRegularization& regularization,
                                               const TFloatVecVec& candidateSplits,
@@ -118,7 +118,7 @@ private:
 
 private:
     CBoostedTreeLeafNodeStatisticsIncremental(const TSizeVec& extraColumns,
-                                              std::size_t numberLossParameters,
+                                              std::size_t dimensionGradient,
                                               const TFloatVecVec& candidateSplits,
                                               CSplitsDerivatives derivatives);
     SSplitStatistics computeBestSplitStatistics(std::size_t numberThreads,

--- a/include/maths/analytics/CBoostedTreeLeafNodeStatisticsScratch.h
+++ b/include/maths/analytics/CBoostedTreeLeafNodeStatisticsScratch.h
@@ -47,7 +47,7 @@ class MATHS_ANALYTICS_EXPORT CBoostedTreeLeafNodeStatisticsScratch final
 public:
     CBoostedTreeLeafNodeStatisticsScratch(std::size_t id,
                                           const TSizeVec& extraColumns,
-                                          std::size_t numberLossParameters,
+                                          std::size_t dimensionGradient,
                                           const core::CDataFrame& frame,
                                           const TRegularization& regularization,
                                           const TFloatVecVec& candidateSplits,
@@ -111,7 +111,7 @@ private:
 
 private:
     CBoostedTreeLeafNodeStatisticsScratch(const TSizeVec& extraColumns,
-                                          std::size_t numberLossParameters,
+                                          std::size_t dimensionGradient,
                                           const TFloatVecVec& candidateSplits,
                                           CSplitsDerivatives derivatives);
     SSplitStatistics computeBestSplitStatistics(std::size_t numberThreads,

--- a/include/maths/analytics/CBoostedTreeLeafNodeStatisticsThreading.h
+++ b/include/maths/analytics/CBoostedTreeLeafNodeStatisticsThreading.h
@@ -50,31 +50,30 @@ public:
                                                                 std::size_t rows);
 
     //! Get the number of threads to use to add split derivatives.
-    static std::size_t
-    numberThreadsForAddSplitsDerivatives(std::size_t numberThreads,
-                                         std::size_t features,
-                                         std::size_t numberLossParameters,
-                                         std::size_t numberDerivatives);
+    static std::size_t numberThreadsForAddSplitsDerivatives(std::size_t numberThreads,
+                                                            std::size_t features,
+                                                            std::size_t dimensionGradient,
+                                                            std::size_t numberDerivatives);
 
     //! Get the number of threads to use to subtract split derivatives.
     static std::size_t
     numberThreadsForSubtractSplitsDerivatives(std::size_t numberThreads,
                                               std::size_t features,
-                                              std::size_t numberLossParameters,
+                                              std::size_t dimensionGradient,
                                               std::size_t numberDerivatives);
 
     //! Get the number of threads to use to remap curvatures of split derivatives.
     static std::size_t
     numberThreadsForRemapSplitsDerivatives(std::size_t numberThreads,
                                            std::size_t features,
-                                           std::size_t numberLossParameters,
+                                           std::size_t dimensionGradient,
                                            std::size_t numberDerivatives);
 
     //! Get the number of threads to use to compute the best split statistics.
     static std::size_t
     numberThreadsForComputeBestSplitStatistics(std::size_t numberThreads,
                                                std::size_t features,
-                                               std::size_t numberLossParameters,
+                                               std::size_t dimensionGradient,
                                                std::size_t numberDerivatives);
 
     //! Compute the number of threads which optimises throughput given \p totalWork.
@@ -84,17 +83,16 @@ public:
     static double threadCost(double numberThreads);
 
     //! Make the loss function to use for computing leaf node split gain.
-    static TMinimumLoss makeThreadLocalMinimumLossFunction(int numberLossParameters,
-                                                           double lambda);
+    static TMinimumLoss makeThreadLocalMinimumLossFunction(int dimensionGradient, double lambda);
 
 private:
-    static double addSplitsDerivativesTotalWork(std::size_t numberLossParameters,
+    static double addSplitsDerivativesTotalWork(std::size_t dimensionGradient,
                                                 std::size_t numberDerivatives);
-    static double subtractSplitsDerivativesTotalWork(std::size_t numberLossParameters,
+    static double subtractSplitsDerivativesTotalWork(std::size_t dimensionGradient,
                                                      std::size_t numberDerivatives);
-    static double remapSplitsDerivativesTotalWork(std::size_t numberLossParameters,
+    static double remapSplitsDerivativesTotalWork(std::size_t dimensionGradient,
                                                   std::size_t numberDerivatives);
-    static double computeBestSplitStatisticsTotalWork(std::size_t numberLossParameters,
+    static double computeBestSplitStatisticsTotalWork(std::size_t dimensionGradient,
                                                       std::size_t numberDerivatives);
     template<int d>
     static TMinimumLoss makeThreadLocalMinimumLossFunction(double lambda);

--- a/include/maths/analytics/CBoostedTreeLoss.h
+++ b/include/maths/analytics/CBoostedTreeLoss.h
@@ -987,7 +987,7 @@ private:
     const TNodeVec* m_Tree{nullptr};
 };
 
-//!  \brief The loss for multinomial logistic regression.
+//! \brief The loss for multinomial logistic regression.
 //!
 //! DESCRIPTION:\n
 //! This targets the cross-entropy loss using the forest to predict the class
@@ -1062,6 +1062,18 @@ private:
     std::size_t m_NumberClasses;
 };
 
+//! \brief The loss for multinomial logistic regression over a subset of classes.
+//!
+//! DESCRIPTION:\n
+//! Working with the loss Hessian for multinomial logisitic regression becomes
+//! cost prohibitive if there are many classes. We take the approach of working
+//! on a dynamic observed subset of classes for each round of boosting (the "in"
+//! classes of this type). We choose to observe the classes with the highest
+//! total loss (for details on this see CMultinomialLogisticLoss::project). All
+//! classes not being observed (the "out" classes of this type) are treated in
+//! the average sense: specifically, we compute the expectation of the various
+//! derivatives of cross-entropy with respect to their predicted probabilities.
+//! Otherwise, the calculation matches CMultinomialLogisticLoss.
 class MATHS_ANALYTICS_EXPORT CMultinomialLogisticSubsetLoss final
     : public CMultinomialLogisticLoss {
 public:

--- a/include/maths/analytics/CBoostedTreeLoss.h
+++ b/include/maths/analytics/CBoostedTreeLoss.h
@@ -33,6 +33,10 @@
 #include <vector>
 
 namespace ml {
+namespace core {
+class CDataFrame;
+class CPackedBitVector;
+}
 namespace maths {
 namespace analytics {
 class CDataFrameCategoryEncoder;
@@ -489,6 +493,7 @@ private:
 //! \brief Defines the loss function for the regression or classification problem.
 class MATHS_ANALYTICS_EXPORT CLoss {
 public:
+    using TSizeVec = std::vector<std::size_t>;
     using TDoubleVector = common::CDenseVector<double>;
     using TMemoryMappedFloatVector = common::CMemoryMappedDenseVector<common::CFloatStorage>;
     using TWriter = std::function<void(std::size_t, double)>;
@@ -501,11 +506,26 @@ public:
     virtual TLossUPtr clone() const = 0;
     //! Clone the loss for retraining \p tree.
     virtual TLossUPtr incremental(double eta, double mu, const TNodeVec& tree) const = 0;
+    //! Clone the loss function if necessary pruning parameters.
+    //!
+    //! Computing the Hessian for loss functions with many parameters becomes
+    //! cost prohibitive. This chooses the parameters which have the greatest
+    //! impact on the loss based on the current predictions and "projects" on
+    //! to these. The idea would be that these are computed afresh for each
+    //! tree while boosting.
+    virtual TLossUPtr project(std::size_t numberThreads,
+                              core::CDataFrame& frame,
+                              const core::CPackedBitVector& rowMask,
+                              std::size_t targetColumn,
+                              const TSizeVec& extraColumns,
+                              common::CPRNG::CXorOShiro128Plus rng) const = 0;
 
     //! Get the type of prediction problem to which this loss applies.
     virtual ELossType type() const = 0;
-    //! The number of parameters to the loss function.
-    virtual std::size_t numberParameters() const = 0;
+    //! The number of predictions to compute.
+    virtual std::size_t dimensionPrediction() const = 0;
+    //! The number of gradients to compute.
+    virtual std::size_t dimensionGradient() const = 0;
 
     //! The value of the loss function.
     virtual double value(const TMemoryMappedFloatVector& prediction,
@@ -570,8 +590,15 @@ public:
     explicit CMse(core::CStateRestoreTraverser& traverser);
     TLossUPtr clone() const override;
     TLossUPtr incremental(double eta, double mu, const TNodeVec& tree) const override;
+    TLossUPtr project(std::size_t numberThreads,
+                      core::CDataFrame& frame,
+                      const core::CPackedBitVector& rowMask,
+                      std::size_t targetColumn,
+                      const TSizeVec& extraColumns,
+                      common::CPRNG::CXorOShiro128Plus rng) const override;
     ELossType type() const override;
-    std::size_t numberParameters() const override;
+    std::size_t dimensionPrediction() const override;
+    std::size_t dimensionGradient() const override;
     double value(const TMemoryMappedFloatVector& prediction,
                  double actual,
                  double weight = 1.0) const override;
@@ -620,11 +647,17 @@ public:
 
 public:
     CMseIncremental(double eta, double mu, const TNodeVec& tree);
-    [[noreturn]] explicit CMseIncremental(core::CStateRestoreTraverser& traverser);
     TLossUPtr clone() const override;
     TLossUPtr incremental(double eta, double mu, const TNodeVec& tree) const override;
+    TLossUPtr project(std::size_t numberThreads,
+                      core::CDataFrame& frame,
+                      const core::CPackedBitVector& rowMask,
+                      std::size_t targetColumn,
+                      const TSizeVec& extraColumns,
+                      common::CPRNG::CXorOShiro128Plus rng) const override;
     ELossType type() const override;
-    std::size_t numberParameters() const override;
+    std::size_t dimensionPrediction() const override;
+    std::size_t dimensionGradient() const override;
     double value(const TMemoryMappedFloatVector& prediction,
                  double actual,
                  double weight = 1.0) const override;
@@ -667,186 +700,6 @@ private:
     const TNodeVec* m_Tree{nullptr};
 };
 
-//! \brief The loss for binomial logistic regression.
-//!
-//! DESCRIPTION:\n
-//! This targets the cross entropy loss using the tree to predict class log-odds:
-//! <pre class="fragment">
-//!   \f$\displaystyle l_i(p) = -(1 - a_i) \log(1 - S(p)) - a_i \log(S(p))\f$
-//! </pre>
-//! where \f$a_i\f$ denotes the actual class of the i'th example, \f$p\f$ is the
-//! prediction and \f$S(\cdot)\f$ denotes the logistic function.
-class MATHS_ANALYTICS_EXPORT CBinomialLogisticLoss : public CLoss {
-public:
-    static const std::string NAME;
-
-public:
-    CBinomialLogisticLoss() = default;
-    explicit CBinomialLogisticLoss(core::CStateRestoreTraverser& traverser);
-    TLossUPtr clone() const override;
-    TLossUPtr incremental(double eta, double mu, const TNodeVec& tree) const override;
-    ELossType type() const override;
-    std::size_t numberParameters() const override;
-    double value(const TMemoryMappedFloatVector& prediction,
-                 double actual,
-                 double weight = 1.0) const override;
-    void gradient(const CEncodedDataFrameRowRef& /*row*/,
-                  bool /*newExample*/,
-                  const TMemoryMappedFloatVector& prediction,
-                  double actual,
-                  const TWriter& writer,
-                  double weight = 1.0) const override {
-        this->gradient(prediction, actual, writer, weight);
-    }
-    void gradient(const TMemoryMappedFloatVector& prediction,
-                  double actual,
-                  const TWriter& writer,
-                  double weight = 1.0) const;
-    void curvature(const CEncodedDataFrameRowRef& /*row*/,
-                   bool /*newExample*/,
-                   const TMemoryMappedFloatVector& prediction,
-                   double actual,
-                   const TWriter& writer,
-                   double weight = 1.0) const override {
-        this->curvature(prediction, actual, writer, weight);
-    }
-    void curvature(const TMemoryMappedFloatVector& prediction,
-                   double actual,
-                   const TWriter& writer,
-                   double weight = 1.0) const;
-    bool isCurvatureConstant() const override;
-    double difference(const TMemoryMappedFloatVector& prediction,
-                      const TMemoryMappedFloatVector& previousPrediction,
-                      double weight = 1.0) const override;
-    //! \return (P(class 0), P(class 1)).
-    TDoubleVector transform(const TMemoryMappedFloatVector& prediction) const override;
-    CArgMinLoss minimizer(double lambda, const common::CPRNG::CXorOShiro128Plus& rng) const override;
-    const std::string& name() const override;
-    bool isRegression() const override;
-
-private:
-    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
-    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override;
-};
-
-//! \brief The loss for incremental binomial logistic regression.
-//!
-//! DESCRIPTION:\n
-//! This augments the standard loss function by adding the cross-entropy between
-//! predictions and the supplied tree predictions.
-class MATHS_ANALYTICS_EXPORT CBinomialLogisticLossIncremental final : public CBinomialLogisticLoss {
-public:
-    static const std::string NAME;
-
-public:
-    CBinomialLogisticLossIncremental(double eta, double mu, const TNodeVec& tree);
-    [[noreturn]] explicit CBinomialLogisticLossIncremental(core::CStateRestoreTraverser& traverser);
-    TLossUPtr clone() const override;
-    TLossUPtr incremental(double eta, double mu, const TNodeVec& tree) const override;
-    ELossType type() const override;
-    std::size_t numberParameters() const override;
-    double value(const TMemoryMappedFloatVector& prediction,
-                 double actual,
-                 double weight = 1.0) const override;
-    void gradient(const CEncodedDataFrameRowRef& row,
-                  bool newExample,
-                  const TMemoryMappedFloatVector& prediction,
-                  double actual,
-                  const TWriter& writer,
-                  double weight = 1.0) const override;
-    void curvature(const CEncodedDataFrameRowRef& row,
-                   bool newExample,
-                   const TMemoryMappedFloatVector& prediction,
-                   double actual,
-                   const TWriter& writer,
-                   double weight = 1.0) const override;
-    bool isCurvatureConstant() const override;
-    double difference(const TMemoryMappedFloatVector& prediction,
-                      const TMemoryMappedFloatVector& previousPrediction,
-                      double weight = 1.0) const override;
-    //! \return (P(class 0), P(class 1)).
-    TDoubleVector transform(const TMemoryMappedFloatVector& prediction) const override;
-    CArgMinLoss minimizer(double lambda, const common::CPRNG::CXorOShiro128Plus& rng) const override;
-    const std::string& name() const override;
-    bool isRegression() const override;
-
-private:
-    void acceptPersistInserter(core::CStatePersistInserter&) const override {}
-    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override;
-
-private:
-    double m_Eta{0.0};
-    double m_Mu{0.0};
-    const TNodeVec* m_Tree{nullptr};
-};
-
-//!  \brief The loss for multinomial logistic regression.
-//!
-//! DESCRIPTION:\n
-//! This targets the cross-entropy loss using the forest to predict the class
-//! probabilities via the softmax function:
-//! <pre class="fragment">
-//!   \f$\displaystyle l_i(p) = -\sum_i a_{ij} \log(\sigma(p))\f$
-//! </pre>
-//! where \f$a_i\f$ denotes the actual class of the i'th example, \f$p\f$ denotes
-//! the vector valued prediction and \f$\sigma(p)\f$ is the softmax function, i.e.
-//! \f$[\sigma(p)]_j = \frac{e^{p_i}}{\sum_k e^{p_k}}\f$.
-class MATHS_ANALYTICS_EXPORT CMultinomialLogisticLoss final : public CLoss {
-public:
-    static const std::string NAME;
-
-public:
-    explicit CMultinomialLogisticLoss(std::size_t numberClasses);
-    explicit CMultinomialLogisticLoss(core::CStateRestoreTraverser& traverser);
-    ELossType type() const override;
-    TLossUPtr clone() const override;
-    TLossUPtr incremental(double eta, double mu, const TNodeVec& tree) const override;
-    std::size_t numberParameters() const override;
-    double value(const TMemoryMappedFloatVector& prediction,
-                 double actual,
-                 double weight = 1.0) const override;
-    void gradient(const CEncodedDataFrameRowRef& /*row*/,
-                  bool /*newExample*/,
-                  const TMemoryMappedFloatVector& prediction,
-                  double actual,
-                  const TWriter& writer,
-                  double weight = 1.0) const override {
-        this->gradient(prediction, actual, writer, weight);
-    }
-    void gradient(const TMemoryMappedFloatVector& prediction,
-                  double actual,
-                  const TWriter& writer,
-                  double weight = 1.0) const;
-    void curvature(const CEncodedDataFrameRowRef& /*row*/,
-                   bool /*newExample*/,
-                   const TMemoryMappedFloatVector& prediction,
-                   double actual,
-                   const TWriter& writer,
-                   double weight = 1.0) const override {
-        this->curvature(prediction, actual, writer, weight);
-    }
-    void curvature(const TMemoryMappedFloatVector& prediction,
-                   double actual,
-                   const TWriter& writer,
-                   double weight = 1.0) const;
-    bool isCurvatureConstant() const override;
-    double difference(const TMemoryMappedFloatVector& predictions,
-                      const TMemoryMappedFloatVector& previousPredictions,
-                      double weight = 1.0) const override;
-    //! \return (P(class 0), P(class 1), ..., P(class n)).
-    TDoubleVector transform(const TMemoryMappedFloatVector& prediction) const override;
-    CArgMinLoss minimizer(double lambda, const common::CPRNG::CXorOShiro128Plus& rng) const override;
-    const std::string& name() const override;
-    bool isRegression() const override;
-
-private:
-    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
-    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override;
-
-private:
-    std::size_t m_NumberClasses;
-};
-
 //! \brief The MSLE loss function.
 //!
 //! DESCRIPTION:\n
@@ -867,10 +720,17 @@ public:
 public:
     explicit CMsle(double offset = 1.0);
     explicit CMsle(core::CStateRestoreTraverser& traverser);
-    ELossType type() const override;
     TLossUPtr clone() const override;
     TLossUPtr incremental(double eta, double mu, const TNodeVec& tree) const override;
-    std::size_t numberParameters() const override;
+    TLossUPtr project(std::size_t numberThreads,
+                      core::CDataFrame& frame,
+                      const core::CPackedBitVector& rowMask,
+                      std::size_t targetColumn,
+                      const TSizeVec& extraColumns,
+                      common::CPRNG::CXorOShiro128Plus rng) const override;
+    ELossType type() const override;
+    std::size_t dimensionPrediction() const override;
+    std::size_t dimensionGradient() const override;
     double value(const TMemoryMappedFloatVector& prediction,
                  double actual,
                  double weight = 1.0) const override;
@@ -945,10 +805,17 @@ public:
 public:
     explicit CPseudoHuber(double delta);
     explicit CPseudoHuber(core::CStateRestoreTraverser& traverser);
-    ELossType type() const override;
     TLossUPtr clone() const override;
     TLossUPtr incremental(double eta, double mu, const TNodeVec& tree) const override;
-    std::size_t numberParameters() const override;
+    TLossUPtr project(std::size_t numberThreads,
+                      core::CDataFrame& frame,
+                      const core::CPackedBitVector& rowMask,
+                      std::size_t targetColumn,
+                      const TSizeVec& extraColumns,
+                      common::CPRNG::CXorOShiro128Plus rng) const override;
+    ELossType type() const override;
+    std::size_t dimensionPrediction() const override;
+    std::size_t dimensionGradient() const override;
     double value(const TMemoryMappedFloatVector& prediction,
                  double actual,
                  double weight = 1.0) const override;
@@ -992,6 +859,240 @@ private:
 
 private:
     double m_Delta;
+};
+
+//! \brief The loss for binomial logistic regression.
+//!
+//! DESCRIPTION:\n
+//! This targets the cross entropy loss using the tree to predict class log-odds:
+//! <pre class="fragment">
+//!   \f$\displaystyle l_i(p) = -(1 - a_i) \log(1 - S(p)) - a_i \log(S(p))\f$
+//! </pre>
+//! where \f$a_i\f$ denotes the actual class of the i'th example, \f$p\f$ is the
+//! prediction and \f$S(\cdot)\f$ denotes the logistic function.
+class MATHS_ANALYTICS_EXPORT CBinomialLogisticLoss : public CLoss {
+public:
+    static const std::string NAME;
+
+public:
+    CBinomialLogisticLoss() = default;
+    explicit CBinomialLogisticLoss(core::CStateRestoreTraverser& traverser);
+    TLossUPtr clone() const override;
+    TLossUPtr incremental(double eta, double mu, const TNodeVec& tree) const override;
+    TLossUPtr project(std::size_t numberThreads,
+                      core::CDataFrame& frame,
+                      const core::CPackedBitVector& rowMask,
+                      std::size_t targetColumn,
+                      const TSizeVec& extraColumns,
+                      common::CPRNG::CXorOShiro128Plus rng) const override;
+    ELossType type() const override;
+    std::size_t dimensionPrediction() const override;
+    std::size_t dimensionGradient() const override;
+    double value(const TMemoryMappedFloatVector& prediction,
+                 double actual,
+                 double weight = 1.0) const override;
+    void gradient(const CEncodedDataFrameRowRef& /*row*/,
+                  bool /*newExample*/,
+                  const TMemoryMappedFloatVector& prediction,
+                  double actual,
+                  const TWriter& writer,
+                  double weight = 1.0) const override {
+        this->gradient(prediction, actual, writer, weight);
+    }
+    void gradient(const TMemoryMappedFloatVector& prediction,
+                  double actual,
+                  const TWriter& writer,
+                  double weight = 1.0) const;
+    void curvature(const CEncodedDataFrameRowRef& /*row*/,
+                   bool /*newExample*/,
+                   const TMemoryMappedFloatVector& prediction,
+                   double actual,
+                   const TWriter& writer,
+                   double weight = 1.0) const override {
+        this->curvature(prediction, actual, writer, weight);
+    }
+    void curvature(const TMemoryMappedFloatVector& prediction,
+                   double actual,
+                   const TWriter& writer,
+                   double weight = 1.0) const;
+    bool isCurvatureConstant() const override;
+    double difference(const TMemoryMappedFloatVector& prediction,
+                      const TMemoryMappedFloatVector& previousPrediction,
+                      double weight = 1.0) const override;
+    //! \return (P(class 0), P(class 1)).
+    TDoubleVector transform(const TMemoryMappedFloatVector& prediction) const override;
+    CArgMinLoss minimizer(double lambda, const common::CPRNG::CXorOShiro128Plus& rng) const override;
+    const std::string& name() const override;
+    bool isRegression() const override;
+
+private:
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override;
+};
+
+//! \brief The loss for incremental binomial logistic regression.
+//!
+//! DESCRIPTION:\n
+//! This augments the standard loss function by adding the cross-entropy between
+//! predictions and the supplied tree predictions.
+class MATHS_ANALYTICS_EXPORT CBinomialLogisticLossIncremental final : public CBinomialLogisticLoss {
+public:
+    static const std::string NAME;
+
+public:
+    CBinomialLogisticLossIncremental(double eta, double mu, const TNodeVec& tree);
+    TLossUPtr clone() const override;
+    TLossUPtr incremental(double eta, double mu, const TNodeVec& tree) const override;
+    TLossUPtr project(std::size_t numberThreads,
+                      core::CDataFrame& frame,
+                      const core::CPackedBitVector& rowMask,
+                      std::size_t targetColumn,
+                      const TSizeVec& extraColumns,
+                      common::CPRNG::CXorOShiro128Plus rng) const override;
+    ELossType type() const override;
+    std::size_t dimensionPrediction() const override;
+    std::size_t dimensionGradient() const override;
+    double value(const TMemoryMappedFloatVector& prediction,
+                 double actual,
+                 double weight = 1.0) const override;
+    void gradient(const CEncodedDataFrameRowRef& row,
+                  bool newExample,
+                  const TMemoryMappedFloatVector& prediction,
+                  double actual,
+                  const TWriter& writer,
+                  double weight = 1.0) const override;
+    void curvature(const CEncodedDataFrameRowRef& row,
+                   bool newExample,
+                   const TMemoryMappedFloatVector& prediction,
+                   double actual,
+                   const TWriter& writer,
+                   double weight = 1.0) const override;
+    bool isCurvatureConstant() const override;
+    double difference(const TMemoryMappedFloatVector& prediction,
+                      const TMemoryMappedFloatVector& previousPrediction,
+                      double weight = 1.0) const override;
+    //! \return (P(class 0), P(class 1)).
+    TDoubleVector transform(const TMemoryMappedFloatVector& prediction) const override;
+    CArgMinLoss minimizer(double lambda, const common::CPRNG::CXorOShiro128Plus& rng) const override;
+    const std::string& name() const override;
+    bool isRegression() const override;
+
+private:
+    void acceptPersistInserter(core::CStatePersistInserter&) const override {}
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override;
+
+private:
+    double m_Eta{0.0};
+    double m_Mu{0.0};
+    const TNodeVec* m_Tree{nullptr};
+};
+
+//!  \brief The loss for multinomial logistic regression.
+//!
+//! DESCRIPTION:\n
+//! This targets the cross-entropy loss using the forest to predict the class
+//! probabilities via the softmax function:
+//! <pre class="fragment">
+//!   \f$\displaystyle l_i(p) = -\sum_i a_{ij} \log(\sigma(p))\f$
+//! </pre>
+//! where \f$a_i\f$ denotes the actual class of the i'th example, \f$p\f$ denotes
+//! the vector valued prediction and \f$\sigma(p)\f$ is the softmax function, i.e.
+//! \f$[\sigma(p)]_j = \frac{e^{p_i}}{\sum_k e^{p_k}}\f$.
+class MATHS_ANALYTICS_EXPORT CMultinomialLogisticLoss : public CLoss {
+public:
+    static const std::string NAME;
+    static constexpr std::size_t MAX_GRADIENT_DIMENSION{20};
+
+public:
+    explicit CMultinomialLogisticLoss(std::size_t numberClasses);
+    explicit CMultinomialLogisticLoss(core::CStateRestoreTraverser& traverser);
+    TLossUPtr clone() const override;
+    TLossUPtr incremental(double eta, double mu, const TNodeVec& tree) const override;
+    TLossUPtr project(std::size_t numberThreads,
+                      core::CDataFrame& frame,
+                      const core::CPackedBitVector& rowMask,
+                      std::size_t targetColumn,
+                      const TSizeVec& extraColumns,
+                      common::CPRNG::CXorOShiro128Plus rng) const override;
+    ELossType type() const override;
+    std::size_t dimensionPrediction() const override;
+    std::size_t dimensionGradient() const override;
+    double value(const TMemoryMappedFloatVector& prediction,
+                 double actual,
+                 double weight = 1.0) const override;
+    void gradient(const CEncodedDataFrameRowRef& /*row*/,
+                  bool /*newExample*/,
+                  const TMemoryMappedFloatVector& prediction,
+                  double actual,
+                  const TWriter& writer,
+                  double weight = 1.0) const override {
+        this->gradient(prediction, actual, writer, weight);
+    }
+    void gradient(const TMemoryMappedFloatVector& prediction,
+                  double actual,
+                  const TWriter& writer,
+                  double weight = 1.0) const;
+    void curvature(const CEncodedDataFrameRowRef& /*row*/,
+                   bool /*newExample*/,
+                   const TMemoryMappedFloatVector& prediction,
+                   double actual,
+                   const TWriter& writer,
+                   double weight = 1.0) const override {
+        this->curvature(prediction, actual, writer, weight);
+    }
+    void curvature(const TMemoryMappedFloatVector& prediction,
+                   double actual,
+                   const TWriter& writer,
+                   double weight = 1.0) const;
+    bool isCurvatureConstant() const override;
+    double difference(const TMemoryMappedFloatVector& prediction,
+                      const TMemoryMappedFloatVector& previousPrediction,
+                      double weight = 1.0) const override;
+    //! \return (P(class 0), P(class 1), ..., P(class n)).
+    TDoubleVector transform(const TMemoryMappedFloatVector& prediction) const override;
+    CArgMinLoss minimizer(double lambda, const common::CPRNG::CXorOShiro128Plus& rng) const override;
+    const std::string& name() const override;
+    bool isRegression() const override;
+
+private:
+    void acceptPersistInserter(core::CStatePersistInserter& inserter) const override;
+    bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser) override;
+
+private:
+    std::size_t m_NumberClasses;
+};
+
+class MATHS_ANALYTICS_EXPORT CSubsetMultinomialLogisticLoss final
+    : public CMultinomialLogisticLoss {
+public:
+    CSubsetMultinomialLogisticLoss(std::size_t numberClasses, const TSizeVec& classes);
+    TLossUPtr clone() const override;
+    TLossUPtr incremental(double eta, double mu, const TNodeVec& tree) const override;
+    TLossUPtr project(std::size_t numberThreads,
+                      core::CDataFrame& frame,
+                      const core::CPackedBitVector& rowMask,
+                      std::size_t targetColumn,
+                      const TSizeVec& extraColumns,
+                      common::CPRNG::CXorOShiro128Plus rng) const override;
+    void gradient(const CEncodedDataFrameRowRef& /*row*/,
+                  bool /*newExample*/,
+                  const TMemoryMappedFloatVector& prediction,
+                  double actual,
+                  const TWriter& writer,
+                  double weight = 1.0) const override;
+    void curvature(const CEncodedDataFrameRowRef& /*row*/,
+                   bool /*newExample*/,
+                   const TMemoryMappedFloatVector& prediction,
+                   double actual,
+                   const TWriter& writer,
+                   double weight = 1.0) const override;
+
+private:
+    using TIntVec = std::vector<int>;
+
+private:
+    TIntVec m_InClasses;
+    TIntVec m_OutClasses;
 };
 }
 }

--- a/include/maths/analytics/CBoostedTreeLoss.h
+++ b/include/maths/analytics/CBoostedTreeLoss.h
@@ -1020,6 +1020,14 @@ public:
     double value(const TMemoryMappedFloatVector& prediction,
                  double actual,
                  double weight = 1.0) const override;
+    virtual void gradient(const TMemoryMappedFloatVector& prediction,
+                          double actual,
+                          const TWriter& writer,
+                          double weight = 1.0) const;
+    virtual void curvature(const TMemoryMappedFloatVector& prediction,
+                           double actual,
+                           const TWriter& writer,
+                           double weight = 1.0) const;
     void gradient(const CEncodedDataFrameRowRef& /*row*/,
                   bool /*newExample*/,
                   const TMemoryMappedFloatVector& prediction,
@@ -1028,10 +1036,6 @@ public:
                   double weight = 1.0) const override {
         this->gradient(prediction, actual, writer, weight);
     }
-    void gradient(const TMemoryMappedFloatVector& prediction,
-                  double actual,
-                  const TWriter& writer,
-                  double weight = 1.0) const;
     void curvature(const CEncodedDataFrameRowRef& /*row*/,
                    bool /*newExample*/,
                    const TMemoryMappedFloatVector& prediction,
@@ -1040,10 +1044,6 @@ public:
                    double weight = 1.0) const override {
         this->curvature(prediction, actual, writer, weight);
     }
-    void curvature(const TMemoryMappedFloatVector& prediction,
-                   double actual,
-                   const TWriter& writer,
-                   double weight = 1.0) const;
     bool isCurvatureConstant() const override;
     double difference(const TMemoryMappedFloatVector& prediction,
                       const TMemoryMappedFloatVector& previousPrediction,
@@ -1062,10 +1062,10 @@ private:
     std::size_t m_NumberClasses;
 };
 
-class MATHS_ANALYTICS_EXPORT CSubsetMultinomialLogisticLoss final
+class MATHS_ANALYTICS_EXPORT CMultinomialLogisticSubsetLoss final
     : public CMultinomialLogisticLoss {
 public:
-    CSubsetMultinomialLogisticLoss(std::size_t numberClasses, const TSizeVec& classes);
+    CMultinomialLogisticSubsetLoss(std::size_t numberClasses, const TSizeVec& classes);
     TLossUPtr clone() const override;
     TLossUPtr incremental(double eta, double mu, const TNodeVec& tree) const override;
     TLossUPtr project(std::size_t numberThreads,
@@ -1074,15 +1074,11 @@ public:
                       std::size_t targetColumn,
                       const TSizeVec& extraColumns,
                       common::CPRNG::CXorOShiro128Plus rng) const override;
-    void gradient(const CEncodedDataFrameRowRef& /*row*/,
-                  bool /*newExample*/,
-                  const TMemoryMappedFloatVector& prediction,
+    void gradient(const TMemoryMappedFloatVector& prediction,
                   double actual,
                   const TWriter& writer,
                   double weight = 1.0) const override;
-    void curvature(const CEncodedDataFrameRowRef& /*row*/,
-                   bool /*newExample*/,
-                   const TMemoryMappedFloatVector& prediction,
+    void curvature(const TMemoryMappedFloatVector& prediction,
                    double actual,
                    const TWriter& writer,
                    double weight = 1.0) const override;

--- a/include/maths/analytics/CBoostedTreeUtils.h
+++ b/include/maths/analytics/CBoostedTreeUtils.h
@@ -272,8 +272,8 @@ inline std::size_t missingSplit(const CSearchTree& candidateSplits) {
 }
 
 //! Get the size of upper triangle of the loss Hessain.
-inline std::size_t lossHessianUpperTriangleSize(std::size_t numberLossParameters) {
-    return numberLossParameters * (numberLossParameters + 1) / 2;
+inline std::size_t lossHessianUpperTriangleSize(std::size_t dimensionGradient) {
+    return dimensionGradient * (dimensionGradient + 1) / 2;
 }
 
 //! Get the tags for extra columns needed by training.
@@ -312,48 +312,47 @@ inline TSizeVec extraColumnTagsForPredict() {
 //! Read the prediction from \p row.
 inline TMemoryMappedFloatVector readPrediction(const TRowRef& row,
                                                const TSizeVec& extraColumns,
-                                               std::size_t numberLossParameters) {
-    return {row.data() + extraColumns[E_Prediction], static_cast<int>(numberLossParameters)};
+                                               std::size_t dimensionPrediction) {
+    return {row.data() + extraColumns[E_Prediction], static_cast<int>(dimensionPrediction)};
 }
 
 //! Zero the prediction of \p row.
 MATHS_ANALYTICS_EXPORT
-void zeroPrediction(const TRowRef& row, const TSizeVec& extraColumns, std::size_t numberLossParameters);
+void zeroPrediction(const TRowRef& row, const TSizeVec& extraColumns, std::size_t dimensionPrediction);
 
 //! Write \p value to \p row prediction column(s).
 MATHS_ANALYTICS_EXPORT
 void writePrediction(const TRowRef& row,
                      const TSizeVec& extraColumns,
-                     std::size_t numberLossParameters,
+                     std::size_t dimensionPrediction,
                      const TMemoryMappedFloatVector& value);
 
 //! Write \p value to \p row previous prediction column(s).
 MATHS_ANALYTICS_EXPORT
 void writePreviousPrediction(const TRowRef& row,
                              const TSizeVec& extraColumns,
-                             std::size_t numberLossParameters,
+                             std::size_t dimensionPrediction,
                              const TMemoryMappedFloatVector& value);
 
 //! Read the previous prediction for \p row if training incementally.
 MATHS_ANALYTICS_EXPORT
 inline TMemoryMappedFloatVector readPreviousPrediction(const TRowRef& row,
                                                        const TSizeVec& extraColumns,
-                                                       std::size_t numberLossParameters) {
+                                                       std::size_t dimensionPrediction) {
     return {row.data() + extraColumns[E_PreviousPrediction],
-            static_cast<int>(numberLossParameters)};
+            static_cast<int>(dimensionPrediction)};
 }
 
 //! Read all the loss derivatives from \p row into an aligned vector.
 inline TAlignedMemoryMappedFloatVector
-readLossDerivatives(const TRowRef& row, const TSizeVec& extraColumns, std::size_t numberLossParameters) {
+readLossDerivatives(const TRowRef& row, const TSizeVec& extraColumns, std::size_t dimensionGradient) {
     return {row.data() + extraColumns[E_Gradient],
-            static_cast<int>(numberLossParameters +
-                             lossHessianUpperTriangleSize(numberLossParameters))};
+            static_cast<int>(dimensionGradient + lossHessianUpperTriangleSize(dimensionGradient))};
 }
 
 //! Zero the loss gradient of \p row.
 MATHS_ANALYTICS_EXPORT
-void zeroLossGradient(const TRowRef& row, const TSizeVec& extraColumns, std::size_t numberLossParameters);
+void zeroLossGradient(const TRowRef& row, const TSizeVec& extraColumns, std::size_t dimensionGradient);
 
 //! Write the loss gradient to \p row.
 MATHS_ANALYTICS_EXPORT
@@ -369,14 +368,14 @@ void writeLossGradient(const TRowRef& row,
 //! Read the loss flat column major Hessian from \p row.
 inline TMemoryMappedFloatVector readLossCurvature(const TRowRef& row,
                                                   const TSizeVec& extraColumns,
-                                                  std::size_t numberLossParameters) {
+                                                  std::size_t dimensionGradient) {
     return {row.data() + extraColumns[E_Curvature],
-            static_cast<int>(lossHessianUpperTriangleSize(numberLossParameters))};
+            static_cast<int>(lossHessianUpperTriangleSize(dimensionGradient))};
 }
 
 //! Zero the loss Hessian of \p row.
 MATHS_ANALYTICS_EXPORT
-void zeroLossCurvature(const TRowRef& row, const TSizeVec& extraColumns, std::size_t numberLossParameters);
+void zeroLossCurvature(const TRowRef& row, const TSizeVec& extraColumns, std::size_t dimensionGradient);
 
 //! Write the loss Hessian to \p row.
 MATHS_ANALYTICS_EXPORT

--- a/include/maths/analytics/CBoostedTreeUtils.h
+++ b/include/maths/analytics/CBoostedTreeUtils.h
@@ -282,10 +282,11 @@ inline TSizeVec extraColumnTagsForTrain() {
 }
 
 //! Get the extra columns needed by training.
-inline TSizeAlignmentPrVec extraColumnsForTrain(std::size_t numberLossParameters) {
-    return {{numberLossParameters, core::CAlignment::E_Unaligned}, // prediction
-            {numberLossParameters, core::CAlignment::E_Aligned16}, // gradient
-            {numberLossParameters * numberLossParameters, core::CAlignment::E_Unaligned}}; // curvature
+inline TSizeAlignmentPrVec extraColumnsForTrain(std::size_t dimensionPrediction,
+                                                std::size_t dimensionGradient) {
+    return {{dimensionPrediction, core::CAlignment::E_Unaligned}, // prediction
+            {dimensionGradient, core::CAlignment::E_Aligned16},   // gradient
+            {dimensionGradient * dimensionGradient, core::CAlignment::E_Unaligned}}; // curvature
 }
 
 //! Get the tags for extra columns needed by training.
@@ -294,13 +295,13 @@ inline TSizeVec extraColumnTagsForIncrementalTrain() {
 }
 
 //! Get the extra columns needed by incremental training.
-inline TSizeAlignmentPrVec extraColumnsForIncrementalTrain(std::size_t numberLossParameters) {
-    return {{numberLossParameters, core::CAlignment::E_Unaligned}}; // previous prediction
+inline TSizeAlignmentPrVec extraColumnsForIncrementalTrain(std::size_t dimensionPrediction) {
+    return {{dimensionPrediction, core::CAlignment::E_Unaligned}}; // previous prediction
 }
 
 //! Get the extra columns needed for prediction.
-inline TSizeAlignmentPrVec extraColumnsForPredict(std::size_t numberLossParameters) {
-    return {{numberLossParameters, core::CAlignment::E_Unaligned}}; // prediction
+inline TSizeAlignmentPrVec extraColumnsForPredict(std::size_t dimensionPrediction) {
+    return {{dimensionPrediction, core::CAlignment::E_Unaligned}}; // prediction
 }
 
 //! Get the tags for extra columns needed for prediction.

--- a/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeClassifierRunner.cc
@@ -357,7 +357,7 @@ CDataFrameTrainBoostedTreeClassifierRunner::inferenceModelMetadata() const {
 // clang-format off
 // The MAX_NUMBER_CLASSES must match the value used in the Java code. See the
 // MAX_DEPENDENT_VARIABLE_CARDINALITY in the x-pack classification code.
-const std::size_t CDataFrameTrainBoostedTreeClassifierRunner::MAX_NUMBER_CLASSES{30};
+const std::size_t CDataFrameTrainBoostedTreeClassifierRunner::MAX_NUMBER_CLASSES{100};
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::NUM_CLASSES{"num_classes"};
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::NUM_TOP_CLASSES{"num_top_classes"};
 const std::string CDataFrameTrainBoostedTreeClassifierRunner::PREDICTION_FIELD_TYPE{"prediction_field_type"};

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -127,8 +127,9 @@ CDataFrameTrainBoostedTreeRunner::CDataFrameTrainBoostedTreeRunner(
     const CDataFrameAnalysisParameters& parameters,
     TLossFunctionUPtr loss,
     TDataFrameUPtrTemporaryDirectoryPtrPr* frameAndDirectory)
-    : CDataFrameAnalysisRunner{spec}, m_NumberLossParameters{loss->numberParameters()},
-      m_Instrumentation{spec.jobId(), spec.memoryLimit()} {
+    : CDataFrameAnalysisRunner{spec}, m_DimensionPrediction{loss->dimensionPrediction()},
+      m_DimensionGradient{loss->dimensionGradient()}, m_Instrumentation{spec.jobId(),
+                                                                        spec.memoryLimit()} {
 
     if (loss == nullptr) {
         HANDLE_FATAL(<< "Internal error: must provide a loss function for training."
@@ -332,13 +333,13 @@ std::size_t CDataFrameTrainBoostedTreeRunner::numberExtraColumns() const {
         return maths::analytics::CBoostedTreeFactory::estimateExtraColumnsForEncode();
     case api_t::E_Train:
         return maths::analytics::CBoostedTreeFactory::estimateExtraColumnsForTrain(
-            this->spec().numberColumns(), m_NumberLossParameters);
+            this->spec().numberColumns(), m_DimensionPrediction, m_DimensionGradient);
     case api_t::E_Update:
         return maths::analytics::CBoostedTreeFactory::estimateExtraColumnsForTrainIncremental(
-            this->spec().numberColumns(), m_NumberLossParameters);
+            this->spec().numberColumns(), m_DimensionPrediction, m_DimensionGradient);
     case api_t::E_Predict:
         return maths::analytics::CBoostedTreeFactory::estimateExtraColumnsForPredict(
-            m_NumberLossParameters);
+            m_DimensionPrediction);
     }
 }
 

--- a/lib/maths/analytics/CBoostedTree.cc
+++ b/lib/maths/analytics/CBoostedTree.cc
@@ -51,8 +51,8 @@ const std::string SPLIT_FEATURE_TAG{"split_feature"};
 const std::string SPLIT_VALUE_TAG{"split_value"};
 }
 
-CBoostedTreeNode::CBoostedTreeNode(std::size_t numberLossParameters)
-    : m_NodeValue{TVector::Zero(numberLossParameters)} {
+CBoostedTreeNode::CBoostedTreeNode(std::size_t dimensionPrediction)
+    : m_NodeValue{TVector::Zero(dimensionPrediction)} {
 }
 
 CBoostedTreeNode::TNodeIndex CBoostedTreeNode::leafIndex(const CEncodedDataFrameRowRef& row,

--- a/lib/maths/analytics/CBoostedTree.cc
+++ b/lib/maths/analytics/CBoostedTree.cc
@@ -128,9 +128,9 @@ std::size_t CBoostedTreeNode::memoryUsage() const {
     return core::memory::dynamicSize(m_NodeValue);
 }
 
-std::size_t CBoostedTreeNode::estimateMemoryUsage(std::size_t numberLossParameters) {
+std::size_t CBoostedTreeNode::estimateMemoryUsage(std::size_t dimensionPrediction) {
     return sizeof(CBoostedTreeNode) +
-           common::las::estimateMemoryUsage<TVector>(numberLossParameters);
+           common::las::estimateMemoryUsage<TVector>(dimensionPrediction);
 }
 
 std::size_t CBoostedTreeNode::deployedSize() const {
@@ -280,14 +280,15 @@ const core::CPackedBitVector& CBoostedTree::newTrainingRowMask() const {
 CBoostedTree::TDouble2Vec CBoostedTree::prediction(const TRowRef& row) const {
     const auto& loss = m_Impl->loss();
     return loss
-        .transform(readPrediction(row, m_Impl->extraColumns(), loss.numberParameters()))
+        .transform(readPrediction(row, m_Impl->extraColumns(), loss.dimensionPrediction()))
         .to<TDouble2Vec>();
 }
 
 CBoostedTree::TDouble2Vec CBoostedTree::previousPrediction(const TRowRef& row) const {
     const auto& loss = m_Impl->loss();
     return loss
-        .transform(readPreviousPrediction(row, m_Impl->extraColumns(), loss.numberParameters()))
+        .transform(readPreviousPrediction(row, m_Impl->extraColumns(),
+                                          loss.dimensionPrediction()))
         .to<TDouble2Vec>();
 }
 
@@ -296,7 +297,7 @@ CBoostedTree::TDouble2Vec CBoostedTree::adjustedPrediction(const TRowRef& row) c
     const auto& loss = m_Impl->loss();
 
     auto prediction = loss.transform(
-        readPrediction(row, m_Impl->extraColumns(), loss.numberParameters()));
+        readPrediction(row, m_Impl->extraColumns(), loss.dimensionPrediction()));
 
     switch (loss.type()) {
     case E_BinaryClassification:

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -61,8 +61,6 @@ using namespace boosted_tree;
 using namespace boosted_tree_detail;
 using TStrVec = std::vector<std::string>;
 using TRowItr = core::CDataFrame::TRowItr;
-using TDoubleVector = common::CDenseVector<double>;
-using TDoubleVectorVec = std::vector<TDoubleVector>;
 using TMeanAccumulator = common::CBasicStatistics::SSampleMean<double>::TAccumulator;
 using TMeanAccumulatorVec = std::vector<TMeanAccumulator>;
 using TMemoryUsageCallback = CDataFrameAnalysisInstrumentationInterface::TMemoryUsageCallback;
@@ -263,16 +261,16 @@ std::size_t minimumSplitRefreshInterval(double eta, std::size_t numberFeatures) 
         std::max({0.5 / eta, static_cast<double>(numberFeatures) / 50.0, 3.0})));
 }
 
-void propagateLossGradients(std::size_t node,
-                            const std::vector<CBoostedTreeNode>& tree,
-                            TDoubleVectorVec& lossGradients) {
+void propagateLosses(std::size_t node,
+                     const std::vector<CBoostedTreeNode>& tree,
+                     TDoubleVec& lossGradients) {
 
     if (tree[node].isLeaf()) {
         return;
     }
 
-    propagateLossGradients(tree[node].leftChildIndex(), tree, lossGradients);
-    propagateLossGradients(tree[node].rightChildIndex(), tree, lossGradients);
+    propagateLosses(tree[node].leftChildIndex(), tree, lossGradients);
+    propagateLosses(tree[node].rightChildIndex(), tree, lossGradients);
 
     // A post order depth first traversal means that loss gradients are written
     // to child nodes before they are read here.
@@ -462,7 +460,7 @@ void CBoostedTreeImpl::trainIncremental(core::CDataFrame& frame,
     std::size_t oldBestForestSize{m_BestForest.size()};
     m_BestForest.resize(oldBestForestSize + m_MaximumNumberNewTrees);
     for (auto i = oldBestForestSize; i < m_BestForest.size(); ++i) {
-        m_BestForest[i] = {CBoostedTreeNode(m_Loss->numberParameters())};
+        m_BestForest[i] = {CBoostedTreeNode(m_Loss->dimensionPrediction())};
     }
     m_TreesToRetrain.resize(m_TreesToRetrain.size() + m_MaximumNumberNewTrees);
     std::iota(m_TreesToRetrain.end() - m_MaximumNumberNewTrees,
@@ -646,9 +644,9 @@ void CBoostedTreeImpl::predict(const core::CPackedBitVector& rowMask,
     std::tie(std::ignore, successful) = frame.writeColumns(
         m_NumberThreads, 0, frame.numberRows(),
         [&](const TRowItr& beginRows, const TRowItr& endRows) {
-            std::size_t numberLossParameters{m_Loss->numberParameters()};
+            std::size_t dimensionPrediction{m_Loss->dimensionPrediction()};
             for (auto row = beginRows; row != endRows; ++row) {
-                auto prediction = readPrediction(*row, m_ExtraColumns, numberLossParameters);
+                auto prediction = readPrediction(*row, m_ExtraColumns, dimensionPrediction);
                 prediction = this->predictRow(m_Encoder->encode(*row));
             }
         },
@@ -688,9 +686,9 @@ std::size_t CBoostedTreeImpl::estimateMemoryUsageForTraining(std::size_t numberR
     std::size_t hyperparametersMemoryUsage{m_Hyperparameters.estimateMemoryUsage() -
                                            sizeof(CBoostedTreeHyperparameters)};
     std::size_t forestMemoryUsage{
-        numberTrees *
-        (sizeof(TNodeVec) + maximumNumberNodes * CBoostedTreeNode::estimateMemoryUsage(
-                                                     m_Loss->numberParameters()))};
+        numberTrees * (sizeof(TNodeVec) +
+                       maximumNumberNodes * CBoostedTreeNode::estimateMemoryUsage(
+                                                m_Loss->dimensionPrediction()))};
     std::size_t foldRoundLossMemoryUsage{core::memory::dynamicSize(TOptionalDoubleVecVec(
         m_NumberFolds.value(), TOptionalDoubleVec(m_Hyperparameters.numberRounds())))};
     // The leaves' row masks memory is accounted for here because it's proportional
@@ -710,7 +708,7 @@ std::size_t CBoostedTreeImpl::estimateMemoryUsageForTraining(std::size_t numberR
         rowMaskMemoryUsage + maximumNumberLeaves *
                                  CBoostedTreeLeafNodeStatisticsScratch::estimateMemoryUsage(
                                      maximumNumberFeatures, m_NumberSplitsPerFeature,
-                                     m_Loss->numberParameters()) /
+                                     m_Loss->dimensionGradient()) /
                                  2};
     std::size_t categoryEncoderMemoryUsage{sizeof(CDataFrameCategoryEncoder)};
     std::size_t dataTypeMemoryUsage{
@@ -850,8 +848,9 @@ void CBoostedTreeImpl::computeClassificationWeights(const core::CDataFrame& fram
 
     if (m_Loss->type() == E_BinaryClassification || m_Loss->type() == E_MulticlassClassification) {
 
-        std::size_t numberClasses{
-            m_Loss->type() == E_BinaryClassification ? 2 : m_Loss->numberParameters()};
+        std::size_t numberClasses{m_Loss->type() == E_BinaryClassification
+                                      ? 2
+                                      : m_Loss->dimensionPrediction()};
         TFloatVec storage(2);
 
         switch (m_ClassAssignmentObjective) {
@@ -866,7 +865,7 @@ void CBoostedTreeImpl::computeClassificationWeights(const core::CDataFrame& fram
                     if (m_Loss->type() == E_BinaryClassification) {
                         // We predict the log-odds but this is expected to return
                         // the log of the predicted class probabilities.
-                        TMemoryMappedFloatVector result{&storage[0], 2};
+                        TMemoryMappedFloatVector result{storage.data(), 2};
                         result.array() =
                             m_Loss
                                 ->transform(readPrediction(row, m_ExtraColumns, numberClasses))
@@ -946,48 +945,44 @@ CBoostedTreeImpl::retrainTreeSelectionProbabilities(const core::CDataFrame& fram
         return {};
     }
 
-    using TDoubleVectorVecVec = std::vector<TDoubleVectorVec>;
+    using TDoubleVecVec = std::vector<TDoubleVec>;
 
-    std::size_t numberLossParameters{m_Loss->numberParameters()};
+    std::size_t dimensionPrediction{m_Loss->dimensionPrediction()};
     LOG_TRACE(<< "dependent variable " << m_DependentVariable);
     LOG_TRACE(<< "number loss parameters = " << numberLossParameters);
 
-    auto makeComputeTotalLossGradient = [&]() {
-        return [&](TDoubleVectorVecVec& leafLossGradients,
-                   const TRowItr& beginRows, const TRowItr& endRows) {
+    auto makeComputeTotalLosses = [&]() {
+        return [&](TDoubleVecVec& leafLossGradients, const TRowItr& beginRows,
+                   const TRowItr& endRows) {
             for (auto row = beginRows; row != endRows; ++row) {
-                auto prediction = readPrediction(*row, m_ExtraColumns, numberLossParameters);
+                auto prediction = readPrediction(*row, m_ExtraColumns, dimensionPrediction);
                 double actual{readActual(*row, m_DependentVariable)};
                 double weight{readExampleWeight(*row, m_ExtraColumns)};
                 for (std::size_t i = 0; i < forest.size(); ++i) {
                     auto encodedRow = m_Encoder->encode(*row);
                     std::size_t leaf{root(forest[i]).leafIndex(encodedRow, forest[i])};
-                    auto writer = [&](std::size_t j, double gradient) {
-                        leafLossGradients[i][leaf](j) = gradient;
-                    };
-                    m_Loss->gradient(encodedRow, true, prediction, actual, writer, weight);
+                    leafLossGradients[i][leaf] += weight * m_Loss->value(prediction, actual);
                 }
             }
         };
     };
 
-    auto makeZeroLeafLossGradients = [&] {
-        TDoubleVectorVecVec leafLossGradients;
-        leafLossGradients.reserve(forest.size());
+    auto makeZeroLosses = [&] {
+        TDoubleVecVec result;
+        result.reserve(forest.size());
         for (const auto& tree : forest) {
-            leafLossGradients.emplace_back(tree.size(), TDoubleVector::Zero(numberLossParameters));
+            result.emplace_back(tree.size(), 0.0);
         }
-        return leafLossGradients;
+        return result;
     };
 
-    auto computeLeafLossGradients = [&](const core::CPackedBitVector& rowMask) {
+    auto computeLeafLosses = [&](const core::CPackedBitVector& rowMask) {
         auto results = frame.readRows(
             m_NumberThreads, 0, frame.numberRows(),
-            core::bindRetrievableState(makeComputeTotalLossGradient(),
-                                       makeZeroLeafLossGradients()),
+            core::bindRetrievableState(makeComputeTotalLosses(), makeZeroLosses()),
             &rowMask);
 
-        TDoubleVectorVecVec leafLossGradients{std::move(results.first[0].s_FunctionState)};
+        TDoubleVecVec leafLossGradients{std::move(results.first[0].s_FunctionState)};
         for (std::size_t i = 1; i < results.first.size(); ++i) {
             auto& resultsForWorker = results.first[i].s_FunctionState;
             for (std::size_t j = 0; j < resultsForWorker.size(); ++j) {
@@ -1001,9 +996,9 @@ CBoostedTreeImpl::retrainTreeSelectionProbabilities(const core::CDataFrame& fram
     };
 
     // Compute the sum of loss gradients for each node.
-    auto trainingDataLossGradients = computeLeafLossGradients(trainingDataRowMask);
+    auto trainingDataLosses = computeLeafLosses(trainingDataRowMask);
     for (std::size_t i = 0; i < forest.size(); ++i) {
-        propagateLossGradients(rootIndex(), forest[i], trainingDataLossGradients[i]);
+        propagateLosses(rootIndex(), forest[i], trainingDataLosses[i]);
     }
     LOG_TRACE(<< "loss gradients = " << trainingDataLossGradients);
 
@@ -1018,7 +1013,7 @@ CBoostedTreeImpl::retrainTreeSelectionProbabilities(const core::CDataFrame& fram
     double Z{0.0};
     for (std::size_t i = 1; i < forest.size(); ++i) {
         for (std::size_t j = 1; j < forest[i].size(); ++j) {
-            result[i] += trainingDataLossGradients[i][j].lpNorm<1>();
+            result[i] += trainingDataLosses[i][j];
         }
         Z += result[i];
     }
@@ -1113,21 +1108,25 @@ CBoostedTreeImpl::TNodeVec CBoostedTreeImpl::initializePredictionsAndLossDerivat
     const core::CPackedBitVector& trainingRowMask,
     const core::CPackedBitVector& testingRowMask) const {
 
+    auto loss = m_Loss->project(m_NumberThreads, frame, trainingRowMask,
+                                m_DependentVariable, m_ExtraColumns, m_Rng);
+
     core::CPackedBitVector updateRowMask{trainingRowMask | testingRowMask};
     frame.writeColumns(
         m_NumberThreads, 0, frame.numberRows(),
-        [this](const TRowItr& beginRows, const TRowItr& endRows) {
-            std::size_t numberLossParameters{m_Loss->numberParameters()};
+        [&](const TRowItr& beginRows, const TRowItr& endRows) {
+            std::size_t dimensionPrediction{loss->dimensionPrediction()};
+            std::size_t dimensionGradient{loss->dimensionGradient()};
             for (auto row_ = beginRows; row_ != endRows; ++row_) {
                 auto row = *row_;
                 if (m_Hyperparameters.incrementalTraining()) {
-                    writePrediction(row, m_ExtraColumns, numberLossParameters,
+                    writePrediction(row, m_ExtraColumns, dimensionPrediction,
                                     readPreviousPrediction(row, m_ExtraColumns,
-                                                           numberLossParameters));
+                                                           dimensionPrediction));
                 } else {
-                    zeroPrediction(row, m_ExtraColumns, numberLossParameters);
-                    zeroLossGradient(row, m_ExtraColumns, numberLossParameters);
-                    zeroLossCurvature(row, m_ExtraColumns, numberLossParameters);
+                    zeroPrediction(row, m_ExtraColumns, dimensionPrediction);
+                    zeroLossGradient(row, m_ExtraColumns, dimensionGradient);
+                    zeroLossCurvature(row, m_ExtraColumns, dimensionGradient);
                 }
             }
         },
@@ -1136,11 +1135,11 @@ CBoostedTreeImpl::TNodeVec CBoostedTreeImpl::initializePredictionsAndLossDerivat
     TNodeVec tree;
     if (m_Hyperparameters.incrementalTraining() == false) {
         // At the start we will centre the data w.r.t. the given loss function.
-        tree.assign({CBoostedTreeNode{m_Loss->numberParameters()}});
-        this->computeLeafValues(frame, trainingRowMask, *m_Loss, 1.0 /*eta*/,
+        tree.assign({CBoostedTreeNode{loss->dimensionPrediction()}});
+        this->computeLeafValues(frame, trainingRowMask, *loss, 1.0 /*eta*/,
                                 0.0 /*lambda*/, tree);
         this->refreshPredictionsAndLossDerivatives(
-            frame, trainingRowMask | testingRowMask, *m_Loss,
+            frame, trainingRowMask | testingRowMask, *loss,
             [&](const TRowRef& row, TMemoryMappedFloatVector& prediction) {
                 prediction += root(tree).value(m_Encoder->encode(row), tree);
             });
@@ -1169,7 +1168,7 @@ CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
             const TSizeVec& nodeFeatureBag,
             const core::CPackedBitVector& trainingRowMask_, TWorkspace& workspace) {
             return std::make_unique<CBoostedTreeLeafNodeStatisticsScratch>(
-                rootIndex(), m_ExtraColumns, m_Loss->numberParameters(), frame,
+                rootIndex(), m_ExtraColumns, m_Loss->dimensionGradient(), frame,
                 m_Hyperparameters, candidateSplits, treeFeatureBag,
                 nodeFeatureBag, 0 /*depth*/, trainingRowMask_, workspace);
         };
@@ -1216,7 +1215,7 @@ CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
 
     CTrainingLossCurveStats lossCurveStats{
         m_Hyperparameters.maximumNumberTrees().value(), minTestLoss};
-    TWorkspace workspace{m_Loss->numberParameters()};
+    TWorkspace workspace{m_Loss->dimensionGradient()};
 
     // For each iteration:
     //  1. Periodically compute weighted quantiles for features F and candidate
@@ -1247,8 +1246,10 @@ CBoostedTreeImpl::trainForest(core::CDataFrame& frame,
             this->computeLeafValues(
                 frame, trainingRowMask, *m_Loss, eta,
                 m_Hyperparameters.leafWeightPenaltyMultiplier().value(), tree);
+            auto loss = m_Loss->project(m_NumberThreads, frame, trainingRowMask,
+                                        m_DependentVariable, m_ExtraColumns, m_Rng);
             this->refreshPredictionsAndLossDerivatives(
-                frame, trainingRowMask | testingRowMask, *m_Loss,
+                frame, trainingRowMask | testingRowMask, *loss,
                 [&](const TRowRef& row, TMemoryMappedFloatVector& prediction) {
                     prediction += root(tree).value(m_Encoder->encode(row), tree);
                 });
@@ -1322,7 +1323,7 @@ CBoostedTreeImpl::updateForest(core::CDataFrame& frame,
             const TSizeVec& nodeFeatureBag,
             const core::CPackedBitVector& trainingRowMask_, TWorkspace& workspace) {
             return std::make_unique<CBoostedTreeLeafNodeStatisticsIncremental>(
-                rootIndex(), m_ExtraColumns, m_Loss->numberParameters(), frame,
+                rootIndex(), m_ExtraColumns, m_Loss->dimensionGradient(), frame,
                 m_Hyperparameters, candidateSplits, treeFeatureBag,
                 nodeFeatureBag, 0 /*depth*/, trainingRowMask_, workspace);
         };
@@ -1358,7 +1359,7 @@ CBoostedTreeImpl::updateForest(core::CDataFrame& frame,
     testLosses.reserve(m_TreesToRetrain.size());
     scopeMemoryUsage.add(testLosses);
 
-    TWorkspace workspace{m_Loss->numberParameters()};
+    TWorkspace workspace{m_Loss->dimensionGradient()};
 
     // The exact sequence of operations in this loop is important. For each
     // iteration:
@@ -1589,10 +1590,10 @@ CBoostedTreeImpl::candidateSplits(const core::CDataFrame& frame,
                 std::max(m_NumberSplitsPerFeature, std::size_t{50}), m_Rng},
             m_Encoder.get(),
             [this](const TRowRef& row) {
-                std::size_t numberLossParameters{m_Loss->numberParameters()};
+                std::size_t dimensionGradient{m_Loss->dimensionGradient()};
                 double weight{readExampleWeight(row, m_ExtraColumns)};
-                return weight * trace(numberLossParameters,
-                                      readLossCurvature(row, m_ExtraColumns, numberLossParameters));
+                return weight * trace(dimensionGradient,
+                                      readLossCurvature(row, m_ExtraColumns, dimensionGradient));
             })
             .first;
 
@@ -2154,12 +2155,12 @@ void CBoostedTreeImpl::minimumLossLeafValues(bool newExample,
     minimizers.reserve(result.size());
     for (auto& leafValues : result) {
         minimizers.push_back([&](const TRowItr& beginRows, const TRowItr& endRows) {
-            std::size_t numberLossParameters{loss.numberParameters()};
+            std::size_t dimensionPrediction{loss.dimensionPrediction()};
             const auto& rootNode = root(tree);
             for (auto row_ = beginRows; row_ != endRows; ++row_) {
                 auto row = *row_;
                 auto encodedRow = m_Encoder->encode(row);
-                auto prediction = readPrediction(row, m_ExtraColumns, numberLossParameters);
+                auto prediction = readPrediction(row, m_ExtraColumns, dimensionPrediction);
                 double actual{readActual(row, m_DependentVariable)};
                 double weight{readExampleWeight(row, m_ExtraColumns)};
                 std::size_t index{rootNode.leafIndex(row, m_ExtraColumns, tree)};
@@ -2194,11 +2195,11 @@ void CBoostedTreeImpl::refreshPredictionsAndLossDerivatives(
     frame.writeColumns(
         m_NumberThreads, 0, frame.numberRows(),
         [&](const TRowItr& beginRows, const TRowItr& endRows) {
-            std::size_t numberLossParameters{loss.numberParameters()};
+            std::size_t dimensionPrediction{loss.dimensionPrediction()};
             for (auto row_ = beginRows; row_ != endRows; ++row_) {
                 auto row = *row_;
                 auto encodedRow = m_Encoder->encode(row);
-                auto prediction = readPrediction(row, m_ExtraColumns, numberLossParameters);
+                auto prediction = readPrediction(row, m_ExtraColumns, dimensionPrediction);
                 double actual{readActual(row, m_DependentVariable)};
                 double weight{readExampleWeight(row, m_ExtraColumns)};
                 updateRowPrediction(row, prediction);
@@ -2217,11 +2218,11 @@ void CBoostedTreeImpl::refreshPredictions(core::CDataFrame& frame,
                                           const TUpdateRowPrediction& updateRowPrediction) const {
     frame.writeColumns(m_NumberThreads, 0, frame.numberRows(),
                        [&](const TRowItr& beginRows, const TRowItr& endRows) {
-                           std::size_t numberLossParameters{loss.numberParameters()};
+                           std::size_t dimensionPrediction{loss.dimensionPrediction()};
                            for (auto row_ = beginRows; row_ != endRows; ++row_) {
                                auto row = *row_;
                                auto prediction = readPrediction(
-                                   row, m_ExtraColumns, numberLossParameters);
+                                   row, m_ExtraColumns, dimensionPrediction);
                                updateRowPrediction(row, prediction);
                            }
                        },
@@ -2239,10 +2240,10 @@ CBoostedTreeImpl::meanLoss(const core::CDataFrame& frame,
         core::bindRetrievableState( // Prevents weird formatting.
             [ this, rng = m_Rng, samples = TSizeVec{} ](
                 TMeanAccumulatorVec & losses, const TRowItr& beginRows, const TRowItr& endRows) mutable {
-                std::size_t numberLossParameters{m_Loss->numberParameters()};
+                std::size_t dimensionPrediction{m_Loss->dimensionPrediction()};
                 for (auto row_ = beginRows; row_ != endRows; ++row_) {
                     auto row = *row_;
-                    auto prediction = readPrediction(row, m_ExtraColumns, numberLossParameters);
+                    auto prediction = readPrediction(row, m_ExtraColumns, dimensionPrediction);
                     double actual{readActual(row, m_DependentVariable)};
                     double weight{readExampleWeight(row, m_ExtraColumns)};
                     double loss{m_Loss->value(prediction, actual)};
@@ -2292,12 +2293,12 @@ CBoostedTreeImpl::meanChangePenalisedLoss(const core::CDataFrame& frame,
         m_NumberThreads, 0, frame.numberRows(),
         core::bindRetrievableState(
             [&](TMeanAccumulator& loss, const TRowItr& beginRows, const TRowItr& endRows) {
-                std::size_t numberLossParameters{m_Loss->numberParameters()};
+                std::size_t dimensionPrediction{m_Loss->dimensionPrediction()};
                 for (auto row_ = beginRows; row_ != endRows; ++row_) {
                     auto row = *row_;
-                    auto prediction = readPrediction(row, m_ExtraColumns, numberLossParameters);
+                    auto prediction = readPrediction(row, m_ExtraColumns, dimensionPrediction);
                     auto previousPrediction = readPreviousPrediction(
-                        row, m_ExtraColumns, numberLossParameters);
+                        row, m_ExtraColumns, dimensionPrediction);
                     double weight{readExampleWeight(row, m_ExtraColumns)};
                     loss.add(m_Loss->difference(prediction, previousPrediction, 0.01), weight);
                 }
@@ -2335,7 +2336,7 @@ double CBoostedTreeImpl::betweenFoldTestLossVariance() const {
 }
 
 CBoostedTreeImpl::TVector CBoostedTreeImpl::predictRow(const CEncodedDataFrameRowRef& row) const {
-    TVector result{TVector::Zero(m_Loss->numberParameters())};
+    TVector result{TVector::Zero(m_Loss->dimensionPrediction())};
     for (const auto& tree : m_BestForest) {
         result += root(tree).value(row, tree);
     }

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -1000,7 +1000,7 @@ CBoostedTreeImpl::retrainTreeSelectionProbabilities(const core::CDataFrame& fram
     for (std::size_t i = 0; i < forest.size(); ++i) {
         propagateLosses(rootIndex(), forest[i], trainingDataLosses[i]);
     }
-    LOG_TRACE(<< "loss gradients = " << trainingDataLossGradients);
+    LOG_TRACE(<< "loss gradients = " << trainingDataLosses);
 
     // We are interested in choosing trees for which the total gradient of the
     // loss at the current predictions for all nodes is the largest. These trees,

--- a/lib/maths/analytics/CBoostedTreeImpl.cc
+++ b/lib/maths/analytics/CBoostedTreeImpl.cc
@@ -949,7 +949,7 @@ CBoostedTreeImpl::retrainTreeSelectionProbabilities(const core::CDataFrame& fram
 
     std::size_t dimensionPrediction{m_Loss->dimensionPrediction()};
     LOG_TRACE(<< "dependent variable " << m_DependentVariable);
-    LOG_TRACE(<< "number loss parameters = " << numberLossParameters);
+    LOG_TRACE(<< "dimension prediction = " << dimensionPrediction);
 
     auto makeComputeTotalLosses = [&]() {
         return [&](TDoubleVecVec& leafLossGradients, const TRowItr& beginRows,

--- a/lib/maths/analytics/CBoostedTreeLoss.cc
+++ b/lib/maths/analytics/CBoostedTreeLoss.cc
@@ -1695,8 +1695,9 @@ void CMultinomialLogisticLoss::gradient(const TMemoryMappedFloatVector& predicti
             // is less than epsilon, for which we'd lose all nearly precision
             // when adding to the normalisation coefficient.
             pEps += std::exp(prediction(i) - zmax);
+        } else {
+            logZ += std::exp(prediction(i) - zmax);
         }
-        logZ += std::exp(prediction(i) - zmax);
     }
     pEps = common::CTools::stable(pEps / logZ);
     logZ = zmax + common::CTools::stableLog(logZ);
@@ -1736,8 +1737,9 @@ void CMultinomialLogisticLoss::curvature(const TMemoryMappedFloatVector& predict
             // is less than epsilon, for which we'd lose all nearly precision
             // when adding to the normalisation coefficient.
             pEps += pAdj;
+        } else {
+            logZ += pAdj;
         }
-        logZ += std::exp(prediction(i) - zmax);
     }
     pEps = common::CTools::stable(pEps / logZ);
     logZ = zmax + common::CTools::stableLog(logZ);
@@ -1876,8 +1878,9 @@ void CSubsetMultinomialLogisticLoss::gradient(const CEncodedDataFrameRowRef& /*r
             // is less than epsilon, for which we'd lose all nearly precision
             // when adding to the normalisation coefficient.
             pEps += pAdj;
+        } else {
+            logZ += pAdj;
         }
-        logZ += pAdj;
     }
     for (auto i : m_OutClasses) {
         double pAdj{std::exp(prediction(i) - zmax)};
@@ -1928,8 +1931,9 @@ void CSubsetMultinomialLogisticLoss::curvature(const CEncodedDataFrameRowRef& /*
             // is less than epsilon, for which we'd lose all nearly precision
             // when adding to the normalisation coefficient.
             pEps += pAdj;
+        } else {
+            logZ += pAdj;
         }
-        logZ += pAdj;
     }
     for (auto i : m_OutClasses) {
         double pAdj{std::exp(prediction(i) - zmax)};

--- a/lib/maths/analytics/CBoostedTreeLoss.cc
+++ b/lib/maths/analytics/CBoostedTreeLoss.cc
@@ -1885,7 +1885,7 @@ void CMultinomialLogisticSubsetLoss::gradient(const TMemoryMappedFloatVector& pr
     logZ = zmax + std::log(logZ);
     pAgg = common::CTools::stable(pAgg * std::exp(zmax - logZ) /
                                   static_cast<double>(m_OutClasses.size()));
-    LOG_TRACE(<< "p(agg) = " << std::exp(logPAgg - logZ));
+    LOG_TRACE(<< "p(agg) = " << pAgg);
 
     for (std::size_t i = 0; i <= m_InClasses.size(); ++i) {
         bool iAgg{i < m_InClasses.size()};
@@ -1932,7 +1932,7 @@ void CMultinomialLogisticSubsetLoss::curvature(const TMemoryMappedFloatVector& p
     logZ = zmax + common::CTools::stableLog(logZ);
     pAgg = common::CTools::stable(pAgg * std::exp(zmax - logZ) /
                                   static_cast<double>(m_OutClasses.size()));
-    LOG_TRACE(<< "p(agg) = " << std::exp(logPAgg - logZ));
+    LOG_TRACE(<< "p(agg) = " << pAgg);
 
     auto probability = [&](std::size_t i) {
         return i < m_InClasses.size()

--- a/lib/maths/analytics/CBoostedTreeLoss.cc
+++ b/lib/maths/analytics/CBoostedTreeLoss.cc
@@ -949,12 +949,12 @@ CMse::TLossUPtr CMse::incremental(double eta, double mu, const TNodeVec& tree) c
     return std::make_unique<CMseIncremental>(eta, mu, tree);
 }
 
-CMse::TLossUPtr CMse::project(std::size_t,
-                              core::CDataFrame&,
-                              const core::CPackedBitVector&,
-                              std::size_t,
-                              const TSizeVec&,
-                              common::CPRNG::CXorOShiro128Plus) const {
+CMse::TLossUPtr CMse::project(std::size_t /*numberThreads*/,
+                              core::CDataFrame& /*frame*/,
+                              const core::CPackedBitVector& /*rowMask*/,
+                              std::size_t /*targetColumn*/,
+                              const TSizeVec& /*extrColumns*/,
+                              common::CPRNG::CXorOShiro128Plus /*rng*/) const {
     return this->clone();
 }
 
@@ -1036,12 +1036,13 @@ CMseIncremental::incremental(double eta, double mu, const TNodeVec& tree) const 
     return std::make_unique<CMseIncremental>(eta, mu, tree);
 }
 
-CMseIncremental::TLossUPtr CMseIncremental::project(std::size_t,
-                                                    core::CDataFrame&,
-                                                    const core::CPackedBitVector&,
-                                                    std::size_t,
-                                                    const TSizeVec&,
-                                                    common::CPRNG::CXorOShiro128Plus) const {
+CMseIncremental::TLossUPtr
+CMseIncremental::project(std::size_t /*numberThreads*/,
+                         core::CDataFrame& /*frame*/,
+                         const core::CPackedBitVector& /*rowMask*/,
+                         std::size_t /*targetColumn*/,
+                         const TSizeVec& /*extrColumns*/,
+                         common::CPRNG::CXorOShiro128Plus /*rng*/) const {
     return this->clone();
 }
 
@@ -1142,12 +1143,12 @@ CMsle::TLossUPtr CMsle::incremental(double, double, const TNodeVec&) const {
     return nullptr;
 }
 
-CMsle::TLossUPtr CMsle::project(std::size_t,
-                                core::CDataFrame&,
-                                const core::CPackedBitVector&,
-                                std::size_t,
-                                const TSizeVec&,
-                                common::CPRNG::CXorOShiro128Plus) const {
+CMsle::TLossUPtr CMsle::project(std::size_t /*numberThreads*/,
+                                core::CDataFrame& /*frame*/,
+                                const core::CPackedBitVector& /*rowMask*/,
+                                std::size_t /*targetColumn*/,
+                                const TSizeVec& /*extrColumns*/,
+                                common::CPRNG::CXorOShiro128Plus /*rng*/) const {
     return this->clone();
 }
 
@@ -1263,12 +1264,12 @@ CPseudoHuber::TLossUPtr CPseudoHuber::incremental(double, double, const TNodeVec
     return nullptr;
 }
 
-CPseudoHuber::TLossUPtr CPseudoHuber::project(std::size_t,
-                                              core::CDataFrame&,
-                                              const core::CPackedBitVector&,
-                                              std::size_t,
-                                              const TSizeVec&,
-                                              common::CPRNG::CXorOShiro128Plus) const {
+CPseudoHuber::TLossUPtr CPseudoHuber::project(std::size_t /*numberThreads*/,
+                                              core::CDataFrame& /*frame*/,
+                                              const core::CPackedBitVector& /*rowMask*/,
+                                              std::size_t /*targetColumn*/,
+                                              const TSizeVec& /*extrColumns*/,
+                                              common::CPRNG::CXorOShiro128Plus /*rng*/) const {
     return this->clone();
 }
 
@@ -1374,12 +1375,12 @@ CBinomialLogisticLoss::incremental(double eta, double mu, const TNodeVec& tree) 
 }
 
 CBinomialLogisticLoss::TLossUPtr
-CBinomialLogisticLoss::project(std::size_t,
-                               core::CDataFrame&,
-                               const core::CPackedBitVector&,
-                               std::size_t,
-                               const TSizeVec&,
-                               common::CPRNG::CXorOShiro128Plus) const {
+CBinomialLogisticLoss::project(std::size_t /*numberThreads*/,
+                               core::CDataFrame& /*frame*/,
+                               const core::CPackedBitVector& /*rowMask*/,
+                               std::size_t /*targetColumn*/,
+                               const TSizeVec& /*extrColumns*/,
+                               common::CPRNG::CXorOShiro128Plus /*rng*/) const {
     return this->clone();
 }
 
@@ -1484,12 +1485,12 @@ CBinomialLogisticLossIncremental::incremental(double eta, double mu, const TNode
 }
 
 CBinomialLogisticLossIncremental::TLossUPtr
-CBinomialLogisticLossIncremental::project(std::size_t,
-                                          core::CDataFrame&,
-                                          const core::CPackedBitVector&,
-                                          std::size_t,
-                                          const TSizeVec&,
-                                          common::CPRNG::CXorOShiro128Plus) const {
+CBinomialLogisticLossIncremental::project(std::size_t /*numberThreads*/,
+                                          core::CDataFrame& /*frame*/,
+                                          const core::CPackedBitVector& /*rowMask*/,
+                                          std::size_t /*targetColumn*/,
+                                          const TSizeVec& /*extrColumns*/,
+                                          common::CPRNG::CXorOShiro128Plus /*rng*/) const {
     return this->clone();
 }
 
@@ -1650,7 +1651,7 @@ CMultinomialLogisticLoss::project(std::size_t numberThreads,
         rng, losses, MAX_GRADIENT_DIMENSION - 1, classes);
     std::sort(classes.begin(), classes.end());
 
-    return std::make_unique<CSubsetMultinomialLogisticLoss>(m_NumberClasses, classes);
+    return std::make_unique<CMultinomialLogisticSubsetLoss>(m_NumberClasses, classes);
 }
 
 ELossType CMultinomialLogisticLoss::type() const {
@@ -1816,43 +1817,46 @@ bool CMultinomialLogisticLoss::acceptRestoreTraverser(core::CStateRestoreTravers
 
 const std::string CMultinomialLogisticLoss::NAME{"multinomial_logistic"};
 
-CSubsetMultinomialLogisticLoss::CSubsetMultinomialLogisticLoss(std::size_t numberClasses,
+CMultinomialLogisticSubsetLoss::CMultinomialLogisticSubsetLoss(std::size_t numberClasses,
                                                                const TSizeVec& classes)
     : CMultinomialLogisticLoss{numberClasses} {
     m_InClasses.reserve(classes.size());
     for (auto i : classes) {
+        if (i >= numberClasses) {
+            HANDLE_FATAL(<< "Invalid class " << i << " out-of-range [0, "
+                         << numberClasses << ").");
+        }
         m_InClasses.push_back(static_cast<int>(i));
     }
-    m_OutClasses.resize(numberClasses - classes.size());
+    m_OutClasses.resize(numberClasses);
     std::iota(m_OutClasses.begin(), m_OutClasses.end(), 0);
     m_OutClasses.erase(std::set_difference(m_OutClasses.begin(), m_OutClasses.end(),
                                            m_InClasses.begin(), m_InClasses.end(),
                                            m_OutClasses.begin()),
                        m_OutClasses.end());
+    LOG_TRACE(<< "in = " << m_InClasses << ", out = " << m_OutClasses);
 }
 
-CSubsetMultinomialLogisticLoss::TLossUPtr CSubsetMultinomialLogisticLoss::clone() const {
-    return std::make_unique<CSubsetMultinomialLogisticLoss>(*this);
+CMultinomialLogisticSubsetLoss::TLossUPtr CMultinomialLogisticSubsetLoss::clone() const {
+    return std::make_unique<CMultinomialLogisticSubsetLoss>(*this);
 }
 
-CSubsetMultinomialLogisticLoss::TLossUPtr
-CSubsetMultinomialLogisticLoss::incremental(double, double, const TNodeVec&) const {
+CMultinomialLogisticSubsetLoss::TLossUPtr
+CMultinomialLogisticSubsetLoss::incremental(double, double, const TNodeVec&) const {
     return nullptr;
 }
 
-CSubsetMultinomialLogisticLoss::TLossUPtr
-CSubsetMultinomialLogisticLoss::project(std::size_t,
-                                        core::CDataFrame&,
-                                        const core::CPackedBitVector&,
-                                        std::size_t,
-                                        const TSizeVec&,
-                                        common::CPRNG::CXorOShiro128Plus) const {
+CMultinomialLogisticSubsetLoss::TLossUPtr
+CMultinomialLogisticSubsetLoss::project(std::size_t /*numberThreads*/,
+                                        core::CDataFrame& /*frame*/,
+                                        const core::CPackedBitVector& /*rowMask*/,
+                                        std::size_t /*targetColumn*/,
+                                        const TSizeVec& /*extrColumns*/,
+                                        common::CPRNG::CXorOShiro128Plus /*rng*/) const {
     return this->clone();
 }
 
-void CSubsetMultinomialLogisticLoss::gradient(const CEncodedDataFrameRowRef& /*row*/,
-                                              bool /*newExample*/,
-                                              const TMemoryMappedFloatVector& prediction,
+void CMultinomialLogisticSubsetLoss::gradient(const TMemoryMappedFloatVector& prediction,
                                               double actual,
                                               const TWriter& writer,
                                               double weight) const {
@@ -1860,11 +1864,12 @@ void CSubsetMultinomialLogisticLoss::gradient(const CEncodedDataFrameRowRef& /*r
     // We prefer an implementation which avoids any memory allocations.
 
     int actual_{static_cast<int>(actual)};
-    double zmax{prediction.maxCoeff()};
+
     double pEps{0.0};
     double logZ{0.0};
-    double logPAgg{0.0};
+    double pAgg{0.0};
     bool isActualIn{false};
+    double zmax{prediction.maxCoeff()};
     for (auto i : m_InClasses) {
         double pAdj{std::exp(prediction(i) - zmax)};
         // Sum the contributions from classes whose predicted probability
@@ -1875,19 +1880,19 @@ void CSubsetMultinomialLogisticLoss::gradient(const CEncodedDataFrameRowRef& /*r
     }
     for (auto i : m_OutClasses) {
         double pAdj{std::exp(prediction(i) - zmax)};
-        logPAgg += pAdj;
+        pAgg += pAdj;
     }
-    (logPAgg < EPSILON * logZ ? pEps : logZ) += logPAgg;
+    (pAgg < EPSILON * logZ ? pEps : logZ) += pAgg;
     pEps = common::CTools::stable(pEps / logZ);
     logZ = zmax + std::log(logZ);
-    logPAgg = zmax + std::log(logPAgg);
+    pAgg = common::CTools::stable(pAgg * std::exp(zmax - logZ)) /
+           static_cast<double>(m_OutClasses.size());
+    LOG_TRACE(<< "p(agg) = " << std::exp(logPAgg - logZ));
 
     for (std::size_t i = 0; i <= m_InClasses.size(); ++i) {
-        double pi{common::CTools::stableExp(
-            (i < m_InClasses.size() ? static_cast<double>(prediction(m_InClasses[i])) : logPAgg) -
-            logZ)};
-        bool isActual{i < m_InClasses.size() ? (m_InClasses[i] == actual_)
-                                             : (isActualIn == false)};
+        bool iAgg{i < m_InClasses.size()};
+        double pi{iAgg ? common::CTools::stableExp(prediction(m_InClasses[i]) - logZ) : pAgg};
+        bool isActual{iAgg ? (m_InClasses[i] == actual_) : (isActualIn == false)};
         if (isActual) {
             // We have that p = 1 / (1 + eps) and the gradient is p - 1.
             // Use a Taylor expansion and drop terms of O(eps^2) to get:
@@ -1898,9 +1903,7 @@ void CSubsetMultinomialLogisticLoss::gradient(const CEncodedDataFrameRowRef& /*r
     }
 }
 
-void CSubsetMultinomialLogisticLoss::curvature(const CEncodedDataFrameRowRef& /*row*/,
-                                               bool /*newExample*/,
-                                               const TMemoryMappedFloatVector& prediction,
+void CMultinomialLogisticSubsetLoss::curvature(const TMemoryMappedFloatVector& prediction,
                                                double /*actual*/,
                                                const TWriter& writer,
                                                double weight) const {
@@ -1909,10 +1912,10 @@ void CSubsetMultinomialLogisticLoss::curvature(const CEncodedDataFrameRowRef& /*
 
     // We prefer an implementation which avoids any memory allocations.
 
-    double zmax{prediction.maxCoeff()};
     double pEps{0.0};
     double logZ{0.0};
     double pAgg{0.0};
+    double zmax{prediction.maxCoeff()};
     for (auto i : m_InClasses) {
         double pAdj{std::exp(prediction(i) - zmax)};
         if (prediction(i) - zmax < LOG_EPSILON) {
@@ -1926,25 +1929,28 @@ void CSubsetMultinomialLogisticLoss::curvature(const CEncodedDataFrameRowRef& /*
     }
     for (auto i : m_OutClasses) {
         double pAdj{std::exp(prediction(i) - zmax)};
-        logZ += pAdj;
         pAgg += pAdj;
     }
-    pEps = common::CTools::stable((pEps + (pAgg < EPSILON * logZ ? pAgg : 0.0)) / logZ);
+    (pAgg < EPSILON * logZ ? pEps : logZ) += pAgg;
+    pEps = common::CTools::stable(pEps / logZ);
     logZ = zmax + common::CTools::stableLog(logZ);
-    pAgg = pAgg * common::CTools::stableExp(zmax - logZ);
+    pAgg = common::CTools::stable(pAgg * std::exp(zmax - logZ)) /
+           static_cast<double>(m_OutClasses.size());
+
+    auto probability = [&](std::size_t i) {
+        return i < m_InClasses.size()
+                   ? common::CTools::stableExp(prediction(m_InClasses[i]) - logZ)
+                   : pAgg;
+    };
 
     std::size_t k{0};
     for (std::size_t i = 0; i <= m_InClasses.size(); ++i) {
-        double pi{i < m_InClasses.size()
-                      ? common::CTools::stableExp(prediction(m_InClasses[i]) - logZ)
-                      : pAgg};
+        double pi{probability(i)};
         // We have that p = 1 / (1 + eps) and the curvature is p (1 - p).
         // Use a Taylor expansion and drop terms of O(eps^2) to get:
         writer(k++, weight * (pi == 1.0 ? pEps : pi * (1.0 - pi)));
         for (std::size_t j = i + 1; j <= m_InClasses.size(); ++j) {
-            double pij{pi * (j < m_InClasses.size()
-                                 ? common::CTools::stableExp(prediction(m_InClasses[j]) - logZ)
-                                 : pAgg)};
+            double pij{pi * probability(j)};
             writer(k++, -weight * pij);
         }
     }

--- a/lib/maths/analytics/CBoostedTreeLoss.cc
+++ b/lib/maths/analytics/CBoostedTreeLoss.cc
@@ -11,7 +11,9 @@
 
 #include <maths/analytics/CBoostedTreeLoss.h>
 
+#include <core/CDataFrame.h>
 #include <core/CPersistUtils.h>
+#include <core/Concurrency.h>
 
 #include <maths/analytics/CBoostedTreeUtils.h>
 #include <maths/analytics/CDataFrameCategoryEncoder.h>
@@ -25,13 +27,16 @@
 #include <maths/common/CTools.h>
 #include <maths/common/CToolsDetail.h>
 
+#include <algorithm>
 #include <exception>
 #include <limits>
+#include <memory>
 
 namespace ml {
 namespace maths {
 namespace analytics {
 using namespace boosted_tree_detail;
+using TRowItr = core::CDataFrame::TRowItr;
 
 namespace {
 const double EPSILON{100.0 * std::numeric_limits<double>::epsilon()};
@@ -867,9 +872,6 @@ CLoss::TLossUPtr CLoss::restoreLoss(core::CStateRestoreTraverser& traverser) {
         if (lossFunctionName == CMse::NAME) {
             return std::make_unique<CMse>(traverser);
         }
-        if (lossFunctionName == CMseIncremental::NAME) {
-            return std::make_unique<CMse>(traverser);
-        }
         if (lossFunctionName == CMsle::NAME) {
             return std::make_unique<CMsle>(traverser);
         }
@@ -878,9 +880,6 @@ CLoss::TLossUPtr CLoss::restoreLoss(core::CStateRestoreTraverser& traverser) {
         }
         if (lossFunctionName == CBinomialLogisticLoss::NAME) {
             return std::make_unique<CBinomialLogisticLoss>(traverser);
-        }
-        if (lossFunctionName == CBinomialLogisticLossIncremental::NAME) {
-            return std::make_unique<CMse>(traverser);
         }
         if (lossFunctionName == CMultinomialLogisticLoss::NAME) {
             return std::make_unique<CMultinomialLogisticLoss>(traverser);
@@ -950,11 +949,24 @@ CMse::TLossUPtr CMse::incremental(double eta, double mu, const TNodeVec& tree) c
     return std::make_unique<CMseIncremental>(eta, mu, tree);
 }
 
+CMse::TLossUPtr CMse::project(std::size_t,
+                              core::CDataFrame&,
+                              const core::CPackedBitVector&,
+                              std::size_t,
+                              const TSizeVec&,
+                              common::CPRNG::CXorOShiro128Plus) const {
+    return this->clone();
+}
+
 ELossType CMse::type() const {
     return E_MseRegression;
 }
 
-std::size_t CMse::numberParameters() const {
+std::size_t CMse::dimensionPrediction() const {
+    return 1;
+}
+
+std::size_t CMse::dimensionGradient() const {
     return 1;
 }
 
@@ -1011,12 +1023,6 @@ bool CMse::acceptRestoreTraverser(core::CStateRestoreTraverser& /* traverser */)
 
 const std::string CMse::NAME{"mse"};
 
-CMseIncremental::CMseIncremental(core::CStateRestoreTraverser&) {
-    // We purposely don't persist and restore the state since this only exists
-    // temporarily between persistence events.
-    throw std::runtime_error{"restore is not supported for CMseIncremental"};
-}
-
 CMseIncremental::CMseIncremental(double eta, double mu, const TNodeVec& tree)
     : m_Eta{eta}, m_Mu{mu}, m_Tree{&tree} {
 }
@@ -1030,11 +1036,24 @@ CMseIncremental::incremental(double eta, double mu, const TNodeVec& tree) const 
     return std::make_unique<CMseIncremental>(eta, mu, tree);
 }
 
+CMseIncremental::TLossUPtr CMseIncremental::project(std::size_t,
+                                                    core::CDataFrame&,
+                                                    const core::CPackedBitVector&,
+                                                    std::size_t,
+                                                    const TSizeVec&,
+                                                    common::CPRNG::CXorOShiro128Plus) const {
+    return this->clone();
+}
+
 ELossType CMseIncremental::type() const {
     return E_MseRegression;
 }
 
-std::size_t CMseIncremental::numberParameters() const {
+std::size_t CMseIncremental::dimensionPrediction() const {
+    return 1;
+}
+
+std::size_t CMseIncremental::dimensionGradient() const {
     return 1;
 }
 
@@ -1115,10 +1134,6 @@ CMsle::CMsle(core::CStateRestoreTraverser& traverser) {
     }
 }
 
-ELossType CMsle::type() const {
-    return E_MsleRegression;
-}
-
 CMsle::TLossUPtr CMsle::clone() const {
     return std::make_unique<CMsle>(*this);
 }
@@ -1127,7 +1142,24 @@ CMsle::TLossUPtr CMsle::incremental(double, double, const TNodeVec&) const {
     return nullptr;
 }
 
-std::size_t CMsle::numberParameters() const {
+CMsle::TLossUPtr CMsle::project(std::size_t,
+                                core::CDataFrame&,
+                                const core::CPackedBitVector&,
+                                std::size_t,
+                                const TSizeVec&,
+                                common::CPRNG::CXorOShiro128Plus) const {
+    return this->clone();
+}
+
+ELossType CMsle::type() const {
+    return E_MsleRegression;
+}
+
+std::size_t CMsle::dimensionPrediction() const {
+    return 1;
+}
+
+std::size_t CMsle::dimensionGradient() const {
     return 1;
 }
 
@@ -1223,10 +1255,6 @@ CPseudoHuber::CPseudoHuber(core::CStateRestoreTraverser& traverser) {
     }
 }
 
-ELossType CPseudoHuber::type() const {
-    return E_HuberRegression;
-}
-
 CPseudoHuber::TLossUPtr CPseudoHuber::clone() const {
     return std::make_unique<CPseudoHuber>(*this);
 }
@@ -1235,7 +1263,24 @@ CPseudoHuber::TLossUPtr CPseudoHuber::incremental(double, double, const TNodeVec
     return nullptr;
 }
 
-std::size_t CPseudoHuber::numberParameters() const {
+CPseudoHuber::TLossUPtr CPseudoHuber::project(std::size_t,
+                                              core::CDataFrame&,
+                                              const core::CPackedBitVector&,
+                                              std::size_t,
+                                              const TSizeVec&,
+                                              common::CPRNG::CXorOShiro128Plus) const {
+    return this->clone();
+}
+
+ELossType CPseudoHuber::type() const {
+    return E_HuberRegression;
+}
+
+std::size_t CPseudoHuber::dimensionPrediction() const {
+    return 1;
+}
+
+std::size_t CPseudoHuber::dimensionGradient() const {
     return 1;
 }
 
@@ -1328,11 +1373,25 @@ CBinomialLogisticLoss::incremental(double eta, double mu, const TNodeVec& tree) 
     return std::make_unique<CBinomialLogisticLossIncremental>(eta, mu, tree);
 }
 
+CBinomialLogisticLoss::TLossUPtr
+CBinomialLogisticLoss::project(std::size_t,
+                               core::CDataFrame&,
+                               const core::CPackedBitVector&,
+                               std::size_t,
+                               const TSizeVec&,
+                               common::CPRNG::CXorOShiro128Plus) const {
+    return this->clone();
+}
+
 ELossType CBinomialLogisticLoss::type() const {
     return E_BinaryClassification;
 }
 
-std::size_t CBinomialLogisticLoss::numberParameters() const {
+std::size_t CBinomialLogisticLoss::dimensionPrediction() const {
+    return 1;
+}
+
+std::size_t CBinomialLogisticLoss::dimensionGradient() const {
     return 1;
 }
 
@@ -1415,12 +1474,6 @@ CBinomialLogisticLossIncremental::CBinomialLogisticLossIncremental(double eta,
     : m_Eta{eta}, m_Mu{mu}, m_Tree{&tree} {
 }
 
-CBinomialLogisticLossIncremental::CBinomialLogisticLossIncremental(core::CStateRestoreTraverser&) {
-    // We purposely don't persist and restore the state since this only exists
-    // temporarily between persistence events.
-    throw std::runtime_error{"restore is not supported for CBinomialLogisticLossIncremental"};
-}
-
 CBinomialLogisticLossIncremental::TLossUPtr CBinomialLogisticLossIncremental::clone() const {
     return std::make_unique<CBinomialLogisticLossIncremental>(*this);
 }
@@ -1430,11 +1483,25 @@ CBinomialLogisticLossIncremental::incremental(double eta, double mu, const TNode
     return std::make_unique<CBinomialLogisticLossIncremental>(eta, mu, tree);
 }
 
+CBinomialLogisticLossIncremental::TLossUPtr
+CBinomialLogisticLossIncremental::project(std::size_t,
+                                          core::CDataFrame&,
+                                          const core::CPackedBitVector&,
+                                          std::size_t,
+                                          const TSizeVec&,
+                                          common::CPRNG::CXorOShiro128Plus) const {
+    return this->clone();
+}
+
 ELossType CBinomialLogisticLossIncremental::type() const {
     return E_BinaryClassification;
 }
 
-std::size_t CBinomialLogisticLossIncremental::numberParameters() const {
+std::size_t CBinomialLogisticLossIncremental::dimensionPrediction() const {
+    return 1;
+}
+
+std::size_t CBinomialLogisticLossIncremental::dimensionGradient() const {
     return 1;
 }
 
@@ -1541,68 +1608,116 @@ CMultinomialLogisticLoss::incremental(double, double, const TNodeVec&) const {
     return nullptr;
 }
 
+CMultinomialLogisticLoss::TLossUPtr
+CMultinomialLogisticLoss::project(std::size_t numberThreads,
+                                  core::CDataFrame& frame,
+                                  const core::CPackedBitVector& rowMask,
+                                  std::size_t targetColumn,
+                                  const TSizeVec& extraColumns,
+                                  common::CPRNG::CXorOShiro128Plus rng) const {
+    if (MAX_GRADIENT_DIMENSION < m_NumberClasses) {
+        return this->clone();
+    }
+
+    // Compute total loss over masked rows.
+    auto result =
+        frame
+            .readRows(
+                numberThreads, 0, frame.numberRows(),
+                core::bindRetrievableState(
+                    [&](TDoubleVec& losses, const TRowItr& beginRows, const TRowItr& endRows) {
+                        for (auto row = beginRows; row != endRows; ++row) {
+                            auto prediction = readPrediction(*row, extraColumns, m_NumberClasses);
+                            double actual{readActual(*row, targetColumn)};
+                            double weight{readExampleWeight(*row, extraColumns)};
+                            losses[static_cast<int>(actual)] +=
+                                this->value(prediction, actual, weight);
+                        }
+                    },
+                    TDoubleVec(m_NumberClasses, 0.0)),
+                &rowMask)
+            .first;
+
+    auto losses = std::move(result[0].s_FunctionState);
+    for (std::size_t i = 1; i < result.size(); ++i) {
+        for (std::size_t j = 1; j < losses.size(); ++j) {
+            losses[j] += result[i].s_FunctionState[j];
+        }
+    }
+
+    TSizeVec classes;
+    common::CSampling::categoricalSampleWithoutReplacement(
+        rng, losses, MAX_GRADIENT_DIMENSION - 1, classes);
+    std::sort(classes.begin(), classes.end());
+
+    return std::make_unique<CSubsetMultinomialLogisticLoss>(m_NumberClasses, classes);
+}
+
 ELossType CMultinomialLogisticLoss::type() const {
     return E_MulticlassClassification;
 }
 
-std::size_t CMultinomialLogisticLoss::numberParameters() const {
+std::size_t CMultinomialLogisticLoss::dimensionPrediction() const {
     return m_NumberClasses;
 }
 
-double CMultinomialLogisticLoss::value(const TMemoryMappedFloatVector& predictions,
+std::size_t CMultinomialLogisticLoss::dimensionGradient() const {
+    return std::min(m_NumberClasses, MAX_GRADIENT_DIMENSION);
+}
+
+double CMultinomialLogisticLoss::value(const TMemoryMappedFloatVector& prediction,
                                        double actual,
                                        double weight) const {
-    double zmax{predictions.maxCoeff()};
+    double zmax{prediction.maxCoeff()};
     double logZ{0.0};
-    for (int i = 0; i < predictions.size(); ++i) {
-        logZ += std::exp(predictions(i) - zmax);
+    for (int i = 0; i < prediction.size(); ++i) {
+        logZ += std::exp(prediction(i) - zmax);
     }
     logZ = zmax + common::CTools::stableLog(logZ);
 
     // i.e. -log(z(actual))
-    return weight * (logZ - predictions(static_cast<std::size_t>(actual)));
+    return weight * (logZ - prediction(static_cast<int>(actual)));
 }
 
-void CMultinomialLogisticLoss::gradient(const TMemoryMappedFloatVector& predictions,
+void CMultinomialLogisticLoss::gradient(const TMemoryMappedFloatVector& prediction,
                                         double actual,
                                         const TWriter& writer,
                                         double weight) const {
 
     // We prefer an implementation which avoids any memory allocations.
 
-    double zmax{predictions.maxCoeff()};
-    double eps{0.0};
+    double zmax{prediction.maxCoeff()};
+    double pEps{0.0};
     double logZ{0.0};
-    for (int i = 0; i < predictions.size(); ++i) {
-        if (predictions(i) - zmax < LOG_EPSILON) {
+    for (int i = 0; i < prediction.size(); ++i) {
+        if (prediction(i) - zmax < LOG_EPSILON) {
             // Sum the contributions from classes whose predicted probability
             // is less than epsilon, for which we'd lose all nearly precision
             // when adding to the normalisation coefficient.
-            eps += std::exp(predictions(i) - zmax);
-        } else {
-            logZ += std::exp(predictions(i) - zmax);
+            pEps += std::exp(prediction(i) - zmax);
         }
+        logZ += std::exp(prediction(i) - zmax);
     }
-    eps = common::CTools::stable(eps);
+    pEps = common::CTools::stable(pEps / logZ);
     logZ = zmax + common::CTools::stableLog(logZ);
 
-    for (int i = 0; i < predictions.size(); ++i) {
+    for (int i = 0; i < prediction.size(); ++i) {
+        double p{common::CTools::stableExp(prediction(i) - logZ)};
         if (i == static_cast<int>(actual)) {
-            double probability{common::CTools::stableExp(predictions(i) - logZ)};
-            if (probability == 1.0) {
+            if (p == 1.0) {
                 // We have that p = 1 / (1 + eps) and the gradient is p - 1.
                 // Use a Taylor expansion and drop terms of O(eps^2) to get:
-                writer(i, -weight * eps);
+                writer(i, -weight * pEps);
             } else {
-                writer(i, weight * (probability - 1.0));
+                writer(i, weight * (p - 1.0));
             }
         } else {
-            writer(i, weight * common::CTools::stableExp(predictions(i) - logZ));
+            writer(i, weight * p);
         }
     }
 }
 
-void CMultinomialLogisticLoss::curvature(const TMemoryMappedFloatVector& predictions,
+void CMultinomialLogisticLoss::curvature(const TMemoryMappedFloatVector& prediction,
                                          double /*actual*/,
                                          const TWriter& writer,
                                          double weight) const {
@@ -1611,35 +1726,34 @@ void CMultinomialLogisticLoss::curvature(const TMemoryMappedFloatVector& predict
 
     // We prefer an implementation which avoids any memory allocations.
 
-    double zmax{predictions.maxCoeff()};
-    double eps{0.0};
+    double zmax{prediction.maxCoeff()};
+    double pEps{0.0};
     double logZ{0.0};
-    for (int i = 0; i < predictions.size(); ++i) {
-        if (predictions(i) - zmax < LOG_EPSILON) {
+    for (int i = 0; i < prediction.size(); ++i) {
+        double pAdj{std::exp(prediction(i) - zmax)};
+        if (prediction(i) - zmax < LOG_EPSILON) {
             // Sum the contributions from classes whose predicted probability
             // is less than epsilon, for which we'd lose all nearly precision
             // when adding to the normalisation coefficient.
-            eps += std::exp(predictions(i) - zmax);
-        } else {
-            logZ += std::exp(predictions(i) - zmax);
+            pEps += pAdj;
         }
+        logZ += std::exp(prediction(i) - zmax);
     }
-    eps = common::CTools::stable(eps);
+    pEps = common::CTools::stable(pEps / logZ);
     logZ = zmax + common::CTools::stableLog(logZ);
 
-    for (std::size_t i = 0, k = 0; i < m_NumberClasses; ++i) {
-        double probability{common::CTools::stableExp(predictions(i) - logZ)};
-        if (probability == 1.0) {
+    for (int i = 0, k = 0; i < prediction.size(); ++i) {
+        double pi{common::CTools::stableExp(prediction(i) - logZ)};
+        if (pi == 1.0) {
             // We have that p = 1 / (1 + eps) and the curvature is p (1 - p).
             // Use a Taylor expansion and drop terms of O(eps^2) to get:
-            writer(k++, weight * eps);
+            writer(k++, weight * pEps);
         } else {
-            writer(k++, weight * probability * (1.0 - probability));
+            writer(k++, weight * pi * (1.0 - pi));
         }
-        for (std::size_t j = i + 1; j < m_NumberClasses; ++j) {
-            double probabilities[]{common::CTools::stableExp(predictions(i) - logZ),
-                                   common::CTools::stableExp(predictions(j) - logZ)};
-            writer(k++, -weight * probabilities[0] * probabilities[1]);
+        for (int j = i + 1; j < prediction.size(); ++j) {
+            double pij{common::CTools::stableExp(prediction(i) + prediction(j) - 2.0 * logZ)};
+            writer(k++, -weight * pij);
         }
     }
 }
@@ -1648,23 +1762,23 @@ bool CMultinomialLogisticLoss::isCurvatureConstant() const {
     return false;
 }
 
-double CMultinomialLogisticLoss::difference(const TMemoryMappedFloatVector& predictions,
-                                            const TMemoryMappedFloatVector& previousPredictions,
+double CMultinomialLogisticLoss::difference(const TMemoryMappedFloatVector& prediction,
+                                            const TMemoryMappedFloatVector& previousPrediction,
                                             double weight) const {
 
     // The cross entropy of the new predicted probabilities given the previous ones.
 
-    double zmax{predictions.maxCoeff()};
+    double zmax{prediction.maxCoeff()};
     double logZ{0.0};
-    for (int i = 0; i < predictions.size(); ++i) {
-        logZ += std::exp(predictions(i) - zmax);
+    for (int i = 0; i < prediction.size(); ++i) {
+        logZ += std::exp(prediction(i) - zmax);
     }
     logZ = zmax + common::CTools::stableLog(logZ);
 
     double result{0};
-    auto previousProbabilities = this->transform(previousPredictions);
-    for (int i = 0; i < predictions.size(); ++i) {
-        result += previousProbabilities(i) * (logZ - predictions(i));
+    auto previousProbabilities = this->transform(previousPrediction);
+    for (int i = 0; i < prediction.size(); ++i) {
+        result += previousProbabilities(i) * (logZ - prediction(i));
     }
 
     return weight * result;
@@ -1705,6 +1819,155 @@ bool CMultinomialLogisticLoss::acceptRestoreTraverser(core::CStateRestoreTravers
 }
 
 const std::string CMultinomialLogisticLoss::NAME{"multinomial_logistic"};
+
+CSubsetMultinomialLogisticLoss::CSubsetMultinomialLogisticLoss(std::size_t numberClasses,
+                                                               const TSizeVec& classes)
+    : CMultinomialLogisticLoss{numberClasses} {
+    m_InClasses.reserve(classes.size());
+    for (auto i : classes) {
+        m_InClasses.push_back(static_cast<int>(i));
+    }
+    m_OutClasses.resize(numberClasses - classes.size());
+    std::iota(m_OutClasses.begin(), m_OutClasses.end(), 0);
+    m_OutClasses.erase(std::set_difference(m_OutClasses.begin(), m_OutClasses.end(),
+                                           m_InClasses.begin(), m_InClasses.end(),
+                                           m_OutClasses.begin()),
+                       m_OutClasses.end());
+}
+
+CSubsetMultinomialLogisticLoss::TLossUPtr CSubsetMultinomialLogisticLoss::clone() const {
+    return std::make_unique<CSubsetMultinomialLogisticLoss>(*this);
+}
+
+CSubsetMultinomialLogisticLoss::TLossUPtr
+CSubsetMultinomialLogisticLoss::incremental(double, double, const TNodeVec&) const {
+    return nullptr;
+}
+
+CSubsetMultinomialLogisticLoss::TLossUPtr
+CSubsetMultinomialLogisticLoss::project(std::size_t,
+                                        core::CDataFrame&,
+                                        const core::CPackedBitVector&,
+                                        std::size_t,
+                                        const TSizeVec&,
+                                        common::CPRNG::CXorOShiro128Plus) const {
+    return this->clone();
+}
+
+void CSubsetMultinomialLogisticLoss::gradient(const CEncodedDataFrameRowRef& /*row*/,
+                                              bool /*newExample*/,
+                                              const TMemoryMappedFloatVector& prediction,
+                                              double actual,
+                                              const TWriter& writer,
+                                              double weight) const {
+
+    // We prefer an implementation which avoids any memory allocations.
+
+    int actual_{static_cast<int>(actual)};
+    double zmax{prediction.maxCoeff()};
+    double pEps{0.0};
+    double logZ{0.0};
+    double logPAgg{0.0};
+    bool usePAgg{false};
+    for (auto i : m_InClasses) {
+        double pAdj{std::exp(prediction(i) - zmax)};
+        if (prediction(i) - zmax < LOG_EPSILON) {
+            // Sum the contributions from classes whose predicted probability
+            // is less than epsilon, for which we'd lose all nearly precision
+            // when adding to the normalisation coefficient.
+            pEps += pAdj;
+        }
+        logZ += pAdj;
+    }
+    for (auto i : m_OutClasses) {
+        double pAdj{std::exp(prediction(i) - zmax)};
+        logZ += pAdj;
+        logPAgg += pAdj;
+        usePAgg |= (actual_ == i);
+    }
+    pEps = common::CTools::stable((pEps + (logPAgg < EPSILON * logZ ? logPAgg : 0.0)) / logZ);
+    logZ = zmax + std::log(logZ);
+    logPAgg = zmax + std::log(logPAgg);
+
+    for (int i = 0; i < prediction.size(); ++i) {
+        double p{common::CTools::stableExp(
+            (usePAgg ? logPAgg : static_cast<double>(prediction(i))) - logZ)};
+        if (i == actual_) {
+            if (p == 1.0) {
+                // We have that p = 1 / (1 + eps) and the gradient is p - 1.
+                // Use a Taylor expansion and drop terms of O(eps^2) to get:
+                writer(i, -weight * pEps);
+            } else {
+                writer(i, weight * (p - 1.0));
+            }
+        } else {
+            writer(i, weight * p);
+        }
+    }
+}
+
+void CSubsetMultinomialLogisticLoss::curvature(const CEncodedDataFrameRowRef& /*row*/,
+                                               bool /*newExample*/,
+                                               const TMemoryMappedFloatVector& prediction,
+                                               double /*actual*/,
+                                               const TWriter& writer,
+                                               double weight) const {
+
+    // Return the lower triangle of the Hessian column major.
+
+    // We prefer an implementation which avoids any memory allocations.
+
+    double zmax{prediction.maxCoeff()};
+    double pEps{0.0};
+    double logZ{0.0};
+    double pAgg{0.0};
+    for (auto i : m_InClasses) {
+        double pAdj{std::exp(prediction(i) - zmax)};
+        if (prediction(i) - zmax < LOG_EPSILON) {
+            // Sum the contributions from classes whose predicted probability
+            // is less than epsilon, for which we'd lose all nearly precision
+            // when adding to the normalisation coefficient.
+            pEps += pAdj;
+        }
+        logZ += pAdj;
+    }
+    for (auto i : m_OutClasses) {
+        double pAdj{std::exp(prediction(i) - zmax)};
+        logZ += pAdj;
+        pAgg += pAdj;
+    }
+    pEps = common::CTools::stable((pEps + (pAgg < EPSILON * logZ ? pAgg : 0.0)) / logZ);
+    logZ = zmax + common::CTools::stableLog(logZ);
+    pAgg = pAgg * common::CTools::stableExp(zmax - logZ);
+
+    auto in1 = m_InClasses.begin();
+    for (int i = 0, k = 0; i < prediction.size(); ++i) {
+
+        double pi{pAgg};
+        if (in1 != m_InClasses.end() && *in1 == i) {
+            pi = common::CTools::stableExp(prediction(i) - logZ);
+            ++in1;
+        }
+        if (pi == 1.0) {
+            // We have that p = 1 / (1 + eps) and the curvature is p (1 - p).
+            // Use a Taylor expansion and drop terms of O(eps^2) to get:
+            writer(k++, weight * pEps);
+        } else {
+            writer(k++, weight * pi * (1.0 - pi));
+        }
+        auto in2 = in1;
+        for (int j = i + 1; j < prediction.size(); ++j) {
+            double pij{pi};
+            if (in2 != m_InClasses.end() && *in2 == j) {
+                pij *= common::CTools::stableExp(prediction(j) - logZ);
+                ++in2;
+            } else {
+                pij *= pAgg;
+            }
+            writer(k++, -weight * pij);
+        }
+    }
+}
 }
 }
 }

--- a/lib/maths/analytics/CBoostedTreeUtils.cc
+++ b/lib/maths/analytics/CBoostedTreeUtils.cc
@@ -82,32 +82,32 @@ CBoostedTreeNode& root(std::vector<CBoostedTreeNode>& tree) {
     return tree[rootIndex()];
 }
 
-void zeroPrediction(const TRowRef& row, const TSizeVec& extraColumns, std::size_t numberLossParameters) {
-    for (std::size_t i = 0; i < numberLossParameters; ++i) {
+void zeroPrediction(const TRowRef& row, const TSizeVec& extraColumns, std::size_t dimensionPrediction) {
+    for (std::size_t i = 0; i < dimensionPrediction; ++i) {
         row.writeColumn(extraColumns[E_Prediction] + i, 0.0);
     }
 }
 
 void writePrediction(const TRowRef& row,
                      const TSizeVec& extraColumns,
-                     std::size_t numberLossParameters,
+                     std::size_t dimensionPrediction,
                      const TMemoryMappedFloatVector& value) {
-    for (std::size_t i = 0; i < numberLossParameters; ++i) {
+    for (std::size_t i = 0; i < dimensionPrediction; ++i) {
         row.writeColumn(extraColumns[E_Prediction] + i, value(i));
     }
 }
 
 void writePreviousPrediction(const TRowRef& row,
                              const TSizeVec& extraColumns,
-                             std::size_t numberLossParameters,
+                             std::size_t dimensionPrediction,
                              const TMemoryMappedFloatVector& value) {
-    for (std::size_t i = 0; i < numberLossParameters; ++i) {
+    for (std::size_t i = 0; i < dimensionPrediction; ++i) {
         row.writeColumn(extraColumns[E_PreviousPrediction] + i, value(i));
     }
 }
 
-void zeroLossGradient(const TRowRef& row, const TSizeVec& extraColumns, std::size_t numberLossParameters) {
-    for (std::size_t i = 0; i < numberLossParameters; ++i) {
+void zeroLossGradient(const TRowRef& row, const TSizeVec& extraColumns, std::size_t dimensionGradient) {
+    for (std::size_t i = 0; i < dimensionGradient; ++i) {
         row.writeColumn(extraColumns[E_Gradient] + i, 0.0);
     }
 }
@@ -129,8 +129,8 @@ void writeLossGradient(const TRowRef& row,
                   [&writer](std::size_t i, double value) { writer(i, value); }, weight);
 }
 
-void zeroLossCurvature(const TRowRef& row, const TSizeVec& extraColumns, std::size_t numberLossParameters) {
-    for (std::size_t i = 0, size = lossHessianUpperTriangleSize(numberLossParameters);
+void zeroLossCurvature(const TRowRef& row, const TSizeVec& extraColumns, std::size_t dimensionGradient) {
+    for (std::size_t i = 0, size = lossHessianUpperTriangleSize(dimensionGradient);
          i < size; ++i) {
         row.writeColumn(extraColumns[E_Curvature] + i, 0.0);
     }

--- a/lib/maths/analytics/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeLeafNodeStatisticsTest.cc
@@ -335,11 +335,11 @@ TFloatVecVec generateCandidateSplits(const TSizeVec& numberCandidateSplits) {
 
 TSplitsDerivatives generateSplitsDerivatives(test::CRandomNumbers& rng,
                                              const TSizeVec& numberCandidateSplits,
-                                             std::size_t numberLossParameters) {
+                                             std::size_t dimensionGradient) {
 
     TFloatVecVec candidateSplits(generateCandidateSplits(numberCandidateSplits));
 
-    TSplitsDerivatives derivatives{candidateSplits, numberLossParameters};
+    TSplitsDerivatives derivatives{candidateSplits, dimensionGradient};
     derivatives.zero();
 
     TAlignedFloatVec values;
@@ -347,8 +347,8 @@ TSplitsDerivatives generateSplitsDerivatives(test::CRandomNumbers& rng,
     for (std::size_t i = 0; i < numberCandidateSplits.size(); ++i) {
         for (std::size_t j = 0; j < numberCandidateSplits[i]; ++j) {
             rng.generateUniformSamples(
-                0.0, 1.0, numberLossParameters * (numberLossParameters + 3) / 2, values_);
-            for (std::size_t k = numberLossParameters, l = numberLossParameters;
+                0.0, 1.0, dimensionGradient * (dimensionGradient + 3) / 2, values_);
+            for (std::size_t k = dimensionGradient, l = dimensionGradient;
                  l > 0; k += l, --l) {
                 values_[k] += 2.0;
             }
@@ -356,8 +356,8 @@ TSplitsDerivatives generateSplitsDerivatives(test::CRandomNumbers& rng,
             derivatives.addDerivatives(
                 i, j,
                 maths::analytics::CBoostedTreeLeafNodeStatistics::TMemoryMappedFloatVector{
-                    values.data(), static_cast<int>((numberLossParameters *
-                                                     (numberLossParameters + 3) / 2))});
+                    values.data(),
+                    static_cast<int>((dimensionGradient * (dimensionGradient + 3) / 2))});
         }
     }
 

--- a/lib/maths/analytics/unittest/CBoostedTreeLossTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeLossTest.cc
@@ -796,7 +796,8 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticLossForUnderflow) {
         logits(1.0 - std::log(eps), storage[0]);
         logits(1.0 + std::log(eps), storage[1]);
 
-        TMemoryMappedFloatVector predictions[]{{&storage[0][0], 2}, {&storage[1][0], 2}};
+        TMemoryMappedFloatVector predictions[]{{storage[0].data(), 2},
+                                               {storage[1].data(), 2}};
         TDoubleVec previousLoss{loss.value(predictions[0], 0.0),
                                 loss.value(predictions[1], 1.0)};
 
@@ -819,8 +820,8 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticLossForUnderflow) {
             TFloatVec storage[2];
             logits(prediction + std::log(eps), storage[0]);
             logits(prediction - std::log(eps), storage[1]);
-            TMemoryMappedFloatVector predictions[]{{&storage[0][0], 2},
-                                                   {&storage[1][0], 2}};
+            TMemoryMappedFloatVector predictions[]{{storage[0].data(), 2},
+                                                   {storage[1].data(), 2}};
             loss.gradient(predictions[0], 0.0, [&](std::size_t i, double value) {
                 gradients[0][i] = value;
             });

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -2282,14 +2282,14 @@ BOOST_AUTO_TEST_CASE(testBinomialLogisticRegression) {
                 }
             }
         });
-        LOG_DEBUG(<< "log relative error = "
+        LOG_DEBUG(<< "KL divergence = "
                   << maths::common::CBasicStatistics::mean(klDivergence));
 
-        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(klDivergence) < 0.05);
+        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(klDivergence) < 0.06);
         meanKlDivergence.add(maths::common::CBasicStatistics::mean(klDivergence));
     }
 
-    LOG_DEBUG(<< "mean log relative error = "
+    LOG_DEBUG(<< "mean KL divergence = "
               << maths::common::CBasicStatistics::mean(meanKlDivergence));
     BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanKlDivergence) < 0.04);
 }
@@ -2841,14 +2841,14 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {
                 }
             }
         });
-        LOG_DEBUG(<< "log relative error = "
+        LOG_DEBUG(<< "KL divergence = "
                   << maths::common::CBasicStatistics::mean(klDivergence));
 
         BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(klDivergence) < 0.16);
         meanKLDivergence.add(maths::common::CBasicStatistics::mean(klDivergence));
     }
 
-    LOG_DEBUG(<< "mean log relative error = "
+    LOG_DEBUG(<< "mean KL divergence = "
               << maths::common::CBasicStatistics::mean(meanKLDivergence));
     BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanKLDivergence) < 0.12);
 }
@@ -2861,18 +2861,16 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegressionForManyClasses,
     maths::common::CPRNG::CXorOShiro128Plus rng;
     test::CRandomNumbers testRng;
 
-    std::size_t trainRows{800};
-    std::size_t rows{1000};
+    std::size_t trainRows{1800};
+    std::size_t rows{2000};
     std::size_t cols{20};
     int numberClasses{30};
     int numberFeatures{static_cast<int>(cols - 1)};
 
     TDoubleVec weights;
     TDoubleVec noise;
-    TDoubleVec uniform01;
     testRng.generateUniformSamples(-2.0, 2.0, numberClasses * numberFeatures, weights);
-    testRng.generateNormalSamples(0.0, 1.0, numberFeatures * rows, noise);
-    testRng.generateUniformSamples(0.0, 1.0, rows, uniform01);
+    testRng.generateNormalSamples(0.0, 0.2, numberFeatures * rows, noise);
     auto probability = [&](const TRowRef& row) {
         TMemoryMappedMatrix W(weights.data(), numberClasses, numberFeatures);
         TVector x(numberFeatures);
@@ -2907,10 +2905,6 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegressionForManyClasses,
     auto classifier =
         maths::analytics::CBoostedTreeFactory::constructFromParameters(
             1, std::make_unique<maths::analytics::boosted_tree::CMultinomialLogisticLoss>(numberClasses))
-            .maximumNumberTrees(100)
-            .softTreeDepthLimit({5})
-            .eta({0.05})
-            .featureBagFraction({0.7})
             .buildForTrain(*frame, cols - 1);
 
     classifier->train();
@@ -2931,9 +2925,8 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegressionForManyClasses,
         }
     });
 
-    LOG_DEBUG(<< "log relative error = "
-              << maths::common::CBasicStatistics::mean(klDivergence));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(klDivergence) < 0.45);
+    LOG_DEBUG(<< "KL divergence = " << maths::common::CBasicStatistics::mean(klDivergence));
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(klDivergence) < 0.27);
 }
 
 BOOST_AUTO_TEST_CASE(testEstimateMemory) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -2853,7 +2853,7 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {
     BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(meanKLDivergence) < 0.12);
 }
 
-BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegressionManyClasses,
+BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegressionForManyClasses,
                      *boost::unit_test::disabled()) {
 
     // This is too slow to run as part of regular testing.
@@ -2933,7 +2933,7 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegressionManyClasses,
 
     LOG_DEBUG(<< "log relative error = "
               << maths::common::CBasicStatistics::mean(klDivergence));
-    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(klDivergence) < 0.42);
+    BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(klDivergence) < 0.45);
 }
 
 BOOST_AUTO_TEST_CASE(testEstimateMemory) {

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -2938,7 +2938,7 @@ BOOST_AUTO_TEST_CASE(testEstimateMemory) {
         LOG_DEBUG(<< "Train...");
 
         extraCols = maths::analytics::CBoostedTreeFactory::estimateExtraColumnsForTrain(
-            cols, 1);
+            cols, 1 /*dimension predictions*/, 1 /*dimension gradients*/);
         estimatedMemory =
             core::CDataFrame::estimateMemoryUsage(true, rows, cols + extraCols,
                                                   core::CAlignment::E_Aligned16) +
@@ -2965,7 +2965,7 @@ BOOST_AUTO_TEST_CASE(testEstimateMemory) {
         LOG_DEBUG(<< "Train incremental...");
 
         extraCols = maths::analytics::CBoostedTreeFactory::estimateExtraColumnsForTrainIncremental(
-            cols, 1);
+            cols, 1 /*dimension predictions*/, 1 /*dimension gradients*/);
         estimatedMemory =
             core::CDataFrame::estimateMemoryUsage(true, rows, cols + extraCols,
                                                   core::CAlignment::E_Aligned16) +


### PR DESCRIPTION
This addresses the bottleneck preventing us from increasing the maximum number of distinct classes we'll support and raises the limit from 30 to 100.

The issue is computing the hessian which scales like `n(n+1)/2` for `n` distinct classes. Here I've taken the approach of targeting just the classes which satisfy `arg top-k_{c \in C}{ \sum_i 1{c_i = c} loss(p_i, c_i) }` where `p_i` are the prediction probabilities for the i'th example, `c_i` is the true class, `C` is the set of all classes and `1{.}` denotes the indicator function, when computing best splits. This limits the hessian to `k(k+1)/2` and I've capped `k` at 20. We simply lump all classes not selected into a hold all other class when we chose the best splits and compute the expected derivatives of the loss for them. However, since we choose classes afresh for each round of boosting, we should still find splits which discriminate between all classes in the forest as a whole.

I tested this on synthetic data with 30 and 40 classes generated by the distribution `p = softmax(W x + n)` for `x` the features, `n` noise and `p` the class probabilities (see testMultinomialLogisticRegressionForManyClasses). Since I reduced `k` the maximum number of classes we consider per tree to 20 both are in the approximation regime. For the "old" case with 40 classes I increased the threshold. The results for the test data are as follows:

 approach | # classes|runtime /s | KL vs generating distribution
---- | ---- | ---- | ----
old | 30 | 450 | 0.31
old | 40 | 1954 | 0.67
new | 30 | 285 | 0.27
new | 40 | 550 | 0.66

Note that lower KL divergence is better so these represent a win for both runtime and accuracy.

This closes #2246.