### PR TITLE
[ML] Fix BUILD_SNAPSHOT env vars in catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -145,7 +145,7 @@ spec:
       cancel_intermediate_builds: true
       clone_method: https
       env:
-        BUILD_SNAPSHOT: true
+        BUILD_SNAPSHOT: "true"
       pipeline_file: .buildkite/branch.json.py
       provider_settings:
         build_branches: true
@@ -205,7 +205,7 @@ spec:
       cancel_intermediate_builds: true
       clone_method: https
       env:
-        BUILD_SNAPSHOT: false
+        BUILD_SNAPSHOT: "false"
       pipeline_file: .buildkite/branch.json.py
       provider_settings:
         filter_condition: 'build.branch =~ /^[0-9]+\.[0-9]+\$/ ||


### PR DESCRIPTION
The value of the BUILD_SNAPSHOT env vars must be a quoted string, either "true" or "false"