### PR TITLE
[ML] Correct path to AWS credentials in CI vault

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -56,7 +56,7 @@ steps:
       cpu: "16"
       ephemeralStorage: "20G"
       memory: "32G"
-      image: "docker.elastic.co/ml-dev/ml_cpp_linux_x86_64_jdk17:1"
+      image: "docker.elastic.co/ml-dev/ml_cpp_linux_x86_64_jdk17:2"
       # Run as a non-root user
       imageUID: "1000"
     env:
@@ -74,6 +74,6 @@ steps:
       cpu: "2"
       ephemeralStorage: "20G"
       memory: "4G"
-      image: "docker.elastic.co/ml-dev/ml_cpp_linux_x86_64_jdk17:1"
+      image: "docker.elastic.co/ml-dev/ml_cpp_linux_x86_64_jdk17:2"
       # Run as a non-root user
       imageUID: "1000"

--- a/dev-tools/aws_creds_from_vault.sh
+++ b/dev-tools/aws_creds_from_vault.sh
@@ -52,7 +52,7 @@ fi
 unset ML_AWS_ACCESS_KEY ML_AWS_SECRET_KEY
 FAILURES=0
 while [[ $FAILURES -lt 3 && -z "$ML_AWS_ACCESS_KEY" ]] ; do
-    AWS_CREDS=$(vault read -format=json -field=data ${PRFEIX}aws-dev/creds/prelertartifacts)
+    AWS_CREDS=$(vault read -format=json -field=data ${PREFIX}aws-dev/creds/prelertartifacts)
     if [ $? -eq 0 ] ; then
         export ML_AWS_ACCESS_KEY=$(echo $AWS_CREDS | jq -r '.access_key')
         export ML_AWS_SECRET_KEY=$(echo $AWS_CREDS | jq -r '.secret_key')

--- a/dev-tools/docker/build_linux_jdk.sh
+++ b/dev-tools/docker/build_linux_jdk.sh
@@ -30,7 +30,7 @@ sleep 5
 HOST=docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml_cpp_linux_x86_64_jdk17
-VERSION=1
+VERSION=2
 
 set -e
 

--- a/dev-tools/docker/ml_cpp_jdk/Dockerfile
+++ b/dev-tools/docker/ml_cpp_jdk/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 RUN apt-get update && apt-get upgrade -y
-RUN DEBIAN_FRONTEND=noninteractive apt-get install aptitude ssh git openjdk-17-jre openjdk-17-jdk -y
+RUN DEBIAN_FRONTEND=noninteractive apt-get install aptitude ssh git openjdk-17-jre openjdk-17-jdk jq -y
 RUN useradd -ms /bin/bash -u 1000 elasticsearch
 
 USER elasticsearch


### PR DESCRIPTION
Fix a typo affecting the path to the AWS credentials used for uploading artifacts to S3