### PR TITLE
[ML] Upgrade to PyTorch 2.3.1

### DIFF
--- a/.buildkite/pipelines/build_linux.json.py
+++ b/.buildkite/pipelines/build_linux.json.py
@@ -36,7 +36,7 @@ agents = {
       "cpu": "6",
       "ephemeralStorage": "20G",
       "memory": "64G",
-      "image": "docker.elastic.co/ml-dev/ml-linux-build:29"
+      "image": "docker.elastic.co/ml-dev/ml-linux-build:30"
    },
    "aarch64": {
       "provider": "aws",
@@ -100,7 +100,7 @@ def main(args):
               "cpu": "6",
               "ephemeralStorage": "20G",
               "memory": "64G",
-              "image": "docker.elastic.co/ml-dev/ml-linux-aarch64-cross-build:12"
+              "image": "docker.elastic.co/ml-dev/ml-linux-aarch64-cross-build:13"
             },
             "commands": [
               ".buildkite/scripts/steps/build_and_test.sh"

--- a/.buildkite/pipelines/build_macos.json.py
+++ b/.buildkite/pipelines/build_macos.json.py
@@ -84,7 +84,7 @@ def main(args):
           "cpu": "6",
           "ephemeralStorage": "20G",
           "memory": "64G",
-          "image": "docker.elastic.co/ml-dev/ml-macosx-build:18"
+          "image": "docker.elastic.co/ml-dev/ml-macosx-build:19"
         },
         "commands": [
           f'if [[ "{args.action}" == "debug" ]]; then export ML_DEBUG=1; fi',

--- a/.buildkite/pipelines/build_macos.json.py
+++ b/.buildkite/pipelines/build_macos.json.py
@@ -57,6 +57,7 @@ envs = {
       "HOMEBREW_PREFIX": "/opt/homebrew",
       "PATH": "/opt/homebrew/bin:$PATH",
       "ML_DEBUG": "0",
+      "CPP_CROSS_COMPILE": "",
       "CMAKE_FLAGS": "-DCMAKE_TOOLCHAIN_FILE=cmake/darwin-x86_64.cmake",
       "RUN_TESTS": "true",
       "BOOST_TEST_OUTPUT_FORMAT_FLAGS": "--logger=JUNIT,error,boost_test_results.junit",

--- a/.buildkite/scripts/steps/build_and_test.sh
+++ b/.buildkite/scripts/steps/build_and_test.sh
@@ -70,33 +70,46 @@ fi
 # For now, re-use our existing CI scripts based on Docker
 # Don't perform these steps for native linux aarch64 builds as
 # they are built using docker, see above.
-if ! [[ "$HARDWARE_ARCH" = aarch64 && -z "$CPP_CROSS_COMPILE" ]] ; then 
-  if [ "$RUN_TESTS" = "true" ]; then
-    ${REPO_ROOT}/dev-tools/docker/docker_entrypoint.sh --test
-    grep passed build/test_status.txt || TEST_OUTCOME=$?
-  else
-    ${REPO_ROOT}/dev-tools/docker/docker_entrypoint.sh
+if [[ `uname` = "Linux" ]]; then
+  if ! [[ "$HARDWARE_ARCH" = aarch64 && -z "$CPP_CROSS_COMPILE" ]] ; then
+    if [ "$RUN_TESTS" = "true" ]; then
+      ${REPO_ROOT}/dev-tools/docker/docker_entrypoint.sh --test
+      grep passed build/test_status.txt || TEST_OUTCOME=$?
+    else
+      ${REPO_ROOT}/dev-tools/docker/docker_entrypoint.sh
+    fi
   fi
 else
-  if [[ `uname` = "Darwin" ]]; then
-     # For macOS, build directly on the machine
-     sudo -E ${REPO_ROOT}/dev-tools/download_macos_deps.sh
-     if [ "$RUN_TESTS" = false ] ; then
-         TASKS="clean buildZip buildZipSymbols"
-     else
-         TASKS="clean buildZip buildZipSymbols check"
-     fi
-     # For macOS we usually only use a particular version as our build platform
-     # once Xcode has stopped receiving updates for it. However, with Big Sur
-     # on ARM we couldn't do this, as Big Sur was the first macOS version for
-     # ARM. Therefore, the compiler may get upgraded on a CI server, and we
-     # need to hardcode the version that was used to build Boost for that
-     # version of Elasticsearch.
-     if [ "$HARDWARE_ARCH" = aarch64 ] ; then
-         export BOOSTCLANGVER=13
-     fi
+  #sudo -E ${REPO_ROOT}/dev-tools/download_macos_deps.sh
+  if [[ "$HARDWARE_ARCH" = aarch64 ]] ; then
+    # For macOS aarch64, build directly on the machine using gradle
+    if [ "$RUN_TESTS" = false ] ; then
+       TASKS="clean buildZip buildZipSymbols"
+    else
+       TASKS="clean buildZip buildZipSymbols check"
+    fi
+    # For macOS we usually only use a particular version as our build platform
+    # once Xcode has stopped receiving updates for it. However, with Big Sur
+    # on ARM we couldn't do this, as Big Sur was the first macOS version for
+    # ARM. Therefore, the compiler may get upgraded on a CI server, and we
+    # need to hardcode the version that was used to build Boost for that
+    # version of Elasticsearch.
+    if [ "$HARDWARE_ARCH" = aarch64 ] ; then
+       export BOOSTCLANGVER=13
+    fi
 
-     (cd ${REPO_ROOT} && ./gradlew --info -Dbuild.version_qualifier=${VERSION_QUALIFIER:-} -Dbuild.snapshot=$BUILD_SNAPSHOT -Dbuild.ml_debug=$ML_DEBUG $TASKS) || TEST_OUTCOME=$?
+    (cd ${REPO_ROOT} && ./gradlew --info -Dbuild.version_qualifier=${VERSION_QUALIFIER:-} -Dbuild.snapshot=$BUILD_SNAPSHOT -Dbuild.ml_debug=$ML_DEBUG $TASKS) || TEST_OUTCOME=$?
+  else
+    function nproc() {
+        sysctl -n hw.logicalcpu
+    }
+    export -f nproc
+    if [ "$RUN_TESTS" = "true" ]; then
+      ${REPO_ROOT}/dev-tools/docker/docker_entrypoint.sh --test
+      grep passed build/test_status.txt || TEST_OUTCOME=$?
+    else
+      ${REPO_ROOT}/dev-tools/docker/docker_entrypoint.sh
+    fi
   fi
 fi
 

--- a/.buildkite/scripts/steps/build_and_test.sh
+++ b/.buildkite/scripts/steps/build_and_test.sh
@@ -78,7 +78,7 @@ if ! [[ "$HARDWARE_ARCH" = aarch64 && -z "$CPP_CROSS_COMPILE" ]] ; then
     ${REPO_ROOT}/dev-tools/docker/docker_entrypoint.sh
   fi
 else
-  if [[ `uname` = "Darwin" && "$HARDWARE_ARCH" = "aarch64" ]]; then
+  if [[ `uname` = "Darwin" ]]; then
      # For macOS, build directly on the machine
      sudo -E ${REPO_ROOT}/dev-tools/download_macos_deps.sh
      if [ "$RUN_TESTS" = false ] ; then

--- a/.buildkite/scripts/steps/build_and_test.sh
+++ b/.buildkite/scripts/steps/build_and_test.sh
@@ -80,7 +80,7 @@ if [[ `uname` = "Linux" ]]; then
     fi
   fi
 else
-  #sudo -E ${REPO_ROOT}/dev-tools/download_macos_deps.sh
+  sudo -E ${REPO_ROOT}/dev-tools/download_macos_deps.sh
   if [[ "$HARDWARE_ARCH" = aarch64 ]] ; then
     # For macOS aarch64, build directly on the machine using gradle
     if [ "$RUN_TESTS" = false ] ; then

--- a/.ci/orka/README.md
+++ b/.ci/orka/README.md
@@ -19,6 +19,10 @@ If you haven't run these before, run the following once so packer downloads the 
 ```
 packer init orka-macos-12-arm.pkr.hcl
 ```
+or
+```
+packer init orka-macos-12-x86_64.pkr.hcl
+```
 
 ## Build
 
@@ -38,9 +42,11 @@ The name of the resulting images are hard-coded (currently), and end in a sequen
 
 ## Source Images
 
-The source image used for the MacOS 12 ARM build is a slightly modified copy of the standard Orka image 90GBMontereySSH.orkasi:
+The source images used for the MacOS builds are slightly modified copies of the standard Orka images, e.g. 90GBMontereySSH.orkasi:
 
-The source image is named `ml-macos-12-base-arm-fundamental.orkasi`
+The source images are named:
+ * `ml-macos-12-base-arm-fundamental.orkasi`
+ * `ml-macos-12-base-x86_64-fundamental.img`
 
 The source image only has the following changes on it:
     * Adding passwordless `sudo` for the default `admin` user
@@ -64,4 +70,7 @@ The packer script does the following:
 
 ## Caveats
 
-* At the moment we only need Orka for ARM builds (CI and dependencies).
+* Prior to the dependency on PyTorch 2.3.1 we only needed Orka for ARM builds (CI and dependencies), x86_64 builds were
+  performed via cross-compilation. However, PyTorch 2.3.1 now requires a more modern version of `clang` that our cross
+  compilation framework provided. As a suitable Orka base image is available for x86_64, it is now simpler to compile
+  natively for that architecture.

--- a/.ci/orka/orka-macos-12-x86_64.pkr.hcl
+++ b/.ci/orka/orka-macos-12-x86_64.pkr.hcl
@@ -1,0 +1,53 @@
+packer {
+  required_plugins {
+    macstadium-orka = {
+      version = "= 2.3.0"
+      source  = "github.com/macstadium/macstadium-orka"
+    }
+  }
+}
+
+locals {
+  orka_endpoint = vault("secret/ci/elastic-ml-cpp/orka", "orka_endpoint")
+  orka_user     = vault("secret/ci/elastic-ml-cpp/orka", "orka_user")
+  orka_password = vault("secret/ci/elastic-ml-cpp/orka", "orka_password")
+  ssh_username  = vault("secret/ci/elastic-ml-cpp/orka", "ssh_username")
+  ssh_password  = vault("secret/ci/elastic-ml-cpp/orka", "ssh_password")
+  sensitive     = true
+}
+
+source "macstadium-orka" "image" {
+  source_image     = "ml-macos-12-base-x86_64-fundamental.img"
+  image_name       = "ml-macos-12-x86_64-001.img"
+  orka_endpoint    = local.orka_endpoint
+  orka_user        = local.orka_user
+  orka_password    = local.orka_password
+  ssh_username     = local.ssh_username
+  ssh_password     = local.ssh_password
+  orka_vm_cpu_core = 4
+  no_delete_vm     = false
+}
+
+build {
+  sources = [
+    "macstadium-orka.image"
+  ]
+  provisioner "file" {
+    source = "install.sh"
+    destination = "/tmp/install.sh"
+  }
+  provisioner "file" {
+    source = "gobld-bootstrap.sh"
+    destination = "/tmp/gobld-bootstrap.sh"
+  }
+  provisioner "file" {
+    source = "gobld-bootstrap.plist"
+    destination = "/tmp/gobld-bootstrap.plist"
+  }
+  provisioner "shell" {
+    inline = [
+      "chmod u+x /tmp/install.sh",
+      "/tmp/install.sh",
+    ]
+  }
+}

--- a/3rd_party/licenses/pytorch-INFO.csv
+++ b/3rd_party/licenses/pytorch-INFO.csv
@@ -1,2 +1,2 @@
 name,version,revision,url,license,copyright,sourceURL
-PyTorch,2.1.2,a8e7c98cb95ff97bb30a728c6b2a1ce6bff946eb,https://pytorch.org,BSD-3-Clause,,
+PyTorch,2.3.1,63d5e9221bedd1546b7d364b5ce4171547db12a9,https://pytorch.org,BSD-3-Clause,,

--- a/build-setup/linux.md
+++ b/build-setup/linux.md
@@ -51,7 +51,7 @@ These environment variables only need to be set when building tools on Linux. Th
 
 ### gcc
 
-We have to build on old Linux versions to enable our software to run on the older versions of Linux that users have.  However, this means the default compiler on our Linux build servers is also very old.  To enable use of more modern C++ features, we use the default compiler to build a newer version of gcc and then use that to build all our other dependencies.
+We have to build on old Linux versions to enable our software to run on the older versions of Linux that users have
 
 Download `gcc-10.3.0.tar.gz` from <http://ftpmirror.gnu.org/gcc/gcc-10.3.0/gcc-10.3.0.tar.gz>.
 
@@ -332,7 +332,7 @@ Then copy the shared libraries to the system directory:
 (cd /opt/intel/oneapi/mkl/2024.0 && tar cf - lib) | (cd /usr/local/gcc103 && sudo tar xvf -)
 ```
 
-### PyTorch 2.1.2
+### PyTorch 2.3.1
 
 (This step requires a reasonable amount of memory. It failed on a machine with 8GB of RAM. It succeeded on a 16GB machine. You can specify the number of parallel jobs using environment variable MAX_JOBS. Lower number of jobs will reduce memory usage.)
 
@@ -351,7 +351,7 @@ sudo /usr/local/gcc103/bin/python3.10 -m pip install install numpy pyyaml setupt
 Then obtain the PyTorch code:
 
 ```
-git clone --depth=1 --branch=v2.1.2 git@github.com:pytorch/pytorch.git
+git clone --depth=1 --branch=v2.3.1 git@github.com:pytorch/pytorch.git
 cd pytorch
 git submodule sync
 git submodule update --init --recursive
@@ -379,7 +379,7 @@ export USE_MKLDNN=ON
 export USE_QNNPACK=OFF
 export USE_PYTORCH_QNNPACK=OFF
 [ $(uname -m) = x86_64 ] && export USE_XNNPACK=OFF
-export PYTORCH_BUILD_VERSION=2.1.2
+export PYTORCH_BUILD_VERSION=2.3.1
 export PYTORCH_BUILD_NUMBER=1
 /usr/local/gcc103/bin/python3.10 setup.py install
 ```

--- a/build-setup/linux.md
+++ b/build-setup/linux.md
@@ -51,7 +51,7 @@ These environment variables only need to be set when building tools on Linux. Th
 
 ### gcc
 
-We have to build on old Linux versions to enable our software to run on the older versions of Linux that users have
+We have to build on old Linux versions to enable our software to run on the older versions of Linux that users have. However, this means the default compiler on our Linux build servers is also very old. To enable use of more modern C++ features, we use the default compiler to build a newer version of gcc and then use that to build all our other dependencies.
 
 Download `gcc-10.3.0.tar.gz` from <http://ftpmirror.gnu.org/gcc/gcc-10.3.0/gcc-10.3.0.tar.gz>.
 

--- a/build-setup/windows.md
+++ b/build-setup/windows.md
@@ -193,7 +193,7 @@ On the "Advanced Options" screen, check "Install for all users" and "Add Python 
 
 For the time being, do not take advantage of the option on the final installer screen to reconfigure the machine to allow paths longer than 260 characters.  We still support Windows versions that do not have this option.
 
-### PyTorch 2.1.2
+### PyTorch 2.3.1
 
 (This step requires a lot of memory. It failed on a machine with 12GB of RAM. It just about fitted on a 20GB machine. 32GB RAM is recommended.)
 
@@ -209,7 +209,7 @@ Next, in a Git bash shell run:
 
 ```
 cd /c/tools
-git clone --depth=1 --branch=v2.1.2 https://github.com/pytorch/pytorch.git
+git clone --depth=1 --branch=v2.3.1 https://github.com/pytorch/pytorch.git
 cd pytorch
 git submodule sync
 git submodule update --init --recursive
@@ -265,7 +265,7 @@ set USE_QNNPACK=OFF
 set USE_PYTORCH_QNNPACK=OFF
 set USE_XNNPACK=OFF
 set MSVC_Z7_OVERRIDE=OFF
-set PYTORCH_BUILD_VERSION=2.1.2
+set PYTORCH_BUILD_VERSION=2.3.1
 set PYTORCH_BUILD_NUMBER=1
 python setup.py install
 ```

--- a/dev-tools/docker/build_linux_aarch64_cross_build_image.sh
+++ b/dev-tools/docker/build_linux_aarch64_cross_build_image.sh
@@ -22,7 +22,7 @@
 HOST=docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-linux-aarch64-cross-build
-VERSION=12
+VERSION=13
 
 set -e
 

--- a/dev-tools/docker/build_linux_aarch64_native_build_image.sh
+++ b/dev-tools/docker/build_linux_aarch64_native_build_image.sh
@@ -34,7 +34,7 @@ sleep 5
 HOST=docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-linux-aarch64-native-build
-VERSION=12
+VERSION=13
 
 set -e
 

--- a/dev-tools/docker/build_linux_build_image.sh
+++ b/dev-tools/docker/build_linux_build_image.sh
@@ -34,7 +34,7 @@ sleep 5
 HOST=docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-linux-build
-VERSION=29
+VERSION=30
 
 set -e
 

--- a/dev-tools/docker/build_macosx_build_image.sh
+++ b/dev-tools/docker/build_macosx_build_image.sh
@@ -22,7 +22,7 @@
 HOST=docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-macosx-build
-VERSION=18
+VERSION=19
 
 set -e
 

--- a/dev-tools/docker/linux_aarch64_cross_builder/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_cross_builder/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-aarch64-cross-build:12
+FROM docker.elastic.co/ml-dev/ml-linux-aarch64-cross-build:13
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_aarch64_cross_image/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_cross_image/Dockerfile
@@ -17,6 +17,9 @@ MAINTAINER David Roberts <dave.roberts@elastic.co>
 
 # Make sure OS packages are up to date and required packages are installed
 RUN \
+  sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+  sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+  yum repolist enabled && \
   rm /var/lib/rpm/__db.* && \
   yum install -y bzip2 gcc gcc-c++ git make texinfo unzip wget which zip zlib-devel
 

--- a/dev-tools/docker/linux_aarch64_cross_image/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_cross_image/Dockerfile
@@ -24,7 +24,7 @@ RUN \
 RUN \
   mkdir -p /usr/local/sysroot-aarch64-linux-gnu/usr && \
   cd /usr/local/sysroot-aarch64-linux-gnu/usr && \
-  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/usr-aarch64-linux-gnu-12.tar.bz2 | tar jxf - && \
+  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/usr-aarch64-linux-gnu-13.tar.bz2 | tar jxf - && \
   cd .. && \
   ln -s usr/lib lib && \
   ln -s usr/lib64 lib64

--- a/dev-tools/docker/linux_aarch64_native_builder/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_builder/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-aarch64-native-build:12
+FROM docker.elastic.co/ml-dev/ml-linux-aarch64-native-build:13
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_aarch64_native_image/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_image/Dockerfile
@@ -138,7 +138,7 @@ RUN \
 # If the PyTorch branch is changed also update PYTORCH_BUILD_VERSION
 RUN \
   cd ${build_dir} && \
-  git -c advice.detachedHead=false clone --depth=1 --branch=v2.1.2 https://github.com/pytorch/pytorch.git && \
+  git -c advice.detachedHead=false clone --depth=1 --branch=v2.3.1 https://github.com/pytorch/pytorch.git && \
   cd pytorch && \
   git submodule sync && \
   git submodule update --init --recursive && \
@@ -151,7 +151,7 @@ RUN \
   export USE_MKLDNN=ON && \
   export USE_QNNPACK=OFF && \
   export USE_PYTORCH_QNNPACK=OFF && \
-  export PYTORCH_BUILD_VERSION=2.1.2 && \
+  export PYTORCH_BUILD_VERSION=2.3.1 && \
   export PYTORCH_BUILD_NUMBER=1 && \
   /usr/local/bin/python3.10 setup.py install && \
   mkdir /usr/local/gcc103/include/pytorch && \

--- a/dev-tools/docker/linux_aarch64_native_image/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_image/Dockerfile
@@ -18,6 +18,9 @@ MAINTAINER David Roberts <dave.roberts@elastic.co>
 # Make sure OS packages are up to date and required packages are installed
 # libffi is required for building Python
 RUN \
+  sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+  sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+  yum repolist enabled && \
   rm /var/lib/rpm/__db.* && \
   yum install -y bzip2 gcc gcc-c++ git libffi-devel make texinfo unzip wget which xz zip zlib-devel
 
@@ -164,5 +167,8 @@ RUN \
 FROM centos:7
 COPY --from=builder /usr/local/gcc103 /usr/local/gcc103
 RUN \
+  sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+  sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+  yum repolist enabled && \
   rm /var/lib/rpm/__db.* && \
   yum install -y bzip2 gcc git make unzip which zip zlib-devel

--- a/dev-tools/docker/linux_aarch64_native_tester/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_tester/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-aarch64-native-build:12
+FROM docker.elastic.co/ml-dev/ml-linux-aarch64-native-build:13
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_builder/Dockerfile
+++ b/dev-tools/docker/linux_builder/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-build:29
+FROM docker.elastic.co/ml-dev/ml-linux-build:30
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -18,6 +18,9 @@ MAINTAINER David Roberts <dave.roberts@elastic.co>
 # Make sure OS packages are up to date and required packages are installed
 # libffi is required for building Python
 RUN \
+  sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+  sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+  yum repolist enabled && \
   rm /var/lib/rpm/__db.* && \
   yum install -y bzip2 gcc gcc-c++ git libffi-devel make texinfo unzip wget which xz zip zlib-devel
 
@@ -179,5 +182,8 @@ RUN \
 FROM centos:7
 COPY --from=builder /usr/local/gcc103 /usr/local/gcc103
 RUN \
+  sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+  sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+  yum repolist enabled && \
   rm /var/lib/rpm/__db.* && \
   yum install -y bzip2 gcc git make unzip which zip zlib-devel

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -151,7 +151,7 @@ gpgkey=https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.
 # If the PyTorch branch is changed also update PYTORCH_BUILD_VERSION
 RUN \
   cd ${build_dir} && \
-  git -c advice.detachedHead=false clone --depth=1 --branch=v2.1.2 https://github.com/pytorch/pytorch.git && \
+  git -c advice.detachedHead=false clone --depth=1 --branch=v2.3.1 https://github.com/pytorch/pytorch.git && \
   cd pytorch && \
   git submodule sync && \
   git submodule update --init --recursive && \
@@ -165,7 +165,7 @@ RUN \
   export USE_QNNPACK=OFF && \
   export USE_PYTORCH_QNNPACK=OFF && \
   export USE_XNNPACK=OFF && \
-  export PYTORCH_BUILD_VERSION=2.1.2 && \
+  export PYTORCH_BUILD_VERSION=2.3.1 && \
   export PYTORCH_BUILD_NUMBER=1 && \
   export MAX_JOBS=10 && \
   /usr/local/bin/python3.10 setup.py install && \

--- a/dev-tools/docker/linux_tester/Dockerfile
+++ b/dev-tools/docker/linux_tester/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-linux-build:29
+FROM docker.elastic.co/ml-dev/ml-linux-build:30
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/macosx_builder/Dockerfile
+++ b/dev-tools/docker/macosx_builder/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # Increment the version here when a new tools/3rd party components image is built
-FROM docker.elastic.co/ml-dev/ml-macosx-build:18
+FROM docker.elastic.co/ml-dev/ml-macosx-build:19
 
 MAINTAINER David Roberts <dave.roberts@elastic.co>
 

--- a/dev-tools/docker/macosx_image/Dockerfile
+++ b/dev-tools/docker/macosx_image/Dockerfile
@@ -31,7 +31,7 @@ RUN \
 RUN \
   mkdir -p /usr/local/sysroot-x86_64-apple-macosx10.14/usr && \
   cd /usr/local/sysroot-x86_64-apple-macosx10.14/usr && \
-  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/usr-x86_64-apple-macosx10.14-9.tar.bz2 | tar jxf - && \
+  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/usr-x86_64-apple-macosx10.14-10.tar.bz2 | tar jxf - && \
   wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/xcode-x86_64-apple-macosx10.14-1.tar.bz2 | tar jxf - && \
   wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/sdk-x86_64-apple-macosx10.14-1.tar.bz2 | tar jxf -
 

--- a/dev-tools/download_macos_deps.sh
+++ b/dev-tools/download_macos_deps.sh
@@ -25,7 +25,7 @@ DEST=/usr
 case `uname -m` in
 
     arm64)
-        ARCHIVE=local-arm64-apple-macosx11.1-9.tar.bz2
+        ARCHIVE=local-arm64-apple-macosx11.1-10.tar.bz2
         ;;
 
     *)

--- a/dev-tools/download_macos_deps.sh
+++ b/dev-tools/download_macos_deps.sh
@@ -24,6 +24,9 @@ DEST=/usr
 
 case `uname -m` in
 
+    x86_64)
+        ARCHIVE=local-x86_64-apple-macosx12.0-1.tar.bz2
+        ;;
     arm64)
         ARCHIVE=local-arm64-apple-macosx11.1-10.tar.bz2
         ;;

--- a/dev-tools/download_windows_deps.ps1
+++ b/dev-tools/download_windows_deps.ps1
@@ -9,11 +9,11 @@
 # limitation.
 #
 $ErrorActionPreference="Stop"
-$Archive="usr-x86_64-windows-2016-12.zip"
+$Archive="usr-x86_64-windows-2016-13.zip"
 $Destination="C:\"
-# If PyTorch is not version 2.1.2 then we need the latest download
+# If PyTorch is not version 2.3.1 then we need the latest download
 if (!(Test-Path "$Destination\usr\local\include\pytorch\torch\csrc\api\include\torch\version.h") -Or
-    !(Select-String -Path "$Destination\usr\local\include\pytorch\torch\csrc\api\include\torch\version.h" -Pattern "2.1.2" -Quiet)) {
+    !(Select-String -Path "$Destination\usr\local\include\pytorch\torch\csrc\api\include\torch\version.h" -Pattern "2.3.1" -Quiet)) {
     Remove-Item "$Destination\usr" -Recurse -Force -ErrorAction Ignore
     $ZipSource="https://storage.googleapis.com/elastic-ml-public/dependencies/$Archive"
     $ZipDestination="$Env:TEMP\$Archive"

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -30,7 +30,7 @@
 
 == {es} version 8.16.0
 
-* Upgrade Pytorch to version 2.3.1. (See {ml-pull}2688[#2688].)
+* Update the Pytorch library to version 2.3.1. (See {ml-pull}2688[#2688].)
 
 == {es} version 8.15.0
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,10 @@
 
 //=== Regressions
 
+== {es} version 8.16.0
+
+* Upgrade Pytorch to version 2.3.1. (See {ml-pull}2688[#2688].)
+
 == {es} version 8.15.0
 
 === Bug Fixes


### PR DESCRIPTION
Update Docker images and dependency files with PyTorch 2.3.1.

Testing on Linux x86_64 gives promising indications that this version of
PyTorch may resolve some memory allocation issues related to the
`pytorch_inference` process.

Opening this PR to better test it across the range of platforms and
architectures that we support.