### PR TITLE
[ML] Don't keep categorization tokens when existing category matches

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -37,6 +37,12 @@
 * Increase the limit on the maximum number of classes to 100 for training classification
   models. (See {ml-pull}2395[#2395] issue: {ml-issue}2246[#2246].)
 
+== {es} version 8.4.2
+
+=== Bug Fixes
+
+* Do not retain categorization tokens when existing category matches. (See {ml-pull}2398[#2398].)
+
 == {es} version 8.4.0
 
 === Enhancements

--- a/include/model/CTokenListDataCategorizerBase.h
+++ b/include/model/CTokenListDataCategorizerBase.h
@@ -262,6 +262,12 @@ protected:
     //! being seen for the first time)
     std::size_t idForToken(const std::string& token);
 
+    //! Discard the most recently added tokens from the token to ID map.
+    //! This must only be called if the caller is certain that none of
+    //! the tokens that will be discarded are referenced in any other part
+    //! of the categorizer state.
+    void discardLatestTokens(std::size_t previousTokenCount);
+
     //! Is the category considered rare?
     bool isCategoryCountRare(std::size_t count) const;
 


### PR DESCRIPTION
In categorization, when a new message matches an existing category
we don't need to keep a record of any new distinct tokens found in
the new message, as the category definition doesn't need them.

We used to store all unique tokens ever seen, but this can lead to
unbounded memory build-up if a particular type of logs has some
sort of unique ID that doesn't get filtered by the token filter of
the categorization analyzer.

This PR removes new distinct tokens from the token store for all
code paths other than a message causing a new category to be
created.