### PR TITLE
[8.10] [ML] Include an extra header in CDataFrameRowSlice

### DIFF
--- a/include/model/CStringStore.h
+++ b/include/model/CStringStore.h
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <functional>
 #include <string>
+#include <vector>
 
 namespace CResourceMonitorTest {
 class CTestFixture;

--- a/lib/core/CDataFrameRowSlice.cc
+++ b/lib/core/CDataFrameRowSlice.cc
@@ -20,6 +20,7 @@
 
 #include <boost/filesystem.hpp>
 
+#include <fstream>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
Our two ARM macOS build servers have somehow ended up running different versions of Xcode - one is running version 12 and the other version 13.

There have been changes to the C++ standard library between these versions that reveal a technical violation that we were previously getting away with: CDataFrameRowSlice.cc uses file streams without including the necessary header. Previously it must have been indirectly included. This PR includes it explicitly.

Backport of #2563