### PR TITLE
[ML] Upload build artifacts from BuildKite

### DIFF
--- a/.buildkite/pipelines/upload_dra_to_gcs.yml.sh
+++ b/.buildkite/pipelines/upload_dra_to_gcs.yml.sh
@@ -21,8 +21,7 @@ steps:
     depends_on: create_dra_artifacts
     command:
       - 'buildkite-agent artifact download "build/distributions/*" .'
-      - 'echo "${RED}This step is disabled until BuildKite migration is complete${NOCOLOR}"'
-      #- '.buildkite/scripts/steps/upload_dra_to_gcs.sh'
+      - '.buildkite/scripts/steps/upload_dra_to_gcs.sh'
     agents:
       provider: gcp
 EOL

--- a/build.gradle
+++ b/build.gradle
@@ -453,9 +453,7 @@ task uploadAll(type: UploadS3Task) {
     include "ml-cpp-${project.version}*.zip", "dependencies-${version}.csv"
   }
   for (file in fileDir) {
-    // TODO: swap back when Jenkins is switched off
-    upload file, "maven/${artifactGroupPath}/${artifactName}/BuildKite/${file.name}"
-    // upload file, "maven/${artifactGroupPath}/${artifactName}/${project.version}/${file.name}"
+    upload file, "maven/${artifactGroupPath}/${artifactName}/${project.version}/${file.name}"
   }
   description = 'Upload all C++ artifacts to S3 Bucket'
 }

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -104,11 +104,12 @@ if ($LastExitCode -ne 0) {
     Exit $LastExitCode
 }
 
-# If this isn't a PR build and isn't a debug build then upload the artifacts
-if (!(Test-Path Env:PR_AUTHOR) -And !(Test-Path Env:ML_DEBUG)) {
-    # The | % { "$_" } at the end converts any error objects on stderr to strings
-    & ".\gradlew.bat" --info "-Dbuild.version_qualifier=$Env:VERSION_QUALIFIER" "-Dbuild.snapshot=$Env:BUILD_SNAPSHOT" upload 2>&1 | % { "$_" }
-    if ($LastExitCode -ne 0) {
-        Exit $LastExitCode
-    }
-}
+# Do not upload artifacts from the Jenkins' build while testing uploading from BuildKite pipelines
+## If this isn't a PR build and isn't a debug build then upload the artifacts
+#if (!(Test-Path Env:PR_AUTHOR) -And !(Test-Path Env:ML_DEBUG)) {
+#    # The | % { "$_" } at the end converts any error objects on stderr to strings
+#    & ".\gradlew.bat" --info "-Dbuild.version_qualifier=$Env:VERSION_QUALIFIER" "-Dbuild.snapshot=$Env:BUILD_SNAPSHOT" upload 2>&1 | % { "$_" }
+#    if ($LastExitCode -ne 0) {
+#        Exit $LastExitCode
+#    }
+#}

--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -160,8 +160,9 @@ case `uname` in
         ;;
 esac
 
-# If this isn't a PR build and isn't a debug build then upload the artifacts
-if [[ -z "$PR_AUTHOR" && -z "$ML_DEBUG" ]] ; then
-    (cd .. && ./gradlew --info -Dbuild.version_qualifier=$VERSION_QUALIFIER -Dbuild.snapshot=$BUILD_SNAPSHOT upload)
-fi
-
+# Do not upload artifacts from the Jenkins' build while testing uploading from BuildKite pipelines
+## If this isn't a PR build and isn't a debug build then upload the artifacts
+#if [[ -z "$PR_AUTHOR" && -z "$ML_DEBUG" ]] ; then
+#    (cd .. && ./gradlew --info -Dbuild.version_qualifier=$VERSION_QUALIFIER -Dbuild.snapshot=$BUILD_SNAPSHOT upload)
+#fi
+#

--- a/dev-tools/jenkins_combine_artifacts.sh
+++ b/dev-tools/jenkins_combine_artifacts.sh
@@ -22,6 +22,9 @@
 #    GCS, where release manager builds will download them from.
 #
 
+# Do not upload artifacts from the Jenkins' build while testing uploading from BuildKite pipelines
+exit 0
+
 : "${HOME:?Need to set HOME to a non-empty value.}"
 : "${WORKSPACE:?Need to set WORKSPACE to a non-empty value.}"
 


### PR DESCRIPTION
For the snapshot and staging builds:

 * Disable uploading from Jenkins
 * Enable uploading from BuildKite

The intention is to merge this at a point where it will cause least disruption should anything go wrong.
Likewise, the backports will happen slowly, after a number of days. Again to ensure all is at it should be.