### PR TITLE
[ML] Remove allocators from cache after usage

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -30,7 +30,7 @@
 
 == {es} version 8.14.1
 
-=== Bug Fixes
+=== Enhancements
 
 * Improve memory allocation management for JSON processing to reduce memory usage.
   (See {ml-pull}2676[#2676].)

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,13 @@
 
 //=== Regressions
 
+== {es} version 8.14.1
+
+=== Bug Fixes
+
+* Improve memory allocation management for JSON processing to reduce memory usage.
+  (See {ml-pull}2676[#2676].)
+
 == {es} version 8.14.0
 
 === Bug Fixes

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -33,7 +33,8 @@
 === Enhancements
 
 * Improve memory allocation management for JSON processing to reduce memory usage.
-  (See {ml-pull}2676[#2676].)
+  (See {ml-pull}2679[#2679].)
+
 
 == {es} version 8.14.0
 

--- a/include/api/CJsonOutputWriter.h
+++ b/include/api/CJsonOutputWriter.h
@@ -273,8 +273,8 @@ private:
     //! \p allocatorName A unique identifier for the allocator
     void pushAllocator(const std::string& allocatorName);
 
-    //! release the allocator
-    void releaseAllocator(const std::string& allocatorName);
+    //! remove allocator from cache
+    void removeAllocator(const std::string& allocatorName);
 
     //! revert to using the previous allocator for JSON output processing
     void popAllocator();

--- a/include/api/CJsonOutputWriter.h
+++ b/include/api/CJsonOutputWriter.h
@@ -273,6 +273,9 @@ private:
     //! \p allocatorName A unique identifier for the allocator
     void pushAllocator(const std::string& allocatorName);
 
+    //! release the allocator
+    void releaseAllocator(const std::string& allocatorName);
+
     //! revert to using the previous allocator for JSON output processing
     void popAllocator();
 

--- a/include/core/CBoostJsonWriterBase.h
+++ b/include/core/CBoostJsonWriterBase.h
@@ -132,10 +132,10 @@ public:
     }
 
     void removeAllocator(const std::string& allocatorName) {
-        if (m_AllocatorCache.find(allocatorName) != m_AllocatorCache.end()) {
-            TPoolAllocatorPtr allocator = m_AllocatorCache[allocatorName];
-            allocator.reset();
-            m_AllocatorCache.erase(allocatorName);
+        auto allocator = m_AllocatorCache.find(allocatorName);
+        if (allocator != m_AllocatorCache.end()) {
+            allocator->second.reset();
+            m_AllocatorCache.erase(allocator);
         }
     }
 

--- a/include/core/CBoostJsonWriterBase.h
+++ b/include/core/CBoostJsonWriterBase.h
@@ -24,10 +24,7 @@
 #include <boost/unordered_set.hpp>
 
 #include <cmath>
-#include <iomanip>
-#include <iostream>
 #include <memory>
-#include <regex>
 #include <stack>
 
 namespace json = boost::json;
@@ -132,6 +129,14 @@ public:
 
     boost::json::storage_ptr& getStoragePointer() const {
         return this->getAllocator()->get();
+    }
+
+    void releaseAllocator(const std::string& allocatorName) {
+        if (m_AllocatorCache.find(allocatorName) != m_AllocatorCache.end()) {
+            TPoolAllocatorPtr allocator = m_AllocatorCache[allocatorName];
+            allocator.reset();
+            m_AllocatorCache.erase(allocatorName);
+        }
     }
 
     bool isComplete() const {

--- a/include/core/CBoostJsonWriterBase.h
+++ b/include/core/CBoostJsonWriterBase.h
@@ -131,7 +131,7 @@ public:
         return this->getAllocator()->get();
     }
 
-    void releaseAllocator(const std::string& allocatorName) {
+    void removeAllocator(const std::string& allocatorName) {
         if (m_AllocatorCache.find(allocatorName) != m_AllocatorCache.end()) {
             TPoolAllocatorPtr allocator = m_AllocatorCache[allocatorName];
             allocator.reset();

--- a/include/core/CScopedBoostJsonPoolAllocator.h
+++ b/include/core/CScopedBoostJsonPoolAllocator.h
@@ -36,10 +36,10 @@ public:
         m_Writer.pushAllocator(allocatorName);
     }
 
-    ~CScopedBoostJsonPoolAllocator() { 
-        m_Writer.popAllocator(); 
+    ~CScopedBoostJsonPoolAllocator() {
+        m_Writer.popAllocator();
         m_Writer.releaseAllocator(m_AllocatorName);
-        }
+    }
 
 private:
     T& m_Writer;

--- a/include/core/CScopedBoostJsonPoolAllocator.h
+++ b/include/core/CScopedBoostJsonPoolAllocator.h
@@ -12,6 +12,7 @@
 #define INCLUDED_ml_core_CScopedBoostJsonPoolAllocator_h
 
 #include <boost/json.hpp>
+#include <string>
 
 namespace ml {
 namespace core {
@@ -31,14 +32,18 @@ public:
     //! \p allocatorName Unique identifier for the allocator
     //! \p jsonOutputWriter JSON output writer that will make use of the allocator
     CScopedBoostJsonPoolAllocator(const std::string& allocatorName, T& writer)
-        : m_Writer(writer) {
+        : m_Writer(writer), m_AllocatorName(allocatorName) {
         m_Writer.pushAllocator(allocatorName);
     }
 
-    ~CScopedBoostJsonPoolAllocator() { m_Writer.popAllocator(); }
+    ~CScopedBoostJsonPoolAllocator() { 
+        m_Writer.popAllocator(); 
+        m_Writer.releaseAllocator(m_AllocatorName);
+        }
 
 private:
     T& m_Writer;
+    std::string m_AllocatorName;
 };
 }
 }

--- a/include/core/CScopedBoostJsonPoolAllocator.h
+++ b/include/core/CScopedBoostJsonPoolAllocator.h
@@ -38,7 +38,7 @@ public:
 
     ~CScopedBoostJsonPoolAllocator() {
         m_Writer.popAllocator();
-        m_Writer.releaseAllocator(m_AllocatorName);
+        m_Writer.removeAllocator(m_AllocatorName);
     }
 
 private:

--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -850,6 +850,10 @@ void CJsonOutputWriter::pushAllocator(const std::string& allocatorName) {
     m_Writer.pushAllocator(allocatorName);
 }
 
+void CJsonOutputWriter::releaseAllocator(const std::string& allocatorName) {
+    m_Writer.releaseAllocator(allocatorName);
+}
+
 void CJsonOutputWriter::popAllocator() {
     m_Writer.popAllocator();
 }

--- a/lib/api/CJsonOutputWriter.cc
+++ b/lib/api/CJsonOutputWriter.cc
@@ -850,8 +850,8 @@ void CJsonOutputWriter::pushAllocator(const std::string& allocatorName) {
     m_Writer.pushAllocator(allocatorName);
 }
 
-void CJsonOutputWriter::releaseAllocator(const std::string& allocatorName) {
-    m_Writer.releaseAllocator(allocatorName);
+void CJsonOutputWriter::removeAllocator(const std::string& allocatorName) {
+    m_Writer.removeAllocator(allocatorName);
 }
 
 void CJsonOutputWriter::popAllocator() {


### PR DESCRIPTION
In the `CBoostJsonWriteBase` class, we maintain a cache of allocators that should be reused when we write new results. Although we took measures to free memory in these allocators, it was still not completely possible. As a result, we noticed a gradual increase in memory usage by native processes due to the increasing size of the allocators in the cache.

This PR ensures that the allocator is removed from the cache and the memory is freed.

Related to #2664 