### PR TITLE
[ML] Test web-hook for newly created PR pipeline

### DIFF
--- a/lib/ver/unittest/CBuildInfoTest.cc
+++ b/lib/ver/unittest/CBuildInfoTest.cc
@@ -27,6 +27,7 @@ BOOST_AUTO_TEST_CASE(testFullInfo) {
         ml::core::CTimeUtils::toIso8601(ml::core::CTimeUtils::now()), 0, 4);
     LOG_DEBUG(<< "Current year is " << currentYear);
 
+    BOOST_TEST_REQUIRE(fullInfo.find("a deliberate test failure") != std::string::npos);
     BOOST_TEST_REQUIRE(fullInfo.find("ml_test") != std::string::npos);
     BOOST_TEST_REQUIRE(fullInfo.find("Version") != std::string::npos);
     BOOST_TEST_REQUIRE(fullInfo.find("Build") != std::string::npos);


### PR DESCRIPTION
Now that the BuildKite PR pipeline has been recreated with a more descriptive name, test to ensure that the PR web-hook still works with it.