### PR TITLE
[ML] Add `codesign` CMake target

### DIFF
--- a/.entitlements.xml
+++ b/.entitlements.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd"\>
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.get-task-allow</key>
+        <true/>
+    </dict>
+</plist>

--- a/bin/autodetect/CMakeLists.txt
+++ b/bin/autodetect/CMakeLists.txt
@@ -25,3 +25,5 @@ set(ML_LINK_LIBRARIES
 ml_add_executable(autodetect
   CCmdLineParser.cc
   )
+
+ml_codesign(autodetect)

--- a/bin/pytorch_inference/CMakeLists.txt
+++ b/bin/pytorch_inference/CMakeLists.txt
@@ -29,3 +29,4 @@ ml_add_executable(pytorch_inference
   CThreadSettings.cc
   )
 
+ml_codesign(pytorch_inference)

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -395,6 +395,22 @@ function(ml_add_test_executable _target)
   endif()
 endfunction()
 
+function(ml_codesign _target)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    add_custom_target(codesign_${_target}
+      DEPENDS ${_target}
+      COMMAND codesign -s - -v -f --entitlements=${CMAKE_SOURCE_DIR}/.entitlements.xml ${CMAKE_INSTALL_PREFIX}${EXE_DIR}/${_target}
+      COMMENT "Running codesign -s - -v -f --entitlements=${CMAKE_SOURCE_DIR}/.entitlements.xml ${CMAKE_INSTALL_PREFIX}${EXE_DIR}/${_target}"
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+  else()
+    add_custom_target(codesign_${_target}
+      COMMAND false
+      COMMENT "Running codesign not supported on ${CMAKE_SYSTEM_NAME}"
+    )
+  endif()
+endfunction()
+
 #
 # Add a target to the list of unittests to be built and run
 # _directory: Relative path to unittest binary directory, e.g. lib/maths/common/unittest


### PR DESCRIPTION
This PR adds the `codesign_autodetect` and `codesign_pytorch_inference` targets to CMake. These targets add the `get-task-allow` entitlement to the respective executables, which is necessary to allow debugging with e.g. `Instruments` on `macOS`

The `codesign` targets are only applicable on `macOS`. Attempting to run them on any other platform will fail with an explanatory message.

Labelling as a `>non-issue` as this is purely a development aid.