### PR TITLE
[ML] Fix warning: 'boost::json::operator <<': inconsistent dll linkage

### DIFF
--- a/bin/pytorch_inference/CCommandParser.cc
+++ b/bin/pytorch_inference/CCommandParser.cc
@@ -21,13 +21,6 @@
 #include <sstream>
 #include <string>
 
-namespace boost::json {
-
-std::ostream& operator<<(std::ostream& os, const json::value& doc) {
-    return os << json::serialize(doc);
-}
-}
-
 namespace ml {
 namespace torch {
 


### PR DESCRIPTION
The windows build logs show the warnings

```
     9>C:\buildkite-agent\builds\bk-agent-prod-gcp-1712709148528061232\elastic\ml-cpp-snapshot-builds\bin\pytorch_inference\CCommandParser.cc(26,68): warning C4273: 'boost::json::operator <<': inconsistent dll linkage [C:\buildkite-agent\builds\bk-agent-prod-gcp-1712709148528061232\elastic\ml-cpp-snapshot-builds\cmake-build-relwithdebinfo\bin\pytorch_inference\Mlpytorch_inference.vcxproj]
C:\buildkite-agent\builds\bk-agent-prod-gcp-1712709148528061232\elastic\ml-cpp-snapshot-builds\bin\pytorch_inference\CCommandParser.cc(26,68): warning C4273: std::ostream& operator<<(std::ostream& os, const json::value& doc) { [C:\buildkite-agent\builds\bk-agent-prod-gcp-1712709148528061232\elastic\ml-cpp-snapshot-builds\cmake-build-relwithdebinfo\bin\pytorch_inference\Mlpytorch_inference.vcxproj]
C:\buildkite-agent\builds\bk-agent-prod-gcp-1712709148528061232\elastic\ml-cpp-snapshot-builds\bin\pytorch_inference\CCommandParser.cc(26,68): warning C4273:                                                                    ^ [C:\buildkite-agent\builds\bk-agent-prod-gcp-1712709148528061232\elastic\ml-cpp-snapshot-builds\cmake-build-relwithdebinfo\bin\pytorch_inference\Mlpytorch_inference.vcxproj]
     6>ClCompile:
         CCommandProcessor.cc
     9>ClCompile:
       C:\usr\local\include\boost-1_83\boost/json/value.hpp(3471,5): message : see previous definition of '<<' [C:\buildkite-agent\builds\bk-agent-prod-gcp-1712709148528061232\elastic\ml-cpp-snapshot-builds\cmake-build-relwithdebinfo\bin\pytorch_inference\Mlpytorch_inference.vcxproj]
       C:\usr\local\include\boost-1_83\boost/json/value.hpp(3471,5): message :     operator<<( [C:\buildkite-agent\builds\bk-agent-prod-gcp-1712709148528061232\elastic\ml-cpp-snapshot-builds\cmake-build-relwithdebinfo\bin\pytorch_inference\Mlpytorch_inference.vcxproj]
       C:\usr\local\include\boost-1_83\boost/json/value.hpp(3471,5): message :     ^ [C:\buildkite-agent\builds\bk-agent-prod-gcp-1712709148528061232\elastic\ml-cpp-snapshot-builds\cmake-build-relwithdebinfo\bin\pytorch_inference\Mlpytorch_inference.vcxproj]
```

This PR removes the unneeded (re)definition of
```
std::ostream& operator<<(std::ostream& os, const json::value& doc)
```
 in pytorch_inference CCommandParser.cc. (Boost::Json supplies one for free)

Relates #2653