### PR TITLE
[ML] Remove inaccurate log message

### DIFF
--- a/include/core/CCompressedLfuCache.h
+++ b/include/core/CCompressedLfuCache.h
@@ -132,11 +132,8 @@ public:
                     ++m_NumberHits;
                     readValue(*hit, true);
                     return true;
-                } else {
-                    // null values are not written to the cache this should never be hit
-                    LOG_ERROR(<< "Inconsistent state: null value read from cache");
-                    return false;
                 }
+                return false;
             })) {
             if (this->guardWrite(TIME_OUT, [&] {
                     this->incrementCount(compressedKey);


### PR DESCRIPTION
#2576 added an error message when a null value was is read in `CCompressedLfuCache::lookup` as the cache should not contain null values. This was based on a misreading of the code, a null value means the item was not found in the cache.

The curious thing is that the message was only logged once by my application when I would expect to see it every time `CCompressedLfuCache::lookup` was called, I'm assuming this is due to the log throttler removing exact duplicate messages.  

