### PR TITLE
[8.7][ML]Add separate BuildKite pipeline for branch builds (#2452)

### DIFF
--- a/.buildkite/dra.json.py
+++ b/.buildkite/dra.json.py
@@ -14,7 +14,8 @@
 #    of the ML CI job.
 # 2. Combine the platform-specific artifacts into an all-platforms bundle,
 #    as used by the Elasticsearch build.
-# 3. Upload the all-platforms bundle to S3, where day-to-day Elasticsearch
+# 3. Upload all artifacts, both platform-specific and all-platforms, to
+#    S3, where day-to-day Elasticsearch
 #    builds will download it from.
 # 4. Upload all artifacts, both platform-specific and all-platforms, to
 #    GCS, where release manager builds will download them from.

--- a/.buildkite/job-build-test-all-debug.json.py
+++ b/.buildkite/job-build-test-all-debug.json.py
@@ -41,13 +41,13 @@ def main():
     config = buildConfig.Config()
     config.parse()
     if config.build_windows:
-        debug_windows = pipeline_steps.generate_step_template("Windows", "debug", config.snapshot, config.version_qualifier)
+        debug_windows = pipeline_steps.generate_step_template("Windows", "debug")
         pipeline_steps.append(debug_windows)
     if config.build_macos:
-        debug_macos = pipeline_steps.generate_step_template("MacOS", "debug", config.snapshot, config.version_qualifier)
+        debug_macos = pipeline_steps.generate_step_template("MacOS", "debug")
         pipeline_steps.append(debug_macos)
     if config.build_linux:
-        debug_linux = pipeline_steps.generate_step_template("Linux", "debug", config.snapshot, config.version_qualifier)
+        debug_linux = pipeline_steps.generate_step_template("Linux", "debug")
         pipeline_steps.append(debug_linux)
 
     pipeline["env"] = env

--- a/.buildkite/ml_pipeline/config.py
+++ b/.buildkite/ml_pipeline/config.py
@@ -9,24 +9,17 @@
 # limitation.
 
 import os
+import re
 
 class Config:
     build_windows: bool = False
     build_macos: bool = False
     build_linux: bool = False
     action: str = "build"
-    snapshot: str = "true"
-    version_qualifier: str = None
 
     def parse_comment(self):
         if "GITHUB_PR_COMMENT_VAR_ACTION" in os.environ:
             self.action = os.environ["GITHUB_PR_COMMENT_VAR_ACTION"]
-
-        if "GITHUB_PR_COMMENT_VAR_SNAPSHOT" in os.environ:
-            self.snapshot = os.environ["GITHUB_PR_COMMENT_VAR_SNAPSHOT"]
-
-        if "GITHUB_PR_COMMENT_VAR_VERSION_QUALIFIER" in os.environ:
-            self.version_qualifier = os.environ["GITHUB_PR_COMMENT_VAR_VERSION_QUALIFIER"]
 
         if "GITHUB_PR_COMMENT_VAR_PLATFORM" in os.environ:
             csv_platform = os.environ["GITHUB_PR_COMMENT_VAR_PLATFORM"]
@@ -43,17 +36,21 @@ class Config:
             self.build_linux = True
 
     def parse_label(self):
-        for label in [x.strip().lower() for x in os.environ["GITHUB_PR_LABELS"].split(",")]:
-            if "ci:build-windows" == label:
-                self.build_windows = True
-            elif "ci:build-macos" == label:
-                self.build_macos = True
-            elif "ci:build-linux" == label:
-                self.build_linux = True
-            else:
-                self.build_windows = True
-                self.build_macos = True
-                self.build_linux = True
+        build_labels = ['ci:build-linux','ci:build-macos','ci:build-windows']
+        all_labels = [x.strip().lower() for x in os.environ["GITHUB_PR_LABELS"].split(",")]
+        ci_labels = [label for label in all_labels if re.search("|".join(build_labels), label)]
+        if not ci_labels:
+            self.build_windows = True
+            self.build_macos = True
+            self.build_linux = True
+        else:
+            for label in ci_labels:
+                if "ci:build-windows" == label:
+                    self.build_windows = True
+                elif "ci:build-macos" == label:
+                    self.build_macos = True
+                elif "ci:build-linux" == label:
+                    self.build_linux = True
 
     def parse(self):
         """Parse Github label or Github comment passed through buildkite-pr-bot."""

--- a/.buildkite/ml_pipeline/step.py
+++ b/.buildkite/ml_pipeline/step.py
@@ -21,9 +21,9 @@ class PipelineStep(list):
     }
     return step
 
-  def generate_step_template(self, platform, action, snapshot, version_qualifier):
+  def generate_step_template(self, platform, action):
     platform_lower = platform.lower()
     platform_emoji = ":"+platform_lower+":"
     label = f"Upload {action} pipeline for {platform} {platform_emoji}"
-    command = f"python3 .buildkite/pipelines/build_{platform_lower}.json.py --action={action} --snapshot={snapshot} --version_qualifier={version_qualifier}"
+    command = f"python3 .buildkite/pipelines/build_{platform_lower}.json.py --action={action}"
     return self.generate_step(label, command)

--- a/.buildkite/pipelines/build_linux.json.py
+++ b/.buildkite/pipelines/build_linux.json.py
@@ -31,10 +31,6 @@ actions = [
     "build",
     "debug"
 ]
-build_snapshot = [
-    "true",
-    "false"
-]
 agents = {
    "x86_64": {
       "cpu": "6",
@@ -64,8 +60,6 @@ def main(args):
             "agents": agents[arch],
             "commands": [
               f'if [[ "{args.action}" == "debug" ]]; then export ML_DEBUG=1; fi',
-              f'if [[ "{args.snapshot}" != "None" ]]; then export BUILD_SNAPSHOT={args.snapshot}; fi',
-              f'if [[ "{args.version_qualifier}" != "None" ]]; then export VERSION_QUALIFIER={args.version_qualifier}; fi',
               ".buildkite/scripts/steps/build_and_test.sh"
             ],
             "depends_on": "check_style",
@@ -108,9 +102,6 @@ def main(args):
               "image": "docker.elastic.co/ml-dev/ml-linux-aarch64-cross-build:10"
             },
             "commands": [
-              f'if [[ "{args.snapshot}" != "None" ]]; then export BUILD_SNAPSHOT={args.snapshot}; fi',
-              f'if [[ "{args.version_qualifier}" != "None" ]]; then export VERSION_QUALIFIER={args.version_qualifier}; fi',
-              "env",
               ".buildkite/scripts/steps/build_and_test.sh"
             ],
             "depends_on": "check_style",
@@ -148,15 +139,6 @@ if __name__ == "__main__":
                         choices=actions,
                         default="build",
                         help="Specify a build action.")
-    parser.add_argument("--snapshot",
-                        required=False,
-                        choices=build_snapshot,
-                        default=None,
-                        help="Specify if a snapshot build is wanted.")
-    parser.add_argument("--version_qualifier",
-                        required=False,
-                        default=None,
-                        help="Specify a version qualifier.")
 
     args = parser.parse_args()
 

--- a/.buildkite/pipelines/build_macos.json.py
+++ b/.buildkite/pipelines/build_macos.json.py
@@ -30,10 +30,6 @@ actions = [
   "build",
   "debug"
 ]
-build_snapshot = [
-    "true",
-    "false"
-]
 
 def main(args):
     pipeline_steps = []
@@ -49,8 +45,6 @@ def main(args):
             },
             "commands": [
               f'if [[ "{args.action}" == "debug" ]]; then export ML_DEBUG=1; fi',
-              f'if [[ "{args.snapshot}" != "None" ]]; then export BUILD_SNAPSHOT={args.snapshot}; fi',
-              f'if [[ "{args.version_qualifier}" != "None" ]]; then export VERSION_QUALIFIER={args.version_qualifier}; fi',
               f'echo "MacOS {arch} build not yet supported";'
             ],
             "depends_on": "check_style",
@@ -88,8 +82,6 @@ def main(args):
         },
         "commands": [
           f'if [[ "{args.action}" == "debug" ]]; then export ML_DEBUG=1; fi',
-          f'if [[ "{args.snapshot}" != "None" ]]; then export BUILD_SNAPSHOT={args.snapshot}; fi',
-          f'if [[ "{args.version_qualifier}" != "None" ]]; then export VERSION_QUALIFIER={args.version_qualifier}; fi',
           ".buildkite/scripts/steps/build_and_test.sh"
         ],
         "depends_on": "check_style",
@@ -127,14 +119,6 @@ if __name__ == '__main__':
                         choices=actions,
                         default="build",
                         help="Specify a build action")
-    parser.add_argument("--snapshot",
-                        required=False,
-                        default="true",
-                        help="Specify if a snapshot build is wanted.")
-    parser.add_argument("--version_qualifier",
-                        required=False,
-                        default=None,
-                        help="Specify a version qualifier.")
 
     args = parser.parse_args()
 

--- a/.buildkite/pipelines/build_windows.json.py
+++ b/.buildkite/pipelines/build_windows.json.py
@@ -30,10 +30,6 @@ actions = [
     "build",
     "debug"
 ]
-build_snapshot = [
-    "true",
-    "false"
-]
 
 def main(args):
     pipeline_steps = []
@@ -53,8 +49,6 @@ def main(args):
             },
             "commands": [
               f'if ( "{args.action}" -eq "debug" ) {{\$Env:ML_DEBUG="1"}}',
-              f'if ( "{args.snapshot}" -ne "None" ) {{\\$Env:BUILD_SNAPSHOT="{args.snapshot}"}}',
-              f'if ( "{args.version_qualifier}" -ne "None" ) {{\\$Env:VERSION_QUALIFIER="{args.version_qualifier}"}}',
               "& .buildkite\\scripts\\steps\\build_and_test.ps1"
             ],
             "depends_on": "check_style",
@@ -100,15 +94,6 @@ if __name__ == "__main__":
                         choices=actions,
                         default="build",
                         help="Specify a build action.")
-    parser.add_argument("--snapshot",
-                        required=False,
-                        choices=build_snapshot,
-                        default=None,
-                        help="Specify if a snapshot build is wanted.")
-    parser.add_argument("--version_qualifier",
-                        required=False,
-                        default=None,
-                        help="Specify a version qualifier.")
 
     args = parser.parse_args()
 

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -9,7 +9,7 @@
       "commit_status_context": "ml-cpp-ci",
       "build_on_commit": true,
       "build_on_comment": true,
-      "trigger_comment_regex": "^(?:(?:buildkite +)(?<action>build|debug) +(?: *on *(?<platform>(?:[ ,]*(?:windows|linux|mac(os)?))+))?( +snapshot *= *(?<snapshot>true|false))?( +version_qualifier *= *(?<version_qualifier>\\w+))?)$",
+      "trigger_comment_regex": "^(?:(?:buildkite +)(?<action>build|debug) +(?: *on *(?<platform>(?:[ ,]*(?:windows|linux|mac(os)?))+))?)$",
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "skip_ci_labels": ["skip-ci", "jenkins-ci", ">test-mute", ">docs"],
       "skip_target_branches": ["6.8", "7.11", "7.12"],

--- a/.buildkite/scripts/steps/build_and_test.sh
+++ b/.buildkite/scripts/steps/build_and_test.sh
@@ -11,7 +11,7 @@
 set -euo pipefail
 
 # Default to a snapshot build
-if [ -z "$BUILD_SNAPSHOT" ] ; then
+if [ "${BUILD_SNAPSHOT:=true}" != false] ; then
     BUILD_SNAPSHOT=true
 fi
 
@@ -29,7 +29,7 @@ else
 fi
 
 # Version qualifier shouldn't be used in PR builds
-if [[ x"$BUILDKITE_PULL_REQUEST" != xfalse && -n "$VERSION_QUALIFIER" ]] ; then
+if [[ x"$BUILDKITE_PULL_REQUEST" != xfalse && -n "${VERSION_QUALIFIER:=""}" ]] ; then
     echo "VERSION_QUALIFIER should not be set in PR builds: was $VERSION_QUALIFIER"
     exit 2
 fi

--- a/.buildkite/scripts/steps/run_es_tests.sh
+++ b/.buildkite/scripts/steps/run_es_tests.sh
@@ -15,7 +15,7 @@ echo "pwd = $(pwd)"
 export HARDWARE_ARCH=$(uname -m | sed 's/arm64/aarch64/')
 
 VERSION=$(cat ${REPO_ROOT}/gradle.properties | grep '^elasticsearchVersion' | awk -F= '{ print $2 }' | xargs echo)
-if [ "$BUILD_SNAPSHOT" = "true" ] ; then
+if [ "${BUILD_SNAPSHOT:=true}" = "true" ] ; then
     VERSION=${VERSION}-SNAPSHOT
 fi
 export VERSION

--- a/.buildkite/snapshot.yml
+++ b/.buildkite/snapshot.yml
@@ -1,0 +1,17 @@
+## 🏠/.buildkite/pipeline.yml
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
+env:
+  "BUILD_SNAPSHOT": "true"
+steps:
+  - label: "Upload Dynamic configuration for snapshot builds"
+    command: "python .buildkite/branch.json.py | buildkite-agent pipeline upload"
+    agents:
+      image: "python"

--- a/.buildkite/staging.yml
+++ b/.buildkite/staging.yml
@@ -1,0 +1,17 @@
+## 🏠/.buildkite/pipeline.yml
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
+env:
+  "BUILD_SNAPSHOT": "false"
+steps:
+  - label: "Upload Dynamic configuration for staging builds"
+    command: "python .buildkite/branch.json.py | buildkite-agent pipeline upload"
+    agents:
+      image: "python"


### PR DESCRIPTION
Separate the concerns of branch builds away from those of PR builds. This simplifies and fixes a problem of the latter whereby builds were being triggered twice, once by BuildKite directly and again from an API call from within a PR webhook.

Backports #2452