### PR TITLE
[ML] Packer configuration for macOS ARM Orka image

### DIFF
--- a/.ci/orka/README.md
+++ b/.ci/orka/README.md
@@ -1,0 +1,67 @@
+# Create Orka Images via Packer
+
+## Requirements
+
+- Packer
+- Vault
+- Orka VPN
+
+## Files
+
+- `install.sh` The script that does the software installs on the image
+- `orka-macos-12-arm.pkr.hcl` The packer definition for a MacOS 12 ARM builder image
+
+
+## Set Up Packer
+
+If you haven't run these before, run the following once so packer downloads the `vault` integration:
+
+```
+packer init orka-macos-12-arm.pkr.hcl
+```
+
+## Build
+
+Make sure you are connected to the Orka VM.
+
+Packer requires access to secrets in vault, where VAULT_ADDR=https://vault-ci-prod.elastic.dev and VAULT_TOKEN must be set appropriately in the environment.
+
+Run the following to create the image (MacOS 12 ARM in this example):
+
+```
+packer build orka-macos-12-arm.pkr.hcl
+```
+
+## Versioning
+
+The name of the resulting images are hard-coded (currently), and end in a sequence number (e.g., `001`).  When creating a new image, bump the sequence number, otherwise you won't be able to create an image if it already exists.
+
+## Source Images
+
+The source image used for the MacOS 12 ARM build is a slightly modified copy of the standard Orka image 90GBMontereySSH.orkasi:
+
+The source image is named `ml-macos-12-base-arm-fundamental.orkasi`
+
+The source image only has the following changes on it:
+    * Adding passwordless `sudo` for the default `admin` user
+    * Configured `admin` user to be automatically logged in
+    * Installed Xcode command line tools version 13 (by running `clang++ --version` and clicking through the dialogues)
+
+## Packer Install Steps
+
+The packer script does the following:
+    * Install Brew `4.2.21`
+    * Install JDK `11.0.23`
+    * Install python3
+    * Install vault
+    * Install jq
+    * Install Google Cloud SDK into `~admin/google-cloud-sdk/`
+    * Install CMake 3.23.3
+    * Install `gobld-bootstrap.sh` script to run at system startup
+        * This script pulls down and runs another script from a static location to do the following:
+            * Unseal one-time vault token from gobld
+            * Install and run the latest `buildkite-agent`
+
+## Caveats
+
+* At the moment we only need Orka for ARM builds (CI and dependencies).

--- a/.ci/orka/gobld-bootstrap.plist
+++ b/.ci/orka/gobld-bootstrap.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key>
+      <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:</string>
+    </dict>
+    <key>Label</key>
+    <string>co.elastic.gobld-bootstrap</string>
+    <key>Program</key>
+    <string>/usr/local/bin/gobld-bootstrap.sh</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>SessionCreate</key>
+    <true/>
+    <key>LaunchOnlyOnce</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/gobld-bootstrap.stdout</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/gobld-bootstrap.stderr</string>
+    <key>UserName</key>
+    <string>admin</string>
+    <key>GroupName</key>
+    <string>staff</string>
+    <key>InitGroups</key>
+    <true/>
+  </dict>
+</plist>

--- a/.ci/orka/gobld-bootstrap.sh
+++ b/.ci/orka/gobld-bootstrap.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+retry() {
+  local retries=$1; shift
+  local delay=$1; shift
+  local attempts=1
+
+  until "$@"; do
+    retry_exit_status=$?
+    echo "Exited with $retry_exit_status" >&2
+    if (( retries == "0" )); then
+      return $retry_exit_status
+    elif (( attempts == retries )); then
+      echo "Failed $attempts retries" >&2
+      return $retry_exit_status
+    else
+      echo "Retrying $((retries - attempts)) more times..." >&2
+      attempts=$((attempts + 1))
+      sleep "$delay"
+    fi
+  done
+}
+
+# Retry up to ~80 seconds as network is not guaranteed to be available when the script starts.
+retry 16 5 curl -s https://storage.googleapis.com/ci-systems-orka-provisioner-prod/gobld-bootstrap.sh | bash

--- a/.ci/orka/install.sh
+++ b/.ci/orka/install.sh
@@ -4,22 +4,18 @@ export PATH=/opt/homebrew/bin:/usr/local/bin:$PATH
 
 MACHINE_TYPE=$(uname -m)
 
+PYTHON3_URL=https://www.python.org/ftp/python/3.10.8/python-3.10.8-macos11.pkg
+PYTHON3_FILE=python-3.10.8-macos11.pkg
+
+GCLOUD_SDK_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-408.0.1-darwin-x86_64.tar.gz
+GCLOUD_SDK_FILE=google-cloud-cli.tar.gz
+
 if [ ${MACHINE_TYPE} == "x86_64" ]; then
     echo "Running on x86_64"
 
-    PYTHON3_URL=https://www.python.org/ftp/python/3.10.8/python-3.10.8-macos11.pkg
-    PYTHON3_FILE=python-3.10.8-macos11.pkg
-
-    GCLOUD_SDK_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-408.0.1-darwin-x86_64.tar.gz
-    GCLOUD_SDK_FILE=google-cloud-cli.tar.gz
 elif [ ${MACHINE_TYPE} == "arm64" ]; then
     echo "Running on arm64"
 
-    PYTHON3_URL=https://www.python.org/ftp/python/3.10.8/python-3.10.8-macos11.pkg
-    PYTHON3_FILE=python-3.10.8-macos11.pkg
-
-    GCLOUD_SDK_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-408.0.1-darwin-arm.tar.gz
-    GCLOUD_SDK_FILE=google-cloud-cli.tar.gz
 else
     echo "Unknown architecture: ${MACHINE_TYPE}"
     exit 1

--- a/.ci/orka/install.sh
+++ b/.ci/orka/install.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -xe
+export PATH=/opt/homebrew/bin:/usr/local/bin:$PATH
+
+MACHINE_TYPE=$(uname -m)
+
+if [ ${MACHINE_TYPE} == "x86_64" ]; then
+    echo "Running on x86_64"
+
+    PYTHON3_URL=https://www.python.org/ftp/python/3.10.8/python-3.10.8-macos11.pkg
+    PYTHON3_FILE=python-3.10.8-macos11.pkg
+
+    GCLOUD_SDK_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-408.0.1-darwin-x86_64.tar.gz
+    GCLOUD_SDK_FILE=google-cloud-cli.tar.gz
+elif [ ${MACHINE_TYPE} == "arm64" ]; then
+    echo "Running on arm64"
+
+    PYTHON3_URL=https://www.python.org/ftp/python/3.10.8/python-3.10.8-macos11.pkg
+    PYTHON3_FILE=python-3.10.8-macos11.pkg
+
+    GCLOUD_SDK_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-408.0.1-darwin-arm.tar.gz
+    GCLOUD_SDK_FILE=google-cloud-cli.tar.gz
+else
+    echo "Unknown architecture: ${MACHINE_TYPE}"
+    exit 1
+fi
+
+if ! command -v brew 2> /dev/null ; then
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
+
+eval "$(brew shellenv)"
+
+if ! java --version 2> /dev/null ; then
+  echo 'install jdk 11'
+  brew install openjdk@11
+  sudo ln -sfn /opt/homebrew/opt/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk
+fi
+
+if ! command -v vault 2> /dev/null ; then
+    echo "Install vault"
+    brew install vault
+fi
+
+if ! command -v jq 2> /dev/null ; then
+    echo "Install jq"
+    brew install jq
+fi
+
+if ! command -v orka-vm-tools 2> /dev/null ; then
+    echo "Install orka-vm-tools"
+    brew install orka-vm-tools
+fi
+
+echo "Install google cloud sdk in home dir"
+pushd ~
+/bin/bash -c "$(curl -s ${GCLOUD_SDK_URL} --output ${GCLOUD_SDK_FILE})"
+tar zxf ${GCLOUD_SDK_FILE}
+rm -f ${GCLOUD_SDK_FILE}
+popd
+
+echo "Install python 3"
+/bin/bash -c "$(curl -s ${PYTHON3_URL} --output ${PYTHON3_FILE})"
+sudo installer -pkg ${PYTHON3_FILE} -target /
+rm -f ${PYTHON3_FILE}
+
+# Install the gobld bootstrap script
+echo "Install gobld bootstrap callout script"
+sudo mkdir -p /usr/local/bin
+sudo cp /tmp/gobld-bootstrap.sh /usr/local/bin/gobld-bootstrap.sh
+sudo chmod +x /usr/local/bin/gobld-bootstrap.sh
+sudo cp /tmp/gobld-bootstrap.plist /Library/LaunchDaemons/gobld-bootstrap.plist
+sudo launchctl bootstrap system /Library/LaunchDaemons/gobld-bootstrap.plist
+sudo cp /tmp/gobld-bootstrap.plist /Users/admin
+
+# Install CMake
+echo "Install CMake"
+curl -v -L https://github.com/Kitware/CMake/releases/download/v3.23.3/cmake-3.23.3-macos-universal.tar.gz | tar xvzf - --strip-components 1 -C /Applications
+sudo ln -sf /Applications/CMake.app/Contents/bin/cmake /usr/local/bin/cmake
+
+# Make sure all changes are written to disk
+sync

--- a/.ci/orka/orka-macos-12-arm.pkr.hcl
+++ b/.ci/orka/orka-macos-12-arm.pkr.hcl
@@ -1,0 +1,53 @@
+packer {
+  required_plugins {
+    macstadium-orka = {
+      version = "= 2.3.0"
+      source  = "github.com/macstadium/macstadium-orka"
+    }
+  }
+}
+
+locals {
+  orka_endpoint = vault("secret/ci/elastic-ml-cpp/orka", "orka_endpoint")
+  orka_user     = vault("secret/ci/elastic-ml-cpp/orka", "orka_user")
+  orka_password = vault("secret/ci/elastic-ml-cpp/orka", "orka_password")
+  ssh_username  = vault("secret/ci/elastic-ml-cpp/orka", "ssh_username")
+  ssh_password  = vault("secret/ci/elastic-ml-cpp/orka", "ssh_password")
+  sensitive     = true
+}
+
+source "macstadium-orka" "image" {
+  source_image     = "ml-macos-12-base-arm-fundamental.orkasi"
+  image_name       = "ml-macos-12-arm-001.orkasi"
+  orka_endpoint    = local.orka_endpoint
+  orka_user        = local.orka_user
+  orka_password    = local.orka_password
+  ssh_username     = local.ssh_username
+  ssh_password     = local.ssh_password
+  orka_vm_cpu_core = 4
+  no_delete_vm     = false
+}
+
+build {
+  sources = [
+    "macstadium-orka.image"
+  ]
+  provisioner "file" {
+    source = "install.sh"
+    destination = "/tmp/install.sh"
+  }
+  provisioner "file" {
+    source = "gobld-bootstrap.sh"
+    destination = "/tmp/gobld-bootstrap.sh"
+  }
+  provisioner "file" {
+    source = "gobld-bootstrap.plist"
+    destination = "/tmp/gobld-bootstrap.plist"
+  }
+  provisioner "shell" {
+    inline = [
+      "chmod u+x /tmp/install.sh",
+      "/tmp/install.sh",
+    ]
+  }
+}


### PR DESCRIPTION
Adds the Packer configuration files and installation scripts required to create the macOS ARM image used for BuildKite CI builds.

Labelling as `>non-issue` as this is purely related to the internal build system.