### PR TITLE
[8.8][ML] Amalgamate DRA pipeline into branch builds (#2520)

### DIFF
--- a/.buildkite/pipelines/create_dra.yml.sh
+++ b/.buildkite/pipelines/create_dra.yml.sh
@@ -14,6 +14,13 @@ steps:
     key: "create_dra_artifacts"
     command:
         - "./.buildkite/scripts/steps/create_dra.sh"
+    depends_on:
+        - "build_test_linux-aarch64-RelWithDebInfo"
+        - "build_test_linux-x86_64-RelWithDebInfo"
+        - "build_macos_x86_64_cross-RelWithDebInfo"
+        - "build_test_macos-aarch64-RelWithDebInfo"
+        - "build_test_Windows-x86_64-RelWithDebInfo"
+
     agents:
       cpu: "2"
       ephemeralStorage: "20G"

--- a/.buildkite/pipelines/upload_dra_to_gcs.yml.sh
+++ b/.buildkite/pipelines/upload_dra_to_gcs.yml.sh
@@ -16,7 +16,7 @@
 
 cat <<EOL
 steps:
-  - label: "Upload DRA artifacts to GCS :gcloud:"
+  - label: ":rocket: Upload DRA artifacts to GCS :gcloud:"
     key: "upload_dra_artifacts_to_gcs"
     depends_on: create_dra_artifacts
     command:

--- a/.buildkite/pipelines/upload_dra_to_s3.yml.sh
+++ b/.buildkite/pipelines/upload_dra_to_s3.yml.sh
@@ -12,7 +12,7 @@
 
 cat <<EOL
 steps:
-  - label: "Upload DRA artifacts to S3 :s3:"
+  - label: ":rocket: Upload DRA artifacts to S3 :s3:"
     key: "upload_dra_artifacts"
     depends_on: create_dra_artifacts
     command:


### PR DESCRIPTION
Add the steps to create and upload build artifacts directly into the branch pipelines. This makes notification and diagnosis of build failures simpler.

Backports #2520 