### PR TITLE
[8.13][ML] Escape special characters in keys as well as string values

### DIFF
--- a/include/core/CBoostJsonWriterBase.h
+++ b/include/core/CBoostJsonWriterBase.h
@@ -189,7 +189,7 @@ public:
 
     virtual bool onKey(const std::string& key) {
         this->append((isComplete() ? "" : ","));
-        this->append("\"" + key + "\":");
+        this->append(json::serialize(key) + ":");
         return true;
     }
 
@@ -352,9 +352,7 @@ public:
 
         m_Levels.top()++;
 
-        this->append("\"");
-        this->append(str);
-        this->append("\"");
+        this->append(json::serialize(str));
 
         return true;
     }


### PR DESCRIPTION
Use json::serialize to perform escaping of special characters.

Backports #2631
