### PR TITLE
[ML] Do not remove eigen directory as part of "clean" step

### DIFF
--- a/3rd_party/CMakeLists.txt
+++ b/3rd_party/CMakeLists.txt
@@ -39,5 +39,3 @@ execute_process(
     COMMAND ${CMAKE_COMMAND} -P ./pull-valijson.cmake
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
-
-set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${CMAKE_SOURCE_DIR}/3rd_party/eigen)


### PR DESCRIPTION
The scripts that clone the eigen repo already have logic to remove an existing directory structure prior to cloning, and removing it as part of the clean step forces a cmake reconfigure before subsequent builds will succeed (as the eigen headers will be missing)

Labelling as `>non-issue` as this only affects the build scripts.