### PR TITLE
[ML] Fix incorrect auto type

### DIFF
--- a/lib/maths/time_series/CTimeSeriesTestForChange.cc
+++ b/lib/maths/time_series/CTimeSeriesTestForChange.cc
@@ -447,7 +447,7 @@ CTimeSeriesTestForChange::CTimeSeriesTestForChange(int testFor,
 
     TMeanVarAccumulator predictionMoments;
     auto bucketPredictor = this->bucketPredictor();
-    for (auto time = 0; time < WEEK; time += m_BucketLength) {
+    for (core_t::TTime time = 0; time < WEEK; time += m_BucketLength) {
         predictionMoments.add(bucketPredictor(time));
     }
     m_PredictionVariance = common::CBasicStatistics::variance(predictionMoments);


### PR DESCRIPTION
This is something that was flagged as a compiler warning.

There was a test where an `auto` variable resolved to an `int`, but it really should be 64 bit. It's being used to store a time in epoch seconds, so we get away with this type of error in general until 2038. In the exact test where the problem occurred it will never be a problem as the times being used are very small. However, it's not good practice to use a technically incorrect pattern that may get copied to other places where it matters.