### PR TITLE
[ML] Productionize the PyTorch Docker build

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -24,6 +24,6 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == ml-cpp* ]]; then
   else [[ "$BUILDKITE_STEP_KEY" == "build_test_Windows-x86_64-RelWithDebInfo" ]]
     export BUILDKITE_ANALYTICS_TOKEN=$(vault read secret/ci/elastic-ml-cpp/buildkite/test_analytics/windows_x86_64 | awk '/^token/ {print $2;}')
   fi
-  export DOCKER_REGISTRY_USERNAME="$(vault-ci read -field=username secret/ci/elastic-ml-cpp/prod_docker_registry_credentials)"
-  export DOCKER_REGISTRY_PASSWORD="$(vault-ci read -field=password secret/ci/elastic-ml-cpp/prod_docker_registry_credentials)"
+  export DOCKER_REGISTRY_USERNAME="$(vault read -field=username secret/ci/elastic-ml-cpp/prod_docker_registry_credentials)"
+  export DOCKER_REGISTRY_PASSWORD="$(vault read -field=password secret/ci/elastic-ml-cpp/prod_docker_registry_credentials)"
 fi

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -24,6 +24,10 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == ml-cpp* ]]; then
   else [[ "$BUILDKITE_STEP_KEY" == "build_test_Windows-x86_64-RelWithDebInfo" ]]
     export BUILDKITE_ANALYTICS_TOKEN=$(vault read secret/ci/elastic-ml-cpp/buildkite/test_analytics/windows_x86_64 | awk '/^token/ {print $2;}')
   fi
-  export DOCKER_REGISTRY_USERNAME="$(vault read -field=username secret/ci/elastic-ml-cpp/prod_docker_registry_credentials)"
-  export DOCKER_REGISTRY_PASSWORD="$(vault read -field=password secret/ci/elastic-ml-cpp/prod_docker_registry_credentials)"
+
+  if [[ "$BUILDKITE_STEP_KEY" == "build_pytorch_docker_image" ]]; then
+    DOCKER_CREDS="$(vault read secret/ci/elastic-ml-cpp/prod_docker_registry_credentials)"
+    export DOCKER_REGISTRY_USERNAME=$(echo $DOCKER_CREDS | awk '/^username/ {print $2}')
+    export DOCKER_REGISTRY_PASSWORD=$(echo $DOCKER_CREDS | awk '/^password/ {print $2}')
+  fi
 fi

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -24,4 +24,6 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == ml-cpp* ]]; then
   else [[ "$BUILDKITE_STEP_KEY" == "build_test_Windows-x86_64-RelWithDebInfo" ]]
     export BUILDKITE_ANALYTICS_TOKEN=$(vault read secret/ci/elastic-ml-cpp/buildkite/test_analytics/windows_x86_64 | awk '/^token/ {print $2;}')
   fi
+  export DOCKER_REGISTRY_USERNAME="$(vault-ci read -field=username secret/ci/elastic-ml-cpp/prod_docker_registry_credentials)"
+  export DOCKER_REGISTRY_PASSWORD="$(vault-ci read -field=password secret/ci/elastic-ml-cpp/prod_docker_registry_credentials)"
 fi

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -25,7 +25,8 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == ml-cpp* ]]; then
     export BUILDKITE_ANALYTICS_TOKEN=$(vault read secret/ci/elastic-ml-cpp/buildkite/test_analytics/windows_x86_64 | awk '/^token/ {print $2;}')
   fi
 
-  DOCKER_CREDS="$(vault read secret/ci/elastic-ml-cpp/prod_docker_registry_credentials)"
-  export DOCKER_REGISTRY_USERNAME=$(echo $DOCKER_CREDS | awk '/^username/ {print $2}')
-  export DOCKER_REGISTRY_PASSWORD=$(echo $DOCKER_CREDS | awk '/^password/ {print $2}')
+  if [[ "$BUILDKITE_STEP_KEY" == "build_pytorch_docker_image" ]]; then
+    export DOCKER_REGISTRY_USERNAME=$(vault read --field=username  secret/ci/elastic-ml-cpp/prod_docker_registry_credentials)
+    export DOCKER_REGISTRY_PASSWORD=$(vault read --field=password  secret/ci/elastic-ml-cpp/prod_docker_registry_credentials)
+  fi
 fi

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -25,9 +25,7 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == ml-cpp* ]]; then
     export BUILDKITE_ANALYTICS_TOKEN=$(vault read secret/ci/elastic-ml-cpp/buildkite/test_analytics/windows_x86_64 | awk '/^token/ {print $2;}')
   fi
 
-  if [[ "$BUILDKITE_STEP_KEY" == "build_pytorch_docker_image" ]]; then
-    DOCKER_CREDS="$(vault read secret/ci/elastic-ml-cpp/prod_docker_registry_credentials)"
-    export DOCKER_REGISTRY_USERNAME=$(echo $DOCKER_CREDS | awk '/^username/ {print $2}')
-    export DOCKER_REGISTRY_PASSWORD=$(echo $DOCKER_CREDS | awk '/^password/ {print $2}')
-  fi
+  DOCKER_CREDS="$(vault read secret/ci/elastic-ml-cpp/prod_docker_registry_credentials)"
+  export DOCKER_REGISTRY_USERNAME=$(echo $DOCKER_CREDS | awk '/^username/ {print $2}')
+  export DOCKER_REGISTRY_PASSWORD=$(echo $DOCKER_CREDS | awk '/^password/ {print $2}')
 fi

--- a/.buildkite/pipeline.json.py
+++ b/.buildkite/pipeline.json.py
@@ -48,16 +48,18 @@ def main():
     if config.build_linux:
         build_linux = pipeline_steps.generate_step_template("Linux", config.action, config.build_aarch64, config.build_x86_64)
         pipeline_steps.append(build_linux)
-    pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests x86_64 runner pipeline",
-                                                       ".buildkite/pipelines/run_es_tests_x86_64.yml.sh"))
-    pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests aarch64 runner pipeline",
-                                                       ".buildkite/pipelines/run_es_tests_aarch64.yml.sh"))
-    if config.run_qa_tests:
-        pipeline_steps.append(pipeline_steps.generate_step("Upload QA tests runner pipeline",
-                                                           ".buildkite/pipelines/run_qa_tests.yml.sh"))
+
     if config.run_pytorch_tests:
         pipeline_steps.append(pipeline_steps.generate_step("Upload QA PyTorch tests runner pipeline",
                                                            ".buildkite/pipelines/run_pytorch_tests.yml.sh"))
+    else:
+        pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests x86_64 runner pipeline",
+                                                           ".buildkite/pipelines/run_es_tests_x86_64.yml.sh"))
+        pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests aarch64 runner pipeline",
+                                                           ".buildkite/pipelines/run_es_tests_aarch64.yml.sh"))
+    if config.run_qa_tests:
+        pipeline_steps.append(pipeline_steps.generate_step("Upload QA tests runner pipeline",
+                                                           ".buildkite/pipelines/run_qa_tests.yml.sh"))
     pipeline["env"] = env
     pipeline["steps"] = pipeline_steps
     print(json.dumps(pipeline, indent=2))

--- a/.buildkite/pipeline.json.py
+++ b/.buildkite/pipeline.json.py
@@ -49,17 +49,20 @@ def main():
         build_linux = pipeline_steps.generate_step_template("Linux", config.action, config.build_aarch64, config.build_x86_64)
         pipeline_steps.append(build_linux)
 
-    if config.run_pytorch_tests:
-        pipeline_steps.append(pipeline_steps.generate_step("Upload QA PyTorch tests runner pipeline",
-                                                           ".buildkite/pipelines/run_pytorch_tests.yml.sh"))
-    else:
-        pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests x86_64 runner pipeline",
-                                                           ".buildkite/pipelines/run_es_tests_x86_64.yml.sh"))
-        pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests aarch64 runner pipeline",
-                                                           ".buildkite/pipelines/run_es_tests_aarch64.yml.sh"))
-    if config.run_qa_tests:
-        pipeline_steps.append(pipeline_steps.generate_step("Upload QA tests runner pipeline",
-                                                           ".buildkite/pipelines/run_qa_tests.yml.sh"))
+        if config.build_x86_64:
+            pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests x86_64 runner pipeline",
+                                                               ".buildkite/pipelines/run_es_tests_x86_64.yml.sh"))
+            # We only use linux x86_64 builds for QA tests.
+            if config.run_qa_tests:
+                pipeline_steps.append(pipeline_steps.generate_step("Upload QA tests runner pipeline",
+                                                                   ".buildkite/pipelines/run_qa_tests.yml.sh"))
+            if config.run_pytorch_tests:
+                pipeline_steps.append(pipeline_steps.generate_step("Upload QA PyTorch tests runner pipeline",
+                                                                   ".buildkite/pipelines/run_pytorch_tests.yml.sh"))
+        if config.build_aarch64:
+            pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests aarch64 runner pipeline",
+                                                               ".buildkite/pipelines/run_es_tests_aarch64.yml.sh"))
+
     pipeline["env"] = env
     pipeline["steps"] = pipeline_steps
     print(json.dumps(pipeline, indent=2))

--- a/.buildkite/pipelines/build_pytorch_docker_image.yml.sh
+++ b/.buildkite/pipelines/build_pytorch_docker_image.yml.sh
@@ -25,7 +25,7 @@ steps:
     build:
       message: "${BUILDKITE_MESSAGE}"
       env:
-        DOCKER_IMAGE: "docker.elastic.co/ml-dev/ml-linux-dependency-build:pytorch_viable_strict"
+        DOCKER_IMAGE: "docker.elastic.co/ml-dev/ml-linux-dependency-build:pytorch_latest"
         GITHUB_PR_COMMENT_VAR_PLATFORM: "linux"
         GITHUB_PR_COMMENT_VAR_ARCH: "x86_64"
         GITHUB_PR_COMMENT_VAR_ACTION: "run_pytorch_tests"

--- a/.buildkite/pipelines/build_pytorch_docker_image.yml.sh
+++ b/.buildkite/pipelines/build_pytorch_docker_image.yml.sh
@@ -14,7 +14,7 @@ steps:
     key: "build_pytorch_docker_image"
     command: "./dev-tools/docker/build_pytorch_linux_build_image.sh"
     agents:
-      "provider": "gcp",
+      "provider": "gcp"
       "machineType": "c2-standard-16"
     notify:
       - github_commit_status:

--- a/.buildkite/pipelines/build_pytorch_docker_image.yml.sh
+++ b/.buildkite/pipelines/build_pytorch_docker_image.yml.sh
@@ -13,8 +13,7 @@ cat <<EOL
 steps:
   - label: "Build PyTorch Docker Image"
     key: "build_pytorch_docker_image"
-    # command: "./dev-tools/docker/build_pytorch_linux_build_image.sh"
-    command: true
+    command: "./dev-tools/docker/build_pytorch_linux_build_image.sh"
     agents:
       "provider": "gcp"
       "machineType": "c2-standard-16"

--- a/.buildkite/pipelines/build_pytorch_docker_image.yml.sh
+++ b/.buildkite/pipelines/build_pytorch_docker_image.yml.sh
@@ -28,9 +28,8 @@ steps:
       branch: "${BUILDKITE_BRANCH}"
       commit: "${BUILDKITE_COMMIT}"
       message: "${BUILDKITE_MESSAGE}"
-      env: >
-        DOCKER_IMAGE:
-          "docker.elastic.co/ml-dev/ml-linux-dependency-build:pytorch_latest"
+      env:
+        DOCKER_IMAGE: "docker.elastic.co/ml-dev/ml-linux-dependency-build:pytorch_latest"
         GITHUB_PR_COMMENT_VAR_PLATFORM: "linux"
         GITHUB_PR_COMMENT_VAR_ARCH: "x86_64"
         GITHUB_PR_COMMENT_VAR_ACTION: "run_pytorch_tests"

--- a/.buildkite/pipelines/build_pytorch_docker_image.yml.sh
+++ b/.buildkite/pipelines/build_pytorch_docker_image.yml.sh
@@ -14,7 +14,8 @@ steps:
     key: "build_pytorch_docker_image"
     command: "./dev-tools/docker/build_pytorch_linux_build_image.sh"
     agents:
-      "provider": "gcp"
+      "provider": "gcp",
+      "machineType": "c2-standard-16"
     notify:
       - github_commit_status:
           context: "Build PyTorch Docker image"

--- a/.buildkite/pipelines/build_pytorch_docker_image.yml.sh
+++ b/.buildkite/pipelines/build_pytorch_docker_image.yml.sh
@@ -9,10 +9,12 @@
 # limitation.
 
 cat <<EOL
+---
 steps:
   - label: "Build PyTorch Docker Image"
     key: "build_pytorch_docker_image"
-    command: "./dev-tools/docker/build_pytorch_linux_build_image.sh"
+    # command: "./dev-tools/docker/build_pytorch_linux_build_image.sh"
+    command: true
     agents:
       "provider": "gcp"
       "machineType": "c2-standard-16"
@@ -23,9 +25,12 @@ steps:
   - trigger: ml-cpp-pr-builds
     async: false
     build:
+      branch: "${BUILDKITE_BRANCH}"
+      commit: "${BUILDKITE_COMMIT}"
       message: "${BUILDKITE_MESSAGE}"
-      env:
-        DOCKER_IMAGE: "docker.elastic.co/ml-dev/ml-linux-dependency-build:pytorch_latest"
+      env: >
+        DOCKER_IMAGE:
+          "docker.elastic.co/ml-dev/ml-linux-dependency-build:pytorch_latest"
         GITHUB_PR_COMMENT_VAR_PLATFORM: "linux"
         GITHUB_PR_COMMENT_VAR_ARCH: "x86_64"
         GITHUB_PR_COMMENT_VAR_ACTION: "run_pytorch_tests"

--- a/.buildkite/pipelines/run_pytorch_tests.yml.sh
+++ b/.buildkite/pipelines/run_pytorch_tests.yml.sh
@@ -13,13 +13,14 @@ steps:
   - label: "Trigger Appex PyTorch Tests :test_tube:"
     command:
       - echo 'Trigger PyTorch Tests'
+      - echo 'Using appex-qa-stateful-custom-ml-cpp-build-testing as a placeholder pipeline'
       - 'buildkite-agent artifact download "build/*" . --step build_test_linux-x86_64-RelWithDebInfo'
     depends_on: "build_test_linux-x86_64-RelWithDebInfo"
     notify:
       -  github_commit_status:
            context: "Trigger Appex QA PyTorch Tests"
   - wait
-  - trigger: TBD
+  - trigger: appex-qa-stateful-custom-ml-cpp-build-testing
     async: false
     build:
       message: "${BUILDKITE_MESSAGE}"

--- a/dev-tools/docker/build_pytorch_linux_build_image.sh
+++ b/dev-tools/docker/build_pytorch_linux_build_image.sh
@@ -50,11 +50,8 @@ else
   echo "VERSION = $VERSION"
   docker build --progress=plain --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION $CONTEXT
 fi
-# Get a username and password for this by visiting
-# https://docker-auth.elastic.co and allowing it to authenticate against your
-# GitHub account
 
-echo "Disabling docker push until service account has been enabled"
-#docker login $HOST
-#docker push $HOST/$ACCOUNT/$REPOSITORY:$VERSION
-
+# We use a special machine user account to authenticate to docker.elastic.co from within our Buildkite pipelines
+echo "Pushing $HOST/$ACCOUNT/$REPOSITORY:$VERSION"
+echo "$DOCKER_REGISTRY_PASSWORD" | docker login -u "$DOCKER_REGISTRY_USERNAME" --password-stdin docker.elastic.co
+docker push $HOST/$ACCOUNT/$REPOSITORY:$VERSION

--- a/dev-tools/docker/build_pytorch_linux_build_image.sh
+++ b/dev-tools/docker/build_pytorch_linux_build_image.sh
@@ -42,16 +42,16 @@ cd `dirname $0`
 . ./prefetch_docker_image.sh
 CONTEXT=pytorch_linux_image
 prefetch_docker_base_image $CONTEXT/Dockerfile
-#if [ $# -gt 0 ]; then
-#  VERSION=pytorch_latest
-#  echo "VERSION = $VERSION"
-#  docker build --progress=plain --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION --build-arg pytorch_branch=viable/strict $CONTEXT
-#else
-#  echo "VERSION = $VERSION"
-#  docker build --progress=plain --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION $CONTEXT
-#fi
+if [ $# -gt 0 ]; then
+  VERSION=pytorch_latest
+  echo "VERSION = $VERSION"
+  docker build --progress=plain --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION --build-arg pytorch_branch=viable/strict $CONTEXT
+else
+  echo "VERSION = $VERSION"
+  docker build --progress=plain --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION $CONTEXT
+fi
 
 # We use a special machine user account to authenticate to docker.elastic.co from within our Buildkite pipelines
 echo "Pushing $HOST/$ACCOUNT/$REPOSITORY:$VERSION"
 echo "$DOCKER_REGISTRY_PASSWORD" | docker login -u "$DOCKER_REGISTRY_USERNAME" --password-stdin docker.elastic.co
-#docker push $HOST/$ACCOUNT/$REPOSITORY:$VERSION
+docker push $HOST/$ACCOUNT/$REPOSITORY:$VERSION

--- a/dev-tools/docker/build_pytorch_linux_build_image.sh
+++ b/dev-tools/docker/build_pytorch_linux_build_image.sh
@@ -42,16 +42,16 @@ cd `dirname $0`
 . ./prefetch_docker_image.sh
 CONTEXT=pytorch_linux_image
 prefetch_docker_base_image $CONTEXT/Dockerfile
-if [ $# -gt 0 ]; then
-  VERSION=pytorch_latest
-  echo "VERSION = $VERSION"
-  docker build --progress=plain --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION --build-arg pytorch_branch=viable/strict $CONTEXT
-else
-  echo "VERSION = $VERSION"
-  docker build --progress=plain --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION $CONTEXT
-fi
+#if [ $# -gt 0 ]; then
+#  VERSION=pytorch_latest
+#  echo "VERSION = $VERSION"
+#  docker build --progress=plain --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION --build-arg pytorch_branch=viable/strict $CONTEXT
+#else
+#  echo "VERSION = $VERSION"
+#  docker build --progress=plain --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION $CONTEXT
+#fi
 
 # We use a special machine user account to authenticate to docker.elastic.co from within our Buildkite pipelines
 echo "Pushing $HOST/$ACCOUNT/$REPOSITORY:$VERSION"
 echo "$DOCKER_REGISTRY_PASSWORD" | docker login -u "$DOCKER_REGISTRY_USERNAME" --password-stdin docker.elastic.co
-docker push $HOST/$ACCOUNT/$REPOSITORY:$VERSION
+#docker push $HOST/$ACCOUNT/$REPOSITORY:$VERSION

--- a/dev-tools/docker/build_pytorch_linux_build_image.sh
+++ b/dev-tools/docker/build_pytorch_linux_build_image.sh
@@ -45,10 +45,10 @@ prefetch_docker_base_image $CONTEXT/Dockerfile
 if [ $# -gt 0 ]; then
   VERSION=pytorch_latest
   echo "VERSION = $VERSION"
-  docker build --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION --build-arg pytorch_branch=viable/strict $CONTEXT
+  docker build --progress=plain --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION --build-arg pytorch_branch=viable/strict $CONTEXT
 else
   echo "VERSION = $VERSION"
-  docker build --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION $CONTEXT
+  docker build --progress=plain --no-cache -t $HOST/$ACCOUNT/$REPOSITORY:$VERSION $CONTEXT
 fi
 # Get a username and password for this by visiting
 # https://docker-auth.elastic.co and allowing it to authenticate against your


### PR DESCRIPTION
Tidy the PyTorch Docker build scripts and configuration, in order to:

* Enable full logging from the docker build process - to simplify investigation should something go wrong
* Read Docker credentials from Vault.
* Limit the scope during which the Docker credentials are in play.
* Push PyTorch Docker image to registry upon successful build.
* Simplify Buildkite pipeline steps so that the QA tests are only run upon success of `Linux x86_64 builds`
* Use a `c2-standard-16` GCP machine for the Docker build step - this greatly improves build times.
* Trigger the `appex-qa-stateful-custom-ml-cpp-build-testing ` pipeline after successfully building the `ml-cpp` code in the newly built PyTorch Docker image - This may be subject to change, but does serve the purpose of some QA testing on the `ml-cpp` code.