### PR TITLE
[8.8][ML] Better handle test suite failures (#2496)

### DIFF
--- a/.buildkite/scripts/steps/build_and_test.ps1
+++ b/.buildkite/scripts/steps/build_and_test.ps1
@@ -58,10 +58,13 @@ $ErrorActionPreference="Continue"
 # Run the build and unit tests
 # The | % { "$_" } at the end converts any error objects on stderr to strings
 & ".\gradlew.bat" --info "-Dbuild.version_qualifier=$Env:VERSION_QUALIFIER" "-Dbuild.snapshot=$Env:BUILD_SNAPSHOT" $DebugOption $Tasks 2>&1 | % { "$_" }
-if ($LastExitCode -ne 0) {
-    Exit $LastExitCode
-}
+$ExitCode=$LastExitCode
 
 Get-ChildItem -Path . -Include *.out -File -Recurse -ErrorAction SilentlyContinue | Compress-Archive -DestinationPath windows-x86_64-unit_test_results.zip
+buildkite-agent artifact upload "windows-x86_64-unit_test_results.zip"
 
-buildkite-agent artifact upload "build/distributions/*;windows-x86_64-unit_test_results.zip"
+if ($ExitCode -ne 0) {
+    Exit $ExitCode
+}
+
+buildkite-agent artifact upload "build/distributions/*"


### PR DESCRIPTION
Ensure test results and output files are uploaded as artifacts should the tests fail, on all platforms.

Backports #2496