### PR TITLE
[ML] Use Orka for macOS ARM builds.

### DIFF
--- a/.buildkite/pipelines/build_macos.json.py
+++ b/.buildkite/pipelines/build_macos.json.py
@@ -43,7 +43,7 @@ def main(args):
             "timeout_in_minutes": "240",
             "agents": {
               "provider": "orka",
-              "imagePrefix": "ml-macos-12-arm"
+              "image": "ml-macos-12-arm-001.orkasi"
             },
             "commands": [
               f'if [[ "{args.action}" == "debug" ]]; then export ML_DEBUG=1; fi',
@@ -55,8 +55,6 @@ def main(args):
               "TMPDIR": "/tmp",
               "HOMEBREW_PREFIX": "/opt/homebrew",
               "PATH": "/opt/homebrew/bin:$PATH",
-              "JAVA_HOME": "/var/lib/jenkins/.java/zulu11",
-              "PATH": "$JAVA_HOME/bin:$PATH",
               "ML_DEBUG": "0",
               "CPP_CROSS_COMPILE": "",
               "CMAKE_FLAGS": "-DCMAKE_TOOLCHAIN_FILE=cmake/darwin-aarch64.cmake",

--- a/.buildkite/pipelines/build_macos.json.py
+++ b/.buildkite/pipelines/build_macos.json.py
@@ -42,7 +42,8 @@ def main(args):
             "label": f"Build & test :cpp: for MacOS-{arch}-{build_type} :macos:",
             "timeout_in_minutes": "240",
             "agents": {
-              "queue": "ml-aarch64-macstadium"
+              "provider": "orka",
+              "imagePrefix": "ml-macos-12-arm"
             },
             "commands": [
               f'if [[ "{args.action}" == "debug" ]]; then export ML_DEBUG=1; fi',
@@ -51,6 +52,9 @@ def main(args):
             "depends_on": "check_style",
             "key": f"build_test_macos-{arch}-{build_type}",
             "env": {
+              "TMPDIR": "/tmp",
+              "HOMEBREW_PREFIX": "/opt/homebrew",
+              "PATH": "/opt/homebrew/bin:$PATH",
               "JAVA_HOME": "/var/lib/jenkins/.java/zulu11",
               "PATH": "$JAVA_HOME/bin:$PATH",
               "ML_DEBUG": "0",

--- a/.buildkite/scripts/steps/build_and_test.sh
+++ b/.buildkite/scripts/steps/build_and_test.sh
@@ -80,7 +80,7 @@ if ! [[ "$HARDWARE_ARCH" = aarch64 && -z "$CPP_CROSS_COMPILE" ]] ; then
 else
   if [[ `uname` = "Darwin" && "$HARDWARE_ARCH" = "aarch64" ]]; then
      # For macOS, build directly on the machine
-     ${REPO_ROOT}/dev-tools/download_macos_deps.sh
+     sudo -E ${REPO_ROOT}/dev-tools/download_macos_deps.sh
      if [ "$RUN_TESTS" = false ] ; then
          TASKS="clean buildZip buildZipSymbols"
      else


### PR DESCRIPTION
At the moment macOS ARM builds are performed on bare metal Mac Minis provided by MacStadium. For consistency with the rest of engineering, ease of maintenance, reproducibility of builds, automation of provisioning builders etc. it is preferred that we migrate to using VMs provided by MacStadium Orka.

This PR makes use of an image built using "packer". Where the packer config will live is still TBD.

Labelling as a non-issue as this is purely build related.