### PR TITLE
[ML] Fix lambda capture triggering warning on Windows

### DIFF
--- a/cmake/compiler/msvc.cmake
+++ b/cmake/compiler/msvc.cmake
@@ -41,6 +41,7 @@ list(APPEND ML_C_FLAGS
 list(APPEND ML_CXX_FLAGS
   ${ML_C_FLAGS}
   "/TP"
+  "/Zc:lambda"
   "/Zc:rvalueCast"
   "/Zc:strictStrings"
   "/wd4127"

--- a/lib/model/CTokenListDataCategorizerBase.cc
+++ b/lib/model/CTokenListDataCategorizerBase.cc
@@ -421,9 +421,11 @@ CDataCategorizer::TPersistFunc CTokenListDataCategorizerBase::makeForegroundPers
 
 CDataCategorizer::TPersistFunc CTokenListDataCategorizerBase::makeBackgroundPersistFunc() const {
     // Do NOT change this to capture the member variables by
-    // reference - they MUST be copied for thread safety
+    // reference - they MUST be copied for thread safety.
+    // However, the "this" pointer must be captured to allow the usage of
+    // CTokenListDataCategorizerBase::acceptPersistInserter without a warning
     return [
-        tokenIdLookup = m_TokenIdLookup, categories = m_Categories,
+        this, tokenIdLookup = m_TokenIdLookup, categories = m_Categories,
         memoryCategorizationFailures = m_MemoryCategorizationFailures
     ](core::CStatePersistInserter & inserter) {
         return CTokenListDataCategorizerBase::acceptPersistInserter(

--- a/lib/model/CTokenListDataCategorizerBase.cc
+++ b/lib/model/CTokenListDataCategorizerBase.cc
@@ -422,10 +422,8 @@ CDataCategorizer::TPersistFunc CTokenListDataCategorizerBase::makeForegroundPers
 CDataCategorizer::TPersistFunc CTokenListDataCategorizerBase::makeBackgroundPersistFunc() const {
     // Do NOT change this to capture the member variables by
     // reference - they MUST be copied for thread safety.
-    // However, the "this" pointer must be captured to allow the usage of
-    // CTokenListDataCategorizerBase::acceptPersistInserter without a warning
     return [
-        this, tokenIdLookup = m_TokenIdLookup, categories = m_Categories,
+        tokenIdLookup = m_TokenIdLookup, categories = m_Categories,
         memoryCategorizationFailures = m_MemoryCategorizationFailures
     ](core::CStatePersistInserter & inserter) {
         return CTokenListDataCategorizerBase::acceptPersistInserter(


### PR DESCRIPTION
Windows build logs contain the warning

```
lib\model\CTokenListDataCategorizerBase.cc(429,1): warning C4573: the usage of 'ml::model::CTokenListDataCategorizerBase::acceptPersistInserter' requires the compiler to capture 'this' but the current default capture mode does not allow it
```

This PR fixes that by explicitly capturing the "this" pointer.

Relates #2653