### PR TITLE
[ML] Call readvalue even if cache write fails

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -34,6 +34,11 @@
 
 * Add support for PyTorch models quantized with Intel Extension for PyTorch. This feature is _only_ available on `linux_x86_64`. (See {ml-pull}2547[#2547]).
 
+== {es} version 8.10.3
+
+=== Bug Fixes
+* Fix for lost inference requests when writing to the cache times out leading to processing to stall on the Elasticsearch side. (See {ml-pull}2576[#2576].)
+
 == {es} version 8.9.0
 
 === Enhancements


### PR DESCRIPTION
Cache writes can time out acquiring the write lock, in this situation the `readValue` function should still be called even though the computed value has not been added to the cache.

The failure to call `readValue` under a contended lock causes the `pytorch_inference` process to loose the request and not respond to it. This in turn leaves Elasticsearch waiting for a response causing processing to hang.

 `CCompressedLfuCache::lookup` returns true if the value was read from the cache, that is not of interest the way it is used in `pytorch_inference` so there is no need to check the return value. The general contract for use by `pytorch_inference` is that if `computeValue` returns a null or nullopt then the caller must handle the request response otherwise it can be left to the `readValue` function. 