### PR TITLE
[ML] Amalgamate DRA pipeline into branch builds

### DIFF
--- a/.buildkite/branch.json.py
+++ b/.buildkite/branch.json.py
@@ -28,10 +28,6 @@ def main():
     pipeline["env"] = env
 
     pipeline_steps = step.PipelineStep([])
-
-def main():
-    pipeline = {}
-    pipeline_steps = step.PipelineStep([])
     pipeline_steps.append(pipeline_steps.generate_step("Queue a :slack: notification for the pipeline",
                                                        ".buildkite/pipelines/send_slack_notification.sh"))
     pipeline_steps.append(pipeline_steps.generate_step("Queue a :email: notification for the pipeline",
@@ -49,6 +45,8 @@ def main():
     if config.build_linux:
         build_linux = pipeline_steps.generate_step_template("Linux", "build")
         pipeline_steps.append(build_linux)
+
+    pipeline_steps.append({"wait": None})
 
     # Build the DRA artifacts and upload to S3 and GCS
     pipeline_steps.append(pipeline_steps.generate_step("Create daily releasable artifacts",

--- a/.buildkite/branch.json.py
+++ b/.buildkite/branch.json.py
@@ -18,6 +18,17 @@ from ml_pipeline import (
     config as buildConfig,
 )
 
+env = {
+  "BUILD_SNAPSHOT": "true",
+  "VERSION_QUALIFIER": ""
+}
+
+def main():
+    pipeline = {}
+    pipeline["env"] = env
+
+    pipeline_steps = step.PipelineStep([])
+
 def main():
     pipeline = {}
     pipeline_steps = step.PipelineStep([])
@@ -39,16 +50,13 @@ def main():
         build_linux = pipeline_steps.generate_step_template("Linux", "build")
         pipeline_steps.append(build_linux)
 
-    pipeline_steps.append({"wait": None})
-
-    # Trigger the DRA pipeline to create and upload artifacts to S3 and GCS
-    pipeline_steps.append({"trigger": "ml-cpp-dra",
-                           "label": ":rocket: DRA",
-                           "async": "true",
-                           "build": {
-                               "message": "${BUILDKITE_MESSAGE}",
-                               "commit": "${BUILDKITE_COMMIT}",
-                               "branch": "${BUILDKITE_BRANCH}"}})
+    # Build the DRA artifacts and upload to S3 and GCS
+    pipeline_steps.append(pipeline_steps.generate_step("Create daily releasable artifacts",
+                                                       ".buildkite/pipelines/create_dra.yml.sh"))
+    pipeline_steps.append(pipeline_steps.generate_step("Upload daily releasable artifacts to S3",
+                                                       ".buildkite/pipelines/upload_dra_to_s3.yml.sh"))
+    pipeline_steps.append(pipeline_steps.generate_step("Upload daily releasable artifacts to GCS",
+                                                       ".buildkite/pipelines/upload_dra_to_gcs.yml.sh"))
 
     pipeline["steps"] = pipeline_steps
     print(json.dumps(pipeline, indent=2))

--- a/.buildkite/pipelines/upload_dra_to_gcs.yml.sh
+++ b/.buildkite/pipelines/upload_dra_to_gcs.yml.sh
@@ -16,7 +16,7 @@
 
 cat <<EOL
 steps:
-  - label: "Upload DRA artifacts to GCS :gcloud:"
+  - label: ":rocket: Upload DRA artifacts to GCS :gcloud:"
     key: "upload_dra_artifacts_to_gcs"
     depends_on: create_dra_artifacts
     command:

--- a/.buildkite/pipelines/upload_dra_to_s3.yml.sh
+++ b/.buildkite/pipelines/upload_dra_to_s3.yml.sh
@@ -12,7 +12,7 @@
 
 cat <<EOL
 steps:
-  - label: "Upload DRA artifacts to S3 :s3:"
+  - label: ":rocket: Upload DRA artifacts to S3 :s3:"
     key: "upload_dra_artifacts"
     depends_on: create_dra_artifacts
     command:


### PR DESCRIPTION
Add the steps to create and upload build artifacts directly into the branch pipelines. This makes notification and diagnosis of build failures simpler.