### PR TITLE
[ML] Perform a nightly debug build with assertions enabled

### DIFF
--- a/.buildkite/job-build-test-all-debug.yml
+++ b/.buildkite/job-build-test-all-debug.yml
@@ -18,7 +18,7 @@ steps:
       cpu: "6"
       ephemeralStorage: "20G"
       memory: "64G"
-        image: "docker.elastic.co/ml-dev/ml-linux-build:25"
+      image: "docker.elastic.co/ml-dev/ml-linux-build:25"
     commands:
       - ".buildkite/scripts/steps/build_and_test.sh"
     key: "build_test_linux-x86_64-Debug"


### PR DESCRIPTION
Fix formatting in `.buildkite/job-build-test-all-debug.yml` such that the pipeline for the nightly debug build executes.