### PR TITLE
[ML] Add extra debug handling for the seccomp test.

### DIFF
--- a/.buildkite/pipelines/build_linux.json.py
+++ b/.buildkite/pipelines/build_linux.json.py
@@ -71,7 +71,7 @@ def main(args):
               "RUN_TESTS": "true",
               "BOOST_TEST_OUTPUT_FORMAT_FLAGS": "--logger=JUNIT,error,boost_test_results.junit",
             },
-            "artifact_paths": "*/*/unittest/boost_test_results.junit",
+            "artifact_paths": "*/**/unittest/boost_test_results.junit",
             "plugins": {
               "test-collector#v1.2.0": {                                                              
                 "files": "*/*/unittest/boost_test_results.junit",

--- a/.buildkite/pipelines/build_macos.json.py
+++ b/.buildkite/pipelines/build_macos.json.py
@@ -59,7 +59,7 @@ def main(args):
               "RUN_TESTS": "true",
               "BOOST_TEST_OUTPUT_FORMAT_FLAGS": "--logger=JUNIT,error,boost_test_results.junit",
             },
-            "artifact_paths": "*/*/unittest/boost_test_results.junit",
+            "artifact_paths": "*/**/unittest/boost_test_results.junit;*/**/unittest/ml_test_*",
             "plugins": {
               "test-collector#v1.2.0": {                                                              
                 "files": "*/*/unittest/boost_test_results.junit",

--- a/.buildkite/pipelines/build_windows.json.py
+++ b/.buildkite/pipelines/build_windows.json.py
@@ -60,7 +60,7 @@ def main(args):
               "RUN_TESTS": "true",
               "BOOST_TEST_OUTPUT_FORMAT_FLAGS": "--logger=JUNIT,error,boost_test_results.junit",
             },
-            "artifact_paths": ["*/*/unittest/boost_test_results.junit"],
+            "artifact_paths": ["*/**/unittest/boost_test_results.junit"],
             "plugins": {
               "test-collector#v1.2.0": {
                 "files": "*/*/unittest/boost_test_results.junit",

--- a/cmake/test-runner.cmake
+++ b/cmake/test-runner.cmake
@@ -9,7 +9,12 @@
 # limitation.
 #
 
-execute_process(COMMAND ${TEST_DIR}/${TEST_NAME} $ENV{BOOST_TEST_OUTPUT_FORMAT_FLAGS} --no_color_output  OUTPUT_FILE ${TEST_DIR}/${TEST_NAME}.out ERROR_FILE ${TEST_DIR}/${TEST_NAME}.out RESULT_VARIABLE TEST_SUCCESS)
+if(TEST_NAME STREQUAL "ml_test_seccomp")
+  execute_process(COMMAND ${TEST_DIR}/${TEST_NAME} $ENV{BOOST_TEST_OUTPUT_FORMAT_FLAGS} --logger=HRF,all --report_format=HRF --show_progress=no --no_color_output  OUTPUT_FILE ${TEST_DIR}/${TEST_NAME}.out ERROR_FILE ${TEST_DIR}/${TEST_NAME}.out RESULT_VARIABLE TEST_SUCCESS)
+else()
+  execute_process(COMMAND ${TEST_DIR}/${TEST_NAME} $ENV{BOOST_TEST_OUTPUT_FORMAT_FLAGS} --no_color_output  OUTPUT_FILE ${TEST_DIR}/${TEST_NAME}.out ERROR_FILE ${TEST_DIR}/${TEST_NAME}.out RESULT_VARIABLE TEST_SUCCESS)
+endif()
+
 if (NOT TEST_SUCCESS EQUAL 0)
   execute_process(COMMAND ${CMAKE_COMMAND} -E cat ${TEST_DIR}/${TEST_NAME}.out)
   file(WRITE "${TEST_DIR}/${TEST_NAME}.failed" "")


### PR DESCRIPTION
It appears that the seccomp test may hang on occasion on macOS when instrumented for debug builds.

This PR attempts to gather extra information (temporarily) regarding the tests in general and the seccomp tests in particular.