### PR TITLE
[ML] Fix macos cross compilation build for 7.17

### DIFF
--- a/.buildkite/pipelines/build_macos.json.py
+++ b/.buildkite/pipelines/build_macos.json.py
@@ -90,7 +90,6 @@ def main(args):
         "depends_on": "check_style",
         "key": "build_macos_x86_64_cross-RelWithDebInfo",
         "env": {
-          "ML_DEBUG": "0",
           "CPP_CROSS_COMPILE": "macosx",
           "CMAKE_FLAGS": "-DCMAKE_TOOLCHAIN_FILE=cmake/darwin-x86_64.cmake",
           "RUN_TESTS": "false"


### PR DESCRIPTION
The macos cross compilation build on the 7.17 branch is inadvertently being built with full debugging symbols. This change corrects that.