### PR TITLE
[ML] Add a release note for Boost 1.83 upgrade

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,12 @@
 
 //=== Regressions
 
+== {es} version 8.12.0
+
+=== Enhancements
+
+* Upgrade Boost libraries to version 1.83. (See {ml-pull}2560[#2560].)
+
 == {es} version 8.11.0
 
 === Enhancements


### PR DESCRIPTION
Previously we've release noted major library upgrades like this one.

Relates #2560