### PR TITLE
[ML] Use a custom checkout script in 7.17

### DIFF
--- a/.buildkite/hooks/checkout
+++ b/.buildkite/hooks/checkout
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+#
+# Custom checkout script because the git version in CentOS 6 is too old
+
+git fetch origin
+git checkout $BUILDKITE_COMMIT


### PR DESCRIPTION
Latest Buildkite has an optimised checkout, but it requires Git 2.5, and CentOS 6 uses 1.7.