### PR TITLE
[8.7] [ML] Use a work queue of size 1 in pytorch inference 

### DIFF
--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -255,8 +255,9 @@ int main(int argc, char** argv) {
     ml::torch::CCommandParser commandParser{ioMgr.inputStream(), cacheMemorylimitBytes};
 
     // Size the threadpool to the number of hardware threads
-    // so we can grow and shrink the threadpool dynamically
-    ml::core::startDefaultAsyncExecutor();
+    // so we can grow and shrink the threadpool dynamically.
+    // The task queue size is set to 1.
+    ml::core::startDefaultAsyncExecutor(0, 1);
     // Set the number of threads to use
     ml::core::defaultAsyncExecutor().numberThreadsInUse(threadSettings.numAllocations());
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@
 
 * Add identification of multimodal distribution to anomaly explanations. (See {ml-pull}2440[#2440].)
 * Upgrade PyTorch to version 1.13.1. (See {ml-pull}2430[#2430].)
+* Remove the PyTorch inference work queue as now handled in Elasticsearch
 
 == {es} version 8.6.0
 

--- a/include/core/CConcurrentWrapper.h
+++ b/include/core/CConcurrentWrapper.h
@@ -30,17 +30,17 @@ namespace core {
 //! See https://channel9.msdn.com/Shows/Going+Deep/C-and-Beyond-2012-Herb-Sutter-Concurrency-and-Parallelism
 //!
 //! @tparam T the wrapped object
-//! @tparam QUEUE_CAPACITY internal queue capacity
-//! @tparam NOTIFY_CAPACITY special parameter, for signaling the producer in blocking case
-template<typename T, size_t QUEUE_CAPACITY = 100, size_t NOTIFY_CAPACITY = 50>
+template<typename T>
 class CConcurrentWrapper final : private CNonCopyable {
 public:
     //! Wrap and return the wrapped object
     //!
     //! The object has to wrapped once and only once, pass the reference around in your code.
     //! This starts a background thread.
-    explicit CConcurrentWrapper(T& resource)
-        : m_Resource(resource), m_Done(false) {
+    explicit CConcurrentWrapper(T& resource,
+                                std::size_t queueCapacity = 100,
+                                std::size_t notifyCapacity = 50)
+        : m_Queue(queueCapacity, notifyCapacity), m_Resource(resource), m_Done(false) {
         m_Worker = std::thread([this] {
             while (!m_Done) {
                 m_Queue.pop()();
@@ -72,7 +72,7 @@ public:
 
 private:
     //! Queue for the tasks
-    mutable CConcurrentQueue<std::function<void()>, QUEUE_CAPACITY, NOTIFY_CAPACITY> m_Queue;
+    mutable CConcurrentQueue<std::function<void()>> m_Queue;
 
     //! The wrapped resource
     T& m_Resource;

--- a/include/core/CJsonOutputStreamWrapper.h
+++ b/include/core/CJsonOutputStreamWrapper.h
@@ -99,7 +99,7 @@ private:
     rapidjson::StringBuffer m_StringBuffers[BUFFER_POOL_SIZE];
 
     //! the pool of available buffers
-    CConcurrentQueue<rapidjson::StringBuffer*, BUFFER_POOL_SIZE> m_StringBufferQueue;
+    CConcurrentQueue<rapidjson::StringBuffer*> m_StringBufferQueue;
 
     //! the stream object wrapped by CConcurrentWrapper
     TOStreamConcurrentWrapper m_ConcurrentOutputStream;

--- a/include/core/CStaticThreadPool.h
+++ b/include/core/CStaticThreadPool.h
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <thread>
 #include <vector>
@@ -36,7 +37,7 @@ public:
     using TTask = std::function<void()>;
 
 public:
-    explicit CStaticThreadPool(std::size_t size);
+    explicit CStaticThreadPool(std::size_t size, std::size_t queueCapacity = 50);
 
     ~CStaticThreadPool();
 
@@ -82,8 +83,9 @@ private:
         TOptionalSize m_ThreadId;
     };
     using TOptionalTask = std::optional<CWrappedTask>;
-    using TWrappedTaskQueue = CConcurrentQueue<CWrappedTask, 50>;
-    using TWrappedTaskQueueVec = std::vector<TWrappedTaskQueue>;
+    using TWrappedTaskQueue = CConcurrentQueue<CWrappedTask>;
+    using TWrappedTaskQueueUPtr = std::unique_ptr<TWrappedTaskQueue>;
+    using TWrappedTaskQueueUPtrVec = std::vector<TWrappedTaskQueueUPtr>;
     using TThreadVec = std::vector<std::thread>;
 
 private:
@@ -99,7 +101,7 @@ private:
     std::atomic_bool m_Busy;
     std::atomic<std::uint64_t> m_Cursor;
     std::atomic<std::size_t> m_NumberThreadsInUse;
-    TWrappedTaskQueueVec m_TaskQueues;
+    TWrappedTaskQueueUPtrVec m_TaskQueues;
     TThreadVec m_Pool;
 };
 }

--- a/include/core/Concurrency.h
+++ b/include/core/Concurrency.h
@@ -89,11 +89,13 @@ public:
 //! the size specified here. If called with \p threadPoolSize equal to zero
 //! it defaults to calling std::thread::hardware_concurrency to size the
 //! thread pool.
+//! \p queueCapacity is the size of the work queue
 //!
 //! \note This is not thread safe as the intention is that it is invoked once,
 //! usually at the beginning of main or in single threaded test code.
 CORE_EXPORT
-void startDefaultAsyncExecutor(std::size_t threadPoolSize = 0);
+void startDefaultAsyncExecutor(std::size_t threadPoolSize = 0,
+                               std::size_t queueCapacity = 50);
 
 //! Shutdown the thread pool and reset the executor to sequential in the same thread.
 //!

--- a/lib/core/CJsonOutputStreamWrapper.cc
+++ b/lib/core/CJsonOutputStreamWrapper.cc
@@ -23,7 +23,8 @@ const char CJsonOutputStreamWrapper::JSON_ARRAY_END(']');
 const char CJsonOutputStreamWrapper::JSON_ARRAY_DELIMITER(',');
 
 CJsonOutputStreamWrapper::CJsonOutputStreamWrapper(std::ostream& outStream)
-    : m_ConcurrentOutputStream(outStream), m_FirstObject(true) {
+    : m_StringBufferQueue(CJsonOutputStreamWrapper::BUFFER_POOL_SIZE),
+      m_ConcurrentOutputStream(outStream), m_FirstObject(true) {
     // initialize the bufferpool
     for (auto& stringBuffer : m_StringBuffers) {
         stringBuffer.Reserve(BUFFER_START_SIZE);


### PR DESCRIPTION
Work is queued in Elasticsearch and does not need to be queued here. 
Makes the queue size a ctor parameter to CConcurrentQueue.

Backport of #2456