### PR TITLE
[ML] Run QA tests on PR builds

### DIFF
--- a/.buildkite/ml_pipeline/config.py
+++ b/.buildkite/ml_pipeline/config.py
@@ -15,6 +15,7 @@ class Config:
     build_windows: bool = False
     build_macos: bool = False
     build_linux: bool = False
+    run_qa_tests: bool = False
     action: str = "build"
 
     def parse_comment(self):
@@ -36,13 +37,14 @@ class Config:
             self.build_linux = True
 
     def parse_label(self):
-        build_labels = ['ci:build-linux','ci:build-macos','ci:build-windows']
+        build_labels = ['ci:build-linux','ci:build-macos','ci:build-windows','ci:qa-tests']
         all_labels = [x.strip().lower() for x in os.environ["GITHUB_PR_LABELS"].split(",")]
         ci_labels = [label for label in all_labels if re.search("|".join(build_labels), label)]
         if not ci_labels:
             self.build_windows = True
             self.build_macos = True
             self.build_linux = True
+            self.run_qa_tests = False
         else:
             for label in ci_labels:
                 if "ci:build-windows" == label:
@@ -51,6 +53,8 @@ class Config:
                     self.build_macos = True
                 elif "ci:build-linux" == label:
                     self.build_linux = True
+                elif "ci:run-qa-tests" == label:
+                    self.run_qa_tests = True
 
     def parse(self):
         """Parse Github label or Github comment passed through buildkite-pr-bot."""
@@ -63,4 +67,5 @@ class Config:
             self.build_windows = True
             self.build_macos = True
             self.build_linux = True
+            self.run_qa_tests = False
 

--- a/.buildkite/pipeline.json.py
+++ b/.buildkite/pipeline.json.py
@@ -50,6 +50,9 @@ def main():
         pipeline_steps.append(build_linux)
     pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests runner pipeline",
                                                        ".buildkite/pipelines/run_es_tests.yml.sh"))
+    if config.run_qa_tests:
+        pipeline_steps.append(pipeline_steps.generate_step("Upload QA tests runner pipeline",
+                                                           ".buildkite/pipelines/run_qa_tests.yml.sh"))
     pipeline["env"] = env
     pipeline["steps"] = pipeline_steps
     print(json.dumps(pipeline, indent=2))

--- a/.buildkite/pipelines/run_qa_tests.yml.sh
+++ b/.buildkite/pipelines/run_qa_tests.yml.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
+cat <<EOL
+steps:
+  - label: "Appex QA Tests :test_tube:"
+    key: "appex_qa_tests"
+    command: 
+      - "sudo apt-get -y install openjdk-17-jre openjdk-17-jdk"
+      - 'buildkite-agent artifact download "build/*" . --step build_test_linux-aarch64-RelWithDebInfo'
+      - '.buildkite/scripts/steps/run_qa_tests.sh || (cd ../elasticsearch && find x-pack -name logs | xargs tar cvzf logs.tgz && buildkite-agent artifact upload logs.tgz && false)'
+    depends_on: "build_test_linux-x86_64-RelWithDebInfo"
+    agents:
+      "cpu": "6",
+      "ephemeralStorage": "20G",
+      "memory": "64G",
+      "image": "docker.elastic.co/employees/dolaru/qaf:latest"
+    env:
+      IVY_REPO: "../ivy"
+      GRADLE_JVM_OPTS: "-Dorg.gradle.jvmargs=-Xmx16g"
+    notify:
+      - github_commit_status:
+          context: "QA Tests"
+EOL

--- a/.buildkite/scripts/steps/run_qa_tests.sh
+++ b/.buildkite/scripts/steps/run_qa_tests.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
+set -euo pipefail
+
+echo "pwd = $(pwd)"
+
+export HARDWARE_ARCH=$(uname -m | sed 's/arm64/aarch64/')
+
+RAW_VERSION=$(cat ${REPO_ROOT}/gradle.properties | grep '^elasticsearchVersion' | awk -F= '{ print $2 }' | xargs echo)
+if [ "${BUILD_SNAPSHOT:=true}" = "true" ] ; then
+    VERSION=${RAW_VERSION}-SNAPSHOT
+else
+    VERSION=${RAW_VERSION}
+fi
+export RAW_VERSION
+export VERSION
+
+export PR_AUTHOR=$(expr "$BUILDKITE_BRANCH" : '\(.*\):.*')
+export PR_SOURCE_BRANCH=$(expr "$BUILDKITE_BRANCH" : '.*:\(.*\)')
+export PR_TARGET_BRANCH=${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
+
+mkdir -p "${IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/$VERSION"
+cp "build/distributions/ml-cpp-$VERSION-linux-$HARDWARE_ARCH.zip" "${IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/$VERSION/ml-cpp-$VERSION.zip"
+# Since this is all local, for simplicity, cheat with the dependencies/no-dependencies split
+cp "build/distributions/ml-cpp-$VERSION-linux-$HARDWARE_ARCH.zip" "${IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/$VERSION/ml-cpp-$VERSION-nodeps.zip"
+# We're cheating here - the dependencies are really in the "no dependencies" zip for this flow
+cp dev-tools/minimal.zip "${IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/$VERSION/ml-cpp-$VERSION-deps.zip"
+./dev-tools/run_qa_tests.sh ".." "$(cd "${IVY_REPO}" && pwd)"
+

--- a/dev-tools/run_qa_tests.sh
+++ b/dev-tools/run_qa_tests.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+#
+
+# Runs some Elasticsearch CI tests using C++ artifacts from a local Ivy repo.
+# The elasticsearch fork and branch that are tested are based on the author
+# and branches of the current PR, as recorded in the $PR_AUTHOR,
+# $PR_SOURCE_BRANCH and $PR_TARGET_BRANCH environment variables.
+#
+# This is designed to run on a BuildKite worker where all required versions of
+# Java are installed in the BuildKite user's home directory.
+#
+# Arguments:
+# $1 = Where to clone the elasticsearch repo
+# $2 = Path to local Ivy repo
+
+set -e
+
+function isCloneTargetValid {
+    FORK_TO_CHECK="$1"
+    BRANCH_TO_CHECK="$2"
+    echo "Checking for '$BRANCH_TO_CHECK' branch at $FORK_TO_CHECK/elasticsearch"
+    if [ -n "$(git ls-remote --heads "git@github.com:$FORK_TO_CHECK/elasticsearch.git" "$BRANCH_TO_CHECK" 2>/dev/null)" ]; then
+        echo "Will use '$BRANCH_TO_CHECK' branch at $FORK_TO_CHECK/elasticsearch for ES integration tests"
+        return 0
+    fi
+    return 1
+}
+
+SELECTED_FORK=elastic
+SELECTED_BRANCH=main
+
+function pickCloneTarget {
+
+    if isCloneTargetValid "$PR_AUTHOR" "$PR_SOURCE_BRANCH" ; then
+        SELECTED_FORK="$PR_AUTHOR"
+        SELECTED_BRANCH="$PR_SOURCE_BRANCH"
+        return 0
+    fi
+
+    if isCloneTargetValid "$SELECTED_FORK" "$PR_SOURCE_BRANCH" ; then
+        SELECTED_BRANCH="$PR_SOURCE_BRANCH"
+        return 0
+    fi
+
+    if isCloneTargetValid "$SELECTED_FORK" "$PR_TARGET_BRANCH" ; then
+        SELECTED_BRANCH="$PR_TARGET_BRANCH"
+        return 0
+    fi
+
+    if isCloneTargetValid "$SELECTED_FORK" "$SELECTED_BRANCH" ; then
+        return 0
+    fi
+
+    return 1
+}
+
+pickCloneTarget
+
+cd $1
+IVY_REPO_URL="file://$2"
+
+export SELECTED_FORK
+export SELECTED_BRANCH
+export IVY_REPO_URL
+
+#rm -rf qaf-src
+#git clone git@github.com:elastic/qaf.git qaf-src
+#cd qaf-src
+cd qaf
+pip install -e .
+
+export LOCAL_DEPLOYMENT_NAME=default-${VERSION}
+qaf deployments create --stack-version ${RAW_VERSION} --plan 3-nodes --distribution-source GITHUB
+qaf deployments start
+
+cd ..
+#rm -rf qaf-tests-src
+#git clone git@github.com:elastic/qaf-tests.git qaf-tests-src
+#cd qaf-tests-src
+cd qaf-tests
+USE_LOCAL_QAF=y make setup
+source .venv/bin/activate
+
+.buildkite/scripts/setup-qaf-tests.sh
+.buildkite/scripts/pytest.sh tests/misc/notebooks


### PR DESCRIPTION
Add the option to run a subset of QA tests against a locally built distribution of elasticsearch + ml-cpp
