### PR TITLE
[ML] Reduce log level of OOM killer adjustment warning

### DIFF
--- a/lib/core/CProcessPriority_Linux.cc
+++ b/lib/core/CProcessPriority_Linux.cc
@@ -48,11 +48,16 @@ void increaseOomKillerAdj() {
     // oom_adj is on a scale of -16 to 15.
     // In both cases higher numbers mean the process is more likely to be killed
     // in low memory situations.
+    // These settings cannot be changed in Kubernetes. There's more information
+    // about this in https://github.com/kubernetes/kubernetes/issues/90973 and
+    // it's not ideal for us given that ECK and serverless run on Kubernetes.
+    // To avoid log spam and unnecessary alarm given the prevalence of Kubernetes
+    // we log the failure at a level that won't be seen by default.
     if (writeToSystemFile("/proc/self/oom_score_adj", "667\n") == false &&
         writeToSystemFile("/proc/self/oom_adj", "10\n") == false) {
-        LOG_WARN(<< "Could not increase OOM killer adjustment using "
-                    "/proc/self/oom_score_adj or /proc/self/oom_adj: "
-                 << ::strerror(errno));
+        LOG_DEBUG(<< "Could not increase OOM killer adjustment using "
+                     "/proc/self/oom_score_adj or /proc/self/oom_adj: "
+                  << ::strerror(errno));
     }
 }
 }


### PR DESCRIPTION
Kubernetes doesn't allow OOM killer adjustments. (More on this in https://github.com/kubernetes/kubernetes/issues/90973.)

We try to make these adjustments so that if the kernel has to kill a process it will prefer to kill an ML process rather than the Elasticsearch JVM.

However, with the Kubernetes restriction, the current warning message about not being able to make the adjustment shows up more and more as log spam as ECK and serverless become more prevalent. Therefore, it's best that the message isn't logged by default.

Relates #1899