### PR TITLE
[7.17][ML] Set buildkite_branch_name_separator to "+" (#2641)

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -13,7 +13,8 @@
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "skip_ci_labels": ["skip-ci", "jenkins-ci", ">test-mute", ">docs"],
       "skip_target_branches": ["6.8", "7.11", "7.12"],
-      "skip_ci_on_only_changed": ["^docs/", "^3rd_party/licenses/", "^jupyter/", "README.*", "\\.md$", "\\.mdx$", "^\\.buildkite/pull-requests\\.json$"]
+      "skip_ci_on_only_changed": ["^docs/", "^3rd_party/licenses/", "^jupyter/", "README.*", "\\.md$", "\\.mdx$", "^\\.buildkite/pull-requests\\.json$"],
+      "buildkite_branch_name_separator": "+"
     }
   ]
 }


### PR DESCRIPTION
To work around a problem with BuildKite PR builds on bare metal machines (currently only macOS aarch64 builds), set the value of the character separating username and branchname to be "+" rather than the default ":"

Backports #2641 