### PR TITLE
[ML] Workaround issues with second inference when IPEX is linked

### DIFF
--- a/bin/pytorch_inference/CMakeLists.txt
+++ b/bin/pytorch_inference/CMakeLists.txt
@@ -27,6 +27,7 @@ if (LINK_IPEX)
     ${C10_LIB}
     ${IPEX_LIB} 
     )
+  add_compile_definitions(IPEX_LINKED)
 else()
   set(ML_LINK_LIBRARIES 
     ${Boost_LIBRARIES}

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -248,6 +248,12 @@ int main(int argc, char** argv) {
         ml::core::CProcessPriority::reduceCpuPriority();
     }
 
+#ifdef IPEX_LINKED
+    // Disable JIT profiling mode. This is a workaround for problems where the
+    // first inference works but the second doesn't when IPEX is linked.
+    torch::jit::getProfilingMode() = false;
+#endif
+
     // On Linux we use libgomp (GNU's OMP implementation) for threading and have
     // found that setting this to "threads per allocation" really does allow
     // that number of threads to be used per allocation. On other platforms,


### PR DESCRIPTION
We have observed a couple of issues where IPEX is linked where the first inference call works but the second does not:

- https://github.com/intel/intel-extension-for-pytorch/issues/484 happens with ELSER and PyTorch 2.1
- https://github.com/elastic/elasticsearch/issues/102541 happens with the multilingual E5 base and large models and PyTorch 1.13.1

Disabling JIT profiling avoids the problems.