### PR TITLE
[ML] Suppress LNK4217 linker warning for libMlCore

### DIFF
--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -112,7 +112,7 @@ ml_add_library(MlCore SHARED
   )
 
 if (WIN32)
-  target_link_libraries(MlCore PUBLIC AdvAPI32.lib shell32.lib Version.lib ${STRPTIME_LIB})
+  target_link_libraries(MlCore PUBLIC -ignore:4217 AdvAPI32.lib shell32.lib Version.lib ${STRPTIME_LIB})
   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/date_time_zonespec.csv DESTINATION ${ML_RESOURCES_DIR})
 endif()
 


### PR DESCRIPTION
The link step for libMlCore generates many [LNK4217](https://learn.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-warning-lnk4217?view=msvc-170) warnings referencing `Boost::Json` symbols. The warning is indicating that the definitions of the symbols have already been imported in other translation units in the library.

These warnings are harmless and are safe to suppress (and are not avoidable by any other means as far as I can tell)

Relates #2653 