### PR TITLE
[7.17] [ML] Improve performance of closing files before spawning

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,12 @@
 
 //=== Regressions
 
+== {es} version 7.17.9
+
+=== Bug Fixes
+
+* Improve performance of closing files before spawning. (See {ml-pull}2424[#2424].)
+
 == {es} version 7.17.7
 
 === Bug Fixes

--- a/include/core/CDetachedProcessSpawner.h
+++ b/include/core/CDetachedProcessSpawner.h
@@ -108,6 +108,13 @@ private:
     //! Thread to track which processes that have been created are still
     //! alive.
     TTrackerThreadP m_TrackerThread;
+
+#ifndef Windows
+    //! On *nix testing which files need to be closed when spawning a process
+    //! can be expensive, so this variable is used to learn the highest file
+    //! descriptor that's in use.
+    int m_MaxObservedFd{1000000};
+#endif
 };
 }
 }


### PR DESCRIPTION
Before spawning new processes from the `controller` we close all open file descriptors except for stdin, stdout and stderr.

Previously this was done by checking every possible file descriptor to see if it was open, but this is very expensive if the file descriptor limit is high.  During a lookback a large number of `normalize` processes get started, and this could lead to significant CPU usage by the `controller` process.

This change makes the file closure code learn the highest open file descriptor each time it is used, and work on the basis that no more than 10 files will be opened in between calls to it. This significantly reduces `controller` CPU usage on machines that have high file descriptor limits and run a lot of `normalize` processes.

Backport of #2424