### PR TITLE
[8.8][ML] DRA upload: Only download artifacts once (#2534)

### DIFF
--- a/.buildkite/pipelines/upload_dra_to_gcs.yml.sh
+++ b/.buildkite/pipelines/upload_dra_to_gcs.yml.sh
@@ -20,7 +20,7 @@ steps:
     key: "upload_dra_artifacts_to_gcs"
     depends_on: create_dra_artifacts
     command:
-      - 'buildkite-agent artifact download "build/distributions/*" .'
+      - 'buildkite-agent artifact download "build/distributions/*" --step create_dra_artifacts .'
       - '.buildkite/scripts/steps/upload_dra_to_gcs.sh'
     agents:
       provider: gcp

--- a/.buildkite/pipelines/upload_dra_to_s3.yml.sh
+++ b/.buildkite/pipelines/upload_dra_to_s3.yml.sh
@@ -16,7 +16,7 @@ steps:
     key: "upload_dra_artifacts"
     depends_on: create_dra_artifacts
     command:
-      - 'buildkite-agent artifact download "build/distributions/*" .'
+      - 'buildkite-agent artifact download "build/distributions/*" --step create_dra_artifacts .'
       - "./.buildkite/scripts/steps/upload_dra_to_s3.sh"
     agents:
       cpu: "2"


### PR DESCRIPTION
The DRA upload pipelines are currently downloading required artifacts from multiple pipeline steps. While this is not an error or causing any harm it is slightly more efficient to only download the artifacts once, from the `create_dra_artifacts` step.

Backports #2534