### PR TITLE
[ML] Add zlib.pdb file to Windows' CI dependencies

### DIFF
--- a/dev-tools/download_windows_deps.ps1
+++ b/dev-tools/download_windows_deps.ps1
@@ -9,7 +9,7 @@
 # limitation.
 #
 $ErrorActionPreference="Stop"
-$Archive="usr-x86_64-windows-2016-11.zip"
+$Archive="usr-x86_64-windows-2016-12.zip"
 $Destination="C:\"
 # If PyTorch is not version 2.1.2 then we need the latest download
 if (!(Test-Path "$Destination\usr\local\include\pytorch\torch\csrc\api\include\torch\version.h") -Or


### PR DESCRIPTION
Our logs for Windows CI builds contain warnings similar to:

```
zlib.lib(deflate.obj) : warning LNK4099: PDB 'zlib.pdb' was not found with 'zlib.lib(deflate.obj)'...
```

The PDB file is already built as part of the Windows bootstrapping process - see `build-setup/windows.md`. This change ensures that the dependencies archive deployed to the CI build host contains it.

Relates #2653 