### PR TITLE
[8.9] [ML] Treat Boost version as exact required, not minimum

### DIFF
--- a/cmake/variables.cmake
+++ b/cmake/variables.cmake
@@ -222,7 +222,7 @@ set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_DEBUG_RUNTIME OFF)
 set(Boost_COMPILER "${ML_BOOST_COMPILER_VER}")
 
-find_package(Boost 1.77.0 REQUIRED COMPONENTS iostreams filesystem program_options regex date_time log log_setup thread unit_test_framework)
+find_package(Boost 1.77.0 EXACT REQUIRED COMPONENTS iostreams filesystem program_options regex date_time log log_setup thread unit_test_framework)
 if(Boost_FOUND)
   list(APPEND ML_SYSTEM_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS})
 endif()


### PR DESCRIPTION
A Boost upgrade is not trivial and we don't want CMake deciding to do one for us.

Backport of #2566