### PR TITLE
[ML] Final tidy up of Boost.JSON migration

### DIFF
--- a/include/core/BoostJsonConstants.h
+++ b/include/core/BoostJsonConstants.h
@@ -12,6 +12,8 @@
 #ifndef INCLUDED_ml_core_CBoostJsonConstants_h
 #define INCLUDED_ml_core_CBoostJsonConstants_h
 
+#include <cstddef>
+
 namespace ml {
 namespace core {
 namespace boost_json_constants {

--- a/include/core/BoostJsonConstants.h
+++ b/include/core/BoostJsonConstants.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the following additional limitation. Functionality enabled by the
+ * files subject to the Elastic License 2.0 may only be used in production when
+ * invoked by an Elasticsearch process with a license key installed that permits
+ * use of machine learning features. You may not use this file except in
+ * compliance with the Elastic License 2.0 and the foregoing additional
+ * limitation.
+ */
+
+#ifndef INCLUDED_ml_core_CBoostJsonConstants_h
+#define INCLUDED_ml_core_CBoostJsonConstants_h
+
+namespace ml {
+namespace core {
+namespace boost_json_constants {
+
+// Constants that set upper limits for Boost.JSON SAX style parsing
+
+// The maximum number of elements allowed in an object
+constexpr std::size_t MAX_OBJECT_SIZE = 1'000'000;
+
+// The maximum number of elements allowed in an array
+constexpr std::size_t MAX_ARRAY_SIZE = 1'000'000;
+
+// The maximum number of characters allowed in a key
+constexpr std::size_t MAX_KEY_SIZE = 1 << 10;
+
+// The maximum number of characters allowed in a string
+constexpr std::size_t MAX_STRING_SIZE = 1 << 30;
+}
+}
+}
+
+#endif // INCLUDED_ml_core_CBoostJsonConstants_h

--- a/include/core/CJsonStateRestoreTraverser.h
+++ b/include/core/CJsonStateRestoreTraverser.h
@@ -11,6 +11,7 @@
 #ifndef INCLUDED_ml_core_CJsonStateRestoreTraverser_h
 #define INCLUDED_ml_core_CJsonStateRestoreTraverser_h
 
+#include <core/BoostJsonConstants.h>
 #include <core/CBoostJsonUnbufferedIStreamWrapper.h>
 #include <core/CStateRestoreTraverser.h>
 #include <core/CStringUtils.h>
@@ -118,16 +119,16 @@ private:
         SBoostJsonHandler();
 
         //! The maximum number of elements allowed in an array
-        static constexpr std::size_t max_array_size = 1000000; // 1 million elements
+        static constexpr std::size_t max_array_size = boost_json_constants::MAX_ARRAY_SIZE;
 
         //! The maximum number of elements allowed in an object
-        static constexpr std::size_t max_object_size = 1000000; // 1 million elements
+        static constexpr std::size_t max_object_size = boost_json_constants::MAX_OBJECT_SIZE;
 
         //! The maximum number of characters allowed in a string
-        static constexpr std::size_t max_string_size = 1073741824; // 1GB
+        static constexpr std::size_t max_string_size = boost_json_constants::MAX_STRING_SIZE;
 
         //! The maximum number of characters allowed in a key
-        static constexpr std::size_t max_key_size = 1024; // 1KB
+        static constexpr std::size_t max_key_size = boost_json_constants::MAX_KEY_SIZE;
 
         //! Called once when the JSON parsing begins.
         //!

--- a/include/core/CJsonStateRestoreTraverser.h
+++ b/include/core/CJsonStateRestoreTraverser.h
@@ -118,19 +118,16 @@ private:
         SBoostJsonHandler();
 
         //! The maximum number of elements allowed in an array
-        static constexpr std::size_t max_array_size =
-            std::numeric_limits<std::size_t>::max();
+        static constexpr std::size_t max_array_size = 1000000; // 1 million elements
 
         //! The maximum number of elements allowed in an object
-        static constexpr std::size_t max_object_size =
-            std::numeric_limits<std::size_t>::max();
+        static constexpr std::size_t max_object_size = 1000000; // 1 million elements
 
         //! The maximum number of characters allowed in a string
-        static constexpr std::size_t max_string_size =
-            std::numeric_limits<std::size_t>::max();
+        static constexpr std::size_t max_string_size = 1073741824; // 1GB
 
         //! The maximum number of characters allowed in a key
-        static constexpr std::size_t max_key_size = std::numeric_limits<std::size_t>::max();
+        static constexpr std::size_t max_key_size = 1024; // 1KB
 
         //! Called once when the JSON parsing begins.
         //!

--- a/include/core/CStateDecompressor.h
+++ b/include/core/CStateDecompressor.h
@@ -11,6 +11,7 @@
 #ifndef INCLUDED_ml_core_CStateDecompressor_h
 #define INCLUDED_ml_core_CStateDecompressor_h
 
+#include <core/BoostJsonConstants.h>
 #include <core/CBoostJsonUnbufferedIStreamWrapper.h>
 #include <core/CDataSearcher.h>
 #include <core/ImportExport.h>
@@ -94,16 +95,16 @@ public:
         struct SBaseBoostJsonHandler {
 
             //! The maximum number of elements allowed in an array
-            static constexpr std::size_t max_array_size = 1000000; // 1 milion elements
+            static constexpr std::size_t max_array_size = boost_json_constants::MAX_ARRAY_SIZE;
 
             //! The maximum number of elements allowed in an object
-            static constexpr std::size_t max_object_size = 1000000; // 1 milion elements
+            static constexpr std::size_t max_object_size = boost_json_constants::MAX_OBJECT_SIZE;
 
             //! The maximum number of characters allowed in a string
-            static constexpr std::size_t max_string_size = 1073741824; // !GB
+            static constexpr std::size_t max_string_size = boost_json_constants::MAX_STRING_SIZE;
 
             //! The maximum number of characters allowed in a key
-            static constexpr std::size_t max_key_size = 1024; // 1KB
+            static constexpr std::size_t max_key_size = boost_json_constants::MAX_KEY_SIZE;
 
             //! Called once when the JSON parsing begins.
             //!

--- a/include/core/CStateDecompressor.h
+++ b/include/core/CStateDecompressor.h
@@ -94,20 +94,16 @@ public:
         struct SBaseBoostJsonHandler {
 
             //! The maximum number of elements allowed in an array
-            static constexpr std::size_t max_array_size =
-                std::numeric_limits<std::size_t>::max();
+            static constexpr std::size_t max_array_size = 1000000; // 1 milion elements
 
             //! The maximum number of elements allowed in an object
-            static constexpr std::size_t max_object_size =
-                std::numeric_limits<std::size_t>::max();
+            static constexpr std::size_t max_object_size = 1000000; // 1 milion elements
 
             //! The maximum number of characters allowed in a string
-            static constexpr std::size_t max_string_size =
-                std::numeric_limits<std::size_t>::max();
+            static constexpr std::size_t max_string_size = 1073741824; // !GB
 
             //! The maximum number of characters allowed in a key
-            static constexpr std::size_t max_key_size =
-                std::numeric_limits<std::size_t>::max() - 1;
+            static constexpr std::size_t max_key_size = 1024; // 1KB
 
             //! Called once when the JSON parsing begins.
             //!
@@ -268,14 +264,6 @@ public:
         };
 
         struct SBoostJsonHandler final : public SBaseBoostJsonHandler {
-            constexpr static std::size_t max_object_size =
-                std::numeric_limits<std::size_t>::max();
-            constexpr static std::size_t max_array_size =
-                std::numeric_limits<std::size_t>::max();
-            constexpr static std::size_t max_key_size =
-                std::numeric_limits<std::size_t>::max();
-            constexpr static std::size_t max_string_size =
-                std::numeric_limits<std::size_t>::max();
 
             bool on_bool(bool b, json::error_code& ec);
             bool on_string(std::string_view s, std::size_t n, json::error_code& ec);

--- a/lib/api/CNdJsonInputParser.cc
+++ b/lib/api/CNdJsonInputParser.cc
@@ -248,7 +248,7 @@ bool CNdJsonInputParser::decodeDocumentWithArbitraryFields(const TRegisterMutabl
     return true;
 }
 
-bool CNdJsonInputParser::jsonValueToString(const std::string& fieldName,
+bool CNdJsonInputParser::jsonValueToString(const std::string& /*fieldName*/,
                                            const json::value& jsonValue,
                                            std::string& fieldValueStr) {
     fieldValueStr = json::serialize(jsonValue);

--- a/lib/api/CRetrainableModelJsonReader.cc
+++ b/lib/api/CRetrainableModelJsonReader.cc
@@ -42,7 +42,7 @@ namespace {
 // these object wrappers in an array.
 //
 // Note that the json::value constructed by this parser is only ever meant to be
-// used as an internal intermediary, never to be serialized for external used.
+// used as an internal intermediary, never to be serialized for external use.
 class custom_parser {
     struct handler {
         static inline std::string IDENTITY_ENCODING_TAG = "identity_encoding";
@@ -50,13 +50,11 @@ class custom_parser {
         static inline std::string FREQUENCY_ENCODING_TAG = "frequency_encoding";
         static inline std::string TARGET_MEAN_ENCODING_TAG = "target_mean_encoding";
 
-        constexpr static std::size_t max_object_size =
-            std::numeric_limits<std::size_t>::max();
-        constexpr static std::size_t max_array_size =
-            std::numeric_limits<std::size_t>::max();
-        constexpr static std::size_t max_key_size = std::numeric_limits<std::size_t>::max();
-        constexpr static std::size_t max_string_size =
-            std::numeric_limits<std::size_t>::max();
+        // Upper limits
+        constexpr static std::size_t max_object_size = 1000000; // 1 million entries
+        constexpr static std::size_t max_array_size = 1000000; // 1 million elements
+        constexpr static std::size_t max_key_size = 1024;      // 1KB
+        constexpr static std::size_t max_string_size = 1073741824; // 1GB
 
         bool on_document_begin(json::error_code&) {
             s_Value.emplace_object();

--- a/lib/api/CRetrainableModelJsonReader.cc
+++ b/lib/api/CRetrainableModelJsonReader.cc
@@ -11,9 +11,9 @@
 
 #include <api/CRetrainableModelJsonReader.h>
 
+#include <core/BoostJsonConstants.h>
 #include <core/CBoostJsonParser.h>
 #include <core/CDataFrame.h>
-#include <core/CJsonStateRestoreTraverser.h>
 #include <core/CVectorRange.h>
 
 #include <maths/analytics/CBoostedTree.h>
@@ -51,10 +51,12 @@ class custom_parser {
         static inline std::string TARGET_MEAN_ENCODING_TAG = "target_mean_encoding";
 
         // Upper limits
-        constexpr static std::size_t max_object_size = 1000000; // 1 million entries
-        constexpr static std::size_t max_array_size = 1000000; // 1 million elements
-        constexpr static std::size_t max_key_size = 1024;      // 1KB
-        constexpr static std::size_t max_string_size = 1073741824; // 1GB
+        constexpr static std::size_t max_object_size =
+            ml::core::boost_json_constants::MAX_OBJECT_SIZE;
+        constexpr static std::size_t max_array_size = ml::core::boost_json_constants::MAX_ARRAY_SIZE;
+        constexpr static std::size_t max_key_size = ml::core::boost_json_constants::MAX_KEY_SIZE;
+        constexpr static std::size_t max_string_size =
+            ml::core::boost_json_constants::MAX_STRING_SIZE;
 
         bool on_document_begin(json::error_code&) {
             s_Value.emplace_object();

--- a/lib/maths/analytics/COutliers.cc
+++ b/lib/maths/analytics/COutliers.cc
@@ -1100,19 +1100,19 @@ std::size_t COutliers::estimateMemoryUsedByCompute(const SComputeParameters& par
                                                    std::size_t dimension) {
     using TLof = CLof<TAnnotatedPoint<POINT>, common::CKdTree<TAnnotatedPoint<POINT>>>;
 
-    auto methodSize = [=](std::size_t k, std::size_t numberPoints, std::size_t dimension) {
+    auto methodSize = [=](std::size_t k, std::size_t numberPoints, std::size_t dimension_) {
 
         k = params.s_NumberNeighbours > 0 ? params.s_NumberNeighbours : k;
 
         if (params.s_Method == E_Ensemble) {
             // On average half of models use CLof.
             return TLof::estimateOwnMemoryOverhead(params.s_ComputeFeatureInfluence,
-                                                   k, numberPoints, dimension) /
+                                                   k, numberPoints, dimension_) /
                    2;
         }
         if (params.s_Method == E_Lof) {
             return TLof::estimateOwnMemoryOverhead(params.s_ComputeFeatureInfluence,
-                                                   k, numberPoints, dimension);
+                                                   k, numberPoints, dimension_);
         }
         return std::size_t{0};
     };


### PR DESCRIPTION
Set sensible values for Boost.JSON parser limits

 * fixed a few typos in the comments
 * quietened some compiler warnings

Also, modified some exception handling code to be consistent with elsewhere.

Labeled as `>non-issue` as these changes have no external effects and are not worthy of release noting.

Relates #2622