### PR TITLE
[NLP] Catch exceptions thrown during inference and report as errors

### DIFF
--- a/bin/pytorch_inference/CCommandParser.h
+++ b/bin/pytorch_inference/CCommandParser.h
@@ -19,6 +19,7 @@
 #include <functional>
 #include <iosfwd>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -58,7 +59,7 @@ public:
     //! \brief Inference request cache interface.
     class CRequestCacheInterface {
     public:
-        using TComputeResponse = std::function<std::string(SRequest)>;
+        using TComputeResponse = std::function<std::optional<std::string>(SRequest)>;
         using TReadResponse = std::function<void(const std::string&, bool)>;
 
     public:
@@ -102,7 +103,10 @@ public:
         bool lookup(SRequest request,
                     const TComputeResponse& computeResponse,
                     const TReadResponse& readResponse) override {
-            readResponse(computeResponse(std::move(request)), false);
+            auto computed = computeResponse(std::move(request));
+            if (computed) {
+                readResponse(*computed, false);
+            }
             return false;
         }
 

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -18,6 +18,7 @@
 #include <core/CStringUtils.h>
 #include <core/Concurrency.h>
 
+#include <optional>
 #include <seccomp/CSystemCallFilter.h>
 
 #include <ver/CBuildInfo.h>
@@ -92,16 +93,24 @@ bool handleRequest(ml::torch::CCommandParser::CRequestCacheInterface& cache,
         // We time the combination of the cache lookup and (if necessary)
         // the inference.
         ml::core::CStopWatch stopWatch(true);
-        cache.lookup(std::move(capturedRequest),
-                     [&](auto request_) -> std::string {
-                         torch::Tensor results = infer(module_, request_);
-                         return resultWriter.createInnerResult(results);
-                     },
-                     [&](const auto& innerResponseJson_, bool isCacheHit) {
-                         resultWriter.wrapAndWriteInnerResponse(innerResponseJson_,
-                                                                requestId, isCacheHit,
-                                                                stopWatch.stop());
-                     });
+        cache.lookup(
+            std::move(capturedRequest),
+            [&](auto request_) -> std::optional<std::string> {
+                try {
+                    torch::Tensor results = infer(module_, request_);
+                    return resultWriter.createInnerResult(results);
+                } catch (const c10::Error& e) {
+                    resultWriter.writeError(request_.s_RequestId, e.what());
+                    return std::nullopt;
+                } catch (std::runtime_error& e) {
+                    resultWriter.writeError(request_.s_RequestId, e.what());
+                    return std::nullopt;
+                }
+            },
+            [&](const auto& innerResponseJson_, bool isCacheHit) {
+                resultWriter.wrapAndWriteInnerResponse(
+                    innerResponseJson_, requestId, isCacheHit, stopWatch.stop());
+            });
     });
     return true;
 }

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -18,7 +18,6 @@
 #include <core/CStringUtils.h>
 #include <core/Concurrency.h>
 
-#include <optional>
 #include <seccomp/CSystemCallFilter.h>
 
 #include <ver/CBuildInfo.h>
@@ -38,6 +37,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 
 torch::Tensor infer(torch::jit::script::Module& module_,

--- a/bin/pytorch_inference/evaluate.py
+++ b/bin/pytorch_inference/evaluate.py
@@ -288,7 +288,7 @@ def test_evaluation(args):
         for result in result_docs:
         
             if 'error' in result: 
-                print(f"Inference failed. Request: {result['error']['request_id']}, Msg: {result['error']['error']}")
+                print(f"Inference failed. Request: {result['request_id']}, Msg: {result['error']['error']}")
                 results_match = False
                 continue
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -38,6 +38,7 @@
 
 === Bug Fixes
 * Prevent high memory usage by evaluating batch inference singularly. (See {ml-pull}2538[#2538].)
+* Catch exceptions thrown during inference and report as errors. (See {ml-pull}2542[#2542].)
 
 == {es} version 8.8.0
 

--- a/lib/core/unittest/CCompressedLfuCacheTest.cc
+++ b/lib/core/unittest/CCompressedLfuCacheTest.cc
@@ -24,6 +24,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <chrono>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -610,6 +611,21 @@ BOOST_AUTO_TEST_CASE(testClear) {
     BOOST_REQUIRE_EQUAL(0.0, cache.hitFraction());
 
     BOOST_TEST_REQUIRE(cache.checkInvariants());
+}
+
+BOOST_AUTO_TEST_CASE(testComputeValueReturnsNullOpt) {
+    TStrStrCache cache{32 * core::constants::BYTES_IN_KILOBYTES,
+                       [](const TStrStrCache::TDictionary& dictionary, const std::string& key) {
+                           return dictionary.word(key);
+                       }};
+
+    bool valueRead{false};
+
+    BOOST_REQUIRE_EQUAL(
+        false,
+        cache.lookup("key_1", [](std::string) { return std::nullopt; },
+                     [&valueRead](const std::string&, bool) { valueRead = true; }));
+    BOOST_REQUIRE_EQUAL(false, valueRead);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Inference was previously wrapped in a try catch statement but that was lost during a refactoring which means the errors are swallowed by the executing thread and not propagated to the error handler. 

https://github.com/elastic/ml-cpp/commit/4266662428dd204e99a456a2a40e77bace4df44e#diff-5984f43760a98454db757ddada7f1f9f82a87ffaa4aa1c8a89966f4fc94a8829

Since the refactoring inference is performed from the `computeValue` callback of the `CCompressedLfuCache`. As inference may throw `computeValue` must handle failed computations. I've changed the signature to return a std::optional, if the nullopt is returned the cache will not cache the value.

The consequence of this is that the `readValue` function is never called if `computeValue` fails. Users must be aware that calling `lookup` on the cache may result in `readValue` not being called. If this is considered a trap-y pattern then the alternative is to expose `read` and `write` methods on the cache and rewrite the code to first read the value, call infer if the result is not cached then put and write the inference result.

### Inference Failures
Evaluating the model with the wrong number of arguments is one example of a recoverable failure. 

<details><summary>Example Error Message</summary>
Expected at most 3 argument(s) for operator 'forward', but received 5 argument(s). Declaration: forward(__torch__.transformers.modeling_distilbert.DistilBertForSequenceClassification self, Tensor input_ids, Tensor argument_2) -> ((Tensor))
Exception raised from checkAndNormalizeInputs at /Users/davidkyle/source/pytorch/aten/src/ATen/core/function_schema_inl.h:392 (most recent call first):
frame #0: c10::detail::torchCheckFail(char const*, char const*, unsigned int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 92 (0x1051f68bc in libc10.dylib)
frame #1: void c10::FunctionSchema::checkAndNormalizeInputs<c10::Type>(std::__1::vector<c10::IValue, std::__1::allocator<c10::IValue>>&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, c10::IValue, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, c10::IValue>>> const&) const + 464 (0x11218a094 in libtorch_cpu.dylib)
frame #2: torch::jit::Method::operator()(std::__1::vector<c10::IValue, std::__1::allocator<c10::IValue>>, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, c10::IValue, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, c10::IValue>>> const&) const + 540 (0x11552b078 in libtorch_cpu.dylib)
frame #3: torch::jit::Module::forward(std::__1::vector<c10::IValue, std::__1::allocator<c10::IValue>>, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, c10::IValue, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, c10::IValue>>> const&) + 116 (0x104dd8540 in pytorch_inference)
frame #4: infer(torch::jit::Module&, ml::torch::CCommandParser::SRequest&) + 1268 (0x104dd77a8 in pytorch_inference)
frame #5: std::__1::optional<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>> handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0::operator()()::'lambda'(auto)::operator()<ml::torch::CCommandParser::SRequest>(auto) const + 48 (0x104df1528 in pytorch_inference)
frame #6: decltype(static_cast<auto>(fp)(static_cast<ml::torch::CCommandParser::SRequest>(fp0))) std::__1::__invoke<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0::operator()()::'lambda'(auto)&, ml::torch::CCommandParser::SRequest>(auto&&, ml::torch::CCommandParser::SRequest&&) + 68 (0x104df14c0 in pytorch_inference)
frame #7: std::__1::optional<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>> std::__1::__invoke_void_return_wrapper<std::__1::optional<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, false>::__call<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0::operator()()::'lambda'(auto)&, ml::torch::CCommandParser::SRequest>(handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0::operator()()::'lambda'(auto)&, ml::torch::CCommandParser::SRequest&&) + 40 (0x104df144c in pytorch_inference)
frame #8: std::__1::__function::__alloc_func<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0::operator()()::'lambda'(auto), std::__1::allocator<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0::operator()()::'lambda'(auto)>, std::__1::optional<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>> (ml::torch::CCommandParser::SRequest)>::operator()(ml::torch::CCommandParser::SRequest&&) + 48 (0x104df1418 in pytorch_inference)
frame #9: std::__1::__function::__func<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0::operator()()::'lambda'(auto), std::__1::allocator<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0::operator()()::'lambda'(auto)>, std::__1::optional<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>> (ml::torch::CCommandParser::SRequest)>::operator()(ml::torch::CCommandParser::SRequest&&) + 44 (0x104df0244 in pytorch_inference)
frame #10: std::__1::__function::__value_func<std::__1::optional<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>> (ml::torch::CCommandParser::SRequest)>::operator()(ml::torch::CCommandParser::SRequest&&) const + 88 (0x104e1e1e0 in pytorch_inference)
frame #11: std::__1::function<std::__1::optional<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>> (ml::torch::CCommandParser::SRequest)>::operator()(ml::torch::CCommandParser::SRequest) const + 32 (0x104e1e0cc in pytorch_inference)
frame #12: ml::torch::CCommandParser::CRequestCacheStub::lookup(ml::torch::CCommandParser::SRequest, std::__1::function<std::__1::optional<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>> (ml::torch::CCommandParser::SRequest)> const&, std::__1::function<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, bool)> const&) + 68 (0x104e1e00c in pytorch_inference)
frame #13: handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0::operator()() + 212 (0x104defa68 in pytorch_inference)
frame #14: decltype(static_cast<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0&>(fp)()) std::__1::__invoke<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0&>(handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0&) + 24 (0x104def988 in pytorch_inference)
frame #15: std::__1::__bind_return<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0, std::__1::tuple<>, std::__1::tuple<>, __is_valid_bind_return<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0, std::__1::tuple<>, std::__1::tuple<>>::value>::type std::__1::__apply_functor<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0, std::__1::tuple<>, std::__1::tuple<>>(handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0&, std::__1::tuple<>&, std::__1::__tuple_indices<>, std::__1::tuple<>&&) + 32 (0x104def964 in pytorch_inference)
frame #16: std::__1::__bind_return<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0, std::__1::tuple<>, std::__1::tuple<>, __is_valid_bind_return<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0, std::__1::tuple<>, std::__1::tuple<>>::value>::type std::__1::__bind<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>::operator()<>() + 36 (0x104def938 in pytorch_inference)
frame #17: decltype(static_cast<std::__1::__bind<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>&>(fp)()) std::__1::__invoke<std::__1::__bind<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>&>(std::__1::__bind<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>&) + 24 (0x104def908 in pytorch_inference)
frame #18: void std::__1::__invoke_void_return_wrapper<void, true>::__call<std::__1::__bind<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>&>(std::__1::__bind<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>&) + 24 (0x104def8e4 in pytorch_inference)
frame #19: std::__1::enable_if<is_convertible<std::__1::__bind_return<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0, std::__1::tuple<>, std::__1::tuple<>, __is_valid_bind_return<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0, std::__1::tuple<>, std::__1::tuple<>>::value>::type, void>::value || std::__1::integral_constant<bool, true>::value, void>::type std::__1::__bind_r<void, handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>::operator()<>() + 24 (0x104def8c0 in pytorch_inference)
frame #20: void ml::core::concurrency_detail::invokeAndWriteResultToPromise<std::__1::__bind_r<void, handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>, std::__1::shared_ptr<std::__1::promise<void>>>(std::__1::__bind_r<void, handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>&, std::__1::shared_ptr<std::__1::promise<void>>&, std::__1::integral_constant<bool, true> const&) + 32 (0x104def808 in pytorch_inference)
frame #21: std::__1::future<std::__1::invoke_result<std::__1::decay<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>::type>::type> ml::core::async<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>(ml::core::CExecutor&, handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0&&)::'lambda'()::operator()() + 36 (0x104def7dc in pytorch_inference)
frame #22: decltype(static_cast<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>(fp)()) std::__1::__invoke<std::__1::future<std::__1::invoke_result<std::__1::decay<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>::type>::type> ml::core::async<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>(ml::core::CExecutor&, handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0&&)::'lambda'()&>(handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0&&) + 24 (0x104def7ac in pytorch_inference)
frame #23: void std::__1::__invoke_void_return_wrapper<void, true>::__call<std::__1::future<std::__1::invoke_result<std::__1::decay<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>::type>::type> ml::core::async<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>(ml::core::CExecutor&, handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0&&)::'lambda'()&>(std::__1::future<std::__1::invoke_result<std::__1::decay<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>::type>::type> ml::core::async<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>(ml::core::CExecutor&, handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0&&)::'lambda'()&) + 24 (0x104def764 in pytorch_inference)
frame #24: std::__1::__function::__alloc_func<std::__1::future<std::__1::invoke_result<std::__1::decay<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>::type>::type> ml::core::async<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>(ml::core::CExecutor&, handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0&&)::'lambda'(), std::__1::allocator<std::__1::future<std::__1::invoke_result<std::__1::decay<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>::type>::type> ml::core::async<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>(ml::core::CExecutor&, handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0&&)::'lambda'()>, void ()>::operator()() + 28 (0x104def740 in pytorch_inference)
frame #25: std::__1::__function::__func<std::__1::future<std::__1::invoke_result<std::__1::decay<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>::type>::type> ml::core::async<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>(ml::core::CExecutor&, handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0&&)::'lambda'(), std::__1::allocator<std::__1::future<std::__1::invoke_result<std::__1::decay<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>::type>::type> ml::core::async<handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0>(ml::core::CExecutor&, handleRequest(ml::torch::CCommandParser::CRequestCacheInterface&, ml::torch::CCommandParser::SRequest, torch::jit::Module&, ml::torch::CResultWriter&)::$_0&&)::'lambda'()>, void ()>::operator()() + 28 (0x104ded710 in pytorch_inference)
frame #26: std::__1::__function::__value_func<void ()>::operator()() const + 68 (0x104e30ab0 in pytorch_inference)
frame #27: std::__1::function<void ()>::operator()() const + 24 (0x104e30780 in pytorch_inference)
frame #28: ml::core::CStaticThreadPool::CWrappedTask::operator()() + 52 (0x1073fb9d0 in libMlCore.dylib)
frame #29: ml::core::CStaticThreadPool::worker(unsigned long) + 448 (0x1073fb510 in libMlCore.dylib)
frame #30: ml::core::CStaticThreadPool::CStaticThreadPool(unsigned long, unsigned long)::$_0::operator()() const + 32 (0x10740184c in libMlCore.dylib)
frame #31: decltype(static_cast<ml::core::CStaticThreadPool::CStaticThreadPool(unsigned long, unsigned long)::$_0>(fp)()) std::__1::__invoke<ml::core::CStaticThreadPool::CStaticThreadPool(unsigned long, unsigned long)::$_0>(ml::core::CStaticThreadPool::CStaticThreadPool(unsigned long, unsigned long)::$_0&&) + 24 (0x1074017f8 in libMlCore.dylib)
frame #32: void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, ml::core::CStaticThreadPool::CStaticThreadPool(unsigned long, unsigned long)::$_0>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, ml::core::CStaticThreadPool::CStaticThreadPool(unsigned long, unsigned long)::$_0>&, std::__1::__tuple_indices<>) + 28 (0x107401794 in libMlCore.dylib)
frame #33: void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, ml::core::CStaticThreadPool::CStaticThreadPool(unsigned long, unsigned long)::$_0>>(void*) + 84 (0x107401124 in libMlCore.dylib)
frame #34: _pthread_start + 148 (0x187f3bfa8 in libsystem_pthread.dylib)
frame #35: thread_start + 8 (0x187f36da0 in libsystem_pthread.dylib)
</details>


### Runtime Exceptions
TODO: runtime exceptions may not be recoverable and should fail the inference process. Investigate as a follow up.