### PR TITLE
[ML] Identify multimodal prior distributions for anomaly explanation

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,12 @@
 
 //=== Regressions
 
+== {es} version 8.7.0
+
+=== Enhancements
+
+* Add identification of multimodal distribution to anomaly explanations. (See {ml-pull}2440[#2440].)
+
 == {es} version 8.6.0
 
 === Bug Fixes

--- a/include/maths/common/CModel.h
+++ b/include/maths/common/CModel.h
@@ -260,6 +260,7 @@ struct MATHS_COMMON_EXPORT SAnomalyScoreExplanation {
     double s_UpperConfidenceBound{std::numeric_limits<double>::quiet_NaN()};
     bool s_HighVariancePenalty{false};
     bool s_IncompleteBucketPenalty{false};
+    bool s_MultimodalDistribution{false};
 
     std::string print() const {
         return "Anomaly Score Explanation:\ntype: " + std::to_string(s_AnomalyType) +
@@ -273,7 +274,9 @@ struct MATHS_COMMON_EXPORT SAnomalyScoreExplanation {
                "\n high variance penalty: " +
                std::to_string(static_cast<int>(s_HighVariancePenalty)) +
                ", incomplete bucket_penalty: " +
-               std::to_string(static_cast<int>(s_IncompleteBucketPenalty));
+               std::to_string(static_cast<int>(s_IncompleteBucketPenalty)) +
+               ", is multimodal distribution" +
+               std::to_string(static_cast<int>(s_MultimodalDistribution));
     }
 };
 

--- a/include/maths/common/COneOfNPrior.h
+++ b/include/maths/common/COneOfNPrior.h
@@ -216,6 +216,9 @@ public:
     //! \note \p numberSamples is truncated to the number of samples received.
     void sampleMarginalLikelihood(std::size_t numberSamples, TDouble1Vec& samples) const override;
 
+    //! Determines whether the prior distribution is multimodal.
+    bool isMultimodal() const;
+
 private:
     //! The common c.d.f. implementation.
     bool minusLogJointCdfImpl(bool complement,

--- a/include/maths/common/COneOfNPrior.h
+++ b/include/maths/common/COneOfNPrior.h
@@ -216,8 +216,8 @@ public:
     //! \note \p numberSamples is truncated to the number of samples received.
     void sampleMarginalLikelihood(std::size_t numberSamples, TDouble1Vec& samples) const override;
 
-    //! Determines whether the prior distribution is multimodal.
-    bool isMultimodal() const;
+    //! Determines whether the selected distribution is multimodal.
+    bool isSelectedModelMultimodal() const override;
 
 private:
     //! The common c.d.f. implementation.

--- a/include/maths/common/CPrior.h
+++ b/include/maths/common/CPrior.h
@@ -438,6 +438,9 @@ public:
                                TDouble1Vec& resamples,
                                TDoubleWeightsAry1Vec& resamplesWeights) const;
 
+    //! Determines whether the selected distribution is multimodal.
+    virtual bool isSelectedModelMultimodal() const;
+
 protected:
     //! \brief Defines a set of operations to adjust the offset parameter
     //! of those priors with non-negative support.

--- a/include/maths/time_series/CTimeSeriesModel.h
+++ b/include/maths/time_series/CTimeSeriesModel.h
@@ -272,9 +272,6 @@ private:
     //! Abort on failure.
     void checkRestoredInvariants() const;
 
-    //! Determines whether the residual model has a multimodal prior distribution.
-    bool multimodalPrior() const;
-
 private:
     //! A unique identifier for this model.
     std::size_t m_Id;

--- a/include/maths/time_series/CTimeSeriesModel.h
+++ b/include/maths/time_series/CTimeSeriesModel.h
@@ -272,6 +272,9 @@ private:
     //! Abort on failure.
     void checkRestoredInvariants() const;
 
+    //! Determines whether the residual model has a multimodal prior distribution.
+    bool multimodalPrior() const;
+
 private:
     //! A unique identifier for this model.
     std::size_t m_Id;

--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -95,6 +95,7 @@ const std::string TYPICAL_VALUE("typical_value");
 const std::string UPPER_CONFIDENCE_BOUND("upper_confidence_bound");
 const std::string HIGH_VARIANCE_PENALTY("high_variance_penalty");
 const std::string INCOMPLETE_BUCKET_PENALTY("incomplete_bucket_penalty");
+const std::string MULTIMODAL_DISTRIBUTION("multimodal_distribution");
 
 //! Get a numeric field from a JSON document.
 //! Assumes the document contains the field.
@@ -999,6 +1000,11 @@ void CJsonOutputWriter::writeAnomalyScoreExplanationObject(
     if (results.s_AnomalyScoreExplanation.s_IncompleteBucketPenalty) {
         m_Writer.addBoolFieldToObj(INCOMPLETE_BUCKET_PENALTY,
                                    results.s_AnomalyScoreExplanation.s_IncompleteBucketPenalty,
+                                   anomalyScoreExplanation);
+    }
+    if (results.s_AnomalyScoreExplanation.s_MultimodalDistribution) {
+        m_Writer.addBoolFieldToObj(MULTIMODAL_DISTRIBUTION,
+                                   results.s_AnomalyScoreExplanation.s_MultimodalDistribution,
                                    anomalyScoreExplanation);
     }
 }

--- a/lib/maths/common/COneOfNPrior.cc
+++ b/lib/maths/common/COneOfNPrior.cc
@@ -769,13 +769,10 @@ void COneOfNPrior::sampleMarginalLikelihood(std::size_t numberSamples,
     LOG_TRACE(<< "samples = " << samples);
 }
 
-bool COneOfNPrior::isMultimodal() const {
-    double sumOfWeights{0.0};
-    for (const auto& weight : this->weights()) {
-        sumOfWeights += weight;
-    }
-    for (const auto& model : m_Models) {
-        if (model.second->type() == EPrior::E_Multimodal && model.first / sumOfWeights > 0.1) {
+bool COneOfNPrior::isSelectedModelMultimodal() const {
+    auto weights = this->weights();
+    for (std::size_t i = 0; i < weights.size(); ++i) {
+        if (weights[i] > 0.1 && m_Models[i].second->type() == EPrior::E_Multimodal) {
             return true;
         }
     }

--- a/lib/maths/common/COneOfNPrior.cc
+++ b/lib/maths/common/COneOfNPrior.cc
@@ -769,6 +769,19 @@ void COneOfNPrior::sampleMarginalLikelihood(std::size_t numberSamples,
     LOG_TRACE(<< "samples = " << samples);
 }
 
+bool COneOfNPrior::isMultimodal() const {
+    double sumOfWeights{0.0};
+    for (const auto& weight : this->weights()) {
+        sumOfWeights += weight;
+    }
+    for (const auto& model : m_Models) {
+        if (model.second->type() == EPrior::E_Multimodal && model.first / sumOfWeights > 0.1) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool COneOfNPrior::minusLogJointCdfImpl(bool complement,
                                         const TDouble1Vec& samples,
                                         const TDoubleWeightsAry1Vec& weights,

--- a/lib/maths/common/CPrior.cc
+++ b/lib/maths/common/CPrior.cc
@@ -319,6 +319,11 @@ CPrior::TStrStrPr CPrior::printMarginalLikelihoodStatistics() const {
 
     return this->doPrintMarginalLikelihoodStatistics();
 }
+
+bool CPrior::isSelectedModelMultimodal() const {
+    return false;
+}
+
 const double CPrior::FALLBACK_DECAY_RATE = 0.001;
 const std::size_t CPrior::ADJUST_OFFSET_SAMPLE_SIZE = 50;
 const std::string CPrior::UNKNOWN_VALUE_STRING = "<unknown>";

--- a/lib/maths/common/unittest/COneOfNPriorTest.cc
+++ b/lib/maths/common/unittest/COneOfNPriorTest.cc
@@ -435,6 +435,7 @@ BOOST_AUTO_TEST_CASE(testModelSelection) {
 
         BOOST_TEST_REQUIRE(logWeightRatio > expectedLogWeightRatio);
         BOOST_TEST_REQUIRE(logWeightRatio < 0.95 * expectedLogWeightRatio);
+        BOOST_REQUIRE_EQUAL(filter.isMultimodal(), false);
     }
 
     {
@@ -485,6 +486,7 @@ BOOST_AUTO_TEST_CASE(testModelSelection) {
 
         BOOST_TEST_REQUIRE(logWeightRatio > expectedLogWeightRatio);
         BOOST_TEST_REQUIRE(logWeightRatio < 0.75 * expectedLogWeightRatio);
+        BOOST_REQUIRE_EQUAL(filter.isMultimodal(), false);
     }
     {
         // Check we correctly select the multimodal model when the data have
@@ -522,6 +524,7 @@ BOOST_AUTO_TEST_CASE(testModelSelection) {
 
         LOG_DEBUG(<< "logWeightRatio = " << logWeightRatio);
         BOOST_TEST_REQUIRE(std::exp(logWeightRatio) < 1e-6);
+        BOOST_REQUIRE_EQUAL(filter.isMultimodal(), true);
     }
 }
 

--- a/lib/maths/common/unittest/COneOfNPriorTest.cc
+++ b/lib/maths/common/unittest/COneOfNPriorTest.cc
@@ -435,7 +435,7 @@ BOOST_AUTO_TEST_CASE(testModelSelection) {
 
         BOOST_TEST_REQUIRE(logWeightRatio > expectedLogWeightRatio);
         BOOST_TEST_REQUIRE(logWeightRatio < 0.95 * expectedLogWeightRatio);
-        BOOST_REQUIRE_EQUAL(filter.isMultimodal(), false);
+        BOOST_REQUIRE_EQUAL(filter.isSelectedModelMultimodal(), false);
     }
 
     {
@@ -486,7 +486,7 @@ BOOST_AUTO_TEST_CASE(testModelSelection) {
 
         BOOST_TEST_REQUIRE(logWeightRatio > expectedLogWeightRatio);
         BOOST_TEST_REQUIRE(logWeightRatio < 0.75 * expectedLogWeightRatio);
-        BOOST_REQUIRE_EQUAL(filter.isMultimodal(), false);
+        BOOST_REQUIRE_EQUAL(filter.isSelectedModelMultimodal(), false);
     }
     {
         // Check we correctly select the multimodal model when the data have
@@ -524,7 +524,7 @@ BOOST_AUTO_TEST_CASE(testModelSelection) {
 
         LOG_DEBUG(<< "logWeightRatio = " << logWeightRatio);
         BOOST_TEST_REQUIRE(std::exp(logWeightRatio) < 1e-6);
-        BOOST_REQUIRE_EQUAL(filter.isMultimodal(), true);
+        BOOST_REQUIRE_EQUAL(filter.isSelectedModelMultimodal(), true);
     }
 }
 

--- a/lib/maths/time_series/CTimeSeriesModel.cc
+++ b/lib/maths/time_series/CTimeSeriesModel.cc
@@ -23,7 +23,6 @@
 #include <maths/common/CModelDetail.h>
 #include <maths/common/CMultivariateNormalConjugate.h>
 #include <maths/common/CMultivariatePrior.h>
-#include <maths/common/COneOfNPrior.h>
 #include <maths/common/COrderings.h>
 #include <maths/common/COrderingsSimultaneousSort.h>
 #include <maths/common/CPrior.h>

--- a/lib/maths/time_series/CTimeSeriesModel.cc
+++ b/lib/maths/time_series/CTimeSeriesModel.cc
@@ -23,6 +23,7 @@
 #include <maths/common/CModelDetail.h>
 #include <maths/common/CMultivariateNormalConjugate.h>
 #include <maths/common/CMultivariatePrior.h>
+#include <maths/common/COneOfNPrior.h>
 #include <maths/common/COrderings.h>
 #include <maths/common/COrderingsSimultaneousSort.h>
 #include <maths/common/CPrior.h>
@@ -1075,11 +1076,23 @@ bool CUnivariateTimeSeriesModel::uncorrelatedProbability(
         result.s_AnomalyScoreExplanation.s_UpperConfidenceBound = interval[2][0];
     }
 
+    result.s_AnomalyScoreExplanation.s_MultimodalDistribution = this->multimodalPrior();
+    LOG_DEBUG(<< "Multimodel distribution: "
+              << result.s_AnomalyScoreExplanation.s_MultimodalDistribution);
+
     result.s_Probability = pOverall;
     result.s_FeatureProbabilities = std::move(featureProbabilities);
     result.s_Tail = {tail};
 
     return true;
+}
+
+bool CUnivariateTimeSeriesModel::multimodalPrior() const {
+    LOG_DEBUG(<< "Residual model type " << m_ResidualModel->type());
+    if (m_ResidualModel->type() == common::CPrior::E_OneOfN) {
+        return static_cast<common::COneOfNPrior*>(m_ResidualModel.get())->isMultimodal();
+    }
+    return false;
 }
 
 bool CUnivariateTimeSeriesModel::correlatedProbability(

--- a/lib/maths/time_series/CTimeSeriesModel.cc
+++ b/lib/maths/time_series/CTimeSeriesModel.cc
@@ -1076,7 +1076,8 @@ bool CUnivariateTimeSeriesModel::uncorrelatedProbability(
         result.s_AnomalyScoreExplanation.s_UpperConfidenceBound = interval[2][0];
     }
 
-    result.s_AnomalyScoreExplanation.s_MultimodalDistribution = this->multimodalPrior();
+    result.s_AnomalyScoreExplanation.s_MultimodalDistribution =
+        m_ResidualModel->isSelectedModelMultimodal();
     LOG_DEBUG(<< "Multimodel distribution: "
               << result.s_AnomalyScoreExplanation.s_MultimodalDistribution);
 
@@ -1085,14 +1086,6 @@ bool CUnivariateTimeSeriesModel::uncorrelatedProbability(
     result.s_Tail = {tail};
 
     return true;
-}
-
-bool CUnivariateTimeSeriesModel::multimodalPrior() const {
-    LOG_DEBUG(<< "Residual model type " << m_ResidualModel->type());
-    if (m_ResidualModel->type() == common::CPrior::E_OneOfN) {
-        return static_cast<common::COneOfNPrior*>(m_ResidualModel.get())->isMultimodal();
-    }
-    return false;
 }
 
 bool CUnivariateTimeSeriesModel::correlatedProbability(


### PR DESCRIPTION
As an enhancement for explaining anomalies, it would be helpful to inform the users whether the prior distribution of the observed time series is multi-modal or has a single mode. For instance, if the distribution has two modes, the typical value may lie between the modes and hence not constitute the most probable value.

Closes #2416.