### PR TITLE
[ML] Temporarily disable IPEX

### DIFF
--- a/bin/pytorch_inference/CMakeLists.txt
+++ b/bin/pytorch_inference/CMakeLists.txt
@@ -11,8 +11,11 @@
 
 project("ML PyTorch Inference")
 
+message(STATUS "Linking IPEX libraries temporarily disabled")
+set(IPEX_DISABLED TRUE)
+
 # IPEX is required on Linux x86_64 architecture
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64" AND NOT IPEX_DISABLED)
   set(LINK_IPEX ON)
 endif()
 


### PR DESCRIPTION
Not to be committed.

Create a PR build with IPEX disabled for bench-marking tests.