### PR TITLE
[NLP] Respond to the server when an unknown command is received 

### DIFF
--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -138,7 +138,10 @@ void handleControlMessage(const ml::torch::CCommandParser::SControlMessage& cont
                                        ml::core::CProcessStats::maxResidentSetSize());
         break;
     case ml::torch::CCommandParser::E_Unknown:
-        LOG_ERROR(<< "Attempt to handle unknown control message");
+        std::string message{"Attempt to handle unknown control message"};
+        LOG_ERROR(<< message);
+        resultWriter.writeError(controlMessage.s_RequestId, message);
+
         break;
     }
 }


### PR DESCRIPTION
pytorch_inference must respond to every request as Elasticsearch is waiting for a response. The switch statement in the command handler code logged an error when an unknown command was received but did not write a response. This change adds an error response. 

In practice I cannot see how an unrecognised command could be sent as the Elasticsearch side is closely tied to pytorch_inference, I've labelled this a non-issue rather than a bug for that reason. 