### PR TITLE
[ML] Improve calendar cyclic component modelling for long bucket lengths

### DIFF
--- a/include/maths/time_series/CCalendarCyclicTest.h
+++ b/include/maths/time_series/CCalendarCyclicTest.h
@@ -49,10 +49,10 @@ namespace time_series {
 class MATHS_TIME_SERIES_EXPORT CCalendarCyclicTest {
 public:
     using TFeatureTimePr = std::pair<CCalendarFeature, core_t::TTime>;
-    using TOptionalFeatureTimePr = std::optional<TFeatureTimePr>;
+    using TFeatureTimePrVec = std::vector<TFeatureTimePr>;
 
 public:
-    explicit CCalendarCyclicTest(double decayRate = 0.0);
+    explicit CCalendarCyclicTest(core_t::TTime bucketLength, double decayRate = 0.0);
 
     //! Initialize by reading state from \p traverser.
     bool acceptRestoreTraverser(core::CStateRestoreTraverser& traverser);
@@ -70,7 +70,7 @@ public:
     void add(core_t::TTime time, double error, double weight = 1.0);
 
     //! Check if there are calendar components.
-    TOptionalFeatureTimePr test() const;
+    TFeatureTimePrVec test() const;
 
     //! Get a checksum for this object.
     std::uint64_t checksum(std::uint64_t seed = 0) const;
@@ -108,8 +108,21 @@ private:
     //! Get an estimate of the value of the survival function for \p error.
     double survivalFunction(double error) const;
 
-    //! Get the significance of \p x large errors given \p n samples.
-    double significance(double n, double nl, double nv) const;
+    //! Get the p-value of various error statistics.
+    //!
+    //! We observe \p n errors and have seen \p nl large errors and \p nv
+    //! very large errors.
+    double errorsPValue(double n, double nl, double nv) const;
+
+    //! Get the number of errors we need to observe before we start maintaining
+    //! large errors statistics.
+    double sufficientCountToMeasureLargeErrors() const;
+
+    //! Get the percentile for errors classified as large.
+    double largeErrorPercentile() const;
+
+    //! Get the percentile for errors classified as very large.
+    double veryLargeErrorPercentile() const;
 
     //! Convert to a compressed representation.
     void deflate(const TErrorStatsVec& stats);
@@ -125,16 +138,19 @@ private:
     //! The rate at which the error counts are aged.
     double m_DecayRate;
 
+    //! The raw data bucketing interval.
+    core_t::TTime m_BucketLength;
+
     //! Used to estimate large error thresholds.
     common::CQuantileSketch m_ErrorQuantiles;
 
     //! The start time of the bucket to which the last error
     //! was added.
-    core_t::TTime m_CurrentBucketTime;
+    core_t::TTime m_CurrentBucketTime{0};
 
     //! The start time of the earliest bucket for which we have
     //! error statistics.
-    core_t::TTime m_CurrentBucketIndex;
+    core_t::TTime m_CurrentBucketIndex{0};
 
     //! The bucket statistics currently being updated.
     SErrorStats m_CurrentBucketErrorStats;

--- a/include/maths/time_series/CTimeSeriesDecompositionDetail.h
+++ b/include/maths/time_series/CTimeSeriesDecompositionDetail.h
@@ -512,6 +512,9 @@ public:
         //! Controls the rate at which information is lost.
         double m_DecayRate;
 
+        //! The raw data bucketing interval.
+        core_t::TTime m_BucketLength;
+
         //! The last month for which the test was run.
         int m_LastMonth;
 
@@ -673,7 +676,7 @@ public:
 
         private:
             //! The origin for the mean prediction error regression model.
-            core_t::TTime m_RegressionOrigin = 0;
+            core_t::TTime m_RegressionOrigin{0};
             //! The sum of the absolute component predictions w.r.t. their means.
             TFloatMeanAccumulator m_MeanSumAmplitudes;
             //! A regression model for the absolute component predictions.

--- a/lib/maths/time_series/CCalendarCyclicTest.cc
+++ b/lib/maths/time_series/CCalendarCyclicTest.cc
@@ -408,7 +408,7 @@ double CCalendarCyclicTest::errorsPValue(double n, double nl, double nv) const {
 
 double CCalendarCyclicTest::sufficientCountToMeasureLargeErrors() const {
     // Cap the how long we'll wait identify large errors.
-    return std::min(static_cast<double>(10 * core::constants::DAY) / m_BucketLength, 100.0);
+    return std::min(static_cast<double>(20 * core::constants::DAY) / m_BucketLength, 100.0);
 }
 
 double CCalendarCyclicTest::largeErrorPercentile() const {

--- a/lib/maths/time_series/CCalendarCyclicTest.cc
+++ b/lib/maths/time_series/CCalendarCyclicTest.cc
@@ -263,9 +263,9 @@ CCalendarCyclicTest::TFeatureTimePrVec CCalendarCyclicTest::test() const {
             double nl{static_cast<double>(errors[i].s_LargeErrorCount % (1 << 17))};
             double nv{static_cast<double>(errors[i].s_LargeErrorCount / (1 << 17))};
             double pValue{this->errorsPValue(n, nl, nv)};
-            // It is that the maximum value is at least as large as the mean
-            // We use this to compute a lower bound for the chance of seeing
-            // a larger error on the interval.
+            // It is clear that the maximum value of a set is at least as
+            // large as its mean. We use this to compute a lower bound for
+            // the right tail probability for the largest error.
             double cdf;
             m_ErrorQuantiles.cdf(errors[i].s_LargeErrorSum / n, cdf);
 

--- a/lib/maths/time_series/CCalendarCyclicTest.cc
+++ b/lib/maths/time_series/CCalendarCyclicTest.cc
@@ -318,6 +318,7 @@ CCalendarCyclicTest::TFeatureTimePrVec CCalendarCyclicTest::test() const {
         }
     }
 
+    // Extract features and offsets in descending error sum order.
     TFeatureTimePrVec result;
     largestErrorFeatures.sort();
     std::transform(largestErrorFeatures.begin(), largestErrorFeatures.end(),
@@ -325,6 +326,8 @@ CCalendarCyclicTest::TFeatureTimePrVec CCalendarCyclicTest::test() const {
                        return std::make_pair(featureAndError.s_Feature,
                                              featureAndError.s_Offset);
                    });
+
+    // Enforce a single time zone.
     if (result.size() > 1) {
         auto offset = result[0].second;
         result.erase(std::remove_if(result.begin(), result.end(),
@@ -333,6 +336,7 @@ CCalendarCyclicTest::TFeatureTimePrVec CCalendarCyclicTest::test() const {
                                     }),
                      result.end());
     }
+
     return result;
 }
 

--- a/lib/maths/time_series/CCalendarCyclicTest.cc
+++ b/lib/maths/time_series/CCalendarCyclicTest.cc
@@ -9,7 +9,6 @@
  * limitation.
  */
 
-#include "maths/common/COrderings.h"
 #include <maths/time_series/CCalendarCyclicTest.h>
 
 #include <core/CHashing.h>
@@ -27,6 +26,7 @@
 #include <maths/common/CChecksum.h>
 #include <maths/common/CIntegerTools.h>
 #include <maths/common/CMathsFuncs.h>
+#include <maths/common/COrderings.h>
 #include <maths/common/CTools.h>
 #include <maths/common/Constants.h>
 

--- a/lib/maths/time_series/CCalendarCyclicTest.cc
+++ b/lib/maths/time_series/CCalendarCyclicTest.cc
@@ -9,8 +9,10 @@
  * limitation.
  */
 
+#include "maths/common/COrderings.h"
 #include <maths/time_series/CCalendarCyclicTest.h>
 
+#include <core/CHashing.h>
 #include <core/CLogger.h>
 #include <core/CMemoryDef.h>
 #include <core/CPersistUtils.h>
@@ -35,6 +37,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <iterator>
 #include <limits>
 #include <mutex>
 #include <string>
@@ -46,11 +49,29 @@ namespace {
 using TTimeVec = std::vector<core_t::TTime>;
 
 //! \brief Hashes a calendar feature.
-struct SHashFeature {
-    std::size_t operator()(const CCalendarFeature& feature) const {
-        return feature.checksum(0);
+struct SHashAndOffsetFeature {
+    std::size_t operator()(const std::pair<CCalendarFeature, core_t::TTime>& featureAndOffset) const {
+        return core::CHashing::hashCombine(
+            featureAndOffset.first.checksum(0),
+            static_cast<std::uint64_t>(featureAndOffset.second));
     }
 };
+
+double binomialPValueAdj(double n, double p, double np) {
+    try {
+        boost::math::binomial binom{n, p};
+        p = std::min(2.0 * common::CTools::safeCdfComplement(binom, np - 1.0), 1.0);
+        // We have roughly 31 independent error samples, one for each
+        // day of the month, so the chance of seeing as extreme an event
+        // among all of them is:
+        //   1 - P("don't see as extreme event") = 1 - (1 - P("event"))^31
+        return common::CTools::oneMinusPowOneMinusX(p, 31.0);
+    } catch (const std::exception& e) {
+        LOG_ERROR(<< "Failed to calculate significance: " << e.what()
+                  << " n = " << n << " p = " << p << " np = " << np);
+    }
+    return 1.0;
+}
 
 const std::string VERSION_6_4_TAG("6.4");
 // Version 6.4
@@ -67,25 +88,26 @@ const std::string DELIMITER{","};
 const core_t::TTime SIZE{155};
 const core_t::TTime BUCKET{core::constants::DAY};
 const core_t::TTime WINDOW{SIZE * BUCKET};
+const core_t::TTime LONG_BUCKET{4 * core::constants::HOUR};
 // We can't determine the exact time zone given the state we maintain but we can
 // determine if the whole pattern is shifted 1 day late or early.
 const TTimeVec TIME_ZONE_OFFSETS{0, -12 * core::constants::HOUR - 1,
                                  12 * core::constants::HOUR + 1};
 
 //! The percentile of a large error.
-const double LARGE_ERROR_PERCENTILE{98.5};
+constexpr double LARGE_ERROR_PERCENTILE{98.5};
 //! The percentile of a very large error.
-const double VERY_LARGE_ERROR_PERCENTILE{99.99};
+constexpr double VERY_LARGE_ERROR_PERCENTILE{99.99};
 //! The minimum number of repeats to test a feature.
-const unsigned int MINIMUM_REPEATS{4};
+constexpr unsigned int MINIMUM_REPEATS{4};
 //! The maximum significance to accept a feature.
-const double MAXIMUM_SIGNIFICANCE{0.01};
+constexpr double MAXIMUM_P_VALUE{0.01};
 //! Used to guard setting the timezone.
 std::once_flag setTimeZone;
 }
 
-CCalendarCyclicTest::CCalendarCyclicTest(double decayRate)
-    : m_DecayRate{decayRate}, m_ErrorQuantiles{20}, m_CurrentBucketTime{0}, m_CurrentBucketIndex{0} {
+CCalendarCyclicTest::CCalendarCyclicTest(core_t::TTime bucketLength, double decayRate)
+    : m_DecayRate{decayRate}, m_BucketLength{bucketLength}, m_ErrorQuantiles{20} {
     std::call_once(setTimeZone,
                    [] { core::CTimezone::instance().timezoneName("GMT"); });
     TErrorStatsVec stats(SIZE);
@@ -157,7 +179,7 @@ void CCalendarCyclicTest::add(core_t::TTime time, double error, double weight) {
 
     m_ErrorQuantiles.add(error, weight);
 
-    if (m_ErrorQuantiles.count() > 100.0) {
+    if (m_ErrorQuantiles.count() > this->sufficientCountToMeasureLargeErrors()) {
         time = common::CIntegerTools::floor(time, BUCKET);
         if (time > m_CurrentBucketTime) {
             TErrorStatsVec errors{this->inflate()};
@@ -173,10 +195,10 @@ void CCalendarCyclicTest::add(core_t::TTime time, double error, double weight) {
         ++m_CurrentBucketErrorStats.s_Count;
 
         double largeError;
-        m_ErrorQuantiles.quantile(LARGE_ERROR_PERCENTILE, largeError);
+        m_ErrorQuantiles.quantile(this->largeErrorPercentile(), largeError);
         if (error >= largeError) {
             bool isVeryLarge{100.0 * (1.0 - this->survivalFunction(error)) >=
-                             VERY_LARGE_ERROR_PERCENTILE};
+                             this->veryLargeErrorPercentile()};
             m_CurrentBucketErrorStats.s_LargeErrorCount += std::min(
                 std::numeric_limits<std::uint32_t>::max() -
                     m_CurrentBucketErrorStats.s_LargeErrorCount,
@@ -186,83 +208,132 @@ void CCalendarCyclicTest::add(core_t::TTime time, double error, double weight) {
     }
 }
 
-CCalendarCyclicTest::TOptionalFeatureTimePr CCalendarCyclicTest::test() const {
+CCalendarCyclicTest::TFeatureTimePrVec CCalendarCyclicTest::test() const {
 
     if (m_ErrorQuantiles.count() == 0) {
         return {};
     }
 
     // The statistics we need in order to be able to test for calendar features.
+    using TMaxDoubleAccumulator =
+        common::CBasicStatistics::SMax<double, MINIMUM_REPEATS>::TAccumulator;
     struct SStats {
-        core_t::TTime s_Offset{0};
         unsigned int s_Repeats{0};
-        double s_Sum{0.0};
-        double s_Count{0.0};
+        unsigned int s_RepeatsWithLargeErrors{0};
+        double s_ErrorSum{0.0};
+        double s_ErrorCount{0.0};
+        double s_LargeErrorCount{0.0};
+        double s_VeryLargeErrorCount{0.0};
         double s_PValue{0.0};
+        TMaxDoubleAccumulator s_Cdf;
     };
-    using TFeatureStatsUMap = boost::unordered_map<CCalendarFeature, SStats, SHashFeature>;
+    using TFeatureStatsUMap =
+        boost::unordered_map<std::pair<CCalendarFeature, core_t::TTime>, SStats, SHashAndOffsetFeature>;
 
     TErrorStatsVec errors{this->inflate()};
 
-    double mostSignificantError{0.0};
-    CCalendarFeature mostSignificantFeature;
-    core_t::TTime mostSignificantOffset{0};
+    struct SFeatureAndError {
+        bool operator<(const SFeatureAndError& rhs) const {
+            return common::COrderings::lexicographicalCompare(
+                -s_ErrorSum, std::fabs(s_Offset), -rhs.s_ErrorSum, std::fabs(rhs.s_Offset));
+        }
+        CCalendarFeature s_Feature;
+        core_t::TTime s_Offset;
+        double s_ErrorSum;
+    };
+    using TMaxErrorFeatureAccumulator =
+        common::CBasicStatistics::COrderStatisticsStack<SFeatureAndError, 3>;
+
+    TMaxErrorFeatureAccumulator largestErrorFeatures;
 
     double errorThreshold;
     m_ErrorQuantiles.quantile(50.0, errorThreshold);
     errorThreshold *= 2.0;
 
-    for (auto offset : TIME_ZONE_OFFSETS) {
-        // Note that the current index points to the next bucket to overwrite,
-        // i.e. the earliest bucket error statistics we have. The start of
-        // this bucket is WINDOW before the start time of the current partial
-        // bucket.
-        TFeatureStatsUMap stats{errors.size()};
-        for (core_t::TTime i = m_CurrentBucketIndex, time = m_CurrentBucketTime - WINDOW;
-             time < m_CurrentBucketTime; i = (i + 1) % SIZE, time += BUCKET) {
-            if (errors[i].s_Count > 0) {
-                double n{static_cast<double>(errors[i].s_Count)};
-                double nl{static_cast<double>(errors[i].s_LargeErrorCount % (1 << 17))};
-                double nv{static_cast<double>(errors[i].s_LargeErrorCount / (1 << 17))};
-                double pValue{this->significance(n, nl, nv)};
+    TFeatureStatsUMap stats{TIME_ZONE_OFFSETS.size() * errors.size()};
+
+    // Note that the current index points to the next bucket to overwrite,
+    // i.e. the earliest bucket error statistics we have. The start of
+    // this bucket is WINDOW before the start time of the current partial
+    // bucket.
+    for (core_t::TTime i = m_CurrentBucketIndex, time = m_CurrentBucketTime - WINDOW;
+         time < m_CurrentBucketTime; i = (i + 1) % SIZE, time += BUCKET) {
+        if (errors[i].s_Count > 0) {
+            double n{static_cast<double>(errors[i].s_Count)};
+            double nl{static_cast<double>(errors[i].s_LargeErrorCount % (1 << 17))};
+            double nv{static_cast<double>(errors[i].s_LargeErrorCount / (1 << 17))};
+            double pValue{this->errorsPValue(n, nl, nv)};
+            // It is that the maximum value is at least as large as the mean
+            // We use this to compute a lower bound for the chance of seeing
+            // a larger error on the interval.
+            double cdf;
+            m_ErrorQuantiles.cdf(errors[i].s_LargeErrorSum / n, cdf);
+
+            for (auto offset : TIME_ZONE_OFFSETS) {
                 core_t::TTime midpoint{time + BUCKET / 2 + offset};
                 for (auto feature : CCalendarFeature::features(midpoint)) {
                     if (feature.testForTimeZoneOffset(offset)) {
-                        SStats& stat = stats[feature];
-                        ++stat.s_Repeats;
-                        stat.s_Sum += errors[i].s_LargeErrorSum;
-                        stat.s_Count += nl;
+                        SStats& stat = stats[std::make_pair(feature, offset)];
+                        stat.s_Repeats += 1;
+                        stat.s_RepeatsWithLargeErrors += nl > 0 ? 1 : 0;
+                        stat.s_ErrorSum += errors[i].s_LargeErrorSum;
+                        stat.s_ErrorCount += n;
+                        stat.s_LargeErrorCount += nl;
+                        stat.s_VeryLargeErrorCount += nv;
                         stat.s_PValue = std::max(stat.s_PValue, pValue);
+                        stat.s_Cdf.add(cdf);
                     }
                 }
             }
         }
+    }
 
-        double mostSignificantErrorForOffset{0.0};
-        CCalendarFeature mostSignificantFeatureForOffset;
-        for (const auto& stat : stats) {
-            CCalendarFeature feature = stat.first;
-            double r{static_cast<double>(stat.second.s_Repeats)};
-            double nl{stat.second.s_Count};
-            double sl{stat.second.s_Sum};
-            double pValue{stat.second.s_PValue};
-            if (stat.second.s_Repeats >= MINIMUM_REPEATS &&
-                sl > errorThreshold * nl && sl > mostSignificantErrorForOffset &&
-                std::pow(pValue, r) < MAXIMUM_SIGNIFICANCE) {
-                mostSignificantErrorForOffset = sl;
-                mostSignificantFeatureForOffset = feature;
-            }
+    for (const auto& stat : stats) {
+        auto[feature, offset] = stat.first;
+        unsigned int repeats{stat.second.s_Repeats};
+        unsigned int repeatsWithLargeErrors{stat.second.s_RepeatsWithLargeErrors};
+        double n{stat.second.s_ErrorCount};
+        double nl{stat.second.s_LargeErrorCount};
+        double nv{stat.second.s_VeryLargeErrorCount};
+        double sl{stat.second.s_ErrorSum};
+        double maxBucketPValue{stat.second.s_PValue};
+        double cdf{stat.second.s_Cdf.biggest()};
+
+        if (repeats < MINIMUM_REPEATS || // Insufficient repeats
+            sl <= errorThreshold * nl) { // Error too small to bother modelling
+            continue;
         }
-        if (mostSignificantErrorForOffset > mostSignificantError) {
-            mostSignificantError = mostSignificantErrorForOffset;
-            mostSignificantFeature = mostSignificantFeatureForOffset;
-            mostSignificantOffset = offset;
+        if (std::pow(maxBucketPValue, repeats) < MAXIMUM_P_VALUE) { // High significance for each repeat
+            largestErrorFeatures.add(SFeatureAndError{feature, offset, sl});
+            continue;
+        }
+        if (m_BucketLength < LONG_BUCKET || // Short raw data buckets
+            repeatsWithLargeErrors < MINIMUM_REPEATS) { // Too few repeats with large errors
+            continue;
+        }
+        double windowPValue{std::min(this->errorsPValue(n, nl, nv),
+                                     binomialPValueAdj(n, 1.0 - cdf, repeats))};
+        if (windowPValue < MAXIMUM_P_VALUE) { // High joint significance for all repeats
+            largestErrorFeatures.add(SFeatureAndError{feature, offset, sl});
         }
     }
 
-    return mostSignificantError > 0
-               ? TOptionalFeatureTimePr{std::in_place, mostSignificantFeature, mostSignificantOffset}
-               : TOptionalFeatureTimePr{};
+    TFeatureTimePrVec result;
+    largestErrorFeatures.sort();
+    std::transform(largestErrorFeatures.begin(), largestErrorFeatures.end(),
+                   std::back_inserter(result), [](const auto& featureAndError) {
+                       return std::make_pair(featureAndError.s_Feature,
+                                             featureAndError.s_Offset);
+                   });
+    if (result.size() > 1) {
+        auto offset = result[0].second;
+        result.erase(std::remove_if(result.begin(), result.end(),
+                                    [&](const auto& featureAndOffset) {
+                                        return featureAndOffset.second != offset;
+                                    }),
+                     result.end());
+    }
+    return result;
 }
 
 std::uint64_t CCalendarCyclicTest::checksum(std::uint64_t seed) const {
@@ -302,8 +373,9 @@ double CCalendarCyclicTest::survivalFunction(double error) const {
     TMomentsAccumulator tailMoments;
     for (double i = 0.0; i < 5.0; i += 1.0) {
         double eq;
-        m_ErrorQuantiles.quantile(
-            LARGE_ERROR_PERCENTILE + i * (100.0 - LARGE_ERROR_PERCENTILE) / 5.0, eq);
+        m_ErrorQuantiles.quantile(this->largeErrorPercentile() +
+                                      i * (100.0 - this->largeErrorPercentile()) / 5.0,
+                                  eq);
         tailMoments.add(eq);
     }
 
@@ -313,7 +385,7 @@ double CCalendarCyclicTest::survivalFunction(double error) const {
     try {
         boost::math::normal normal{common::CBasicStatistics::mean(tailMoments),
                                    std::sqrt(common::CBasicStatistics::variance(tailMoments))};
-        return (100.0 - LARGE_ERROR_PERCENTILE) / 100.0 *
+        return (100.0 - this->largeErrorPercentile()) / 100.0 *
                common::CTools::safeCdfComplement(normal, error);
 
     } catch (const std::exception& e) {
@@ -322,24 +394,33 @@ double CCalendarCyclicTest::survivalFunction(double error) const {
     return 1.0;
 }
 
-double CCalendarCyclicTest::significance(double n, double nl, double nv) const {
-    if (n > 0.0) {
-        try {
-            // We have roughly 31 independent error samples, one for each
-            // day of the month, so the chance of seeing as extreme an event
-            // among all of them is:
-            //   1 - P("don't see as extreme event") = 1 - (1 - P("event"))^31
-            boost::math::binomial bl{n, 1.0 - LARGE_ERROR_PERCENTILE / 100.0};
-            boost::math::binomial bv{n, 1.0 - VERY_LARGE_ERROR_PERCENTILE / 100.0};
-            double p{std::min({2.0 * common::CTools::safeCdfComplement(bl, nl - 1.0),
-                               2.0 * common::CTools::safeCdfComplement(bv, nv - 1.0), 1.0})};
-            return common::CTools::oneMinusPowOneMinusX(p, 31.0);
-        } catch (const std::exception& e) {
-            LOG_ERROR(<< "Failed to calculate significance: " << e.what()
-                      << " n = " << n << " nl = " << nl << " nv = " << nv);
-        }
-    }
-    return 1.0;
+double CCalendarCyclicTest::errorsPValue(double n, double nl, double nv) const {
+    return n > 0.0
+               ? std::min(
+                     binomialPValueAdj(n, 1.0 - this->largeErrorPercentile() / 100.0, nl),
+                     binomialPValueAdj(n, 1.0 - this->veryLargeErrorPercentile() / 100.0, nv))
+               : 1.0;
+}
+
+double CCalendarCyclicTest::sufficientCountToMeasureLargeErrors() const {
+    // Cap the how long we'll wait identify large errors.
+    return std::min(static_cast<double>(10 * core::constants::DAY) / m_BucketLength, 100.0);
+}
+
+double CCalendarCyclicTest::largeErrorPercentile() const {
+    // For long bucket lengths we see very few high percentile errors
+    // in the full window. In this case the power of the tests we use
+    // drop greatly. So we adjust the threshold to hold the expected
+    // count of large errors fixed.
+    return 100.0 - (100.0 - LARGE_ERROR_PERCENTILE) *
+                       static_cast<double>(std::max(LONG_BUCKET, m_BucketLength)) /
+                       static_cast<double>(LONG_BUCKET);
+}
+
+double CCalendarCyclicTest::veryLargeErrorPercentile() const {
+    return 100.0 - (100.0 - VERY_LARGE_ERROR_PERCENTILE) *
+                       static_cast<double>(std::max(LONG_BUCKET, m_BucketLength)) /
+                       static_cast<double>(LONG_BUCKET);
 }
 
 void CCalendarCyclicTest::deflate(const TErrorStatsVec& stats) {

--- a/lib/maths/time_series/unittest/CCalendarCyclicTestTest.cc
+++ b/lib/maths/time_series/unittest/CCalendarCyclicTestTest.cc
@@ -9,7 +9,6 @@
  * limitation.
  */
 
-#include <boost/test/unit_test_suite.hpp>
 #include <core/CLogger.h>
 #include <core/CMemoryDef.h>
 #include <core/CRapidXmlParser.h>

--- a/lib/maths/time_series/unittest/CCalendarCyclicTestTest.cc
+++ b/lib/maths/time_series/unittest/CCalendarCyclicTestTest.cc
@@ -9,6 +9,7 @@
  * limitation.
  */
 
+#include <boost/test/unit_test_suite.hpp>
 #include <core/CLogger.h>
 #include <core/CMemoryDef.h>
 #include <core/CRapidXmlParser.h>
@@ -68,7 +69,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
             21081600, // 2nd Sep
             23673600  // 2nd Oct
         };
-        core_t::TTime end = months[months.size() - 1] + 86400;
+        core_t::TTime end = months[months.size() - 1] + DAY;
 
         maths::time_series::CCalendarCyclicTest cyclic(HALF_HOUR);
 
@@ -87,12 +88,13 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
             cyclic.add(time, error[0]);
 
             if (time > 121 * DAY && time % DAY == 0) {
-                auto feature = cyclic.test();
-                if (feature == std::nullopt) {
+                auto features = cyclic.test();
+                if (features.empty()) {
                     falseNegative += 1.0;
                 } else {
-                    (feature->first.print() == "2nd day of month" ? truePositive
-                                                                  : falsePositive) += 1.0;
+                    (features[0].first.print() == "2nd day of month"
+                         ? truePositive
+                         : falsePositive) += 1.0;
                 }
             }
             BOOST_TEST_REQUIRE(core::memory::dynamicSize(&cyclic) < 790);
@@ -114,7 +116,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
             15552000, // 30th June
             18230400  // 31st July
         };
-        core_t::TTime end = months[months.size() - 1] + 86400;
+        core_t::TTime end = months[months.size() - 1] + DAY;
 
         maths::time_series::CCalendarCyclicTest cyclic(HALF_HOUR);
 
@@ -131,11 +133,11 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
             cyclic.add(time, error[0]);
 
             if (time > 121 * DAY && time % DAY == 0) {
-                auto feature = cyclic.test();
-                if (feature == std::nullopt) {
+                auto features = cyclic.test();
+                if (features.empty()) {
                     falseNegative += 1.0;
                 } else {
-                    (feature->first.print() == "0 days before end of month"
+                    (features[0].first.print() == "0 days before end of month"
                          ? truePositive
                          : falsePositive) += 1.0;
                 }
@@ -157,7 +159,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
             8208000, // Mon 6th Apr
             10627200 // Mon 4th May
         };
-        core_t::TTime end = months[months.size() - 1] + 86400;
+        core_t::TTime end = months[months.size() - 1] + DAY;
 
         maths::time_series::CCalendarCyclicTest cyclic(HALF_HOUR);
 
@@ -174,11 +176,11 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
             cyclic.add(time, error[0]);
 
             if (time > 121 * DAY && time % DAY == 0) {
-                auto feature = cyclic.test();
-                if (feature == std::nullopt) {
+                auto features = cyclic.test();
+                if (features.empty()) {
                     falseNegative += 1.0;
                 } else {
-                    (feature->first.print() == "1st Monday of month"
+                    (features[0].first.print() == "1st Monday of month"
                          ? truePositive
                          : falsePositive) += 1.0;
                 }
@@ -200,7 +202,7 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
             9763200, // Fri 24th Apr
             12787200 // Fri 29th May
         };
-        core_t::TTime end = months[months.size() - 1] + 86400;
+        core_t::TTime end = months[months.size() - 1] + DAY;
 
         maths::time_series::CCalendarCyclicTest cyclic(HALF_HOUR);
 
@@ -217,11 +219,11 @@ BOOST_AUTO_TEST_CASE(testTruePositives) {
             cyclic.add(time, error[0]);
 
             if (time > 121 * DAY && time % DAY == 0) {
-                auto feature = cyclic.test();
-                if (feature == std::nullopt) {
+                auto features = cyclic.test();
+                if (features.empty()) {
                     falseNegative += 1.0;
                 } else {
-                    (feature->first.print() == "0 Fridays before end of month"
+                    (features[0].first.print() == "0 Fridays before end of month"
                          ? truePositive
                          : falsePositive) += 1.0;
                 }
@@ -257,7 +259,7 @@ BOOST_AUTO_TEST_CASE(testTimeZones) {
             8121600, // Sun 5th Apr
             10540800 // Sun 3rd May
         };
-        core_t::TTime end = months[months.size() - 1] + 86400;
+        core_t::TTime end = months[months.size() - 1] + DAY;
 
         maths::time_series::CCalendarCyclicTest cyclic(HALF_HOUR);
 
@@ -276,11 +278,11 @@ BOOST_AUTO_TEST_CASE(testTimeZones) {
             cyclic.add(time, error[0]);
 
             if (time > 121 * DAY && time % DAY == 0) {
-                auto feature = cyclic.test();
-                if (feature == std::nullopt) {
+                auto features = cyclic.test();
+                if (features.empty()) {
                     falseNegative += 1.0;
                 } else {
-                    (feature->first.print() == "1st Sunday of month"
+                    (features[0].first.print() == "1st Sunday of month"
                          ? truePositive
                          : falsePositive) += 1.0;
                 }
@@ -303,7 +305,7 @@ BOOST_AUTO_TEST_CASE(testTimeZones) {
             9849600, // Sat 25th Apr
             12873600 // Sat 30th May
         };
-        core_t::TTime end = months[months.size() - 1] + 86400;
+        core_t::TTime end = months[months.size() - 1] + DAY;
 
         maths::time_series::CCalendarCyclicTest cyclic(HALF_HOUR);
 
@@ -322,11 +324,11 @@ BOOST_AUTO_TEST_CASE(testTimeZones) {
             cyclic.add(time, error[0]);
 
             if (time > 121 * DAY && time % DAY == 0) {
-                auto feature = cyclic.test();
-                if (feature == std::nullopt) {
+                auto features = cyclic.test();
+                if (features.empty()) {
                     falseNegative += 1.0;
                 } else {
-                    (feature->first.print() == "0 Saturdays before end of month"
+                    (features[0].first.print() == "0 Saturdays before end of month"
                          ? truePositive
                          : falsePositive) += 1.0;
                 }
@@ -366,7 +368,7 @@ BOOST_AUTO_TEST_CASE(testVeryLargeCyclicSpikes) {
             21081600, // 2nd Sep
             23673600  // 2nd Oct
         };
-        core_t::TTime end = months[months.size() - 1] + 86400;
+        core_t::TTime end = months[months.size() - 1] + DAY;
 
         maths::time_series::CCalendarCyclicTest cyclic(HOUR);
 
@@ -383,12 +385,13 @@ BOOST_AUTO_TEST_CASE(testVeryLargeCyclicSpikes) {
             cyclic.add(time, error[0]);
 
             if (time > 121 * DAY && time % DAY == 0) {
-                auto feature = cyclic.test();
-                if (feature == std::nullopt) {
+                auto features = cyclic.test();
+                if (features.empty()) {
                     falseNegative += 1.0;
                 } else {
-                    (feature->first.print() == "2nd day of month" ? truePositive
-                                                                  : falsePositive) += 1.0;
+                    (features[0].first.print() == "2nd day of month"
+                         ? truePositive
+                         : falsePositive) += 1.0;
                 }
             }
         }
@@ -421,10 +424,10 @@ BOOST_AUTO_TEST_CASE(testFalsePositives) {
             cyclic.add(time, error[0]);
 
             if (time % MONTH == 0) {
-                auto feature = cyclic.test();
-                (feature == std::nullopt ? trueNegatives : falsePositives) += 1.0;
-                if (feature != std::nullopt) {
-                    LOG_DEBUG(<< "Detected = " << feature->first.print());
+                auto features = cyclic.test();
+                (features.empty() ? trueNegatives : falsePositives) += 1.0;
+                if (features.empty() == false) {
+                    LOG_DEBUG(<< "Detected = " << features);
                 }
                 BOOST_TEST_REQUIRE(core::memory::dynamicSize(&cyclic) < 880);
             }
@@ -445,10 +448,10 @@ BOOST_AUTO_TEST_CASE(testFalsePositives) {
             cyclic.add(time, error[0]);
 
             if (time % MONTH == 0) {
-                auto feature = cyclic.test();
-                (feature == std::nullopt ? trueNegatives : falsePositives) += 1.0;
-                if (feature != std::nullopt) {
-                    LOG_DEBUG(<< "Detected = " << feature->first.print());
+                auto features = cyclic.test();
+                (features.empty() ? trueNegatives : falsePositives) += 1.0;
+                if (features.empty() == false) {
+                    LOG_DEBUG(<< "Detected = " << features);
                 }
                 BOOST_TEST_REQUIRE(core::memory::dynamicSize(&cyclic) < 880);
             }
@@ -471,10 +474,10 @@ BOOST_AUTO_TEST_CASE(testFalsePositives) {
             cyclic.add(time, error[0]);
 
             if (time % MONTH == 0) {
-                auto feature = cyclic.test();
-                (feature == std::nullopt ? trueNegatives : falsePositives) += 1.0;
-                if (feature != std::nullopt) {
-                    LOG_DEBUG(<< "Detected = " << feature->first.print());
+                auto features = cyclic.test();
+                (features.empty() ? trueNegatives : falsePositives) += 1.0;
+                if (features.empty() == false) {
+                    LOG_DEBUG(<< "Detected = " << features);
                 }
                 BOOST_TEST_REQUIRE(core::memory::dynamicSize(&cyclic) < 880);
             }
@@ -484,6 +487,64 @@ BOOST_AUTO_TEST_CASE(testFalsePositives) {
     LOG_DEBUG(<< "false positives = " << falsePositives);
 
     double accuracy{trueNegatives / (falsePositives + trueNegatives)};
+    LOG_DEBUG(<< "accuracy = " << accuracy);
+    BOOST_TEST_REQUIRE(accuracy > 0.99);
+}
+
+BOOST_AUTO_TEST_CASE(testLongBuckets) {
+    // Test the true positive rate for 1 day buckets.
+
+    test::CRandomNumbers rng;
+
+    double truePositive{0.0};
+    double falsePositive{0.0};
+    double falseNegative{0.0};
+
+    LOG_DEBUG(<< "Day of month");
+    for (std::size_t t = 0; t < 10; ++t) {
+        // Repeated error on the second day of the month.
+        TTimeVec months{
+            86400,    // 2nd Jan
+            2764800,  // 2nd Feb
+            5184000,  // 2nd Mar
+            7862400,  // 2nd Apr
+            10454400, // 2nd May
+            13132800, // 2nd June
+            15724800, // 2nd July
+            18403200, // 2nd Aug
+            21081600, // 2nd Sep
+            23673600  // 2nd Oct
+        };
+        core_t::TTime end = months[months.size() - 1] + DAY;
+
+        maths::time_series::CCalendarCyclicTest cyclic(DAY);
+
+        TDoubleVec error;
+        for (core_t::TTime time = 0, i = 0; time <= end; time += DAY) {
+            rng.generateNormalSamples(0.0, 9.0, 1, error);
+            if (time >= months[i] && time < months[i] + DAY) {
+                error[0] += 20.0;
+                ++i;
+            }
+            cyclic.add(time, error[0]);
+
+            if (time > 121 * DAY && time % DAY == 0) {
+                auto features = cyclic.test();
+                if (features.empty()) {
+                    falseNegative += 1.0;
+                } else {
+                    (features[0].first.print() == "2nd day of month"
+                         ? truePositive
+                         : falsePositive) += 1.0;
+                }
+            }
+        }
+    }
+    LOG_DEBUG(<< "true positive = " << truePositive);
+    LOG_DEBUG(<< "false negative = " << falseNegative);
+    LOG_DEBUG(<< "false positive = " << falsePositive);
+
+    double accuracy{(truePositive / (truePositive + falseNegative + falsePositive))};
     LOG_DEBUG(<< "accuracy = " << accuracy);
     BOOST_TEST_REQUIRE(accuracy > 0.99);
 }


### PR DESCRIPTION
Our test to find important calendar components to model was not reliable for long bucket lengths. This change addresses some of the short comings:
1. We take too long to warm up the error quantiles,
2. We can't calculate a p-value per repeat because we don't get to observe enough errors per repeat to estimate this properly,
3. We can't estimate high error percentiles accurately with long buckets. (Instead we switch to counting events with fixed expected count as a function of long bucket length rather than fixed probability.)

We also now estimate a lower bound on the right-tail probability for the feature directly from its sum error. This can fall between the error distribution points we count and improves the test sensitivity. Finally, it is useful to be able to detect multiple components per test, otherwise it can take a long time to initialise every component which is needed. This adds the ability to initialise multiple statistically significant components per test run.