### PR TITLE
[8.8][ML] Add native MacOS aarch64 build support in BuildKite (#2470)

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -19,6 +19,8 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == ml-cpp* ]]; then
     export BUILDKITE_ANALYTICS_TOKEN=$(vault read secret/ci/elastic-ml-cpp/buildkite/test_analytics/linux_x86_64 | awk '/^token/ {print $2;}')
   elif [[ "$BUILDKITE_STEP_KEY" == "build_test_linux-aarch64-RelWithDebInfo" ]]; then
     export BUILDKITE_ANALYTICS_TOKEN=$(vault read secret/ci/elastic-ml-cpp/buildkite/test_analytics/linux_aarch64 | awk '/^token/ {print $2;}')
+  elif [[ "$BUILDKITE_STEP_KEY" == "build_test_macos-aarch64-RelWithDebInfo" ]]; then
+    export BUILDKITE_ANALYTICS_TOKEN=$(vault read secret/ci/elastic-ml-cpp/buildkite/test_analytics/macos_aarch64 | awk '/^token/ {print $2;}')
   else [[ "$BUILDKITE_STEP_KEY" == "build_test_Windows-x86_64-RelWithDebInfo" ]]
     export BUILDKITE_ANALYTICS_TOKEN=$(vault read secret/ci/elastic-ml-cpp/buildkite/test_analytics/windows_x86_64 | awk '/^token/ {print $2;}')
   fi

--- a/.buildkite/pipelines/build_linux.json.py
+++ b/.buildkite/pipelines/build_linux.json.py
@@ -65,6 +65,7 @@ def main(args):
             "depends_on": "check_style",
             "key": f"build_test_linux-{arch}-{build_type}",
             "env": {
+              "ML_DEBUG": "0",
               "CMAKE_FLAGS": f"-DCMAKE_TOOLCHAIN_FILE=cmake/linux-{arch}.cmake",
               "CPP_CROSS_COMPILE": "",
               "RUN_TESTS": "true",

--- a/.buildkite/pipelines/build_macos.json.py
+++ b/.buildkite/pipelines/build_macos.json.py
@@ -42,26 +42,30 @@ def main(args):
             "label": f"Build & test :cpp: for MacOS-{arch}-{build_type} :macos:",
             "timeout_in_minutes": "150",
             "agents": {
+              "queue": "ml-aarch64-macstadium"
             },
             "commands": [
               f'if [[ "{args.action}" == "debug" ]]; then export ML_DEBUG=1; fi',
-              f'echo "MacOS {arch} build not yet supported";'
+              ".buildkite/scripts/steps/build_and_test.sh"
             ],
             "depends_on": "check_style",
             "key": f"build_test_macos-{arch}-{build_type}",
             "env": {
+              "JAVA_HOME": "/var/lib/jenkins/.java/zulu11",
+              "PATH": "$JAVA_HOME/bin:$PATH",
+              "ML_DEBUG": "0",
               "CPP_CROSS_COMPILE": "",
-              "CMAKE_FLAGS": "-DCMAKE_TOOLCHAIN_FILE=cmake/darwin-arch64.cmake",
+              "CMAKE_FLAGS": "-DCMAKE_TOOLCHAIN_FILE=cmake/darwin-aarch64.cmake",
               "RUN_TESTS": "true",
               "BOOST_TEST_OUTPUT_FORMAT_FLAGS": "--logger=JUNIT,error,boost_test_results.junit",
             },
             "artifact_paths": "*/*/unittest/boost_test_results.junit",
-            #"plugins": {
-            #  "test-collector#v1.2.0": {                                                              
-            #    "files": "*/*/unittest/boost_test_results.junit",
-            #    "format": "junit"
-            #  }
-            #},
+            "plugins": {
+              "test-collector#v1.2.0": {                                                              
+                "files": "*/*/unittest/boost_test_results.junit",
+                "format": "junit"
+              }
+            },
             "notify": [
               {
                 "github_commit_status": {
@@ -87,6 +91,7 @@ def main(args):
         "depends_on": "check_style",
         "key": "build_macos_x86_64_cross-RelWithDebInfo",
         "env": {
+          "ML_DEBUG": "0",
           "CPP_CROSS_COMPILE": "macosx",
           "CMAKE_FLAGS": "-DCMAKE_TOOLCHAIN_FILE=cmake/darwin-x86_64.cmake",
           "RUN_TESTS": "false"

--- a/.buildkite/pipelines/build_windows.json.py
+++ b/.buildkite/pipelines/build_windows.json.py
@@ -54,6 +54,7 @@ def main(args):
             "depends_on": "check_style",
             "key": f"build_test_Windows-{arch}-{build_type}",
             "env": {
+              "ML_DEBUG": "0",
               "CPP_CROSS_COMPILE": "",
               "CMAKE_FLAGS": "-DCMAKE_TOOLCHAIN_FILE=cmake/windows-x86_64.cmake",
               "RUN_TESTS": "true",


### PR DESCRIPTION
Add a step to build natively on the MacOS aarch64 VM

Backports #2470 