### PR TITLE
[ML] Fix error introduced by backport

### DIFF
--- a/.buildkite/pipelines/build_macos.json.py
+++ b/.buildkite/pipelines/build_macos.json.py
@@ -55,7 +55,6 @@ def main(args):
               "TMPDIR": "/tmp",
               "HOMEBREW_PREFIX": "/opt/homebrew",
               "PATH": "/opt/homebrew/bin:$PATH",
-              "ML_DEBUG": "0",
               "CPP_CROSS_COMPILE": "",
               "CMAKE_FLAGS": "-DCMAKE_TOOLCHAIN_FILE=cmake/darwin-aarch64.cmake",
               "RUN_TESTS": "true",


### PR DESCRIPTION
The backport of the Orka related changes to the `7.17` branch introduced a change that inadvertently set the build type to be `DEBUG`. (This is due to differences in the build scripts in `7.17` to those more recent branches). Consequently the build takes ~ 3.5 hours to complete and all binaries will have full debug symbols and assertions enabled.