### PR TITLE
[ML] Catch any exception thrown by inference 

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -33,6 +33,13 @@
 === Bug Fixes
 
 * Fix "stack use after scope" memory error. (See {ml-pull}2673[#2673].)
+* Handle any exception thrown by inference. (See {ml-pull}2680[#2680].)
+
+== {es} version 8.14.1
+
+=== Bug Fixes
+
+* Handle any exception thrown by inference. (See {ml-pull}2680[#2680].)
 
 == {es} version 8.14.0
 


### PR DESCRIPTION
The `pytorch_inference` process must respond to every request as the Java side is waiting for a response. Partly this is ensured by a try catch block, we can't be certain what types of exception might be thrown so better to catch the base `std::exception` rather than derived classes.