### PR TITLE
[8.8][ML] Add missing contexts for github commit statuses (#2513)

### DIFF
--- a/.buildkite/pipelines/format_and_validation.yml.sh
+++ b/.buildkite/pipelines/format_and_validation.yml.sh
@@ -15,4 +15,7 @@ steps:
     command: ".buildkite/scripts/steps/check-style.sh --all"
     agents:
       image: "docker.elastic.co/ml-dev/ml-check-style:2"
+    notify:
+      - github_commit_status:
+          context: "Validate formatting with clang-format"
 EOL

--- a/.buildkite/pipelines/run_es_tests.yml.sh
+++ b/.buildkite/pipelines/run_es_tests.yml.sh
@@ -26,4 +26,7 @@ steps:
     env:
       IVY_REPO: "../ivy"
       GRADLE_JVM_OPTS: "-Dorg.gradle.jvmargs=-Xmx16g"
+    notify:
+      - github_commit_status:
+          context: "Java Integration Tests"
 EOL


### PR DESCRIPTION
The format validation step and the ES integration step were missing configuration to notify github about their status. This PR _should_ remedy that.

Backports #2513 