### PR TITLE
[ML] Adjust memory calculations for unordered containers

### DIFF
--- a/include/core/CMemoryDec.h
+++ b/include/core/CMemoryDec.h
@@ -80,7 +80,10 @@ std::size_t bucketGroupOverhead(const T&) {
 }
 
 //! The overhead associated with the unordered container's \em bucket_groups.
-//! This is calculated as 4 bits per bucket_group pointer, of which there are 4.
+//! On average this is 4 bits per bucket. This is because the bucket_group
+//! structure consists of a 64 bit bitmask representing up to 64 buckets,
+//! plus 3 pointers, so a 32 byte structure stores the information for up to
+//! 64 buckets.
 //! See https://www.boost.org/doc/libs/1_83_0/libs/unordered/doc/html/unordered.html#structures_closed_addressing_containers
 //! for more detail.
 //! \note { In practice we round up the bucket overhead to the next highest multiple of \em 4 * std::size_t}
@@ -92,8 +95,10 @@ constexpr std::size_t bucketGroupOverhead(const boost::unordered_map<K, V, H, P,
 }
 
 //! The overhead associated with the unordered container's \em bucket_groups.
-//! This is calculated as 4 bits per bucket_group pointer, of which there are 4.
-//! See https://www.boost.org/doc/libs/1_83_0/libs/unordered/doc/html/unordered.html#structures_closed_addressing_containers
+//! On average this is 4 bits per bucket. This is because the bucket_group
+//! structure consists of a 64 bit bitmask representing up to 64 buckets,
+//! plus 3 pointers, so a 32 byte structure stores the information for up to
+//! 64 buckets.//! See https://www.boost.org/doc/libs/1_83_0/libs/unordered/doc/html/unordered.html#structures_closed_addressing_containers
 //! for more detail.
 //! \note { In practice we round up the bucket overhead to the next highest multiple of \em 4 * std::size_t}
 template<typename T, typename H, typename P, typename A>
@@ -115,11 +120,15 @@ constexpr std::size_t storageNodeOverhead(const T&) {
     return 0;
 }
 
+//! In Boost 1.83 the bucket lists and node lists are singly linked, hence
+//! only 1 pointer is needed here
 template<typename K, typename V, typename H, typename P, typename A>
 constexpr std::size_t storageNodeOverhead(const boost::unordered_map<K, V, H, P, A>&) {
     return sizeof(std::size_t);
 }
 
+//! In Boost 1.83 the bucket lists and node lists are singly linked, hence
+//! only 1 pointer is needed here
 template<typename T, typename H, typename P, typename A>
 constexpr std::size_t storageNodeOverhead(const boost::unordered_set<T, H, P, A>&) {
     return sizeof(std::size_t);

--- a/include/core/CMemoryDec.h
+++ b/include/core/CMemoryDec.h
@@ -80,25 +80,27 @@ std::size_t bucketGroupOverhead(const T&) {
 }
 
 //! The overhead associated with the unordered container's \em bucket_groups.
-//! This is calculated as 4 bits per bucket_group.
+//! This is calculated as 4 bits per bucket_group pointer, of which there ae 4.
 //! See https://www.boost.org/doc/libs/1_83_0/libs/unordered/doc/html/unordered.html#structures_closed_addressing_containers
 //! for more detail.
-//! \note { In practice we round up the bucket overhead to the next highest multiple of \em std::size_t}
+//! \note { In practice we round up the bucket overhead to the next highest multiple of \em 4 * std::size_t}
 template<typename K, typename V, typename H, typename P, typename A>
 constexpr std::size_t bucketGroupOverhead(const boost::unordered_map<K, V, H, P, A>& t) {
-    return ((t.bucket_count() + 2 * sizeof(std::size_t) - 1) / (2 * sizeof(std::size_t))) *
-           sizeof(std::size_t);
+    return ((t.bucket_count() + 2 * 4 * sizeof(std::size_t) - 1) /
+            (2 * 4 * sizeof(std::size_t))) *
+           4 * sizeof(std::size_t);
 }
 
 //! The overhead associated with the unordered container's \em bucket_groups.
-//! This is calculated as 4 bits per bucket_group.
+//! This is calculated as 4 bits per bucket_group pointer, of which there are 4.
 //! See https://www.boost.org/doc/libs/1_83_0/libs/unordered/doc/html/unordered.html#structures_closed_addressing_containers
 //! for more detail.
-//! \note { In practice we round up the bucket overhead to the next highest multiple of \em std::size_t}
+//! \note { In practice we round up the bucket overhead to the next highest multiple of \em 4 * std::size_t}
 template<typename T, typename H, typename P, typename A>
 constexpr std::size_t bucketGroupOverhead(const boost::unordered_set<T, H, P, A>& t) {
-    return ((t.bucket_count() + 2 * sizeof(std::size_t) - 1) / (2 * sizeof(std::size_t))) *
-           sizeof(std::size_t);
+    return ((t.bucket_count() + 2 * 4 * sizeof(std::size_t) - 1) /
+            (2 * 4 * sizeof(std::size_t))) *
+           4 * sizeof(std::size_t);
 }
 
 //! Default implementation.
@@ -115,12 +117,12 @@ constexpr std::size_t storageNodeOverhead(const T&) {
 
 template<typename K, typename V, typename H, typename P, typename A>
 constexpr std::size_t storageNodeOverhead(const boost::unordered_map<K, V, H, P, A>&) {
-    return 2 * sizeof(std::size_t);
+    return sizeof(std::size_t);
 }
 
 template<typename T, typename H, typename P, typename A>
 constexpr std::size_t storageNodeOverhead(const boost::unordered_set<T, H, P, A>&) {
-    return 2 * sizeof(std::size_t);
+    return sizeof(std::size_t);
 }
 
 //! Default implementation for non-pointer types.

--- a/include/core/CMemoryDec.h
+++ b/include/core/CMemoryDec.h
@@ -80,7 +80,7 @@ std::size_t bucketGroupOverhead(const T&) {
 }
 
 //! The overhead associated with the unordered container's \em bucket_groups.
-//! This is calculated as 4 bits per bucket_group pointer, of which there ae 4.
+//! This is calculated as 4 bits per bucket_group pointer, of which there are 4.
 //! See https://www.boost.org/doc/libs/1_83_0/libs/unordered/doc/html/unordered.html#structures_closed_addressing_containers
 //! for more detail.
 //! \note { In practice we round up the bucket overhead to the next highest multiple of \em 4 * std::size_t}

--- a/include/core/CMemoryDef.h
+++ b/include/core/CMemoryDef.h
@@ -429,7 +429,7 @@ void dynamicSize(const char* name,
         mem->addItem(ptrName, sizeof(long) + memory::staticSize(*t));
         memory_debug::dynamicSize(name, *t, mem);
     } else {
-        ptrName += "shared_ptr (x" + std::to_string(uc) + ")";
+        ptrName += "_shared_ptr (x" + std::to_string(uc) + ")";
         // Note we add on sizeof(long) here to account for
         // the memory used by the shared reference count.
         // Also, round up.

--- a/lib/api/unittest/CAnomalyJobLimitTest.cc
+++ b/lib/api/unittest/CAnomalyJobLimitTest.cc
@@ -485,7 +485,7 @@ BOOST_AUTO_TEST_CASE(testModelledEntityCountForFixedMemoryLimit) {
             LOG_DEBUG(<< "Memory usage = " << used.s_Usage);
             LOG_DEBUG(<< "Memory limit bytes = " << memoryLimit * 1024 * 1024);
             BOOST_TEST_REQUIRE(used.s_OverFields > testParam.s_ExpectedOverFields);
-            BOOST_TEST_REQUIRE(used.s_OverFields < 7000);
+            BOOST_TEST_REQUIRE(used.s_OverFields < 7100);
             BOOST_REQUIRE_CLOSE_ABSOLUTE(
                 memoryLimit * core::constants::BYTES_IN_MEGABYTES / 2, used.s_Usage,
                 memoryLimit * core::constants::BYTES_IN_MEGABYTES /

--- a/lib/core/unittest/CCompressedLfuCacheTest.cc
+++ b/lib/core/unittest/CCompressedLfuCacheTest.cc
@@ -385,7 +385,7 @@ BOOST_AUTO_TEST_CASE(testEvictionStrategyMemory) {
 
     // Check we have mainly evicted large keys. The way we count hits means we
     // don't immediately only evict large keys.
-    BOOST_TEST_REQUIRE(largeHits < 40);
+    BOOST_TEST_REQUIRE(largeHits < 50);
     BOOST_REQUIRE_EQUAL(100, smallHits);
 
     BOOST_TEST_REQUIRE(cache.checkInvariants());


### PR DESCRIPTION
Boost 1.83 has an entirely different implementation of its unordered containers compared to Boost 1.77 (the previous version used by `ml-cpp`).

This PR adjusts the calculations for memory usage of the unordered containers (map/set) to be commensurate with the new implementation.
