### PR TITLE
[7.17] [ML] Don't keep categorization tokens when existing category matches

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,12 @@
 
 //=== Regressions
 
+== {es} version 7.17.7
+
+=== Bug Fixes
+
+* Do not retain categorization tokens when existing category matches. (See {ml-pull}2398[#2398].)
+
 == {es} version 7.17.6
 
 === Enhancements

--- a/include/model/CTokenListDataCategorizerBase.h
+++ b/include/model/CTokenListDataCategorizerBase.h
@@ -262,6 +262,12 @@ protected:
     //! being seen for the first time)
     std::size_t idForToken(const std::string& token);
 
+    //! Discard the most recently added tokens from the token to ID map.
+    //! This must only be called if the caller is certain that none of
+    //! the tokens that will be discarded are referenced in any other part
+    //! of the categorizer state.
+    void discardLatestTokens(std::size_t previousTokenCount);
+
     //! Is the category considered rare?
     bool isCategoryCountRare(std::size_t count) const;
 

--- a/lib/model/CTokenListDataCategorizerBase.cc
+++ b/lib/model/CTokenListDataCategorizerBase.cc
@@ -69,11 +69,13 @@ CTokenListDataCategorizerBase::computeCategory(bool isDryRun,
     std::size_t workWeight{0};
     std::size_t minReweightedWorkWeight{0};
     std::size_t maxReweightedWorkWeight{0};
+    std::size_t preExistingTokenCount{m_TokenIdLookup.size()};
     auto preTokenisedIter = fields.find(PRETOKENISED_TOKEN_FIELD);
     if (preTokenisedIter != fields.end()) {
         if (this->addPretokenisedTokens(preTokenisedIter->second, m_WorkTokenIds,
                                         m_WorkTokenUniqueIds, workWeight, minReweightedWorkWeight,
                                         maxReweightedWorkWeight) == false) {
+            this->discardLatestTokens(preExistingTokenCount);
             return CLocalCategoryId::softFailure();
         }
     } else {
@@ -144,6 +146,7 @@ CTokenListDataCategorizerBase::computeCategory(bool isDryRun,
             CLocalCategoryId categoryId{iter->second};
             this->addCategoryMatch(isDryRun, str, rawStringLen, m_WorkTokenIds,
                                    m_WorkTokenUniqueIds, iter);
+            this->discardLatestTokens(preExistingTokenCount);
             return categoryId;
         }
 
@@ -167,6 +170,7 @@ CTokenListDataCategorizerBase::computeCategory(bool isDryRun,
         CLocalCategoryId categoryId{bestSoFarIter->second};
         this->addCategoryMatch(isDryRun, str, rawStringLen, m_WorkTokenIds,
                                m_WorkTokenUniqueIds, bestSoFarIter);
+        this->discardLatestTokens(preExistingTokenCount);
         return categoryId;
     }
 
@@ -176,6 +180,7 @@ CTokenListDataCategorizerBase::computeCategory(bool isDryRun,
         if (++m_MemoryCategorizationFailures == 1) {
             LOG_WARN(<< "Categories are not being created due to lack of memory");
         }
+        this->discardLatestTokens(preExistingTokenCount);
         return CLocalCategoryId::hardFailure();
     }
 
@@ -469,6 +474,12 @@ void CTokenListDataCategorizerBase::addCategoryMatch(bool isDryRun,
     // deserves this
     if (swapIter != iter) {
         std::iter_swap(swapIter, iter);
+    }
+}
+
+void CTokenListDataCategorizerBase::discardLatestTokens(std::size_t previousTokenCount) {
+    while (m_TokenIdLookup.size() > previousTokenCount) {
+        m_TokenIdLookup.pop_back();
     }
 }
 

--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -14,7 +14,6 @@
 #include <core/CRapidXmlParser.h>
 #include <core/CRapidXmlStatePersistInserter.h>
 #include <core/CRapidXmlStateRestoreTraverser.h>
-#include <core/CStopWatch.h>
 #include <core/CWordDictionary.h>
 
 #include <model/CLimits.h>
@@ -848,6 +847,32 @@ BOOST_FIXTURE_TEST_CASE(testHardMemoryLimit, CTestFixture) {
         m_Limits.resourceMonitor().refresh(categorizer);
     }
     BOOST_TEST_REQUIRE(categoryId.isHardFailure());
+}
+
+BOOST_FIXTURE_TEST_CASE(testManyUniqueTokens, CTestFixture) {
+
+    TTokenListDataCategorizerKeepsFields categorizer{
+        m_Limits, NO_REVERSE_SEARCH_CREATOR, 0.7, "whatever"};
+
+    ml::model::CLocalCategoryId categoryId;
+    for (int messageNum = 0; messageNum < 20000; ++messageNum) {
+        std::string message{"transaction id [" + makeUniqueToken() + "] completed"};
+        categoryId = categorizer.computeCategory(false, message, message.length());
+    }
+
+    std::string differentMessage{"something entirely different"};
+    categoryId = categorizer.computeCategory(false, differentMessage,
+                                             differentMessage.length());
+    BOOST_REQUIRE_EQUAL(2, categoryId.id());
+
+    m_Limits.resourceMonitor().refresh(categorizer);
+
+    // We should not have stored all the unique tokens that weren't necessary
+    // to define the category. If we have then the memory usage of the
+    // categorizer will be far greater than the number of messages that were
+    // categorized. If we didn't store all the unnecessary unique tokens then
+    // the memory usage will be low, as there are only two categories.
+    BOOST_TEST_REQUIRE(ml::core::memory::dynamicSize(&categorizer) < 20000);
 }
 
 BOOST_FIXTURE_TEST_CASE(testStatsWriteUrgentDueToRareCategories, CTestFixture) {

--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -14,6 +14,7 @@
 #include <core/CRapidXmlParser.h>
 #include <core/CRapidXmlStatePersistInserter.h>
 #include <core/CRapidXmlStateRestoreTraverser.h>
+#include <core/CStopWatch.h>
 #include <core/CWordDictionary.h>
 
 #include <model/CLimits.h>
@@ -872,7 +873,7 @@ BOOST_FIXTURE_TEST_CASE(testManyUniqueTokens, CTestFixture) {
     // categorizer will be far greater than the number of messages that were
     // categorized. If we didn't store all the unnecessary unique tokens then
     // the memory usage will be low, as there are only two categories.
-    BOOST_TEST_REQUIRE(ml::core::memory::dynamicSize(&categorizer) < 20000);
+    BOOST_TEST_REQUIRE(ml::core::CMemory::dynamicSize(&categorizer) < 20000);
 }
 
 BOOST_FIXTURE_TEST_CASE(testStatsWriteUrgentDueToRareCategories, CTestFixture) {


### PR DESCRIPTION
In categorization, when a new message matches an existing category
we don't need to keep a record of any new distinct tokens found in
the new message, as the category definition doesn't need them.

We used to store all unique tokens ever seen, but this can lead to
unbounded memory build-up if a particular type of logs has some
sort of unique ID that doesn't get filtered by the token filter of
the categorization analyzer.

This PR removes new distinct tokens from the token store for all
code paths other than a message causing a new category to be
created.

Backport of #2398