### PR TITLE
[ML] Add option to run pytorch_inference in low priority

### DIFF
--- a/bin/pytorch_inference/CCmdLineParser.cc
+++ b/bin/pytorch_inference/CCmdLineParser.cc
@@ -37,7 +37,8 @@ bool CCmdLineParser::parse(int argc,
                            std::int32_t& numThreadsPerAllocation,
                            std::int32_t& numAllocations,
                            std::size_t& cacheMemorylimitBytes,
-                           bool& validElasticLicenseKeyConfirmed) {
+                           bool& validElasticLicenseKeyConfirmed,
+                           bool& lowPriority) {
     try {
         boost::program_options::options_description desc(DESCRIPTION);
         // clang-format off
@@ -68,6 +69,7 @@ bool CCmdLineParser::parse(int argc,
                         "Optional memory in bytes that the inference cache can use - default is 0 which disables caching")
             ("validElasticLicenseKeyConfirmed", boost::program_options::value<bool>(),
                         "Confirmation that a valid Elastic license key is in use.")
+            ("lowPriority", "Execute process in low priority")
             ;
         // clang-format on
 
@@ -128,6 +130,9 @@ bool CCmdLineParser::parse(int argc,
         if (vm.count("validElasticLicenseKeyConfirmed") > 0) {
             validElasticLicenseKeyConfirmed =
                 vm["validElasticLicenseKeyConfirmed"].as<bool>();
+        }
+        if (vm.count("lowPriority") > 0) {
+            lowPriority = true;
         }
     } catch (std::exception& e) {
         std::cerr << "Error processing command line: " << e.what() << std::endl;

--- a/bin/pytorch_inference/CCmdLineParser.h
+++ b/bin/pytorch_inference/CCmdLineParser.h
@@ -50,7 +50,8 @@ public:
                       std::int32_t& numThreadsPerAllocation,
                       std::int32_t& numAllocations,
                       std::size_t& cacheMemorylimitBytes,
-                      bool& validElasticLicenseKeyConfirmed);
+                      bool& validElasticLicenseKeyConfirmed,
+                      bool& lowPriority);
 
 private:
     static const std::string DESCRIPTION;

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -131,12 +131,13 @@ int main(int argc, char** argv) {
     std::int32_t numAllocations{1};
     std::size_t cacheMemorylimitBytes{0};
     bool validElasticLicenseKeyConfirmed{false};
+    bool lowPriority{false};
 
     if (ml::torch::CCmdLineParser::parse(
             argc, argv, modelId, namedPipeConnectTimeout, inputFileName, isInputFileNamedPipe,
             outputFileName, isOutputFileNamedPipe, restoreFileName, isRestoreFileNamedPipe,
             logFileName, logProperties, numThreadsPerAllocation, numAllocations,
-            cacheMemorylimitBytes, validElasticLicenseKeyConfirmed) == false) {
+            cacheMemorylimitBytes, validElasticLicenseKeyConfirmed, lowPriority) == false) {
         return EXIT_FAILURE;
     }
 
@@ -198,6 +199,10 @@ int main(int argc, char** argv) {
 
     // Reduce memory priority before installing system call filters.
     ml::core::CProcessPriority::reduceMemoryPriority();
+    if (lowPriority == true) {
+        LOG_DEBUG(<< "Running with low priority");
+        ml::core::CProcessPriority::reduceCpuPriority();
+    }
     ml::seccomp::CSystemCallFilter::installSystemCallFilter();
 
     if (ioMgr.initIo() == false) {

--- a/bin/pytorch_inference/evaluate.py
+++ b/bin/pytorch_inference/evaluate.py
@@ -87,6 +87,7 @@ def parse_arguments():
     parser.add_argument('--output_file', default='output_file')
     parser.add_argument('--numThreadsPerAllocation', type=int, help='The number of inference threads used by LibTorch. Defaults to 1.')
     parser.add_argument('--numAllocations', type=int, help='The number of allocations for parallel forwarding. Defaults to 1')
+    parser.add_argument('--lowPriority', action='store_true', help='Run model in low priority')
     benchmark_group = parser.add_mutually_exclusive_group()
     benchmark_group.add_argument('--benchmark', action='store_true', help='Benchmark inference time rather than evaluting expected results')
     benchmark_group.add_argument('--threading_benchmark', action='store_true', help='Threading benchmark')
@@ -124,6 +125,9 @@ def launch_pytorch_app(args):
 
     if args.numAllocations:
         command.append('--numAllocations=' + str(args.numAllocations))
+
+    if args.lowPriority:
+        command.append('--lowPriority')
 
     subprocess.Popen(command).communicate()
 
@@ -239,7 +243,7 @@ def run_benchmark(args):
 
         # ignore the warmup results
         for i in range(NUM_WARM_UP_REQUESTS, len(result_docs)):
-            total_time_ms += result_docs[i]['result']['time_ms']
+            total_time_ms += result_docs[i]['time_ms']
             doc_count += 1
 
         avg_time_ms = total_time_ms / doc_count
@@ -291,7 +295,7 @@ def test_evaluation(args):
             if 'how_close' in test_evaluation[doc_count]:
                 tolerance = test_evaluation[doc_count]['how_close']                                   
 
-            total_time_ms += result['result']['time_ms']
+            total_time_ms += result['time_ms']
 
             # compare to expected
             if compare_results(expected, result['result'], tolerance) == False:


### PR DESCRIPTION
This commit adds an option `--lowPriority` to the pytorch_inference program so it can be run in low priority.