### PR TITLE
Parameterise CConcurrentQueue work queue size 

### DIFF
--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -255,8 +255,9 @@ int main(int argc, char** argv) {
     ml::torch::CCommandParser commandParser{ioMgr.inputStream(), cacheMemorylimitBytes};
 
     // Size the threadpool to the number of hardware threads
-    // so we can grow and shrink the threadpool dynamically
-    ml::core::startDefaultAsyncExecutor();
+    // so we can grow and shrink the threadpool dynamically.
+    // The task queue size is set to 1.
+    ml::core::startDefaultAsyncExecutor(0, 1);
     // Set the number of threads to use
     ml::core::defaultAsyncExecutor().numberThreadsInUse(threadSettings.numAllocations());
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -40,6 +40,7 @@
 
 * Add identification of multimodal distribution to anomaly explanations. (See {ml-pull}2440[#2440].)
 * Upgrade PyTorch to version 1.13.1. (See {ml-pull}2430[#2430].)
+* Remove the PyTorch inference work queue as now handled in Elasticsearch
 
 == {es} version 8.6.0
 

--- a/include/core/CConcurrentQueue.h
+++ b/include/core/CConcurrentQueue.h
@@ -35,19 +35,18 @@ namespace core {
 //! for the price of blocking.
 //!
 //! @tparam T the objects of the queue
-//! @tparam QUEUE_CAPACITY fixed queue capacity
-//! @tparam NOTIFY_CAPACITY special parameter, for signaling the producer in blocking case
-template<typename T, size_t QUEUE_CAPACITY, size_t NOTIFY_CAPACITY = QUEUE_CAPACITY>
+template<typename T>
 class CConcurrentQueue final : private CNonCopyable {
 public:
     using TOptional = std::optional<T>;
 
 public:
-    CConcurrentQueue() : m_Queue(QUEUE_CAPACITY) {
-        static_assert(NOTIFY_CAPACITY > 0, "NOTIFY_CAPACITY must be positive");
-        static_assert(QUEUE_CAPACITY >= NOTIFY_CAPACITY,
-                      "QUEUE_CAPACITY cannot be less than NOTIFY_CAPACITY");
-    }
+    explicit CConcurrentQueue(std::size_t queueCapacity, std::size_t notifyCapacity)
+        : m_QueueCapacity(queueCapacity), m_NotifyCapacity(notifyCapacity),
+          m_Queue(queueCapacity) {}
+
+    explicit CConcurrentQueue(std::size_t queueCapacity)
+        : CConcurrentQueue(queueCapacity, queueCapacity) {}
 
     //! Pop an item out of the queue, this blocks until an item is available
     T pop() {
@@ -109,7 +108,7 @@ public:
     //! Forward \p item to the queue, if the queue is full this fails and returns false
     bool tryPush(T&& item) {
         std::unique_lock<std::mutex> lock(m_Mutex);
-        if (m_Queue.size() >= QUEUE_CAPACITY) {
+        if (m_Queue.size() >= m_QueueCapacity) {
             return false;
         }
 
@@ -141,12 +140,12 @@ private:
     }
     void waitWhileFull(std::unique_lock<std::mutex>& lock) {
         m_ProducerCondition.wait(
-            lock, [this] { return m_Queue.size() < QUEUE_CAPACITY; });
+            lock, [this] { return m_Queue.size() < m_QueueCapacity; });
     }
 
     void notifyIfNoLongerFull(std::unique_lock<std::mutex>& lock, std::size_t oldSize) {
         lock.unlock();
-        if (oldSize >= NOTIFY_CAPACITY) {
+        if (oldSize >= m_NotifyCapacity) {
             m_ProducerCondition.notify_all();
         }
     }
@@ -160,6 +159,9 @@ private:
     static bool always(const T&) { return true; }
 
 private:
+    std::size_t m_QueueCapacity;
+    std::size_t m_NotifyCapacity;
+
     //! The internal queue
     boost::circular_buffer<T> m_Queue;
 

--- a/include/core/CConcurrentQueue.h
+++ b/include/core/CConcurrentQueue.h
@@ -12,7 +12,6 @@
 #define INCLUDED_ml_core_CConcurrentQueue_h
 
 #include <core/CMemoryDec.h>
-#include <core/CNonCopyable.h>
 
 #include <boost/circular_buffer.hpp>
 
@@ -36,7 +35,7 @@ namespace core {
 //!
 //! @tparam T the objects of the queue
 template<typename T>
-class CConcurrentQueue final : private CNonCopyable {
+class CConcurrentQueue final {
 public:
     using TOptional = std::optional<T>;
 
@@ -47,6 +46,12 @@ public:
 
     explicit CConcurrentQueue(std::size_t queueCapacity)
         : CConcurrentQueue(queueCapacity, queueCapacity) {}
+
+    CConcurrentQueue(const CConcurrentQueue&) = delete;
+    CConcurrentQueue& operator=(const CConcurrentQueue&) = delete;
+    // The use of std::mutex prevents this class from being moveable
+    CConcurrentQueue(CConcurrentQueue&&) = delete;
+    CConcurrentQueue& operator=(CConcurrentQueue&&) = delete;
 
     //! Pop an item out of the queue, this blocks until an item is available
     T pop() {

--- a/include/core/CConcurrentQueue.h
+++ b/include/core/CConcurrentQueue.h
@@ -159,7 +159,10 @@ private:
     static bool always(const T&) { return true; }
 
 private:
+    //! Fixed queue capacity
     std::size_t m_QueueCapacity;
+
+    //! For signaling the producer in blocking case
     std::size_t m_NotifyCapacity;
 
     //! The internal queue

--- a/include/core/CConcurrentWrapper.h
+++ b/include/core/CConcurrentWrapper.h
@@ -37,7 +37,9 @@ public:
     //!
     //! The object has to wrapped once and only once, pass the reference around in your code.
     //! This starts a background thread.
-    explicit CConcurrentWrapper(T& resource, std::size_t queueCapacity, std::size_t notifyCapacity)
+    explicit CConcurrentWrapper(T& resource,
+                                std::size_t queueCapacity = 100,
+                                std::size_t notifyCapacity = 50)
         : m_Queue(queueCapacity, notifyCapacity), m_Resource(resource), m_Done(false) {
         m_Worker = std::thread([this] {
             while (!m_Done) {
@@ -45,9 +47,6 @@ public:
             }
         });
     }
-
-    explicit CConcurrentWrapper(T& resource)
-        : CConcurrentWrapper(resource, 100, 50) {}
 
     ~CConcurrentWrapper() {
         m_Queue.push([this] { m_Done = true; });

--- a/include/core/CJsonOutputStreamWrapper.h
+++ b/include/core/CJsonOutputStreamWrapper.h
@@ -99,7 +99,7 @@ private:
     rapidjson::StringBuffer m_StringBuffers[BUFFER_POOL_SIZE];
 
     //! the pool of available buffers
-    CConcurrentQueue<rapidjson::StringBuffer*, BUFFER_POOL_SIZE> m_StringBufferQueue;
+    CConcurrentQueue<rapidjson::StringBuffer*> m_StringBufferQueue;
 
     //! the stream object wrapped by CConcurrentWrapper
     TOStreamConcurrentWrapper m_ConcurrentOutputStream;

--- a/include/core/CStaticThreadPool.h
+++ b/include/core/CStaticThreadPool.h
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <thread>
 #include <vector>
@@ -36,7 +37,7 @@ public:
     using TTask = std::function<void()>;
 
 public:
-    explicit CStaticThreadPool(std::size_t size);
+    explicit CStaticThreadPool(std::size_t size, std::size_t queueCapacity = 50);
 
     ~CStaticThreadPool();
 
@@ -82,8 +83,9 @@ private:
         TOptionalSize m_ThreadId;
     };
     using TOptionalTask = std::optional<CWrappedTask>;
-    using TWrappedTaskQueue = CConcurrentQueue<CWrappedTask, 50>;
-    using TWrappedTaskQueueVec = std::vector<TWrappedTaskQueue>;
+    using TWrappedTaskQueue = CConcurrentQueue<CWrappedTask>;
+    using TWrappedTaskQueueUPtr = std::unique_ptr<TWrappedTaskQueue>;
+    using TWrappedTaskQueueUPtrVec = std::vector<TWrappedTaskQueueUPtr>;
     using TThreadVec = std::vector<std::thread>;
 
 private:
@@ -99,7 +101,7 @@ private:
     std::atomic_bool m_Busy;
     std::atomic<std::uint64_t> m_Cursor;
     std::atomic<std::size_t> m_NumberThreadsInUse;
-    TWrappedTaskQueueVec m_TaskQueues;
+    TWrappedTaskQueueUPtrVec m_TaskQueues;
     TThreadVec m_Pool;
 };
 }

--- a/include/core/Concurrency.h
+++ b/include/core/Concurrency.h
@@ -89,11 +89,13 @@ public:
 //! the size specified here. If called with \p threadPoolSize equal to zero
 //! it defaults to calling std::thread::hardware_concurrency to size the
 //! thread pool.
+//! \p queueCapacity is the size of the work queue
 //!
 //! \note This is not thread safe as the intention is that it is invoked once,
 //! usually at the beginning of main or in single threaded test code.
 CORE_EXPORT
-void startDefaultAsyncExecutor(std::size_t threadPoolSize = 0);
+void startDefaultAsyncExecutor(std::size_t threadPoolSize = 0,
+                               std::size_t queueCapacity = 50);
 
 //! Shutdown the thread pool and reset the executor to sequential in the same thread.
 //!

--- a/lib/core/CJsonOutputStreamWrapper.cc
+++ b/lib/core/CJsonOutputStreamWrapper.cc
@@ -23,7 +23,8 @@ const char CJsonOutputStreamWrapper::JSON_ARRAY_END(']');
 const char CJsonOutputStreamWrapper::JSON_ARRAY_DELIMITER(',');
 
 CJsonOutputStreamWrapper::CJsonOutputStreamWrapper(std::ostream& outStream)
-    : m_ConcurrentOutputStream(outStream), m_FirstObject(true) {
+    : m_StringBufferQueue(CJsonOutputStreamWrapper::BUFFER_POOL_SIZE),
+      m_ConcurrentOutputStream(outStream), m_FirstObject(true) {
     // initialize the bufferpool
     for (auto& stringBuffer : m_StringBuffers) {
         stringBuffer.Reserve(BUFFER_START_SIZE);

--- a/lib/core/CStaticThreadPool.cc
+++ b/lib/core/CStaticThreadPool.cc
@@ -25,7 +25,7 @@ std::size_t computeSize(std::size_t hint) {
 CStaticThreadPool::CStaticThreadPool(std::size_t size, std::size_t queueCapacity)
     : m_Busy{false}, m_Cursor{0} {
 
-    std::size_t poolSize = computeSize(size);
+    std::size_t poolSize{computeSize(size)};
     m_Pool.reserve(poolSize);
 
     for (std::size_t id = 0; id < poolSize; ++id) {

--- a/lib/core/CStaticThreadPool.cc
+++ b/lib/core/CStaticThreadPool.cc
@@ -10,6 +10,7 @@
  */
 
 #include <core/CStaticThreadPool.h>
+#include <memory>
 
 namespace ml {
 namespace core {
@@ -21,11 +22,18 @@ std::size_t computeSize(std::size_t hint) {
 }
 }
 
-CStaticThreadPool::CStaticThreadPool(std::size_t size)
-    : m_Busy{false}, m_Cursor{0}, m_TaskQueues{computeSize(size)} {
-    m_NumberThreadsInUse.store(m_TaskQueues.size());
-    m_Pool.reserve(m_TaskQueues.size());
-    for (std::size_t id = 0; id < m_TaskQueues.size(); ++id) {
+CStaticThreadPool::CStaticThreadPool(std::size_t size, std::size_t queueCapacity)
+    : m_Busy{false}, m_Cursor{0} {
+
+    std::size_t poolSize = computeSize(size);
+    m_Pool.reserve(poolSize);
+
+    for (std::size_t id = 0; id < poolSize; ++id) {
+        m_TaskQueues.push_back(std::make_unique<TWrappedTaskQueue>(queueCapacity));
+    }
+    m_NumberThreadsInUse.store(poolSize);
+
+    for (std::size_t id = 0; id < poolSize; ++id) {
         try {
             m_Pool.emplace_back([this, id] { this->worker(id); });
         } catch (...) {
@@ -55,12 +63,12 @@ void CStaticThreadPool::schedule(TTask&& task_) {
     std::size_t end{i + size};
     CWrappedTask task{std::forward<TTask>(task_)};
     for (/**/; i < end; ++i) {
-        if (m_TaskQueues[i % size].tryPush(std::move(task))) {
+        if (m_TaskQueues[i % size]->tryPush(std::move(task))) {
             break;
         }
     }
     if (i == end) {
-        m_TaskQueues[i % size].push(std::move(task));
+        m_TaskQueues[i % size]->push(std::move(task));
     }
 
     // For many small tasks the best strategy for minimising contention between the
@@ -93,7 +101,7 @@ void CStaticThreadPool::shutdown() {
     // so each thread executes exactly one shutdown task.
     for (std::size_t id = 0; id < m_TaskQueues.size(); ++id) {
         TTask done{[this] { m_Done = true; }};
-        m_TaskQueues[id].push(CWrappedTask{std::move(done), id});
+        m_TaskQueues[id]->push(CWrappedTask{std::move(done), id});
     }
 
     for (auto& thread : m_Pool) {
@@ -132,7 +140,7 @@ void CStaticThreadPool::worker(std::size_t id) {
         // of active worker threads soon adapts to the new limit.
         if (id < size) {
             for (std::size_t i = 0; i < size; ++i) {
-                task = m_TaskQueues[(id + i) % size].tryPop(ifAllowed);
+                task = m_TaskQueues[(id + i) % size]->tryPop(ifAllowed);
                 if (task != std::nullopt) {
                     break;
                 }
@@ -141,7 +149,7 @@ void CStaticThreadPool::worker(std::size_t id) {
             task = std::nullopt;
         }
         if (task == std::nullopt) {
-            task = m_TaskQueues[id].pop();
+            task = m_TaskQueues[id]->pop();
         }
 
         (*task)();
@@ -160,7 +168,7 @@ void CStaticThreadPool::drainQueuesWithoutBlocking() {
     TOptionalTask task;
     auto popTask = [&] {
         for (auto& queue : m_TaskQueues) {
-            task = queue.tryPop();
+            task = queue->tryPop();
             if (task != std::nullopt) {
                 (*task)();
                 return true;

--- a/lib/core/Concurrency.cc
+++ b/lib/core/Concurrency.cc
@@ -55,7 +55,8 @@ private:
 
 class CExecutorHolder {
 public:
-    CExecutorHolder() : m_ThreadPoolSize(0), m_Executor(std::make_unique<CImmediateExecutor>()) {}
+    CExecutorHolder()
+        : m_ThreadPoolSize(0), m_Executor(std::make_unique<CImmediateExecutor>()) {}
 
     static CExecutorHolder makeThreadPool(std::size_t threadPoolSize, std::size_t queueCapacity) {
         if (threadPoolSize == 0) {

--- a/lib/core/Concurrency.cc
+++ b/lib/core/Concurrency.cc
@@ -56,7 +56,7 @@ private:
 class CExecutorHolder {
 public:
     CExecutorHolder()
-        : m_ThreadPoolSize(0), m_Executor(std::make_unique<CImmediateExecutor>()) {}
+        : m_ThreadPoolSize{0}, m_Executor(std::make_unique<CImmediateExecutor>()) {}
 
     static CExecutorHolder makeThreadPool(std::size_t threadPoolSize, std::size_t queueCapacity) {
         if (threadPoolSize == 0) {

--- a/lib/core/Concurrency.cc
+++ b/lib/core/Concurrency.cc
@@ -55,7 +55,7 @@ private:
 
 class CExecutorHolder {
 public:
-    CExecutorHolder() : m_Executor(std::make_unique<CImmediateExecutor>()) {}
+    CExecutorHolder() : m_ThreadPoolSize(0), m_Executor(std::make_unique<CImmediateExecutor>()) {}
 
     static CExecutorHolder makeThreadPool(std::size_t threadPoolSize, std::size_t queueCapacity) {
         if (threadPoolSize == 0) {

--- a/lib/core/Concurrency.cc
+++ b/lib/core/Concurrency.cc
@@ -33,7 +33,8 @@ public:
 //! \brief Executes a function in a thread pool.
 class CThreadPoolExecutor final : public CExecutor {
 public:
-    explicit CThreadPoolExecutor(std::size_t size) : m_ThreadPool{size} {}
+    explicit CThreadPoolExecutor(std::size_t size, std::size_t queueCapacity)
+        : m_ThreadPool{size, queueCapacity} {}
 
     void schedule(std::function<void()>&& f) override {
         m_ThreadPool.schedule(std::forward<std::function<void()>>(f));
@@ -54,17 +55,16 @@ private:
 
 class CExecutorHolder {
 public:
-    CExecutorHolder()
-        : m_ThreadPoolSize{0}, m_Executor(std::make_unique<CImmediateExecutor>()) {}
+    CExecutorHolder() : m_Executor(std::make_unique<CImmediateExecutor>()) {}
 
-    static CExecutorHolder makeThreadPool(std::size_t threadPoolSize) {
+    static CExecutorHolder makeThreadPool(std::size_t threadPoolSize, std::size_t queueCapacity) {
         if (threadPoolSize == 0) {
             threadPoolSize = std::thread::hardware_concurrency();
         }
 
         if (threadPoolSize > 0) {
             try {
-                return CExecutorHolder{threadPoolSize};
+                return CExecutorHolder{threadPoolSize, queueCapacity};
             } catch (const std::exception& e) {
                 LOG_ERROR(<< "Failed to create thread pool with '" << e.what()
                           << "'. Falling back to running single threaded");
@@ -83,9 +83,9 @@ public:
     std::size_t threadPoolSize() const { return m_ThreadPoolSize; }
 
 private:
-    CExecutorHolder(std::size_t threadPoolSize)
+    CExecutorHolder(std::size_t threadPoolSize, std::size_t queueCapacity)
         : m_ThreadPoolSize{threadPoolSize},
-          m_Executor(std::make_unique<CThreadPoolExecutor>(threadPoolSize)) {}
+          m_Executor(std::make_unique<CThreadPoolExecutor>(threadPoolSize, queueCapacity)) {}
 
 private:
     std::size_t m_ThreadPoolSize;
@@ -95,11 +95,11 @@ private:
 CExecutorHolder singletonExecutor;
 }
 
-void startDefaultAsyncExecutor(std::size_t threadPoolSize) {
+void startDefaultAsyncExecutor(std::size_t threadPoolSize, std::size_t queueCapacity) {
     // This is purposely not thread safe. This is only meant to be called once from
     // the main thread, typically from main of an executable or in single threaded
     // test code.
-    singletonExecutor = CExecutorHolder::makeThreadPool(threadPoolSize);
+    singletonExecutor = CExecutorHolder::makeThreadPool(threadPoolSize, queueCapacity);
 }
 
 void stopDefaultAsyncExecutor() {


### PR DESCRIPTION
`CstaticThreadPool` uses a `CConcurrentQueue` to buffer work. The size of the work queue is a template parameter which makes it difficult to change in `CstaticThreadPool`. This change makes the queue size an ctor argument which is passed down to `CConcurrentQueue`

The `pytorch_inference` app is changed to use a queue of 1.


The motivation for this change is to avoid queuing work in the `pytorch_inference` process as requests are already queued on the Java side and certain features require the ability to jump to the front of the queue. Also the number of items in the Java queue is reported via the stats API but that number is not accurate if work is also queued in `pytorch_inference`.