### PR TITLE
[7.17] [ML] Upgrade to latest AWS SDK version

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,8 +10,7 @@ repositories {
 dependencies {
   compileOnly gradleApi()
   compileOnly localGroovy()
-  implementation platform('software.amazon.awssdk:bom:2.15.80')
+  implementation platform('software.amazon.awssdk:bom:2.20.67')
   implementation 'software.amazon.awssdk:s3'
-  implementation 'org.apache.velocity:velocity:1.7'
 }
 

--- a/dev-tools/docker_build.sh
+++ b/dev-tools/docker_build.sh
@@ -83,7 +83,7 @@ do
     docker build --no-cache --force-rm -t $TEMP_TAG --build-arg VERSION_QUALIFIER="$VERSION_QUALIFIER" --build-arg SNAPSHOT=$SNAPSHOT --build-arg ML_DEBUG=$ML_DEBUG -f "$DOCKERFILE" .
     # Using tar to copy the build artifacts out of the container seems more reliable
     # than docker cp, and also means the files end up with the correct uid/gid
-    docker run --rm --workdir=/ml-cpp $TEMP_TAG tar cf - build/distributions | tar xvf -
+    docker run --rm --workdir=/ml-cpp $TEMP_TAG bash -c "tar cf - build/distributions && sleep 30" | tar xvf -
     docker rmi --force $TEMP_TAG
 
 done

--- a/dev-tools/docker_test.sh
+++ b/dev-tools/docker_test.sh
@@ -91,7 +91,7 @@ do
     # Using tar to copy the build and test artifacts out of the container seems
     # more reliable than docker cp, and also means the files end up with the
     # correct uid/gid
-    docker run --rm --workdir=/ml-cpp $TEMP_TAG bash -c "find . $EXTRACT_FIND | xargs tar cf - $EXTRACT_EXPLICIT" | tar xvf -
+    docker run --rm --workdir=/ml-cpp $TEMP_TAG bash -c "find . $EXTRACT_FIND | xargs tar cf - $EXTRACT_EXPLICIT && sleep 30" | tar xvf -
     docker rmi --force $TEMP_TAG
     # The image build is set to return zero (i.e. succeed as far as Docker is
     # concerned) when the only problem is that the unit tests fail, as this


### PR DESCRIPTION
Our Gradle build uses the AWS SDK. We should upgrade to the latest version.

Backport of #2489