### PR TITLE
[ML] Use rapidjson's key function where possible

### DIFF
--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -380,7 +380,7 @@ void CJsonOutputWriter::writeBucket(bool isInterim,
                   bucketData.s_DocumentsToWrite.end(), DETECTOR_PROBABILITY_LESS);
 
         m_Writer.StartObject();
-        m_Writer.String(RECORDS);
+        m_Writer.Key(RECORDS);
         m_Writer.StartArray();
 
         // Iterate over the different detectors that we have results for
@@ -413,7 +413,7 @@ void CJsonOutputWriter::writeBucket(bool isInterim,
     // Write influencers
     if (!bucketData.s_InfluencerDocuments.empty()) {
         m_Writer.StartObject();
-        m_Writer.String(INFLUENCERS);
+        m_Writer.Key(INFLUENCERS);
         m_Writer.StartArray();
         for (TDocumentWeakPtrVecItr influencerIter =
                  bucketData.s_InfluencerDocuments.begin();
@@ -439,30 +439,30 @@ void CJsonOutputWriter::writeBucket(bool isInterim,
 
     // Write bucket at the end, as some of its values need to iterate over records, etc.
     m_Writer.StartObject();
-    m_Writer.String(BUCKET);
+    m_Writer.Key(BUCKET);
 
     m_Writer.StartObject();
-    m_Writer.String(JOB_ID);
+    m_Writer.Key(JOB_ID);
     m_Writer.String(m_JobId);
-    m_Writer.String(TIMESTAMP);
+    m_Writer.Key(TIMESTAMP);
     m_Writer.Time(bucketTime);
 
-    m_Writer.String(ANOMALY_SCORE);
+    m_Writer.Key(ANOMALY_SCORE);
     m_Writer.Double(bucketData.s_MaxBucketInfluencerNormalizedAnomalyScore);
-    m_Writer.String(INITIAL_SCORE);
+    m_Writer.Key(INITIAL_SCORE);
     m_Writer.Double(bucketData.s_MaxBucketInfluencerNormalizedAnomalyScore);
-    m_Writer.String(EVENT_COUNT);
+    m_Writer.Key(EVENT_COUNT);
     m_Writer.Uint64(bucketData.s_InputEventCount);
     if (isInterim) {
-        m_Writer.String(IS_INTERIM);
+        m_Writer.Key(IS_INTERIM);
         m_Writer.Bool(isInterim);
     }
-    m_Writer.String(BUCKET_SPAN);
+    m_Writer.Key(BUCKET_SPAN);
     m_Writer.Int64(bucketData.s_BucketSpan);
 
     if (!bucketData.s_BucketInfluencerDocuments.empty()) {
         // Write the array of influencers
-        m_Writer.String(BUCKET_INFLUENCERS);
+        m_Writer.Key(BUCKET_INFLUENCERS);
         m_Writer.StartArray();
         for (TDocumentWeakPtrVecItr influencerIter =
                  bucketData.s_BucketInfluencerDocuments.begin();
@@ -486,11 +486,11 @@ void CJsonOutputWriter::writeBucket(bool isInterim,
         m_Writer.EndArray();
     }
 
-    m_Writer.String(PROCESSING_TIME);
+    m_Writer.Key(PROCESSING_TIME);
     m_Writer.Uint64(bucketProcessingTime);
 
     if (bucketData.s_ScheduledEventDescriptions.empty() == false) {
-        m_Writer.String(SCHEDULED_EVENTS);
+        m_Writer.Key(SCHEDULED_EVENTS);
         m_Writer.StartArray();
         for (const auto& it : bucketData.s_ScheduledEventDescriptions) {
             m_Writer.String(it);
@@ -833,7 +833,7 @@ void CJsonOutputWriter::persistNormalizer(const model::CHierarchicalResultsNorma
     normalizer.toJson(m_LastNonInterimBucketTime, "api", quantilesState, true);
 
     m_Writer.StartObject();
-    m_Writer.String(QUANTILES);
+    m_Writer.Key(QUANTILES);
     // No need to copy the strings as the doc is written straight away
     CModelSnapshotJsonWriter::writeQuantileState(
         m_JobId, quantilesState, m_LastNonInterimBucketTime, m_Writer);
@@ -873,12 +873,12 @@ void CJsonOutputWriter::writeCategorizerStats(const std::string& partitionFieldN
 void CJsonOutputWriter::acknowledgeFlush(const std::string& flushId,
                                          core_t::TTime lastFinalizedBucketEnd) {
     m_Writer.StartObject();
-    m_Writer.String(FLUSH);
+    m_Writer.Key(FLUSH);
     m_Writer.StartObject();
 
-    m_Writer.String(ID);
+    m_Writer.Key(ID);
     m_Writer.String(flushId);
-    m_Writer.String(LAST_FINALIZED_BUCKET_END);
+    m_Writer.Key(LAST_FINALIZED_BUCKET_END);
     m_Writer.Time(lastFinalizedBucketEnd);
 
     m_Writer.EndObject();

--- a/lib/api/CModelSnapshotJsonWriter.cc
+++ b/lib/api/CModelSnapshotJsonWriter.cc
@@ -40,38 +40,38 @@ CModelSnapshotJsonWriter::CModelSnapshotJsonWriter(const std::string& jobId,
 
 void CModelSnapshotJsonWriter::write(const SModelSnapshotReport& report) {
     m_Writer.StartObject();
-    m_Writer.String(MODEL_SNAPSHOT);
+    m_Writer.Key(MODEL_SNAPSHOT);
     m_Writer.StartObject();
 
-    m_Writer.String(JOB_ID);
+    m_Writer.Key(JOB_ID);
     m_Writer.String(m_JobId);
-    m_Writer.String(MIN_VERSION);
+    m_Writer.Key(MIN_VERSION);
     m_Writer.String(report.s_MinVersion);
-    m_Writer.String(SNAPSHOT_ID);
+    m_Writer.Key(SNAPSHOT_ID);
     m_Writer.String(report.s_SnapshotId);
 
-    m_Writer.String(SNAPSHOT_DOC_COUNT);
+    m_Writer.Key(SNAPSHOT_DOC_COUNT);
     m_Writer.Uint64(report.s_NumDocs);
 
-    m_Writer.String(TIMESTAMP);
+    m_Writer.Key(TIMESTAMP);
     m_Writer.Time(report.s_SnapshotTimestamp);
 
-    m_Writer.String(DESCRIPTION);
+    m_Writer.Key(DESCRIPTION);
     m_Writer.String(report.s_Description);
 
     CModelSizeStatsJsonWriter::write(m_JobId, report.s_ModelSizeStats, m_Writer);
 
     if (report.s_LatestRecordTime > 0) {
-        m_Writer.String(LATEST_RECORD_TIME);
+        m_Writer.Key(LATEST_RECORD_TIME);
         m_Writer.Time(report.s_LatestRecordTime);
     }
     if (report.s_LatestFinalResultTime > 0) {
-        m_Writer.String(LATEST_RESULT_TIME);
+        m_Writer.Key(LATEST_RESULT_TIME);
         m_Writer.Time(report.s_LatestFinalResultTime);
     }
 
     // write normalizerState here
-    m_Writer.String(QUANTILES);
+    m_Writer.Key(QUANTILES);
 
     writeQuantileState(m_JobId, report.s_NormalizerState,
                        report.s_LatestFinalResultTime, m_Writer);
@@ -91,11 +91,11 @@ void CModelSnapshotJsonWriter::writeQuantileState(const std::string& jobId,
                                                   core_t::TTime time,
                                                   core::CRapidJsonConcurrentLineWriter& writer) {
     writer.StartObject();
-    writer.String(JOB_ID);
+    writer.Key(JOB_ID);
     writer.String(jobId);
-    writer.String(QUANTILE_STATE);
+    writer.Key(QUANTILE_STATE);
     writer.String(state);
-    writer.String(TIMESTAMP);
+    writer.Key(TIMESTAMP);
     writer.Time(time);
     writer.EndObject();
 }

--- a/lib/core/CJsonLogLayout.cc
+++ b/lib/core/CJsonLogLayout.cc
@@ -70,25 +70,25 @@ void CJsonLogLayout::operator()(const boost::log::record_view& rec,
 
     writer.StartObject();
 
-    writer.String(LOGGER_NAME);
+    writer.Key(LOGGER_NAME);
     writer.String(LOGGER);
 
-    writer.String(TIMESTAMP_NAME);
+    writer.Key(TIMESTAMP_NAME);
     const auto& timeStamp = boost::log::extract<boost::posix_time::ptime>(
                                 boost::log::aux::default_attribute_names::timestamp(), rec)
                                 .get();
     writer.Int64((timeStamp - EPOCH).total_milliseconds());
 
-    writer.String(LEVEL_NAME);
+    writer.Key(LEVEL_NAME);
     auto level = boost::log::extract<CLogger::ELevel>(
                      boost::log::aux::default_attribute_names::severity(), rec)
                      .get();
     writer.String(CLogger::levelToString(level));
 
-    writer.String(PID_NAME);
+    writer.Key(PID_NAME);
     writer.Int64(PID);
 
-    writer.String(THREAD_NAME);
+    writer.Key(THREAD_NAME);
     auto threadId = boost::log::extract<boost::log::attributes::current_thread_id::value_type>(
                         boost::log::aux::default_attribute_names::thread_id(), rec)
                         .get();
@@ -96,7 +96,7 @@ void CJsonLogLayout::operator()(const boost::log::record_view& rec,
     oss << threadId;
     writer.String(oss.str());
 
-    writer.String(MESSAGE_NAME);
+    writer.Key(MESSAGE_NAME);
     writer.String(rec[boost::log::expressions::smessage].get());
 
     if (m_LocationInfo) {
@@ -107,20 +107,20 @@ void CJsonLogLayout::operator()(const boost::log::record_view& rec,
                 .get());
 
         if (className.empty() == false) {
-            writer.String(CLASS_NAME);
+            writer.Key(CLASS_NAME);
             writer.String(className);
         }
 
-        writer.String(METHOD_NAME);
+        writer.Key(METHOD_NAME);
         writer.String(methodName);
 
-        writer.String(FILE_NAME);
+        writer.Key(FILE_NAME);
         const auto& fullFileName = boost::log::extract<std::string>(
                                        CLogger::instance().fileAttributeName(), rec)
                                        .get();
         writer.String(CJsonLogLayout::cropPath(fullFileName));
 
-        writer.String(LINE_NAME);
+        writer.Key(LINE_NAME);
         writer.Int(boost::log::extract<int>(CLogger::instance().lineAttributeName(), rec)
                        .get());
     }

--- a/lib/core/CMemoryUsageJsonWriter.cc
+++ b/lib/core/CMemoryUsageJsonWriter.cc
@@ -36,7 +36,7 @@ void CMemoryUsageJsonWriter::endObject() {
 }
 
 void CMemoryUsageJsonWriter::startArray(const std::string& description) {
-    m_Writer.String(description);
+    m_Writer.Key(description);
     m_Writer.StartArray();
 }
 
@@ -45,13 +45,13 @@ void CMemoryUsageJsonWriter::endArray() {
 }
 
 void CMemoryUsageJsonWriter::addItem(const CMemoryUsage::SMemoryUsage& item) {
-    m_Writer.String(item.s_Name);
+    m_Writer.Key(item.s_Name);
     m_Writer.StartObject();
 
-    m_Writer.String(MEMORY);
+    m_Writer.Key(MEMORY);
     m_Writer.Int64(item.s_Memory);
     if (item.s_Unused) {
-        m_Writer.String(UNUSED);
+        m_Writer.Key(UNUSED);
         m_Writer.Uint64(item.s_Unused);
     }
     m_Writer.EndObject();

--- a/lib/core/CProgramCounters.cc
+++ b/lib/core/CProgramCounters.cc
@@ -45,13 +45,13 @@ void addStringInt(TGenericLineWriter& writer,
                   std::uint64_t counter) {
     writer.StartObject();
 
-    writer.String(NAME_TYPE);
+    writer.Key(NAME_TYPE);
     writer.String(name);
 
-    writer.String(DESCRIPTION_TYPE);
+    writer.Key(DESCRIPTION_TYPE);
     writer.String(description);
 
-    writer.String(COUNTER_TYPE);
+    writer.Key(COUNTER_TYPE);
     writer.Uint64(counter);
 
     writer.EndObject();


### PR DESCRIPTION
Rapidjson introduced a `Key()` function on the writers which is effectively the same as `String()`. However, using it where keys are written improves readability of the code.

Closes #383