### PR TITLE
[8.7][ML] 8.7 buildkite fix job pending status

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -5,7 +5,7 @@
       "pipeline_slug": "ml-cpp",
       "allow_org_users": true,
       "allowed_repo_permissions": ["admin", "write"],
-      "set_commit_status": true,
+      "set_commit_status": false,
       "commit_status_context": "ml-cpp-ci",
       "build_on_commit": true,
       "build_on_comment": true,


### PR DESCRIPTION
Since "publish_commit_status" is set to "false" on the ml-cpp pipeline it should also be disabled in the pull request config with "set_commit_status: false"

This is because the PR service only sends a commit status when it triggers the build, so if the pipeline isn't configured to send a commit status, a "complete" status will never get sent

This fixes a problem with a PR check for "ml-cpp-ci" continually stuck in the "pending" state.

Backports #2461