### PR TITLE
Remove unnecessary debug info log from inference

### DIFF
--- a/bin/pytorch_inference/CCommandParser.cc
+++ b/bin/pytorch_inference/CCommandParser.cc
@@ -184,7 +184,6 @@ CCommandParser::validateInferenceRequestJson(const json::object& doc,
             return EMessageType::E_MalformedMessage;
         }
 
-        LOG_INFO(<< "val: " << val);
         const json::array& innerArray = val.as_array();
         if (checkArrayContainsInts(innerArray) == false) {
             errorHandler(doc.at(REQUEST_ID).as_string(),


### PR DESCRIPTION
This commit added an extra debug log: https://github.com/elastic/ml-cpp/commit/a8634eb4d74fb102f252736a85591750e475ff16#diff-d55591b8583d119527b80207e8bba9567594f95d206572afa4cca65e3f17a6a4R187

It was printing information for every inference call.

Back-porting to 8.13.0