### PR TITLE
[Backport] [ML] Remove allocators from cache after usage

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,13 @@
 
 //=== Regressions
 
+== {es} version 7.17.23
+
+=== Enhancements
+
+* Improve memory allocation management for JSON processing to reduce memory usage. 
+  (See {ml-pull}#2678[2678].)
+
 == {es} version 7.17.16
 
 === Enhancements

--- a/include/api/CJsonOutputWriter.h
+++ b/include/api/CJsonOutputWriter.h
@@ -266,6 +266,9 @@ private:
     //! \p allocatorName A unique identifier for the allocator
     void pushAllocator(const std::string& allocatorName);
 
+    //! release the allocator
+    void releaseAllocator(const std::string& allocatorName);
+
     //! revert to using the previous allocator for JSON output processing
     void popAllocator();
 

--- a/include/api/CJsonOutputWriter.h
+++ b/include/api/CJsonOutputWriter.h
@@ -266,8 +266,8 @@ private:
     //! \p allocatorName A unique identifier for the allocator
     void pushAllocator(const std::string& allocatorName);
 
-    //! release the allocator
-    void releaseAllocator(const std::string& allocatorName);
+    //! remove the allocator
+    void removeAllocator(const std::string& allocatorName);
 
     //! revert to using the previous allocator for JSON output processing
     void popAllocator();

--- a/include/core/CRapidJsonWriterBase.h
+++ b/include/core/CRapidJsonWriterBase.h
@@ -162,6 +162,15 @@ public:
         return allocator;
     }
 
+    //! remove an allocator from the cache
+    void releaseAllocator(const std::string& allocatorName) {
+        if (m_AllocatorCache.find(allocatorName) != m_AllocatorCache.end()) {
+            TPoolAllocatorPtr allocator = m_AllocatorCache[allocatorName];
+            allocator.reset();
+            m_AllocatorCache.erase(allocatorName);
+        }
+    }
+
     rapidjson::MemoryPoolAllocator<>& getRawAllocator() const {
         return this->getAllocator()->get();
     }

--- a/include/core/CRapidJsonWriterBase.h
+++ b/include/core/CRapidJsonWriterBase.h
@@ -164,10 +164,10 @@ public:
 
     //! remove an allocator from the cache
     void removeAllocator(const std::string& allocatorName) {
-        if (m_AllocatorCache.find(allocatorName) != m_AllocatorCache.end()) {
-            TPoolAllocatorPtr allocator = m_AllocatorCache[allocatorName];
-            allocator.reset();
-            m_AllocatorCache.erase(allocatorName);
+        auto allocator = m_AllocatorCache.find(allocatorName);
+        if (allocator != m_AllocatorCache.end()) {
+            allocator->second.reset();
+            m_AllocatorCache.erase(allocator);
         }
     }
 

--- a/include/core/CRapidJsonWriterBase.h
+++ b/include/core/CRapidJsonWriterBase.h
@@ -163,7 +163,7 @@ public:
     }
 
     //! remove an allocator from the cache
-    void releaseAllocator(const std::string& allocatorName) {
+    void removeAllocator(const std::string& allocatorName) {
         if (m_AllocatorCache.find(allocatorName) != m_AllocatorCache.end()) {
             TPoolAllocatorPtr allocator = m_AllocatorCache[allocatorName];
             allocator.reset();

--- a/include/core/CScopedRapidJsonPoolAllocator.h
+++ b/include/core/CScopedRapidJsonPoolAllocator.h
@@ -31,12 +31,12 @@ class CScopedRapidJsonPoolAllocator {
 public:
     //! \p allocatorName Unique identifier for the allocator
     //! \p jsonOutputWriter JSON output writer that will make use of the allocator
-    CScopedBoostJsonPoolAllocator(const std::string& allocatorName, T& writer)
+    CScopedRapidJsonPoolAllocator(const std::string& allocatorName, T& writer)
         : m_Writer(writer), m_AllocatorName(allocatorName) {
         m_Writer.pushAllocator(allocatorName);
     }
 
-    ~CScopedBoostJsonPoolAllocator() {
+    ~CScopedRapidJsonPoolAllocator() {
         m_Writer.popAllocator();
         m_Writer.removeAllocator(m_AllocatorName);
     }

--- a/include/core/CScopedRapidJsonPoolAllocator.h
+++ b/include/core/CScopedRapidJsonPoolAllocator.h
@@ -31,15 +31,19 @@ class CScopedRapidJsonPoolAllocator {
 public:
     //! \p allocatorName Unique identifier for the allocator
     //! \p jsonOutputWriter JSON output writer that will make use of the allocator
-    CScopedRapidJsonPoolAllocator(const std::string& allocatorName, T& writer)
-        : m_Writer(writer) {
+    CScopedBoostJsonPoolAllocator(const std::string& allocatorName, T& writer)
+        : m_Writer(writer), m_AllocatorName(allocatorName) {
         m_Writer.pushAllocator(allocatorName);
     }
 
-    ~CScopedRapidJsonPoolAllocator() { m_Writer.popAllocator(); }
+    ~CScopedBoostJsonPoolAllocator() { 
+        m_Writer.popAllocator(); 
+        m_Writer.releaseAllocator(m_AllocatorName);
+        }
 
 private:
     T& m_Writer;
+    std::string m_AllocatorName;
 };
 }
 }

--- a/include/core/CScopedRapidJsonPoolAllocator.h
+++ b/include/core/CScopedRapidJsonPoolAllocator.h
@@ -36,10 +36,10 @@ public:
         m_Writer.pushAllocator(allocatorName);
     }
 
-    ~CScopedBoostJsonPoolAllocator() { 
-        m_Writer.popAllocator(); 
-        m_Writer.releaseAllocator(m_AllocatorName);
-        }
+    ~CScopedBoostJsonPoolAllocator() {
+        m_Writer.popAllocator();
+        m_Writer.removeAllocator(m_AllocatorName);
+    }
 
 private:
     T& m_Writer;

--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -825,6 +825,10 @@ void CJsonOutputWriter::pushAllocator(const std::string& allocatorName) {
     m_Writer.pushAllocator(allocatorName);
 }
 
+void CJsonOutputWriter::releaseAllocator(const std::string& allocatorName) {
+    m_Writer.releaseAllocator(allocatorName);
+}
+
 void CJsonOutputWriter::popAllocator() {
     m_Writer.popAllocator();
 }

--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -825,8 +825,8 @@ void CJsonOutputWriter::pushAllocator(const std::string& allocatorName) {
     m_Writer.pushAllocator(allocatorName);
 }
 
-void CJsonOutputWriter::releaseAllocator(const std::string& allocatorName) {
-    m_Writer.releaseAllocator(allocatorName);
+void CJsonOutputWriter::removeAllocator(const std::string& allocatorName) {
+    m_Writer.removeAllocator(allocatorName);
 }
 
 void CJsonOutputWriter::popAllocator() {


### PR DESCRIPTION
In the CBoostJsonWriteBase class, we maintain a cache of allocators that should be reused when we write new results. Although we took measures to free memory in these allocators, it was still not entirely possible. As a result, we noticed a gradual increase in memory usage by native processes due to the increasing size of the allocators in the cache.

This PR ensures that the allocator is removed from the cache and the memory is freed.

Backport of #2679 to 7.17