### PR TITLE
[ML] Fix seed parameter name

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -40,10 +40,6 @@
 * Increase the limit on the maximum number of classes to 100 for training classification
   models. (See {ml-pull}2395[#2395] issue: {ml-issue}2246[#2246].)
 
-=== Bug Fixes
-
-* Accept random number generator seed specified by user. (See {ml-pull}2404[#2404].)
-
 == {es} version 8.4.2
 
 === Bug Fixes

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -40,6 +40,10 @@
 * Increase the limit on the maximum number of classes to 100 for training classification
   models. (See {ml-pull}2395[#2395] issue: {ml-issue}2246[#2246].)
 
+=== Bug Fixes
+
+* Accept random number generator seed specified by user. (See {ml-pull}2404[#2404].)
+
 == {es} version 8.4.2
 
 === Bug Fixes

--- a/lib/api/CDataFrameTrainBoostedTreeRunner.cc
+++ b/lib/api/CDataFrameTrainBoostedTreeRunner.cc
@@ -613,7 +613,7 @@ CDataFrameTrainBoostedTreeRunner::dataSummarization() const {
 }
 
 // clang-format off
-const std::string CDataFrameTrainBoostedTreeRunner::RANDOM_NUMBER_GENERATOR_SEED{"seed"};
+const std::string CDataFrameTrainBoostedTreeRunner::RANDOM_NUMBER_GENERATOR_SEED{"randomize_seed"};
 const std::string CDataFrameTrainBoostedTreeRunner::DEPENDENT_VARIABLE_NAME{"dependent_variable"};
 const std::string CDataFrameTrainBoostedTreeRunner::PREDICTION_FIELD_NAME{"prediction_field_name"};
 const std::string CDataFrameTrainBoostedTreeRunner::TRAINING_PERCENT_FIELD_NAME{"training_percent"};


### PR DESCRIPTION
Java backend was passing the seed configuration parameter using the name `randomize_seed`, while C++ code was expecting `seed`. This PR fixes the misalignment.