### PR TITLE
Update QA tests pipeline slug

### DIFF
--- a/.buildkite/pipelines/run_qa_tests.yml.sh
+++ b/.buildkite/pipelines/run_qa_tests.yml.sh
@@ -16,7 +16,7 @@ steps:
       - 'buildkite-agent artifact download "build/*" . --step build_test_linux-x86_64-RelWithDebInfo'
     depends_on: "build_test_linux-x86_64-RelWithDebInfo"
   - wait
-  - trigger: appex-qa-stateful-custom-ml-c-plus-plus-build-testing
+  - trigger: appex-qa-stateful-custom-ml-cpp-build-testing
     async: false
     build:
       message: "${BUILDKITE_MESSAGE}"


### PR DESCRIPTION
The target QA tests pipeline has been renamed to solve an issue in CI, and the pipeline slug has changed in the process.

This updates the `run_qa_tests.yml.sh` pipeline generator file with the new slug.