### PR TITLE
[ML] Fix failure computing leaf values with multithreading for multi-class classification

### DIFF
--- a/include/maths/common/CSampling.h
+++ b/include/maths/common/CSampling.h
@@ -289,7 +289,7 @@ public:
         double doSample(std::size_t slot, const T& x, double weight) override {
             if (m_Samples.size() <= slot) {
                 m_Samples.resize(slot + 1, x);
-                m_SampleWeights[slot] = weight;
+                // Weights are not available until the sample set is its target size.
             } else {
                 m_Samples[slot] = x;
                 std::swap(m_SampleWeights[slot], weight);
@@ -297,8 +297,8 @@ public:
                     m_MinWeight = *std::min_element(m_SampleWeights.begin(),
                                                     m_SampleWeights.end());
                 }
+                m_MinWeight = std::min(m_MinWeight, weight);
             }
-            m_MinWeight = std::min(m_MinWeight, weight);
             m_Deduplicated = false;
             return weight;
         }

--- a/include/maths/common/CSampling.h
+++ b/include/maths/common/CSampling.h
@@ -293,11 +293,10 @@ public:
             } else {
                 m_Samples[slot] = x;
                 std::swap(m_SampleWeights[slot], weight);
-                if (weight == m_MinWeight) {
-                    m_MinWeight = *std::min_element(m_SampleWeights.begin(),
-                                                    m_SampleWeights.end());
-                }
-                m_MinWeight = std::min(m_MinWeight, weight);
+                m_MinWeight = weight == m_MinWeight
+                                  ? *std::min_element(m_SampleWeights.begin(),
+                                                      m_SampleWeights.end())
+                                  : std::min(m_MinWeight, weight);
             }
             m_Deduplicated = false;
             return weight;

--- a/include/maths/time_series/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/time_series/CTimeSeriesDecompositionDetail.h
@@ -229,8 +229,8 @@ public:
     //! \brief Checks for sudden change or change events.
     class MATHS_TIME_SERIES_EXPORT CChangePointTest : public CHandler {
     public:
-        static constexpr double CHANGE_COUNT_WEIGHT = 0.1;
-        static constexpr core_t::TTime MINIMUM_WINDOW_BUCKET_LENGTH = core::constants::HOUR;
+        static constexpr double CHANGE_COUNT_WEIGHT{0.1};
+        static constexpr core_t::TTime MINIMUM_WINDOW_BUCKET_LENGTH{core::constants::HOUR};
 
     public:
         CChangePointTest(double decayRate, core_t::TTime bucketLength);

--- a/lib/maths/analytics/CBoostedTreeFactory.cc
+++ b/lib/maths/analytics/CBoostedTreeFactory.cc
@@ -1258,11 +1258,11 @@ CBoostedTreeFactory::estimateTreeGainAndCurvature(core::CDataFrame& frame,
     CScopeBoostedTreeParameterOverrides<std::size_t> overrides;
     overrides.apply(m_TreeImpl->m_Hyperparameters.maximumNumberTrees(), 1);
 
-    CBoostedTreeImpl::TNodeVecVec forest{
-        m_TreeImpl
-            ->trainForest(frame, m_TreeImpl->m_TrainingRowMasks[0],
-                          m_TreeImpl->m_TestingRowMasks[0], m_TreeImpl->m_TrainingProgress)
-            .s_Forest};
+    auto forest = m_TreeImpl
+                      ->trainForest(frame, m_TreeImpl->m_TrainingRowMasks[0],
+                                    m_TreeImpl->m_TestingRowMasks[0],
+                                    m_TreeImpl->m_TrainingProgress)
+                      .s_Forest;
 
     TDoubleDoublePrVec result;
     result.reserve(percentiles.size());

--- a/lib/maths/analytics/CBoostedTreeLoss.cc
+++ b/lib/maths/analytics/CBoostedTreeLoss.cc
@@ -484,12 +484,9 @@ bool CArgMinMultinomialLogisticLossImpl::nextPass() {
 
     if (m_CurrentPass++ == 0) {
         m_Centres = std::move(m_Sampler.samples());
-        std::sort(m_Centres.begin(), m_Centres.end());
-        m_Centres.erase(std::unique(m_Centres.begin(), m_Centres.end()),
-                        m_Centres.end());
-        LOG_TRACE(<< "# centres = " << m_Centres.size());
         m_CurrentPass += m_Centres.size() == 1 ? 1 : 0;
         m_CentresClassCounts.resize(m_Centres.size(), TDoubleVector::Zero(m_NumberClasses));
+        LOG_TRACE(<< "# centres = " << m_Centres.size());
     }
 
     LOG_TRACE(<< "current pass = " << m_CurrentPass);
@@ -513,6 +510,10 @@ void CArgMinMultinomialLogisticLossImpl::add(const TMemoryMappedFloatVector& pre
         break;
     }
     case 1: {
+        if (m_Centres.empty()) {
+            HANDLE_FATAL(<< "Internal error: failed computing leaf weights.");
+            return;
+        }
         TMinAccumulator nearest;
         for (std::size_t i = 0; i < m_Centres.size(); ++i) {
             nearest.add({(m_Centres[i] - prediction).squaredNorm(), i});

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -2844,7 +2844,7 @@ BOOST_AUTO_TEST_CASE(testMultinomialLogisticRegression) {
         LOG_DEBUG(<< "KL divergence = "
                   << maths::common::CBasicStatistics::mean(klDivergence));
 
-        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(klDivergence) < 0.16);
+        BOOST_TEST_REQUIRE(maths::common::CBasicStatistics::mean(klDivergence) < 0.21);
         meanKLDivergence.add(maths::common::CBasicStatistics::mean(klDivergence));
     }
 

--- a/lib/maths/common/unittest/CSamplingTest.cc
+++ b/lib/maths/common/unittest/CSamplingTest.cc
@@ -349,15 +349,29 @@ BOOST_AUTO_TEST_CASE(testReservoirSampling) {
 
 BOOST_AUTO_TEST_CASE(testVectorDissimilaritySampler) {
 
-    // Test the average distance between points is significantly larger than
-    // for uniform random sampling.
-
     using TVector = maths::common::CDenseVector<double>;
     using TVectorVec = std::vector<TVector>;
     using TReservoirSampler = maths::common::CSampling::CReservoirSampler<TVector>;
     using TDissimilaritySampler =
         maths::common::CSampling::CVectorDissimilaritySampler<TVector>;
     using TMeanAccumulator = maths::common::CBasicStatistics::SSampleMean<double>::TAccumulator;
+
+    // 1. Test edge case that all points are co-located,
+    {
+        TDissimilaritySampler dissimilaritySampler1{10};
+        TDissimilaritySampler dissimilaritySampler2{10};
+
+        TVector x{TVector::Zero(4)};
+        for (std::size_t i = 0; i < 20; ++i) {
+            dissimilaritySampler1.sample(x);
+            dissimilaritySampler2.sample(x);
+        }
+        dissimilaritySampler1.merge(dissimilaritySampler2);
+        BOOST_TEST_REQUIRE(dissimilaritySampler1.samples().size() > 0);
+    }
+
+    // 2. Test the average distance between points is significantly larger than
+    //    for uniform random sampling.
 
     std::size_t numberSamples{100};
 


### PR DESCRIPTION
In the case that all the samples are duplicates, merging our stream dissimilar vector sampler discards all samples. This behaviour was introduced by #2401: subsequently categorical sample without replacement will not select any sample with zero weight. The upshot is that leaf weight estimation for multi-class classification, which makes use of this class, could yield undefined behaviour. I now explicitly trap the error case and fail gracefully. I also explicitly handle duplicates in both sampling and merging dissimilar vector samplers.

This fixes fallout from #2401. Since this isn't released I've marked as a non-issue.