### PR TITLE
[ML] Run Java integration tests on both Intel and ARM

### DIFF
--- a/.buildkite/pipeline.json.py
+++ b/.buildkite/pipeline.json.py
@@ -48,8 +48,10 @@ def main():
     if config.build_linux:
         build_linux = pipeline_steps.generate_step_template("Linux", config.action)
         pipeline_steps.append(build_linux)
-    pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests runner pipeline",
-                                                       ".buildkite/pipelines/run_es_tests.yml.sh"))
+    pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests x86_64 runner pipeline",
+                                                       ".buildkite/pipelines/run_es_tests_x86_64.yml.sh"))
+    pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests aarch64 runner pipeline",
+                                                       ".buildkite/pipelines/run_es_tests_aarch64.yml.sh"))
     if config.run_qa_tests:
         pipeline_steps.append(pipeline_steps.generate_step("Upload QA tests runner pipeline",
                                                            ".buildkite/pipelines/run_qa_tests.yml.sh"))

--- a/.buildkite/pipelines/run_es_tests_aarch64.yml.sh
+++ b/.buildkite/pipelines/run_es_tests_aarch64.yml.sh
@@ -10,9 +10,9 @@
 
 cat <<EOL
 steps:
-  - label: "Java :java: Integration Tests :hammer:"
-    key: "java_integration_tests"
-    command: 
+  - label: "Java :java: Integration Tests for aarch64 :hammer:"
+    key: "java_integration_tests_aarch64"
+    command:
       - "sudo yum -y install java-17-amazon-corretto-devel"
       - 'buildkite-agent artifact download "build/*" . --step build_test_linux-aarch64-RelWithDebInfo'
       - '.buildkite/scripts/steps/run_es_tests.sh || (cd ../elasticsearch && find x-pack -name logs | xargs tar cvzf logs.tgz && buildkite-agent artifact upload logs.tgz && false)'
@@ -28,5 +28,5 @@ steps:
       GRADLE_JVM_OPTS: "-Dorg.gradle.jvmargs=-Xmx16g"
     notify:
       - github_commit_status:
-          context: "Java Integration Tests"
+          context: "Java Integration Tests for aarch64"
 EOL

--- a/.buildkite/pipelines/run_es_tests_x86_64.yml.sh
+++ b/.buildkite/pipelines/run_es_tests_x86_64.yml.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
+cat <<EOL
+steps:
+  - label: "Java :java: Integration Tests for x86_64 :hammer:"
+    key: "java_integration_tests_x86_64"
+    command:
+      - "sudo yum -y install java-17-amazon-corretto-devel"
+      - 'buildkite-agent artifact download "build/*" . --step build_test_linux-x86_64-RelWithDebInfo'
+      - '.buildkite/scripts/steps/run_es_tests.sh || (cd ../elasticsearch && find x-pack -name logs | xargs tar cvzf logs.tgz && buildkite-agent artifact upload logs.tgz && false)'
+    depends_on: "build_test_linux-x86_64-RelWithDebInfo"
+    agents:
+      provider: aws
+      instanceType: m6i.2xlarge
+      imagePrefix: ci-amazonlinux-2
+      diskSizeGb: 100
+      diskName: '/dev/xvda'
+    env:
+      IVY_REPO: "../ivy"
+      GRADLE_JVM_OPTS: "-Dorg.gradle.jvmargs=-Xmx16g"
+    notify:
+      - github_commit_status:
+          context: "Java Integration Tests for x86_64"
+EOL


### PR DESCRIPTION
Currently the Java integration tests we run against PRs are only run on ARM. Since Intel is our primary platform for Cloud we should also run these tests on Intel.