### PR TITLE
[7.17][ML] Better handle test suite failures (#2496)

### DIFF
--- a/.buildkite/scripts/steps/build_and_test.ps1
+++ b/.buildkite/scripts/steps/build_and_test.ps1
@@ -58,10 +58,13 @@ $ErrorActionPreference="Continue"
 # Run the build and unit tests
 # The | % { "$_" } at the end converts any error objects on stderr to strings
 & ".\gradlew.bat" --info "-Dbuild.version_qualifier=$Env:VERSION_QUALIFIER" "-Dbuild.snapshot=$Env:BUILD_SNAPSHOT" $DebugOption $Tasks 2>&1 | % { "$_" }
-if ($LastExitCode -ne 0) {
-    Exit $LastExitCode
-}
+$ExitCode=$LastExitCode
 
 Get-ChildItem -Path . -Include *.out -File -Recurse -ErrorAction SilentlyContinue | Compress-Archive -DestinationPath windows-x86_64-unit_test_results.zip
+buildkite-agent artifact upload "windows-x86_64-unit_test_results.zip"
 
-buildkite-agent artifact upload "build/distributions/*;windows-x86_64-unit_test_results.zip"
+if ($ExitCode -ne 0) {
+    Exit $ExitCode
+}
+
+buildkite-agent artifact upload "build/distributions/*"

--- a/.buildkite/scripts/steps/build_and_test.sh
+++ b/.buildkite/scripts/steps/build_and_test.sh
@@ -51,11 +51,6 @@ if [[ "$HARDWARE_ARCH" = aarch64 && -z "$CPP_CROSS_COMPILE" && `uname` = Linux ]
     ${REPO_ROOT}/dev-tools/docker_build.sh linux_aarch64_native
   else
     ${REPO_ROOT}/dev-tools/docker_test.sh --extract-unit-tests linux_aarch64_native || TEST_OUTCOME=$?
-    if [[ $TEST_OUTCOME -eq 0 ]]; then
-      echo "Re-running seccomp unit tests outside of Docker container - kernel: $KERNEL_VERSION glibc: $GLIBC_VERSION"
-      (cd ${REPO_ROOT}/cmake-build-docker/test/lib/seccomp/unittest && \
-        LD_LIBRARY_PATH=`cd ../../../../../build/distribution/platform/linux-aarch64/lib && pwd` ./ml_test_seccomp) || TEST_OUTCOME=$?
-    fi
   fi
 fi
 

--- a/.buildkite/scripts/steps/build_and_test.sh
+++ b/.buildkite/scripts/steps/build_and_test.sh
@@ -37,6 +37,7 @@ fi
 VERSION=$(cat ${REPO_ROOT}/gradle.properties | grep '^elasticsearchVersion' | awk -F= '{ print $2 }' | xargs echo)
 HARDWARE_ARCH=$(uname -m | sed 's/arm64/aarch64/')
 
+TEST_OUTCOME=0
 if [[ "$HARDWARE_ARCH" = aarch64 && -z "$CPP_CROSS_COMPILE" && `uname` = Linux ]] ; then 
   # On Linux native aarch64 build using Docker
   
@@ -49,7 +50,12 @@ if [[ "$HARDWARE_ARCH" = aarch64 && -z "$CPP_CROSS_COMPILE" && `uname` = Linux ]
   if [ "$RUN_TESTS" = false ] ; then
     ${REPO_ROOT}/dev-tools/docker_build.sh linux_aarch64_native
   else
-    ${REPO_ROOT}/dev-tools/docker_test.sh --extract-unit-tests linux_aarch64_native
+    ${REPO_ROOT}/dev-tools/docker_test.sh --extract-unit-tests linux_aarch64_native || TEST_OUTCOME=$?
+    if [[ $TEST_OUTCOME -eq 0 ]]; then
+      echo "Re-running seccomp unit tests outside of Docker container - kernel: $KERNEL_VERSION glibc: $GLIBC_VERSION"
+      (cd ${REPO_ROOT}/cmake-build-docker/test/lib/seccomp/unittest && \
+        LD_LIBRARY_PATH=`cd ../../../../../build/distribution/platform/linux-aarch64/lib && pwd` ./ml_test_seccomp) || TEST_OUTCOME=$?
+    fi
   fi
 fi
 
@@ -67,6 +73,7 @@ fi
 if ! [[ "$HARDWARE_ARCH" = aarch64 && -z "$CPP_CROSS_COMPILE" ]] ; then 
   if [ "$RUN_TESTS" = "true" ]; then
     ${REPO_ROOT}/dev-tools/docker/docker_entrypoint.sh --test
+    grep passed build/test_status.txt || TEST_OUTCOME=$?
   else
     ${REPO_ROOT}/dev-tools/docker/docker_entrypoint.sh
   fi
@@ -74,14 +81,10 @@ else
   if [[ `uname` = "Darwin" && "$HARDWARE_ARCH" = "aarch64" ]]; then
      # For macOS, build directly on the machine
      ${REPO_ROOT}/dev-tools/download_macos_deps.sh
-     if [ -z "$BUILDKITE_PULL_REQUEST" ] ; then
-         if [ "$RUN_TESTS" = false ] ; then
-             TASKS="clean buildZip buildZipSymbols"
-         else
-             TASKS="clean buildZip buildZipSymbols check"
-         fi
+     if [ "$RUN_TESTS" = false ] ; then
+         TASKS="clean buildZip buildZipSymbols"
      else
-         TASKS="clean buildZip check"
+         TASKS="clean buildZip buildZipSymbols check"
      fi
      # For macOS we usually only use a particular version as our build platform
      # once Xcode has stopped receiving updates for it. However, with Big Sur
@@ -93,11 +96,11 @@ else
          export BOOSTCLANGVER=120
      fi
 
-     (cd ${REPO_ROOT} && ./gradlew --info -Dbuild.version_qualifier=${VERSION_QUALIFIER:-} -Dbuild.snapshot=${BUILD_SNAPSHOT:-} -Dbuild.ml_debug=${ML_DEBUG:-} $TASKS)
+     (cd ${REPO_ROOT} && ./gradlew --info -Dbuild.version_qualifier=${VERSION_QUALIFIER:-} -Dbuild.snapshot=${BUILD_SNAPSHOT:-} -Dbuild.ml_debug=${ML_DEBUG:-} $TASKS) || TEST_OUTCOME=$?
   fi
 fi
 
-if ! [[ "$HARDWARE_ARCH" = aarch64 && -n "$CPP_CROSS_COMPILE" ]] ; then 
+if ! [[ "$HARDWARE_ARCH" = aarch64 && -n "$CPP_CROSS_COMPILE" ]] && [[ $TEST_OUTCOME -eq 0 ]] ; then 
   buildkite-agent artifact upload "build/distributions/*.zip"
 fi
 
@@ -107,3 +110,5 @@ if [[ -z "$CPP_CROSS_COMPILE" ]] ; then
   find . -path  "*/**/ml_test_*.out" -o -path "*/**/*.junit" | xargs tar cvzf ${TEST_RESULTS_ARCHIVE}
   buildkite-agent artifact upload "${TEST_RESULTS_ARCHIVE}"
 fi
+
+exit $TEST_OUTCOME


### PR DESCRIPTION
Ensure test results and output files are uploaded as artifacts should the tests fail, on all platforms.

Backports #2496 