### PR TITLE
[ML] Fix the regex used to trigger PR builds with flexible configuration

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -9,7 +9,7 @@
       "commit_status_context": "ml-cpp-ci",
       "build_on_commit": true,
       "build_on_comment": true,
-      "trigger_comment_regex": "/^(?:(?:buildkite +)(?<action>build|debug|run_qa_tests|run_pytorch_tests) *(?: *on *(?<platform>(?:[ ,]*(?:windows|linux|mac(os)?))+))?) *(?<arch>(?:[ ,]*aarch64|x86_64)+)?$/gm",
+      "trigger_comment_regex": "^(?:(?:buildkite +)(?<action>build|debug|run_qa_tests|run_pytorch_tests) *(?: *on *(?<platform>(?:[ ,]*(?:windows|linux|mac(os)?))+))?) *(?<arch>(?:[ ,]*aarch64|x86_64)+)?$",
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "skip_ci_labels": ["skip-ci", "jenkins-ci", ">test-mute", ">docs"],
       "skip_target_branches": ["6.8", "7.11", "7.12"],


### PR DESCRIPTION
Fix the `trigger_comment_regex` regular expression that is used to provide a high degree of flexibility when triggering PR builds. 

See https://github.com/elastic/buildkite-pr-bot/blob/c229bf261668611aa11d47455fd980cc0eb86002/README.md for more info.
