### PR TITLE
[ML] Fix Linux PATH in environment file

### DIFF
--- a/set_env.sh
+++ b/set_env.sh
@@ -95,7 +95,7 @@ fi
 case $SIMPLE_PLATFORM in
 
     linux)
-        PATH=/usr/local/gcc103/bin:/usr/bin:/bin:/usr/local/gcc103/sbin:/usr/sbin:/sbin:/usr/local/bin
+        PATH=/usr/local/gcc103/bin:/usr/bin:/bin:/usr/local/gcc103/sbin:/usr/local/cmake/bin:/usr/sbin:/sbin:/usr/local/bin
         ;;
 
     macos)


### PR DESCRIPTION
Our Linux build setup instructions say that cmake should be installed in /usr/local/cmake/bin, but if you do this then you could not build with Gradle because our environment file did not put this directory on the PATH.

This PR changes the PATH to include /usr/local/cmake/bin.