### PR TITLE
[NLP] Evaluate batched inference calls singularly 

### DIFF
--- a/bin/pytorch_inference/CCommandParser.cc
+++ b/bin/pytorch_inference/CCommandParser.cc
@@ -245,12 +245,6 @@ bool CCommandParser::checkArrayContainsUInts(const rapidjson::Value::ConstArray&
            }) == arr.End();
 }
 
-bool CCommandParser::checkArrayContainsDoubles(const rapidjson::Value::ConstArray& arr) {
-    return std::find_if(arr.Begin(), arr.End(), [](const auto& i) {
-               return i.IsDouble() == false;
-           }) == arr.End();
-}
-
 CCommandParser::SRequest
 CCommandParser::jsonToInferenceRequest(const rapidjson::Document& doc) {
     SRequest request;

--- a/bin/pytorch_inference/CCommandParser.h
+++ b/bin/pytorch_inference/CCommandParser.h
@@ -183,7 +183,6 @@ private:
     static EMessageType validateControlMessageJson(const rapidjson::Document& doc,
                                                    const TErrorHandlerFunc& errorHandler);
     static bool checkArrayContainsUInts(const rapidjson::Value::ConstArray& arr);
-    static bool checkArrayContainsDoubles(const rapidjson::Value::ConstArray& arr);
     static SRequest jsonToInferenceRequest(const rapidjson::Document& doc);
     static SControlMessage jsonToControlMessage(const rapidjson::Document& doc);
 

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -45,6 +45,8 @@
 torch::Tensor infer(torch::jit::script::Module& module_,
                     ml::torch::CCommandParser::SRequest& request) {
 
+    LOG_INFO(<< "request " << request.s_RequestId << ", " << request.s_NumberInferences);
+
     std::vector<torch::jit::IValue> inputs;
     inputs.reserve(1 + request.s_SecondaryArguments.size());
 
@@ -57,7 +59,7 @@ torch::Tensor infer(torch::jit::script::Module& module_,
 
     for (int i=0; i<request.s_NumberInferences; i++) {
 
-        std::size_t offset = i * sizeof(std::uint64_t);
+        std::size_t offset = i * request.s_NumberInputTokens * sizeof(std::uint64_t);
 
         // Sequence tokens.
         inputs.emplace_back(torch::from_blob(static_cast<void*>(request.s_Tokens.data() + offset),
@@ -79,6 +81,7 @@ torch::Tensor infer(torch::jit::script::Module& module_,
         inputs.clear();
     }
 
+    LOG_INFO(<< "request processed " << request.s_RequestId);
     return at::cat(all, 0);
 }
 

--- a/bin/pytorch_inference/evaluate.py
+++ b/bin/pytorch_inference/evaluate.py
@@ -303,6 +303,8 @@ def test_evaluation(args):
 
             total_time_ms += result['time_ms']
 
+                    
+
             # compare to expected
             if compare_results(expected, result, tolerance) == False:
                 print()
@@ -364,10 +366,10 @@ def main():
     finally:
         if os.path.isfile(args.restore_file):
             os.remove(args.restore_file)
-        if os.path.isfile(args.input_file):
-            os.remove(args.input_file)
-        if os.path.isfile(args.output_file):
-            os.remove(args.output_file)
+        # if os.path.isfile(args.input_file):
+        #     os.remove(args.input_file)
+        # if os.path.isfile(args.output_file):
+        #     os.remove(args.output_file)
 
 if __name__ == "__main__":
     main()

--- a/bin/pytorch_inference/evaluate.py
+++ b/bin/pytorch_inference/evaluate.py
@@ -301,7 +301,7 @@ def test_evaluation(args):
             if 'how_close' in test_evaluation[doc_count]:
                 tolerance = test_evaluation[doc_count]['how_close']                                   
 
-            total_time_ms += result['time_ms']                   
+            total_time_ms += result['time_ms']
 
             # compare to expected
             if compare_results(expected, result, tolerance) == False:

--- a/bin/pytorch_inference/evaluate.py
+++ b/bin/pytorch_inference/evaluate.py
@@ -286,7 +286,11 @@ def test_evaluation(args):
 
 
         for result in result_docs:
+<<<<<<< HEAD
         
+=======
+            
+>>>>>>> e4ff767d (more)
             if 'error' in result: 
                 print(f"Inference failed. Request: {result['error']['request_id']}, Msg: {result['error']['error']}")
                 results_match = False

--- a/bin/pytorch_inference/evaluate.py
+++ b/bin/pytorch_inference/evaluate.py
@@ -286,11 +286,7 @@ def test_evaluation(args):
 
 
         for result in result_docs:
-<<<<<<< HEAD
         
-=======
-            
->>>>>>> e4ff767d (more)
             if 'error' in result: 
                 print(f"Inference failed. Request: {result['error']['request_id']}, Msg: {result['error']['error']}")
                 results_match = False
@@ -305,9 +301,7 @@ def test_evaluation(args):
             if 'how_close' in test_evaluation[doc_count]:
                 tolerance = test_evaluation[doc_count]['how_close']                                   
 
-            total_time_ms += result['time_ms']
-
-                    
+            total_time_ms += result['time_ms']                   
 
             # compare to expected
             if compare_results(expected, result, tolerance) == False:
@@ -370,10 +364,10 @@ def main():
     finally:
         if os.path.isfile(args.restore_file):
             os.remove(args.restore_file)
-        # if os.path.isfile(args.input_file):
-        #     os.remove(args.input_file)
-        # if os.path.isfile(args.output_file):
-        #     os.remove(args.output_file)
+        if os.path.isfile(args.input_file):
+            os.remove(args.input_file)
+        if os.path.isfile(args.output_file):
+            os.remove(args.output_file)
 
 if __name__ == "__main__":
     main()

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -37,7 +37,7 @@
 * Improve detection of calendar cyclic components with long bucket lengths. (See {ml-pull}2493[#2493].)
 
 === Bug Fixes
-* Prevent high memory usage by evaluating batch inference singularly. (See {ml-pull}2493[#2538].)
+* Prevent high memory usage by evaluating batch inference singularly. (See {ml-pull}2538[#2538].)
 
 == {es} version 8.8.0
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -36,6 +36,9 @@
 * Improve detection of time shifts, for example for day light saving. (See {ml-pull}2479[#2479].)
 * Improve detection of calendar cyclic components with long bucket lengths. (See {ml-pull}2493[#2493].)
 
+=== Bug Fixes
+* Prevent high memory usage by evaluating batch inference singularly. (See {ml-pull}2493[#2538].)
+
 == {es} version 8.8.0
 
 === Enhancements


### PR DESCRIPTION
Batch inference calls use more memory which can lead to OOM errors in extreme cases. This change iterates over the requests in a batch evaluating them one at a time.

Comparing batched to un-batched evaluation, benchmarking shows that memory usage is significantly lower and the total time for inference is similar in both cases. The benchmark data was generated with the ELSER model with different size batches. Each item in the batch contained 512 tokens. *Inference Time* is the time to process the entire batch whether singularly or all at once.


| Num items in request | Memory Max RSS (MB) **Batched** | Memory Max RSS (MB)  | Inference Time (ms) **Batched** |  Inference Time (ms) |
| ------------- | ------------- |---------| ---------|---------|
| 0        |          946  | 943  | 0 | 0 |
| 10  | 2605  | 1219 | 5022 | 5309 |
| 20 | 4237 | 1234 | 9717 | 9478 |
| 30 | 5960 | 1239 | 14434 | 14408 |
| 40 | 6032 | 1251 | 19902 | 19396 |
|50 | 6616 | 1257 | 24853 | 24112 |

