### PR TITLE
[ML] Add internal flag to flush api determining whether to refresh indices or not.

### DIFF
--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -504,6 +504,9 @@ private:
     //! Flag indicating whether or not time has been advanced.
     bool m_TimeAdvanced{false};
 
+    //! Flag indicating whether or not a flush control message should trigger a refresh of the datafeed
+    bool m_ShouldRefresh{true};
+
     //! Introduced in version 8.6
     //! The initial value of the end time of the last bucket
     //! out of latency window we've seen, i.e. this member records

--- a/include/api/CAnomalyJob.h
+++ b/include/api/CAnomalyJob.h
@@ -505,7 +505,7 @@ private:
     bool m_TimeAdvanced{false};
 
     //! Flag indicating whether or not a flush control message should trigger a refresh of the datafeed
-    bool m_ShouldRefresh{true};
+    bool m_RefreshRequired{true};
 
     //! Introduced in version 8.6
     //! The initial value of the end time of the last bucket

--- a/include/api/CJsonOutputWriter.h
+++ b/include/api/CJsonOutputWriter.h
@@ -245,7 +245,9 @@ public:
                                const TOptionalTime& timestamp);
 
     //! Acknowledge a flush request by echoing back the flush ID and the "refreshRequired" flag
-    void acknowledgeFlush(const std::string& flushId, core_t::TTime lastFinalizedBucketEnd, bool refreshRequired=true);
+    void acknowledgeFlush(const std::string& flushId,
+                          core_t::TTime lastFinalizedBucketEnd,
+                          bool refreshRequired = true);
 
     //! Write a category definition
     void writeCategoryDefinition(const std::string& partitionFieldName,

--- a/include/api/CJsonOutputWriter.h
+++ b/include/api/CJsonOutputWriter.h
@@ -244,8 +244,8 @@ public:
                                const model::SCategorizerStats& categorizerStats,
                                const TOptionalTime& timestamp);
 
-    //! Acknowledge a flush request by echoing back the flush ID
-    void acknowledgeFlush(const std::string& flushId, core_t::TTime lastFinalizedBucketEnd);
+    //! Acknowledge a flush request by echoing back the flush ID and the "shouldRefresh" flag
+    void acknowledgeFlush(const std::string& flushId, core_t::TTime lastFinalizedBucketEnd, bool shouldRefresh=true);
 
     //! Write a category definition
     void writeCategoryDefinition(const std::string& partitionFieldName,

--- a/include/api/CJsonOutputWriter.h
+++ b/include/api/CJsonOutputWriter.h
@@ -244,8 +244,8 @@ public:
                                const model::SCategorizerStats& categorizerStats,
                                const TOptionalTime& timestamp);
 
-    //! Acknowledge a flush request by echoing back the flush ID and the "shouldRefresh" flag
-    void acknowledgeFlush(const std::string& flushId, core_t::TTime lastFinalizedBucketEnd, bool shouldRefresh=true);
+    //! Acknowledge a flush request by echoing back the flush ID and the "refreshRequired" flag
+    void acknowledgeFlush(const std::string& flushId, core_t::TTime lastFinalizedBucketEnd, bool refreshRequired=true);
 
     //! Write a category definition
     void writeCategoryDefinition(const std::string& partitionFieldName,

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -366,7 +366,6 @@ bool CAnomalyJob::handleControlMessage(const std::string& controlMessage) {
         if (core::CStringUtils::stringToType(controlMessage.substr(1), refreshRequired) == false) {
             LOG_ERROR(<< "Received request to flush with invalid control message '"
                       << controlMessage << "'");
-            break;
         } else {
             m_RefreshRequired = refreshRequired;
         }

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -361,7 +361,7 @@ bool CAnomalyJob::handleControlMessage(const std::string& controlMessage) {
         this->processPersistControlMessage(controlMessage.substr(1));
         break;
     case 'z':
-        LOG_INFO(<< "Received control message '" << controlMessage << "'");
+        LOG_TRACE(<< "Received control message '" << controlMessage << "'");
         // "refreshRequired" parameter comes after the initial z.
         if (core::CStringUtils::stringToType(controlMessage.substr(1), refreshRequired) == false) {
             LOG_ERROR(<< "Received request to flush with invalid control message '"

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -323,7 +323,7 @@ bool CAnomalyJob::handleControlMessage(const std::string& controlMessage) {
         return false;
     }
 
-    bool shouldRefresh{false};
+    bool refreshRequired{false};
     bool ret{true};
 
     switch (controlMessage[0]) {
@@ -363,15 +363,15 @@ bool CAnomalyJob::handleControlMessage(const std::string& controlMessage) {
         break;
     case 'z':
         LOG_INFO(<< "Received control message '" << controlMessage << "'");
-        // "shouldRefresh" parameter comes after the initial z.
-        if (core::CStringUtils::stringToType(controlMessage.substr(1), shouldRefresh) == false) {
+        // "refreshRequired" parameter comes after the initial z.
+        if (core::CStringUtils::stringToType(controlMessage.substr(1), refreshRequired) == false) {
             LOG_ERROR(<< "Received request to flush with invalid control message '"
                       << controlMessage << "'");
             ret = false;
             break;
         }
 
-        m_ShouldRefresh = shouldRefresh;
+        m_RefreshRequired = refreshRequired;
 
         break;
     default:
@@ -469,7 +469,7 @@ void CAnomalyJob::acknowledgeFlush(const std::string& flushId) {
     } else {
         LOG_TRACE(<< "Received flush control message with ID " << flushId);
     }
-    m_JsonOutputWriter.acknowledgeFlush(flushId, m_LastFinalisedBucketEndTime, m_ShouldRefresh);
+    m_JsonOutputWriter.acknowledgeFlush(flushId, m_LastFinalisedBucketEndTime, m_RefreshRequired);
 }
 
 void CAnomalyJob::updateConfig(const std::string& config) {

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -323,9 +323,7 @@ bool CAnomalyJob::handleControlMessage(const std::string& controlMessage) {
         return false;
     }
 
-    bool refreshRequired{false};
-    bool ret{true};
-
+    bool refreshRequired{true};
     switch (controlMessage[0]) {
     case ' ':
         // Spaces are just used to fill the buffers and force prior messages
@@ -368,11 +366,10 @@ bool CAnomalyJob::handleControlMessage(const std::string& controlMessage) {
         if (core::CStringUtils::stringToType(controlMessage.substr(1), refreshRequired) == false) {
             LOG_ERROR(<< "Received request to flush with invalid control message '"
                       << controlMessage << "'");
-            ret = false;
             break;
+        } else {
+            m_RefreshRequired = refreshRequired;
         }
-
-        m_RefreshRequired = refreshRequired;
 
         break;
     default:
@@ -384,7 +381,7 @@ bool CAnomalyJob::handleControlMessage(const std::string& controlMessage) {
         break;
     }
 
-    return ret;
+    return true;
 }
 
 bool CAnomalyJob::parsePersistControlMessageArgs(const std::string& controlMessageArgs,

--- a/lib/api/CAnomalyJob.cc
+++ b/lib/api/CAnomalyJob.cc
@@ -338,6 +338,7 @@ bool CAnomalyJob::handleControlMessage(const std::string& controlMessage) {
         // rows in input.
         break;
     case 'f':
+        // Flush ID comes after the initial f
         this->acknowledgeFlush(controlMessage.substr(1));
         break;
     case 'i':

--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -67,6 +67,7 @@ const std::string INFLUENCERS("influencers");
 const std::string FLUSH("flush");
 const std::string ID("id");
 const std::string LAST_FINALIZED_BUCKET_END("last_finalized_bucket_end");
+const std::string SHOULD_REFRESH("should_refresh");
 const std::string CATEGORY_ID("category_id");
 const std::string CATEGORY_DEFINITION("category_definition");
 const std::string TERMS("terms");
@@ -874,7 +875,7 @@ void CJsonOutputWriter::writeCategorizerStats(const std::string& partitionFieldN
 }
 
 void CJsonOutputWriter::acknowledgeFlush(const std::string& flushId,
-                                         core_t::TTime lastFinalizedBucketEnd) {
+                                         core_t::TTime lastFinalizedBucketEnd, bool shouldRefresh) {
     m_Writer.StartObject();
     m_Writer.Key(FLUSH);
     m_Writer.StartObject();
@@ -883,6 +884,8 @@ void CJsonOutputWriter::acknowledgeFlush(const std::string& flushId,
     m_Writer.String(flushId);
     m_Writer.Key(LAST_FINALIZED_BUCKET_END);
     m_Writer.Time(lastFinalizedBucketEnd);
+    m_Writer.Key(SHOULD_REFRESH);
+    m_Writer.Bool(shouldRefresh);
 
     m_Writer.EndObject();
     m_Writer.EndObject();

--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -875,7 +875,8 @@ void CJsonOutputWriter::writeCategorizerStats(const std::string& partitionFieldN
 }
 
 void CJsonOutputWriter::acknowledgeFlush(const std::string& flushId,
-                                         core_t::TTime lastFinalizedBucketEnd, bool refreshRequired) {
+                                         core_t::TTime lastFinalizedBucketEnd,
+                                         bool refreshRequired) {
     m_Writer.StartObject();
     m_Writer.Key(FLUSH);
     m_Writer.StartObject();

--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -67,7 +67,7 @@ const std::string INFLUENCERS("influencers");
 const std::string FLUSH("flush");
 const std::string ID("id");
 const std::string LAST_FINALIZED_BUCKET_END("last_finalized_bucket_end");
-const std::string SHOULD_REFRESH("should_refresh");
+const std::string REFRESH_REQUIRED("refresh_required");
 const std::string CATEGORY_ID("category_id");
 const std::string CATEGORY_DEFINITION("category_definition");
 const std::string TERMS("terms");
@@ -875,7 +875,7 @@ void CJsonOutputWriter::writeCategorizerStats(const std::string& partitionFieldN
 }
 
 void CJsonOutputWriter::acknowledgeFlush(const std::string& flushId,
-                                         core_t::TTime lastFinalizedBucketEnd, bool shouldRefresh) {
+                                         core_t::TTime lastFinalizedBucketEnd, bool refreshRequired) {
     m_Writer.StartObject();
     m_Writer.Key(FLUSH);
     m_Writer.StartObject();
@@ -884,8 +884,8 @@ void CJsonOutputWriter::acknowledgeFlush(const std::string& flushId,
     m_Writer.String(flushId);
     m_Writer.Key(LAST_FINALIZED_BUCKET_END);
     m_Writer.Time(lastFinalizedBucketEnd);
-    m_Writer.Key(SHOULD_REFRESH);
-    m_Writer.Bool(shouldRefresh);
+    m_Writer.Key(REFRESH_REQUIRED);
+    m_Writer.Bool(refreshRequired);
 
     m_Writer.EndObject();
     m_Writer.EndObject();

--- a/lib/api/unittest/CFieldDataCategorizerTest.cc
+++ b/lib/api/unittest/CFieldDataCategorizerTest.cc
@@ -573,7 +573,7 @@ BOOST_AUTO_TEST_CASE(testHandleControlMessages) {
 
     const std::string& output{outputStrm.str()};
     LOG_DEBUG(<< "Output is: " << output);
-    BOOST_REQUIRE_EQUAL(0, output.find("[{\"flush\":{\"id\":\"7\",\"last_finalized_bucket_end\":0}}"));
+    BOOST_REQUIRE_EQUAL(0, output.find("[{\"flush\":{\"id\":\"7\",\"last_finalized_bucket_end\":0,\"refresh_required\":true}}"));
 }
 
 BOOST_AUTO_TEST_CASE(testRestoreStateFailsWithEmptyState) {


### PR DESCRIPTION
When datafeeds send flush requests they don't require the indices to be refreshed.
    
Round trip the "should_refresh" flag from ES to ml-cpp code and back again.