### PR TITLE
Add separate BuildKite pipeline for branch builds

### DIFF
--- a/.buildkite/branch.json.py
+++ b/.buildkite/branch.json.py
@@ -38,8 +38,6 @@ def main():
     if config.build_linux:
         build_linux = pipeline_steps.generate_step_template("Linux", "build", None, None)
         pipeline_steps.append(build_linux)
-    pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests runner pipeline",
-                                                       ".buildkite/pipelines/run_es_tests.yml.sh"))
     pipeline_steps.append({"wait": None})
     pipeline_steps.append(pipeline_steps.generate_step("Upload artifact uploader pipeline",
                                                        ".buildkite/pipelines/upload_to_s3.yml.sh"))

--- a/.buildkite/branch.json.py
+++ b/.buildkite/branch.json.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+#
+# This script generates a pipeline JSON for the ml-cpp-branch pipeline.
+# Builds for this pipeline may be triggered by commit or comment.
+#
+import json
+
+from ml_pipeline import (
+    step,
+    config as buildConfig,
+)
+
+def main():
+    pipeline = {}
+    pipeline_steps = step.PipelineStep([])
+    pipeline_steps.append(pipeline_steps.generate_step("Queue a :slack: notification for the pipeline",
+                                                       ".buildkite/pipelines/send_slack_notification.sh"))
+    pipeline_steps.append(pipeline_steps.generate_step("Queue a :email: notification for the pipeline",
+                                                       ".buildkite/pipelines/send_email_notification.sh"))
+    pipeline_steps.append(pipeline_steps.generate_step("Upload clang-format validation",
+                                                       ".buildkite/pipelines/format_and_validation.yml.sh"))
+    config = buildConfig.Config()
+    config.parse()
+    if config.build_windows:
+        build_windows = pipeline_steps.generate_step_template("Windows", "build", None, None)
+        pipeline_steps.append(build_windows)
+    if config.build_macos:
+        build_macos = pipeline_steps.generate_step_template("MacOS", "build", None, None)
+        pipeline_steps.append(build_macos)
+    if config.build_linux:
+        build_linux = pipeline_steps.generate_step_template("Linux", "build", None, None)
+        pipeline_steps.append(build_linux)
+    pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests runner pipeline",
+                                                       ".buildkite/pipelines/run_es_tests.yml.sh"))
+    pipeline_steps.append({"wait": None})
+    pipeline_steps.append(pipeline_steps.generate_step("Upload artifact uploader pipeline",
+                                                       ".buildkite/pipelines/upload_to_s3.yml.sh"))
+    pipeline["steps"] = pipeline_steps
+    print(json.dumps(pipeline, indent=2))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass

--- a/.buildkite/branch.json.py
+++ b/.buildkite/branch.json.py
@@ -9,7 +9,7 @@
 # limitation.
 #
 # This script generates a pipeline JSON for the ml-cpp-branch pipeline.
-# Builds for this pipeline may be triggered by commit or comment.
+# Builds for this pipeline may be triggered by code, API or UI.
 #
 import json
 

--- a/.buildkite/branch.json.py
+++ b/.buildkite/branch.json.py
@@ -8,7 +8,7 @@
 # compliance with the Elastic License 2.0 and the foregoing additional
 # limitation.
 #
-# This script generates a pipeline JSON for the ml-cpp-branch pipeline.
+# This script generates a pipeline JSON for the ml-cpp-branch pipeline for branch builds.
 # Builds for this pipeline may be triggered by code, API or UI.
 #
 import json
@@ -30,13 +30,13 @@ def main():
     config = buildConfig.Config()
     config.parse()
     if config.build_windows:
-        build_windows = pipeline_steps.generate_step_template("Windows", "build", None, None)
+        build_windows = pipeline_steps.generate_step_template("Windows", "build")
         pipeline_steps.append(build_windows)
     if config.build_macos:
-        build_macos = pipeline_steps.generate_step_template("MacOS", "build", None, None)
+        build_macos = pipeline_steps.generate_step_template("MacOS", "build")
         pipeline_steps.append(build_macos)
     if config.build_linux:
-        build_linux = pipeline_steps.generate_step_template("Linux", "build", None, None)
+        build_linux = pipeline_steps.generate_step_template("Linux", "build")
         pipeline_steps.append(build_linux)
     pipeline_steps.append({"wait": None})
     pipeline_steps.append(pipeline_steps.generate_step("Upload artifact uploader pipeline",

--- a/.buildkite/branch.json.py
+++ b/.buildkite/branch.json.py
@@ -41,7 +41,7 @@ def main():
 
     pipeline_steps.append({"wait": None})
 
-	# Trigger the DRA pipeline to create and upload artifacts to S3 and GCS
+    # Trigger the DRA pipeline to create and upload artifacts to S3 and GCS
     pipeline_steps.append({"trigger": "ml-cpp-dra",
                            "label": ":rocket: DRA",
                            "async": "true",

--- a/.buildkite/branch.json.py
+++ b/.buildkite/branch.json.py
@@ -46,7 +46,9 @@ def main():
                            "label": ":rocket: DRA",
                            "async": "true",
                            "build": {
-                               "message": "Triggered DRA build"}})
+                               "message": "${BUILDKITE_MESSAGE}",
+                               "commit": "${BUILDKITE_COMMIT}",
+                               "branch": "${BUILDKITE_BRANCH}"}})
 
     pipeline["steps"] = pipeline_steps
     print(json.dumps(pipeline, indent=2))

--- a/.buildkite/branch.json.py
+++ b/.buildkite/branch.json.py
@@ -38,9 +38,16 @@ def main():
     if config.build_linux:
         build_linux = pipeline_steps.generate_step_template("Linux", "build")
         pipeline_steps.append(build_linux)
+
     pipeline_steps.append({"wait": None})
-    pipeline_steps.append(pipeline_steps.generate_step("Upload artifact uploader pipeline",
-                                                       ".buildkite/pipelines/upload_to_s3.yml.sh"))
+
+	# Trigger the DRA pipeline to create and upload artifacts to S3 and GCS
+    pipeline_steps.append({"trigger": "ml-cpp-dra",
+                           "label": ":rocket: DRA",
+                           "async": "true",
+                           "build": {
+                               "message": "Triggered DRA build"}})
+
     pipeline["steps"] = pipeline_steps
     print(json.dumps(pipeline, indent=2))
 

--- a/.buildkite/branch.yml
+++ b/.buildkite/branch.yml
@@ -1,0 +1,15 @@
+## 🏠/.buildkite/pipeline.yml
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
+steps:
+  - label: "Upload Dynamic configuration for branch builds"
+    command: "python .buildkite/branch.json.py | buildkite-agent pipeline upload"
+    agents:
+      image: "python"

--- a/.buildkite/dra.json.py
+++ b/.buildkite/dra.json.py
@@ -14,7 +14,8 @@
 #    of the ML CI job.
 # 2. Combine the platform-specific artifacts into an all-platforms bundle,
 #    as used by the Elasticsearch build.
-# 3. Upload the all-platforms bundle to S3, where day-to-day Elasticsearch
+# 3. Upload all artifacts, both platform-specific and all-platforms, to
+#    S3, where day-to-day Elasticsearch
 #    builds will download it from.
 # 4. Upload all artifacts, both platform-specific and all-platforms, to
 #    GCS, where release manager builds will download them from.

--- a/.buildkite/job-build-test-all-debug.json.py
+++ b/.buildkite/job-build-test-all-debug.json.py
@@ -41,13 +41,13 @@ def main():
     config = buildConfig.Config()
     config.parse()
     if config.build_windows:
-        debug_windows = pipeline_steps.generate_step_template("Windows", "debug", config.snapshot, config.version_qualifier)
+        debug_windows = pipeline_steps.generate_step_template("Windows", "debug")
         pipeline_steps.append(debug_windows)
     if config.build_macos:
-        debug_macos = pipeline_steps.generate_step_template("MacOS", "debug", config.snapshot, config.version_qualifier)
+        debug_macos = pipeline_steps.generate_step_template("MacOS", "debug")
         pipeline_steps.append(debug_macos)
     if config.build_linux:
-        debug_linux = pipeline_steps.generate_step_template("Linux", "debug", config.snapshot, config.version_qualifier)
+        debug_linux = pipeline_steps.generate_step_template("Linux", "debug")
         pipeline_steps.append(debug_linux)
 
     pipeline["env"] = env

--- a/.buildkite/ml_pipeline/config.py
+++ b/.buildkite/ml_pipeline/config.py
@@ -9,6 +9,7 @@
 # limitation.
 
 import os
+import re
 
 class Config:
     build_windows: bool = False

--- a/.buildkite/ml_pipeline/step.py
+++ b/.buildkite/ml_pipeline/step.py
@@ -21,9 +21,9 @@ class PipelineStep(list):
     }
     return step
 
-  def generate_step_template(self, platform, action, snapshot, version_qualifier):
+  def generate_step_template(self, platform, action):
     platform_lower = platform.lower()
     platform_emoji = ":"+platform_lower+":"
     label = f"Upload {action} pipeline for {platform} {platform_emoji}"
-    command = f"python3 .buildkite/pipelines/build_{platform_lower}.json.py --action={action} --snapshot={snapshot} --version_qualifier={version_qualifier}"
+    command = f"python3 .buildkite/pipelines/build_{platform_lower}.json.py --action={action}"
     return self.generate_step(label, command)

--- a/.buildkite/pipeline.json.py
+++ b/.buildkite/pipeline.json.py
@@ -17,6 +17,7 @@
 #
 
 import json
+import os
 
 from ml_pipeline import (
     step,
@@ -24,8 +25,6 @@ from ml_pipeline import (
 )
 
 env = {
-  "BUILD_SNAPSHOT": "true",
-  "VERSION_QUALIFIER": ""
 }
 
 def main():
@@ -48,8 +47,10 @@ def main():
     if config.build_linux:
         build_linux = pipeline_steps.generate_step_template("Linux", config.action, config.snapshot, config.version_qualifier)
         pipeline_steps.append(build_linux)
-    pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests runner pipeline",
-                                                       ".buildkite/pipelines/run_es_tests.yml.sh"))
+    # Never run the ES integration tests if VERSION_QUALIFIER has been set.
+    if os.environ.get("VERSION_QUALIFIER", "") == "":
+        pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests runner pipeline",
+                                                           ".buildkite/pipelines/run_es_tests.yml.sh"))
     pipeline_steps.append({"wait": None})
     pipeline_steps.append(pipeline_steps.generate_step("Upload artifact uploader pipeline",
                                                        ".buildkite/pipelines/upload_to_s3.yml.sh"))

--- a/.buildkite/pipeline.json.py
+++ b/.buildkite/pipeline.json.py
@@ -17,7 +17,6 @@
 #
 
 import json
-import os
 
 from ml_pipeline import (
     step,

--- a/.buildkite/pipeline.json.py
+++ b/.buildkite/pipeline.json.py
@@ -51,21 +51,6 @@ def main():
         pipeline_steps.append(build_linux)
     pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests runner pipeline",
                                                        ".buildkite/pipelines/run_es_tests.yml.sh"))
-
-    # Upon merge of a pull request to a branch the BUILDKITE_PULL_REQUEST environment variable
-    # is set to false. In this case we want to additionally create and upload artifacts.
-    if os.environ.get('BUILDKITE_PULL_REQUEST', 'false') == 'false':
-        pipeline_steps.append({"wait": None})
-
-        # Trigger the DRA pipeline to create and upload artifacts to S3 and GCS
-        pipeline_steps.append({"trigger": "ml-cpp-dra",
-                               "label": ":rocket: DRA",
-                               "async": "true",
-                               "build": {
-                                   "message": "${BUILDKITE_MESSAGE}",
-                                   "commit": "${BUILDKITE_COMMIT}",
-                                   "branch": "${BUILDKITE_BRANCH}"}})
-
     pipeline["env"] = env
     pipeline["steps"] = pipeline_steps
     print(json.dumps(pipeline, indent=2))

--- a/.buildkite/pipelines/build_linux.json.py
+++ b/.buildkite/pipelines/build_linux.json.py
@@ -31,11 +31,6 @@ actions = [
     "build",
     "debug"
 ]
-build_snapshot = [
-    "None",
-    "true",
-    "false"
-]
 agents = {
    "x86_64": {
       "cpu": "6",
@@ -65,8 +60,6 @@ def main(args):
             "agents": agents[arch],
             "commands": [
               f'if [[ "{args.action}" == "debug" ]]; then export ML_DEBUG=1; fi',
-              f'if [[ "{args.snapshot}" != "None" ]]; then export BUILD_SNAPSHOT={args.snapshot}; fi',
-              f'if [[ "{args.version_qualifier}" != "None" ]]; then export VERSION_QUALIFIER={args.version_qualifier}; fi',
               ".buildkite/scripts/steps/build_and_test.sh"
             ],
             "depends_on": "check_style",
@@ -109,8 +102,6 @@ def main(args):
               "image": "docker.elastic.co/ml-dev/ml-linux-aarch64-cross-build:10"
             },
             "commands": [
-              f'if [[ "{args.snapshot}" != "None" ]]; then export BUILD_SNAPSHOT={args.snapshot}; fi',
-              f'if [[ "{args.version_qualifier}" != "None" ]]; then export VERSION_QUALIFIER={args.version_qualifier}; fi',
               ".buildkite/scripts/steps/build_and_test.sh"
             ],
             "depends_on": "check_style",
@@ -148,15 +139,6 @@ if __name__ == "__main__":
                         choices=actions,
                         default="build",
                         help="Specify a build action.")
-    parser.add_argument("--snapshot",
-                        required=False,
-                        choices=build_snapshot,
-                        default=None,
-                        help="Specify if a snapshot build is wanted.")
-    parser.add_argument("--version_qualifier",
-                        required=False,
-                        default=None,
-                        help="Specify a version qualifier.")
 
     args = parser.parse_args()
 

--- a/.buildkite/pipelines/build_linux.json.py
+++ b/.buildkite/pipelines/build_linux.json.py
@@ -32,6 +32,7 @@ actions = [
     "debug"
 ]
 build_snapshot = [
+    "None",
     "true",
     "false"
 ]
@@ -110,7 +111,6 @@ def main(args):
             "commands": [
               f'if [[ "{args.snapshot}" != "None" ]]; then export BUILD_SNAPSHOT={args.snapshot}; fi',
               f'if [[ "{args.version_qualifier}" != "None" ]]; then export VERSION_QUALIFIER={args.version_qualifier}; fi',
-              "env",
               ".buildkite/scripts/steps/build_and_test.sh"
             ],
             "depends_on": "check_style",

--- a/.buildkite/pipelines/build_macos.json.py
+++ b/.buildkite/pipelines/build_macos.json.py
@@ -30,11 +30,6 @@ actions = [
   "build",
   "debug"
 ]
-build_snapshot = [
-    "None",
-    "true",
-    "false"
-]
 
 def main(args):
     pipeline_steps = []
@@ -50,8 +45,6 @@ def main(args):
             },
             "commands": [
               f'if [[ "{args.action}" == "debug" ]]; then export ML_DEBUG=1; fi',
-              f'if [[ "{args.snapshot}" != "None" ]]; then export BUILD_SNAPSHOT={args.snapshot}; fi',
-              f'if [[ "{args.version_qualifier}" != "None" ]]; then export VERSION_QUALIFIER={args.version_qualifier}; fi',
               f'echo "MacOS {arch} build not yet supported";'
             ],
             "depends_on": "check_style",
@@ -89,8 +82,6 @@ def main(args):
         },
         "commands": [
           f'if [[ "{args.action}" == "debug" ]]; then export ML_DEBUG=1; fi',
-          f'if [[ "{args.snapshot}" != "None" ]]; then export BUILD_SNAPSHOT={args.snapshot}; fi',
-          f'if [[ "{args.version_qualifier}" != "None" ]]; then export VERSION_QUALIFIER={args.version_qualifier}; fi',
           ".buildkite/scripts/steps/build_and_test.sh"
         ],
         "depends_on": "check_style",
@@ -128,14 +119,6 @@ if __name__ == '__main__':
                         choices=actions,
                         default="build",
                         help="Specify a build action")
-    parser.add_argument("--snapshot",
-                        required=False,
-                        default="true",
-                        help="Specify if a snapshot build is wanted.")
-    parser.add_argument("--version_qualifier",
-                        required=False,
-                        default=None,
-                        help="Specify a version qualifier.")
 
     args = parser.parse_args()
 

--- a/.buildkite/pipelines/build_macos.json.py
+++ b/.buildkite/pipelines/build_macos.json.py
@@ -31,6 +31,7 @@ actions = [
   "debug"
 ]
 build_snapshot = [
+    "None",
     "true",
     "false"
 ]

--- a/.buildkite/pipelines/build_windows.json.py
+++ b/.buildkite/pipelines/build_windows.json.py
@@ -30,11 +30,6 @@ actions = [
     "build",
     "debug"
 ]
-build_snapshot = [
-    "None",
-    "true",
-    "false"
-]
 
 def main(args):
     pipeline_steps = []
@@ -54,8 +49,6 @@ def main(args):
             },
             "commands": [
               f'if ( "{args.action}" -eq "debug" ) {{\$Env:ML_DEBUG="1"}}',
-              f'if ( "{args.snapshot}" -ne "None" ) {{\\$Env:BUILD_SNAPSHOT="{args.snapshot}"}}',
-              f'if ( "{args.version_qualifier}" -ne "None" ) {{\\$Env:VERSION_QUALIFIER="{args.version_qualifier}"}}',
               "& .buildkite\\scripts\\steps\\build_and_test.ps1"
             ],
             "depends_on": "check_style",
@@ -101,15 +94,6 @@ if __name__ == "__main__":
                         choices=actions,
                         default="build",
                         help="Specify a build action.")
-    parser.add_argument("--snapshot",
-                        required=False,
-                        choices=build_snapshot,
-                        default=None,
-                        help="Specify if a snapshot build is wanted.")
-    parser.add_argument("--version_qualifier",
-                        required=False,
-                        default=None,
-                        help="Specify a version qualifier.")
 
     args = parser.parse_args()
 

--- a/.buildkite/pipelines/build_windows.json.py
+++ b/.buildkite/pipelines/build_windows.json.py
@@ -31,6 +31,7 @@ actions = [
     "debug"
 ]
 build_snapshot = [
+    "None",
     "true",
     "false"
 ]

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -9,7 +9,7 @@
       "commit_status_context": "ml-cpp-ci",
       "build_on_commit": true,
       "build_on_comment": true,
-      "trigger_comment_regex": "^(?:(?:buildkite +)(?<action>build|debug) +(?: *on *(?<platform>(?:[ ,]*(?:windows|linux|mac(os)?))+))?( +snapshot *= *(?<snapshot>true|false))?( +version_qualifier *= *(?<version_qualifier>\\w+))?)$",
+      "trigger_comment_regex": "^(?:(?:buildkite +)(?<action>build|debug) +(?: *on *(?<platform>(?:[ ,]*(?:windows|linux|mac(os)?))+))?)$",
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "skip_ci_labels": ["skip-ci", "jenkins-ci", ">test-mute", ">docs"],
       "skip_target_branches": ["6.8", "7.11", "7.12"],

--- a/.buildkite/scripts/steps/build_and_test.sh
+++ b/.buildkite/scripts/steps/build_and_test.sh
@@ -11,7 +11,7 @@
 set -euo pipefail
 
 # Default to a snapshot build
-if [ -z "${BUILD_SNAPSHOT:=true}" ] ; then
+if [ "${BUILD_SNAPSHOT:=true}" != false] ; then
     BUILD_SNAPSHOT=true
 fi
 

--- a/.buildkite/scripts/steps/build_and_test.sh
+++ b/.buildkite/scripts/steps/build_and_test.sh
@@ -11,7 +11,7 @@
 set -euo pipefail
 
 # Default to a snapshot build
-if [ -z "$BUILD_SNAPSHOT" ] ; then
+if [ -z "${BUILD_SNAPSHOT:=true}" ] ; then
     BUILD_SNAPSHOT=true
 fi
 
@@ -29,7 +29,7 @@ else
 fi
 
 # Version qualifier shouldn't be used in PR builds
-if [[ x"$BUILDKITE_PULL_REQUEST" != xfalse && -n "$VERSION_QUALIFIER" ]] ; then
+if [[ x"$BUILDKITE_PULL_REQUEST" != xfalse && -n "${VERSION_QUALIFIER:=""}" ]] ; then
     echo "VERSION_QUALIFIER should not be set in PR builds: was $VERSION_QUALIFIER"
     exit 2
 fi

--- a/.buildkite/scripts/steps/run_es_tests.sh
+++ b/.buildkite/scripts/steps/run_es_tests.sh
@@ -15,7 +15,7 @@ echo "pwd = $(pwd)"
 export HARDWARE_ARCH=$(uname -m | sed 's/arm64/aarch64/')
 
 VERSION=$(cat ${REPO_ROOT}/gradle.properties | grep '^elasticsearchVersion' | awk -F= '{ print $2 }' | xargs echo)
-if [ "$BUILD_SNAPSHOT" = "true" ] ; then
+if [ "${BUILD_SNAPSHOT:=true}" = "true" ] ; then
     VERSION=${VERSION}-SNAPSHOT
 fi
 export VERSION

--- a/.buildkite/snapshot.yml
+++ b/.buildkite/snapshot.yml
@@ -8,10 +8,10 @@
 # compliance with the Elastic License 2.0 and the foregoing additional
 # limitation.
 
+env:
+  "BUILD_SNAPSHOT": "true"
 steps:
   - label: "Upload Dynamic configuration for snapshot builds"
-    env:
-      "BUILD_SNAPSHOT": "true"
     command: "python .buildkite/branch.json.py | buildkite-agent pipeline upload"
     agents:
       image: "python"

--- a/.buildkite/snapshot.yml
+++ b/.buildkite/snapshot.yml
@@ -10,7 +10,8 @@
 
 steps:
   - label: "Upload Dynamic configuration for snapshot builds"
-    env: "BUILD_SNAPSHOT": "true"
+    env:
+      "BUILD_SNAPSHOT": "true"
     command: "python .buildkite/branch.json.py | buildkite-agent pipeline upload"
     agents:
       image: "python"

--- a/.buildkite/snapshot.yml
+++ b/.buildkite/snapshot.yml
@@ -1,0 +1,16 @@
+## 🏠/.buildkite/pipeline.yml
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
+steps:
+  - label: "Upload Dynamic configuration for snapshot builds"
+    env: "BUILD_SNAPSHOT": "true"
+    command: "python .buildkite/branch.json.py | buildkite-agent pipeline upload"
+    agents:
+      image: "python"

--- a/.buildkite/staging.yml
+++ b/.buildkite/staging.yml
@@ -10,7 +10,8 @@
 
 steps:
   - label: "Upload Dynamic configuration for staging builds"
-    env: "BUILD_SNAPSHOT": "false"
+    env:
+      "BUILD_SNAPSHOT": "false"
     command: "python .buildkite/branch.json.py | buildkite-agent pipeline upload"
     agents:
       image: "python"

--- a/.buildkite/staging.yml
+++ b/.buildkite/staging.yml
@@ -8,10 +8,10 @@
 # compliance with the Elastic License 2.0 and the foregoing additional
 # limitation.
 
+env:
+  "BUILD_SNAPSHOT": "false"
 steps:
   - label: "Upload Dynamic configuration for staging builds"
-    env:
-      "BUILD_SNAPSHOT": "false"
     command: "python .buildkite/branch.json.py | buildkite-agent pipeline upload"
     agents:
       image: "python"

--- a/.buildkite/staging.yml
+++ b/.buildkite/staging.yml
@@ -9,7 +9,8 @@
 # limitation.
 
 steps:
-  - label: "Upload Dynamic configuration for branch builds"
+  - label: "Upload Dynamic configuration for staging builds"
+    env: "BUILD_SNAPSHOT": "false"
     command: "python .buildkite/branch.json.py | buildkite-agent pipeline upload"
     agents:
       image: "python"


### PR DESCRIPTION
Separate the concerns of branch builds away from those of PR builds. This simplifies and fixes a problem of the latter whereby builds were being triggered twice, once by BuildKite directly and again from an API call from within a PR webhook.