### PR TITLE
Update CMake required version

### DIFF
--- a/build-setup/macos.md
+++ b/build-setup/macos.md
@@ -111,7 +111,7 @@ to install the Boost headers and libraries.
 
 ### CMake
 
-CMake version 3.27.6 is the minimum required to build ml-cpp.  Download the graphical installer for version 3.27.6 from <https://github.com/Kitware/CMake/releases/download/v3.27.6/cmake-3.27.6-macos-universal.dmg> (or get a more recent version).
+For macOS Ventura or later versions CMake version 3.27.6 is the minimum required to build ml-cpp.  Download the graphical installer for version 3.27.6 from <https://github.com/Kitware/CMake/releases/download/v3.27.6/cmake-3.27.6-macos-universal.dmg> (or get a more recent version). For macOS Monterey CMake 3.19.2 is the minimum required to build ml-cpp. 
 
 Open the `.dmg` and install the application it by dragging it to the `Applications` folder.
 

--- a/build-setup/macos.md
+++ b/build-setup/macos.md
@@ -111,7 +111,7 @@ to install the Boost headers and libraries.
 
 ### CMake
 
-CMake version 3.19.2 is the minimum required to build ml-cpp.  Download the graphical installer for version 3.23.2 from <https://github.com/Kitware/CMake/releases/download/v3.23.2/cmake-3.23.2-macos-universal.dmg> (or get a more recent version).
+CMake version 3.27.6 is the minimum required to build ml-cpp.  Download the graphical installer for version 3.27.6 from <https://github.com/Kitware/CMake/releases/download/v3.27.6/cmake-3.27.6-macos-universal.dmg> (or get a more recent version).
 
 Open the `.dmg` and install the application it by dragging it to the `Applications` folder.
 


### PR DESCRIPTION
The newer CMake version is only required on macOS Ventura and higher. Linux, Windows and older macOS can continue to use older CMake.