### PR TITLE
[ML] Update release notes following extra backport of #2597

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -33,12 +33,17 @@
 === Enhancements
 
 * Upgrade Boost libraries to version 1.83. (See {ml-pull}2560[#2560].)
-* Improve forecasting for time series with step changes. (See {ml-pull}#2591[2591],
-  issue: {ml-issue}2466[#2466]).
 
 === Bug Fixes
 
 * Ensure the estimated latitude is within the allowed range (See {ml-pull}#2586[2586].)
+
+== {es} version 8.11.2
+
+=== Enhancements
+
+* Improve forecasting for time series with step changes. (See {ml-pull}#2591[2591],
+  issue: {ml-issue}2466[#2466]).
 
 == {es} version 8.11.0
 


### PR DESCRIPTION
Release notes are correct on the 8.11 branch, but need updating on main.