### PR TITLE
[ML] Fix stack-use-after-scope error

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,12 @@
 
 //=== Regressions
 
+== {es} version 8.15.0
+
+=== Bug Fixes
+
+* Fix "stack use after scope" memory error. (See {ml-pull}2673[#2673].)
+
 == {es} version 8.14.0
 
 === Bug Fixes

--- a/lib/model/CHierarchicalResultsNormalizer.cc
+++ b/lib/model/CHierarchicalResultsNormalizer.cc
@@ -379,9 +379,11 @@ bool CHierarchicalResultsNormalizer::isMemberOfPopulation(const TNode& node,
     // So the person field name and value in the lambda are set to the
     // values for this node.
 
+    // Initialise these string references here as they are used by the
+    // "test" lambda, in this scope, below.
+    const std::string& personName = node.s_Spec.s_PersonFieldName.value_or("");
+    const std::string& personValue = node.s_Spec.s_PersonFieldValue.value_or("");
     if (test == nullptr) {
-        const std::string& personName = node.s_Spec.s_PersonFieldName.value_or("");
-        const std::string& personValue = node.s_Spec.s_PersonFieldValue.value_or("");
         if (personName.empty() || personValue.empty()) {
             return false;
         }


### PR DESCRIPTION
When running the "autodetect" binary, compiled with the address sanitizer enabled, the following error was emitted

```
==7993==ERROR: AddressSanitizer: stack-use-after-scope on address 0x00016bbf0d37 at pc 0x000106e71b70 bp 0x00016bbf0c40 sp 0x00016bbf0c38
READ of size 1 at 0x00016bbf0d37 thread T0
==7993==WARNING: Failed to use and restart external symbolizer!
    #0 0x106e71b6c in std::__1::__function::__func<ml::model::CHierarchicalResultsNormalizer::isMemberOfPopulation(ml::model::hierarchical_results_detail::SNode const&, std::__1::function<bool (ml::model::hierarchical_results_detail::SNode const&)>)::$_0, std::__1::allocator<ml::model::CHierarchicalResultsNormalizer::isMemberOfPopulation(ml::model::hierarchical_results_detail::SNode const&, std::__1::function<bool (ml::model::hierarchical_results_detail::SNode const&)>)::$_0>, bool (ml::model::hierarchical_results_detail::SNode const&)>::operator()(ml::model::hierarchical_results_detail::SNode const&)+0x3c0 (/Users/eds/src/elasticsearch/ml-cpp/build/distribution/platform/darwin-aarch64/controller.app/Contents/lib/libMlModel.dylib:arm64+0x555b6c)
```

This PR provides a fix by maintaining references to the strings used by a lambda in the same scope.