### PR TITLE
Bytes not Kilobytes

### DIFF
--- a/lib/core/CProcessStats_MacOSX.cc
+++ b/lib/core/CProcessStats_MacOSX.cc
@@ -32,8 +32,8 @@ std::size_t CProcessStats::maxResidentSetSize() {
         return 0;
     }
 
-    // ru_maxrss is in kilobytes
-    return static_cast<std::size_t>(rusage.ru_maxrss * 1024L);
+    // ru_maxrss is in bytes
+    return static_cast<std::size_t>(rusage.ru_maxrss);
 }
 }
 }


### PR DESCRIPTION
Max RSS returned by macOS `getrusage` is in bytes not kilobytes. 

The man page for `getrusage` on my mac (Ventura 13.4) states this:
```
ru_maxrss    the maximum resident set size utilized (in bytes).
```
I think the confusion arose because a search for `macOS getrusage` takes you to the [IOS man page](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/getrusage.2.html) where the `ru_maxrss` field _is_ in KB not B


Non issue as this code is not in any public release yet.