### PR TITLE
[ML] Fix release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -32,10 +32,6 @@
 
 === Enhancements
 
-=== Bug Fixes
-
-* Remove dependency on the IPEX library (See {ml-pull}#2605[2605] and {ml-pull}#2606[2606].)
-
 == {es} version 8.12.0
 
 === Enhancements
@@ -45,6 +41,7 @@
 === Bug Fixes
 
 * Ensure the estimated latitude is within the allowed range (See {ml-pull}#2586[2586].)
+* Remove dependency on the IPEX library (See {ml-pull}#2605[2605] and {ml-pull}#2606[2606].)
 
 == {es} version 8.11.2
 


### PR DESCRIPTION
IPEX is now removed from 8.12.

Followup to #2605