### PR TITLE
[ML] Display info for all branches for PR builds

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -25,6 +25,7 @@ spec:
       branch_configuration: main !main
       cancel_intermediate_builds: true
       clone_method: https
+      default_branch: nul
       pipeline_file: .buildkite/pipeline.json.py
       provider_settings:
         build_branches: false


### PR DESCRIPTION
Currently the default value of "main" is used for the default_branch configuration option for the "ml-cpp-pr-build" pipeline. This results in no useful information about PR build history being displayed for that pipeline in the BuildKite UI.

By explicitly setting the default_branch config option to nul BuildKite will display build information for all PR branches, which is much more useful.