### PR TITLE
[ML] Increase testMurmurHash slack factor to 8%

### DIFF
--- a/lib/core/unittest/CHashingTest.cc
+++ b/lib/core/unittest/CHashingTest.cc
@@ -312,8 +312,8 @@ BOOST_AUTO_TEST_CASE(testMurmurHash) {
 
     // Most of the times the murmur lookup time will be faster. But it is not
     // always the case. In order to avoid having failing builds but keep guarding
-    // the performance, we give some slack (6%) to the comparison.
-    BOOST_TEST_REQUIRE(murmurLookupTime < (defaultLookupTime * 106) / 100);
+    // the performance, we give some slack (8%) to the comparison.
+    BOOST_TEST_REQUIRE(murmurLookupTime < (defaultLookupTime * 108) / 100);
 
     // Check the number of collisions.
     TSizeSizeMap uniqueHashes;


### PR DESCRIPTION
The upgrade to Boost 1.83 has resulted in testMurmurHash failing more often. Occasional failures are expected and accounted for in the test with a "slack factor". Increase that factor to 8% to make the test more resilient.