### PR TITLE
[ML] Remove the ML_KEEP_GOING functionality

### DIFF
--- a/dev-tools/docker/docker_entrypoint.sh
+++ b/dev-tools/docker/docker_entrypoint.sh
@@ -59,6 +59,6 @@ if [ "x$1" = "x--test" ] ; then
     # failure is the unit tests, and then the detailed test results can be
     # copied from the image
     echo passed > build/test_status.txt
-    make -j`grep -c '^processor' /proc/cpuinfo` ML_KEEP_GOING=1 test || echo failed > build/test_status.txt
+    make -j`grep -c '^processor' /proc/cpuinfo` test || echo failed > build/test_status.txt
 fi
 

--- a/lib/maths/common/unittest/CKMostCorrelatedTest.cc
+++ b/lib/maths/common/unittest/CKMostCorrelatedTest.cc
@@ -764,18 +764,8 @@ BOOST_AUTO_TEST_CASE(testScale) {
     double sdRatio = std::sqrt(maths::common::CBasicStatistics::variance(slope)) /
                      maths::common::CBasicStatistics::mean(slope);
     LOG_DEBUG(<< "sdRatio = " << sdRatio);
-    // If $ML_KEEP_GOING is set then we're probably running in CI
-    const char* keepGoingEnvVar{std::getenv("ML_KEEP_GOING")};
-    bool likelyInCi = (keepGoingEnvVar != nullptr && *keepGoingEnvVar != '\0');
-    if (likelyInCi) {
-        // Allow more leeway when running in CI because CI is most likely running on
-        // a VM and in this case non-linearity is most likely due to the VM stalling
-        BOOST_TEST_REQUIRE(exponent < 2.0);
-        BOOST_TEST_REQUIRE(sdRatio < 0.75);
-    } else {
-        BOOST_TEST_REQUIRE(exponent < 1.75);
-        BOOST_TEST_REQUIRE(sdRatio < 0.5);
-    }
+    BOOST_TEST_REQUIRE(exponent < 2.0);
+    BOOST_TEST_REQUIRE(sdRatio < 0.75);
 }
 
 BOOST_AUTO_TEST_CASE(testPersistence) {

--- a/lib/model/unittest/CTokenListDataCategorizerTest.cc
+++ b/lib/model/unittest/CTokenListDataCategorizerTest.cc
@@ -716,16 +716,6 @@ BOOST_FIXTURE_TEST_CASE(testPreTokenisedPerformance, CTestFixture) {
         LOG_DEBUG(<< "After test with pre-tokenisation");
         LOG_DEBUG(<< "Pre-tokenisation test took " << preTokenisationTime << "ms");
     }
-
-    const char* keepGoingEnvVar{std::getenv("ML_KEEP_GOING")};
-    bool likelyInCi{keepGoingEnvVar != nullptr && *keepGoingEnvVar != '\0'};
-    if (likelyInCi) {
-        // CI is most likely running on a VM, and this test can fail quite often
-        // due to the VM stalling or being slowed down by noisy neighbours
-        LOG_INFO(<< "Skipping test pre-tokenised performance assertion");
-    } else {
-        BOOST_TEST_REQUIRE(preTokenisationTime <= inlineTokenisationTime);
-    }
 }
 
 BOOST_FIXTURE_TEST_CASE(testUsurpedCategories, CTestFixture) {

--- a/mk/stdmodule.mk
+++ b/mk/stdmodule.mk
@@ -39,9 +39,7 @@ do \
 	if [ $$? -ne 0 ]; then \
 		FAILED=1; \
 		echo "`pwd` make test FAILURE!!!"; \
-		if [ -z "$$ML_KEEP_GOING" ] ; then \
-			exit 1; \
-		fi; \
+		exit 1; \
 	fi; \
 done; \
 exit $$FAILED

--- a/mk/toplevel.mk
+++ b/mk/toplevel.mk
@@ -18,11 +18,6 @@ include $(CPP_SRC_HOME)/mk/rules.mk
 #   recursing into the sub-directories
 # - TOP_DIR_MKF_LAST is used to perform actions at this level AFTER
 #   recursing into the sub-directories
-#
-# If $ML_KEEP_GOING is set then the recursion will stop at the first error;
-# otherwise it will attempt to build every directory even after an earlier
-# one fails.  This latter behaviour is useful during nightly builds as it
-# means each nightly build has a chance to uncover more than one error.
 
 all:
 ifdef TOP_DIR_MKF_FIRST
@@ -35,7 +30,7 @@ endif
 	 (cd $$i && $(MAKE)); \
 	 if [ $$? -ne 0 ] ; then \
 	   FAILED=1; \
-	   if [ -z "$(ML_KEEP_GOING)" ]; then exit 1; fi; \
+	   exit 1; \
 	 fi; \
 	 done; \
 	 exit $$FAILED
@@ -80,7 +75,7 @@ endif
 	 (cd $$i && $(MAKE) analyze ); \
 	 if [ $$? -ne 0 ] ; then \
 	   FAILED=1; \
-	   if [ -z "$(ML_KEEP_GOING)" ]; then exit 1; fi; \
+	   exit 1; \
 	 fi; \
 	 done; \
 	 exit $$FAILED
@@ -111,7 +106,7 @@ test:
 	 $(FIRST_TEST_CMD) ; \
 	 if [ $$? -ne 0 ] ; then \
 	   FAILED=1; \
-	   if [ -z "$(ML_KEEP_GOING)" ]; then exit 1; fi; \
+	   exit 1; \
 	 fi; \
 	 for i in $(COMPONENTS) ; \
 	 do \
@@ -119,7 +114,7 @@ test:
 	 (cd $$i && $(MAKE) test ); \
 	 if [ $$? -ne 0 ] ; then \
 	   FAILED=1; \
-	   if [ -z "$(ML_KEEP_GOING)" ]; then exit 1; fi; \
+	   exit 1; \
 	 fi; \
 	 done; \
 	 exit $$FAILED
@@ -138,7 +133,7 @@ endif
 	 (cd $$i && $(MAKE) relink ); \
 	 if [ $$? -ne 0 ] ; then \
 	   FAILED=1; \
-	   if [ -z "$(ML_KEEP_GOING)" ]; then exit 1; fi; \
+	   exit 1; \
 	 fi; \
 	 done; \
 	 exit $$FAILED
@@ -157,7 +152,7 @@ endif
 	 (cd $$i && $(MAKE) install ); \
 	 if [ $$? -ne 0 ] ; then \
 	   FAILED=1; \
-	   if [ -z "$(ML_KEEP_GOING)" ]; then exit 1; fi; \
+	   exit 1; \
 	 fi; \
 	 done; \
 	 exit $$FAILED

--- a/set_env.sh
+++ b/set_env.sh
@@ -182,10 +182,3 @@ else
     unset CPLUS_INCLUDE_PATH
     unset LIBRARY_PATH
 fi
-
-# Tell the build to keep going under Jenkins so that we get as many errors as
-# possible from an automated build (Jenkins sets $JOB_NAME)
-if [ -n "$JOB_NAME" ] ; then
-    export ML_KEEP_GOING=1
-fi
-


### PR DESCRIPTION
The 7.17 branch still has mentions of the ML_KEEP_GOING functionality which affected behaviour of GNU make builds run under Jenkins. Remove that now we are using BuildKite for CI.