### PR TITLE
[ML] Build Linux x86_64 image in VM

### DIFF
--- a/.buildkite/pipelines/build_linux.json.py
+++ b/.buildkite/pipelines/build_linux.json.py
@@ -33,11 +33,12 @@ actions = [
 ]
 agents = {
    "x86_64": {
-      "cpu": "6",
-      "ephemeralStorage": "20G",
-      "memory": "64G",
-      "image": "docker.elastic.co/ml-dev/ml-linux-build:14"
-   },
+      "provider": "aws",
+      "instanceType": "m6i.2xlarge",
+      "imagePrefix": "ci-amazonlinux-2",
+      "diskSizeGb": "100",
+      "diskName": "/dev/xvda"
+   }
    "aarch64": {
       "provider": "aws",
       "instanceType": "m6g.2xlarge",

--- a/.buildkite/pipelines/build_linux.json.py
+++ b/.buildkite/pipelines/build_linux.json.py
@@ -38,7 +38,7 @@ agents = {
       "imagePrefix": "ci-amazonlinux-2",
       "diskSizeGb": "100",
       "diskName": "/dev/xvda"
-   }
+   },
    "aarch64": {
       "provider": "aws",
       "instanceType": "m6g.2xlarge",

--- a/.buildkite/scripts/steps/build_and_test.sh
+++ b/.buildkite/scripts/steps/build_and_test.sh
@@ -51,7 +51,7 @@ if [[ `uname` = Linux && -z "$CPP_CROSS_COMPILE" ]] ; then
   if [ "$HARDWARE_ARCH" = aarch64 ] ; then
       DOCKER_BUILD_ARG=linux_aarch64_native
   else
-      DOCKER_BUILD_ARG=linux_aarch64_native
+      DOCKER_BUILD_ARG=linux
   fi
 
   if [ "$RUN_TESTS" = false ] ; then

--- a/.buildkite/scripts/steps/build_and_test.sh
+++ b/.buildkite/scripts/steps/build_and_test.sh
@@ -38,13 +38,13 @@ VERSION=$(cat ${REPO_ROOT}/gradle.properties | grep '^elasticsearchVersion' | aw
 HARDWARE_ARCH=$(uname -m | sed 's/arm64/aarch64/')
 
 TEST_OUTCOME=0
-if [[ `uname` = Linux && -z "$CPP_CROSS_COMPILE" ]] ; then 
+if [[ `uname` = Linux && -z "$CPP_CROSS_COMPILE" ]] ; then
   # On native Linux build using Docker
   # This means that we can tolerate a very old Git version inside the Docker container
-  
+
   # The Docker version is helpful to identify version-specific Docker bugs
   docker --version
-  
+
   KERNEL_VERSION=`uname -r`
   GLIBC_VERSION=`ldconfig --version | head -1 | sed 's/ldconfig//'`
 
@@ -69,44 +69,39 @@ if [[ x"$BUILDKITE_PULL_REQUEST" != xfalse && "$CPP_CROSS_COMPILE" = "aarch64" ]
     export ML_DEBUG=1
 fi
 
-# For now, re-use our existing CI scripts based on Docker
-# Don't perform these steps for native linux aarch64 builds as
-# they are built using docker, see above.
-if ! [[ "$HARDWARE_ARCH" = aarch64 && -z "$CPP_CROSS_COMPILE" ]] ; then 
+if [[ `uname` = "Darwin" && "$HARDWARE_ARCH" = "aarch64" ]]; then
+  # For ARM macOS, build directly on the machine
+  ${REPO_ROOT}/dev-tools/download_macos_deps.sh
+  if [ "$RUN_TESTS" = false ] ; then
+      TASKS="clean buildZip buildZipSymbols"
+  else
+      TASKS="clean buildZip buildZipSymbols check"
+  fi
+  # For macOS we usually only use a particular version as our build platform
+  # once Xcode has stopped receiving updates for it. However, with Big Sur
+  # on ARM we couldn't do this, as Big Sur was the first macOS version for
+  # ARM. Therefore, the compiler may get upgraded on a CI server, and we
+  # need to hardcode the version that was used to build Boost for that
+  # version of Elasticsearch.
+  export BOOSTCLANGVER=120
+
+  (cd ${REPO_ROOT} && ./gradlew --info -Dbuild.version_qualifier=${VERSION_QUALIFIER:-} -Dbuild.snapshot=${BUILD_SNAPSHOT:-} -Dbuild.ml_debug=${ML_DEBUG:-} $TASKS) || TEST_OUTCOME=$?
+
+# If cross-compiling re-use our existing CI scripts based on Docker.
+elif [ -n "$CPP_CROSS_COMPILE" ] ; then
   if [ "$RUN_TESTS" = "true" ]; then
     ${REPO_ROOT}/dev-tools/docker/docker_entrypoint.sh --test
     grep passed build/test_status.txt || TEST_OUTCOME=$?
   else
     ${REPO_ROOT}/dev-tools/docker/docker_entrypoint.sh
   fi
-else
-  if [[ `uname` = "Darwin" && "$HARDWARE_ARCH" = "aarch64" ]]; then
-     # For macOS, build directly on the machine
-     ${REPO_ROOT}/dev-tools/download_macos_deps.sh
-     if [ "$RUN_TESTS" = false ] ; then
-         TASKS="clean buildZip buildZipSymbols"
-     else
-         TASKS="clean buildZip buildZipSymbols check"
-     fi
-     # For macOS we usually only use a particular version as our build platform
-     # once Xcode has stopped receiving updates for it. However, with Big Sur
-     # on ARM we couldn't do this, as Big Sur was the first macOS version for
-     # ARM. Therefore, the compiler may get upgraded on a CI server, and we
-     # need to hardcode the version that was used to build Boost for that
-     # version of Elasticsearch.
-     if [ "$HARDWARE_ARCH" = aarch64 ] ; then
-         export BOOSTCLANGVER=120
-     fi
-
-     (cd ${REPO_ROOT} && ./gradlew --info -Dbuild.version_qualifier=${VERSION_QUALIFIER:-} -Dbuild.snapshot=${BUILD_SNAPSHOT:-} -Dbuild.ml_debug=${ML_DEBUG:-} $TASKS) || TEST_OUTCOME=$?
-  fi
 fi
 
-if ! [[ "$HARDWARE_ARCH" = aarch64 && -n "$CPP_CROSS_COMPILE" ]] && [[ $TEST_OUTCOME -eq 0 ]] ; then 
+if ! [[ "$HARDWARE_ARCH" = aarch64 && -n "$CPP_CROSS_COMPILE" ]] && [[ $TEST_OUTCOME -eq 0 ]] ; then
   buildkite-agent artifact upload "build/distributions/*.zip"
 fi
 
-if [[ -z "$CPP_CROSS_COMPILE" ]] ; then 
+if [[ -z "$CPP_CROSS_COMPILE" ]] ; then
   OS=$(uname -s | tr "A-Z" "a-z")
   TEST_RESULTS_ARCHIVE=${OS}-${HARDWARE_ARCH}-unit_test_results.tgz
   find . -path  "*/**/ml_test_*.out" -o -path "*/**/*.junit" | xargs tar cvzf ${TEST_RESULTS_ARCHIVE}


### PR DESCRIPTION
Up to now we've built the Linux x86_64 artifacts in a Docker container hosted on Kubernetes. This means the BuildKite agent needs to run in the build Docker image and use its Git to get the correct code to build. This no longer works with the ancient version of Git on CentOS 6. By building in a VM, BuildKite can run on the (modern) VM distribution and just the compiler needs to run in the ancient Docker image (which is needed for 7.x platform support).