### PR TITLE
[ML] Improve forecasting for time series with step changes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -33,6 +33,8 @@
 === Enhancements
 
 * Upgrade Boost libraries to version 1.83. (See {ml-pull}2560[#2560].)
+* Improve forecasting for time series with step changes. (See {ml-pull}#2591[2591],
+  issue: {ml-issue}2466[#2466]).
 
 === Bug Fixes
 

--- a/include/maths/common/CNaiveBayes.h
+++ b/include/maths/common/CNaiveBayes.h
@@ -237,6 +237,10 @@ public:
     //!
     //! \param[in] n The number of class probabilities to estimate.
     //! \param[in] x The feature values.
+    //! \param[in] weightProvider Computes a feature weight from the class
+    //! conditional log-likelihood of the feature value. It should be in
+    //! the range [0,1]. The smaller the value the less impact the feature
+    //! has on class selection.
     //! \return The class probabilities and the minimum feature weight.
     //! \note \p x size should be equal to the number of features.
     //! A feature is missing is indicated by passing an empty vector
@@ -250,6 +254,10 @@ public:
     //!
     //! \param[in] label The label of the class of interest.
     //! \param[in] x The feature values.
+    //! \param[in] weightProvider Computes a feature weight from the class
+    //! conditional log-likelihood of the feature value. It should be in
+    //! the range [0,1]. The smaller the value the less impact the feature
+    //! has on class selection.
     //! \return The class probabilities and the minimum feature weight.
     //! conditional distributions.
     //! \note \p x size should be equal to the number of features.
@@ -263,8 +271,14 @@ public:
     //! Get the probabilities of all the classes for \p x.
     //!
     //! \param[in] x The feature values.
-    //! \note \p x size should be equal to the number of features.
+    //! \param[in] weightProvider Computes a feature weight from the class
+    //! conditional log-likelihood of the feature value. It should be in
+    //! the range [0,1]. The smaller the value the less impact the feature
+    //! has on class selection.
     //! \return The class probabilities and the minimum feature weight.
+    //! A feature is missing is indicated by passing an empty vector
+    //! for that feature.
+    //! \note \p x size should be equal to the number of features.
     //! A feature is missing is indicated by passing an empty vector
     //! for that feature.
     TDoubleSizePrVecDoublePr

--- a/lib/core/CStateRestoreTraverser.cc
+++ b/lib/core/CStateRestoreTraverser.cc
@@ -18,8 +18,7 @@ namespace core {
 CStateRestoreTraverser::CStateRestoreTraverser() : m_BadState(false) {
 }
 
-CStateRestoreTraverser::~CStateRestoreTraverser() {
-}
+CStateRestoreTraverser::~CStateRestoreTraverser() = default;
 
 bool CStateRestoreTraverser::haveBadState() const {
     return m_BadState;

--- a/lib/maths/common/CNaiveBayes.cc
+++ b/lib/maths/common/CNaiveBayes.cc
@@ -150,8 +150,7 @@ CNaiveBayes::CNaiveBayes(const CNaiveBayesFeatureDensity& exemplar,
     // If we persist before we create class conditional distributions we will
     // not have anything to restore and hasSubLevel will be false. Trying to
     // restore sets the traverser state to bad so we need to handle explicitly.
-    if (traverser.hasSubLevel() &&
-        traverser.traverseSubLevel([&](auto& traverser_) {
+    if (traverser.hasSubLevel() && traverser.traverseSubLevel([&](auto& traverser_) {
             return this->acceptRestoreTraverser(params, traverser_);
         }) == false) {
         traverser.setBadState();

--- a/lib/maths/common/unittest/CLbfgsTest.cc
+++ b/lib/maths/common/unittest/CLbfgsTest.cc
@@ -228,12 +228,12 @@ BOOST_AUTO_TEST_CASE(testConstrainedMinimize) {
         std::tie(x, fx) = lbfgs.constrainedMinimize(f, g, a, b, x0, 0.2);
 
         BOOST_REQUIRE_EQUAL(fx, static_cast<double>(f(x)));
-        BOOST_REQUIRE_CLOSE_ABSOLUTE(static_cast<double>(f(xmin)), fx, 1e-3);
+        BOOST_REQUIRE_CLOSE_ABSOLUTE(static_cast<double>(f(xmin)), fx, 5e-3);
 
         ferror += std::fabs(fx - f(xmin)) / 100.0;
     }
 
-    BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, ferror, 1e-5);
+    BOOST_REQUIRE_CLOSE_ABSOLUTE(0.0, ferror, 5e-5);
 }
 
 BOOST_AUTO_TEST_CASE(testMinimizeWithVerySmallGradient) {

--- a/lib/maths/common/unittest/CNaiveBayesTest.cc
+++ b/lib/maths/common/unittest/CNaiveBayesTest.cc
@@ -282,8 +282,11 @@ BOOST_AUTO_TEST_CASE(testPropagationByTime) {
 }
 
 BOOST_AUTO_TEST_CASE(testExtrapolation) {
-    // Test that we detect when we're extrapolating the class conditional
-    // distributions to predict a class labels.
+    // Test that:
+    //   1. Applying low feature weights means the conditional probabilies
+    //      of all classes tend to 1 / "number of classes",
+    //   2. That the number returned as a confidence in the probabilities
+    //      is the minimum feature weight.
 
     test::CRandomNumbers rng;
 
@@ -311,7 +314,6 @@ BOOST_AUTO_TEST_CASE(testExtrapolation) {
     BOOST_REQUIRE_EQUAL(2, probabilities.size());
     BOOST_REQUIRE_CLOSE_ABSOLUTE(0.5, probabilities[0].first, 1e-2);
     BOOST_REQUIRE_CLOSE_ABSOLUTE(0.5, probabilities[1].first, 1e-2);
-    BOOST_TEST_REQUIRE(confidence >= 0);
     BOOST_REQUIRE_EQUAL(1e-3, confidence);
 }
 

--- a/lib/maths/time_series/unittest/CTrendComponentTest.cc
+++ b/lib/maths/time_series/unittest/CTrendComponentTest.cc
@@ -26,14 +26,14 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <fstream>
 
+namespace {
 BOOST_AUTO_TEST_SUITE(CTrendComponentTest)
 
 using namespace ml;
-
-namespace {
 
 using TDoubleVec = std::vector<double>;
 using TDoubleVecVec = std::vector<TDoubleVec>;
@@ -223,7 +223,6 @@ auto forecastErrors(ITR actual,
     return std::make_pair(maths::common::CBasicStatistics::mean(meanError),
                           maths::common::CBasicStatistics::mean(meanErrorAt95));
 }
-}
 
 BOOST_AUTO_TEST_CASE(testValueAndVariance) {
     // Check that the prediction bias is small in the long run
@@ -360,6 +359,73 @@ BOOST_AUTO_TEST_CASE(testForecast) {
     BOOST_TEST_REQUIRE(errorAt95 < 0.001);
 }
 
+BOOST_AUTO_TEST_CASE(testStepChangeForecasting) {
+    // A randomized test that forecasts of time series with step changes
+    // don't explode. We previously sometimes ran into issues when we
+    // extrapolated the feature distributions we use to predict changes.
+    // In such cases we would predict far too many changes leading to
+    // overly wide forecast bounds and unrealistic predictions.
+
+    using TSizeVec = std::vector<std::size_t>;
+
+    test::CRandomNumbers rng;
+    double interval{20.0};
+
+    maths::time_series::CTrendComponent::TFloatMeanAccumulatorVec values;
+
+    for (std::size_t t = 0; t < 100; ++t) {
+        TSizeVec changePoints;
+        rng.generateUniformSamples(0, 1000, 6, changePoints);
+        std::sort(changePoints.begin(), changePoints.end());
+        changePoints.push_back(1000);
+        TDoubleVec levels;
+        rng.generateUniformSamples(-0.5 * interval, 0.5 * interval, 7, levels);
+
+        maths::time_series::CTrendComponent trendModel{0.012};
+
+        TDoubleVec noise;
+        auto level = levels.begin();
+        auto changePoint = changePoints.begin();
+        TDoubleVec x;
+        core_t::TTime time{1672531200};
+        for (std::size_t i = 0; i < 1000; ++i, time += BUCKET_LENGTH) {
+            rng.generateNormalSamples(0.0, 0.25, 1, noise);
+            double value{*level + noise[0]};
+            trendModel.add(time, value);
+            values.emplace_back().add(value);
+            if (i == *changePoint) {
+                ++level;
+                ++changePoint;
+                double shift{*level - *(level - 1)};
+                core_t::TTime valuesStartTime{
+                    time - static_cast<core_t::TTime>(values.size()) * BUCKET_LENGTH};
+                TSizeVec segments{0, *changePoint - *(changePoint - 1) - 1,
+                                  *changePoint - *(changePoint - 1)};
+                TDoubleVec shifts{0.0, *level - *(level - 1)};
+                trendModel.shiftLevel(shift, valuesStartTime, BUCKET_LENGTH,
+                                      values, segments, shifts);
+                values.clear();
+            } else {
+                trendModel.dontShiftLevel(time, value);
+            }
+            x.push_back(value);
+        }
+
+        TDouble3VecVec forecast;
+        trendModel.forecast(time, time + 200 * BUCKET_LENGTH, BUCKET_LENGTH, 90.0, false,
+                            [](core_t::TTime) { return TDouble3Vec(3, 0.0); },
+                            [&forecast](core_t::TTime, const TDouble3Vec& value) {
+                                forecast.push_back(value);
+                            });
+
+        // Check that the prediction is in the switching interval and
+        // the forecast confidence interval isn't too wide.
+        BOOST_TEST_REQUIRE(forecast.back()[1] > -0.75 * interval);
+        BOOST_TEST_REQUIRE(forecast.back()[1] < 0.75 * interval);
+        BOOST_TEST_REQUIRE(forecast.back()[2] - forecast.back()[0] < 4.0 * interval);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(testPersist) {
     // Check that serialization is idempotent.
 
@@ -393,9 +459,9 @@ BOOST_AUTO_TEST_CASE(testPersist) {
     maths::common::SDistributionRestoreParams params{maths_t::E_ContinuousData, 0.1};
 
     maths::time_series::CTrendComponent restoredComponent{0.1};
-    traverser.traverseSubLevel(
-        std::bind(&maths::time_series::CTrendComponent::acceptRestoreTraverser,
-                  &restoredComponent, std::cref(params), std::placeholders::_1));
+    traverser.traverseSubLevel([&](auto& traverser_) {
+        return restoredComponent.acceptRestoreTraverser(params, traverser_);
+    });
 
     BOOST_REQUIRE_EQUAL(origComponent.checksum(), restoredComponent.checksum());
 
@@ -440,9 +506,9 @@ BOOST_AUTO_TEST_CASE(testUpgradeTo7p1) {
     core::CRapidXmlParser parser;
     BOOST_TEST_REQUIRE(parser.parseStringIgnoreCdata(xml));
     core::CRapidXmlStateRestoreTraverser traverser(parser);
-    traverser.traverseSubLevel(
-        std::bind(&maths::time_series::CTrendComponent::acceptRestoreTraverser,
-                  &component, std::cref(params), std::placeholders::_1));
+    traverser.traverseSubLevel([&](auto& traverser_) {
+        return component.acceptRestoreTraverser(params, traverser_);
+    });
 
     test::CRandomNumbers rng;
 
@@ -455,3 +521,4 @@ BOOST_AUTO_TEST_CASE(testUpgradeTo7p1) {
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+}

--- a/lib/maths/time_series/unittest/CTrendComponentTest.cc
+++ b/lib/maths/time_series/unittest/CTrendComponentTest.cc
@@ -362,8 +362,8 @@ BOOST_AUTO_TEST_CASE(testForecast) {
 BOOST_AUTO_TEST_CASE(testStepChangeForecasting) {
     // A randomized test that forecasts of time series with step changes
     // don't explode. We previously sometimes ran into issues when we
-    // extrapolated the feature distributions we use to predict changes.
-    // In such cases we would predict far too many changes leading to
+    // extrapolated the feature distributions we use to predict steps.
+    // In such cases we would predict far too many steps leading to
     // overly wide forecast bounds and unrealistic predictions.
 
     using TSizeVec = std::vector<std::size_t>;

--- a/lib/maths/time_series/unittest/CTrendComponentTest.cc
+++ b/lib/maths/time_series/unittest/CTrendComponentTest.cc
@@ -386,7 +386,6 @@ BOOST_AUTO_TEST_CASE(testStepChangeForecasting) {
         TDoubleVec noise;
         auto level = levels.begin();
         auto changePoint = changePoints.begin();
-        TDoubleVec x;
         core_t::TTime time{1672531200};
         for (std::size_t i = 0; i < 1000; ++i, time += BUCKET_LENGTH) {
             rng.generateNormalSamples(0.0, 0.25, 1, noise);
@@ -408,7 +407,6 @@ BOOST_AUTO_TEST_CASE(testStepChangeForecasting) {
             } else {
                 trendModel.dontShiftLevel(time, value);
             }
-            x.push_back(value);
         }
 
         TDouble3VecVec forecast;
@@ -422,7 +420,7 @@ BOOST_AUTO_TEST_CASE(testStepChangeForecasting) {
         // the forecast confidence interval isn't too wide.
         BOOST_TEST_REQUIRE(forecast.back()[1] > -0.75 * interval);
         BOOST_TEST_REQUIRE(forecast.back()[1] < 0.75 * interval);
-        BOOST_TEST_REQUIRE(forecast.back()[2] - forecast.back()[0] < 4.0 * interval);
+        BOOST_TEST_REQUIRE(forecast.back()[2] - forecast.back()[0] < 3.5 * interval);
     }
 }
 

--- a/lib/model/unittest/CMetricDataGathererTest.cc
+++ b/lib/model/unittest/CMetricDataGathererTest.cc
@@ -1476,13 +1476,13 @@ BOOST_FIXTURE_TEST_CASE(testInfluenceStatistics, CTestFixture) {
     TStrVec influencerNames(std::begin(influencerNames_), std::end(influencerNames_));
     CDataGatherer gatherer(model_t::E_Metric, model_t::E_None, params, EMPTY_STRING,
                            EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                           influencerNames, KEY, features, startTime, 2u);
+                           influencerNames, KEY, features, startTime, 2);
 
     addPerson("p1", gatherer, m_ResourceMonitor, influencerNames.size());
     addPerson("p2", gatherer, m_ResourceMonitor, influencerNames.size());
 
     core_t::TTime bucketStart = startTime;
-    for (std::size_t i = 0u, b = 0; i < std::size(data); ++i) {
+    for (std::size_t i = 0; i < std::size(data); ++i) {
         if (data[i].get<0>() >= bucketStart + bucketLength) {
             LOG_DEBUG(<< "*** processing bucket ***");
             TFeatureSizeFeatureDataPrVecPrVec featureData;
@@ -1520,7 +1520,6 @@ BOOST_FIXTURE_TEST_CASE(testInfluenceStatistics, CTestFixture) {
             }
 
             bucketStart += bucketLength;
-            ++b;
         }
         for (std::size_t pid = 0; pid < gatherer.numberActivePeople(); ++pid) {
             addArrival(gatherer, m_ResourceMonitor, data[i].get<0>(),

--- a/lib/model/unittest/CMetricPopulationDataGathererTest.cc
+++ b/lib/model/unittest/CMetricPopulationDataGathererTest.cc
@@ -975,10 +975,10 @@ BOOST_FIXTURE_TEST_CASE(testInfluenceStatistics, CTestFixture) {
     TStrVec influencerNames(std::begin(influencerNames_), std::end(influencerNames_));
     CDataGatherer gatherer(model_t::E_PopulationMetric, model_t::E_None, params, EMPTY_STRING,
                            EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                           influencerNames, searchKey, features, startTime, 2u);
+                           influencerNames, searchKey, features, startTime, 2);
 
     core_t::TTime bucketStart = startTime;
-    for (std::size_t i = 0u, b = 0; i < std::size(data); ++i) {
+    for (std::size_t i = 0; i < std::size(data); ++i) {
         if (data[i].s_Time >= bucketStart + bucketLength) {
             LOG_DEBUG(<< "*** processing bucket ***");
             TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
@@ -1016,7 +1016,6 @@ BOOST_FIXTURE_TEST_CASE(testInfluenceStatistics, CTestFixture) {
             }
 
             bucketStart += bucketLength;
-            ++b;
         }
         addArrival(data[i], gatherer, m_ResourceMonitor);
     }

--- a/lib/model/unittest/CResourceMonitorTest.cc
+++ b/lib/model/unittest/CResourceMonitorTest.cc
@@ -56,8 +56,6 @@ public:
         CHierarchicalResults results;
         std::string pervasive("IShouldNotBeRemoved");
 
-        std::size_t numBuckets = 0;
-
         for (core_t::TTime time = firstTime;
              time < static_cast<core_t::TTime>(firstTime + bucketLength * buckets);
              time += (bucketLength / std::max(std::size_t(1), newPeoplePerBucket))) {
@@ -66,7 +64,6 @@ public:
                 detector.buildResults(bucketStart, bucketStart + bucketLength, results);
                 monitor.pruneIfRequired(bucketStart);
                 monitor.updateMoments(monitor.totalMemory(), bucketStart, bucketLength);
-                ++numBuckets;
                 newBucket = true;
             }
 


### PR DESCRIPTION
We model the level of a time series which we've observed having step discontinuities via a Markov process for forecasting. Specifically, we estimate the historical step size distribution and the distribution of the steps in time and as a function of the time series value. For this second part we use an online naive Bayes model to estimate the probability that at any given point in a roll out for forecasting we will get a step.

This approach generally works well unless we're in the tails of the distribution values we've observed for the time series historically when we roll out. In this case, our prediction probability are very sensitive to the tail behaviour of the distributions we fit to the time series values where we saw a step and sometimes we predict far too many steps as a result. We can detect this case: when we're in the tails of time series value distribution.

This change does this and stops predicting changes in such cases, which avoids pathologies. This fixes #2466.