### PR TITLE
[ML] Refactor add annotation

### DIFF
--- a/include/model/CAnomalyDetectorModel.h
+++ b/include/model/CAnomalyDetectorModel.h
@@ -702,6 +702,10 @@ protected:
     //! or attributes to free memory resource.
     static maths::common::CModel* tinyModel();
 
+    virtual void addAnnotation(core_t::TTime,
+                               CAnnotation::EEvent type,
+                               const std::string& annotation) = 0;
+
 private:
     using TModelParamsCRef = std::reference_wrapper<const SModelParams>;
 

--- a/include/model/CAnomalyDetectorModel.h
+++ b/include/model/CAnomalyDetectorModel.h
@@ -702,6 +702,7 @@ protected:
     //! or attributes to free memory resource.
     static maths::common::CModel* tinyModel();
 
+    //! Add an annotation to the model.
     virtual void addAnnotation(core_t::TTime,
                                CAnnotation::EEvent type,
                                const std::string& annotation) = 0;

--- a/include/model/CCountingModel.h
+++ b/include/model/CCountingModel.h
@@ -242,10 +242,6 @@ protected:
     //! Get the non-estimated value of the the memory used by this model.
     std::size_t computeMemoryUsage() const override;
 
-    void addAnnotation(core_t::TTime time,
-                       CAnnotation::EEvent type,
-                       const std::string& annotation) override;
-
 private:
     //! Get the scheduled events that match at sampleTime.
     SModelParams::TStrDetectionRulePrVec checkScheduledEvents(core_t::TTime sampleTime) const;
@@ -286,6 +282,11 @@ private:
 
     //! Get the model memory usage estimator
     CMemoryUsageEstimator* memoryUsageEstimator() const override;
+
+    //! Add an annotation to the model.
+    void addAnnotation(core_t::TTime time,
+                       CAnnotation::EEvent type,
+                       const std::string& annotation) override;
 
 private:
     using TSizeUInt64Pr = std::pair<std::size_t, std::uint64_t>;

--- a/include/model/CCountingModel.h
+++ b/include/model/CCountingModel.h
@@ -12,6 +12,8 @@
 #ifndef INCLUDED_ml_model_CCountingModel_h
 #define INCLUDED_ml_model_CCountingModel_h
 
+#include <core/CoreTypes.h>
+
 #include <model/CAnomalyDetectorModel.h>
 
 #include <maths/common/CBasicStatistics.h>
@@ -239,6 +241,10 @@ protected:
 
     //! Get the non-estimated value of the the memory used by this model.
     std::size_t computeMemoryUsage() const override;
+
+    void addAnnotation(core_t::TTime time,
+                       CAnnotation::EEvent type,
+                       const std::string& annotation) override;
 
 private:
     //! Get the scheduled events that match at sampleTime.

--- a/include/model/CEventRateModel.h
+++ b/include/model/CEventRateModel.h
@@ -279,6 +279,11 @@ public:
     //! Get the annotations produced by this model.
     const TAnnotationVec& annotations() const override;
 
+protected:
+    void addAnnotation(core_t::TTime time,
+                       CAnnotation::EEvent type,
+                       const std::string& annotation) override;
+
 private:
     //! Get the start time of the current bucket.
     core_t::TTime currentBucketStartTime() const override;

--- a/include/model/CEventRateModel.h
+++ b/include/model/CEventRateModel.h
@@ -279,11 +279,6 @@ public:
     //! Get the annotations produced by this model.
     const TAnnotationVec& annotations() const override;
 
-protected:
-    void addAnnotation(core_t::TTime time,
-                       CAnnotation::EEvent type,
-                       const std::string& annotation) override;
-
 private:
     //! Get the start time of the current bucket.
     core_t::TTime currentBucketStartTime() const override;
@@ -326,6 +321,11 @@ private:
               bool interim,
               CProbabilityAndInfluenceCalculator::SCorrelateParams& params,
               TStrCRefDouble1VecDouble1VecPrPrVecVecVec& correlateInfluenceValues) const;
+
+    //! Add an annotation to the model.
+    void addAnnotation(core_t::TTime time,
+                       CAnnotation::EEvent type,
+                       const std::string& annotation) override;
 
 private:
     //! The statistics we maintain about the bucket.

--- a/include/model/CEventRatePopulationModel.h
+++ b/include/model/CEventRatePopulationModel.h
@@ -384,6 +384,11 @@ private:
     //! Get the model memory usage estimator
     CMemoryUsageEstimator* memoryUsageEstimator() const override;
 
+protected:
+    void addAnnotation(core_t::TTime time,
+                       CAnnotation::EEvent type,
+                       const std::string& annotation) override;
+
 private:
     //! The statistics we maintain about the bucket.
     SBucketStats m_CurrentBucketStats;

--- a/include/model/CEventRatePopulationModel.h
+++ b/include/model/CEventRatePopulationModel.h
@@ -384,7 +384,8 @@ private:
     //! Get the model memory usage estimator
     CMemoryUsageEstimator* memoryUsageEstimator() const override;
 
-protected:
+private:
+    //! Add an annotation to the model.
     void addAnnotation(core_t::TTime time,
                        CAnnotation::EEvent type,
                        const std::string& annotation) override;

--- a/include/model/CMetricModel.h
+++ b/include/model/CMetricModel.h
@@ -273,6 +273,11 @@ public:
     //! Get the annotations produced by this model.
     const TAnnotationVec& annotations() const override;
 
+protected:
+    void addAnnotation(core_t::TTime time,
+                       CAnnotation::EEvent type,
+                       const std::string& annotation) override;
+
 private:
     using TOptionalSample = std::optional<CSample>;
     using TTime2Vec = core::CSmallVector<core_t::TTime, 2>;

--- a/include/model/CMetricPopulationModel.h
+++ b/include/model/CMetricPopulationModel.h
@@ -298,7 +298,7 @@ public:
 
     //! Get the annotations produced by this model.
     const TAnnotationVec& annotations() const override;
-    
+
 protected:
     void addAnnotation(core_t::TTime time,
                        CAnnotation::EEvent type,

--- a/include/model/CMetricPopulationModel.h
+++ b/include/model/CMetricPopulationModel.h
@@ -298,6 +298,11 @@ public:
 
     //! Get the annotations produced by this model.
     const TAnnotationVec& annotations() const override;
+    
+protected:
+    void addAnnotation(core_t::TTime time,
+                       CAnnotation::EEvent type,
+                       const std::string& annotation) override;
 
 private:
     //! Initialize the feature models.

--- a/include/model/CMetricPopulationModel.h
+++ b/include/model/CMetricPopulationModel.h
@@ -299,11 +299,6 @@ public:
     //! Get the annotations produced by this model.
     const TAnnotationVec& annotations() const override;
 
-protected:
-    void addAnnotation(core_t::TTime time,
-                       CAnnotation::EEvent type,
-                       const std::string& annotation) override;
-
 private:
     //! Initialize the feature models.
     void initialize(const TFeatureMathsModelSPtrPrVec& newFeatureModels,
@@ -365,6 +360,11 @@ private:
 
     //! Get the model memory usage estimator
     CMemoryUsageEstimator* memoryUsageEstimator() const override;
+
+    //! Add an annotation to the model.
+    void addAnnotation(core_t::TTime time,
+                       CAnnotation::EEvent type,
+                       const std::string& annotation) override;
 
 private:
     //! The statistics we maintain about the bucket.

--- a/lib/model/CCountingModel.cc
+++ b/lib/model/CCountingModel.cc
@@ -14,8 +14,8 @@
 #include <core/CAllocationStrategy.h>
 #include <core/CLogger.h>
 #include <core/CMemoryDef.h>
-#include <core/CoreTypes.h>
 #include <core/CPersistUtils.h>
+#include <core/CoreTypes.h>
 
 #include <maths/common/CBasicStatisticsPersist.h>
 #include <maths/common/CChecksum.h>

--- a/lib/model/CCountingModel.cc
+++ b/lib/model/CCountingModel.cc
@@ -14,6 +14,7 @@
 #include <core/CAllocationStrategy.h>
 #include <core/CLogger.h>
 #include <core/CMemoryDef.h>
+#include <core/CoreTypes.h>
 #include <core/CPersistUtils.h>
 
 #include <maths/common/CBasicStatisticsPersist.h>
@@ -21,9 +22,11 @@
 #include <maths/common/COrderings.h>
 
 #include <model/CAnnotatedProbability.h>
+#include <model/CAnnotation.h>
 #include <model/CDataGatherer.h>
 #include <model/CInterimBucketCorrector.h>
 #include <model/CModelDetailsView.h>
+#include <model/CSearchKey.h>
 
 #include <boost/unordered_set.hpp>
 
@@ -437,6 +440,15 @@ std::string CCountingModel::printCurrentBucket() const {
 
 CMemoryUsageEstimator* CCountingModel::memoryUsageEstimator() const {
     return nullptr;
+}
+
+void CCountingModel::addAnnotation(core_t::TTime time,
+                                   CAnnotation::EEvent event,
+                                   const std::string& annotation) {
+    m_Annotations.emplace_back(time, event, annotation,
+                               this->dataGatherer().searchKey().detectorIndex(),
+                               EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+                               EMPTY_STRING, EMPTY_STRING, EMPTY_STRING);
 }
 }
 }

--- a/lib/model/CEventRateModel.cc
+++ b/lib/model/CEventRateModel.cc
@@ -802,6 +802,14 @@ void CEventRateModel::fill(model_t::EFeature feature,
     }
 }
 
+void CEventRateModel::addAnnotation(core_t::TTime time,
+                                    CAnnotation::EEvent type,
+                                    const std::string& annotation) {
+    m_CurrentBucketStats.s_Annotations.emplace_back(
+        time, type, annotation, this->dataGatherer().searchKey().detectorIndex(), EMPTY_STRING,
+        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING);
+}
+
 ////////// CEventRateModel::SBucketStats Implementation //////////
 
 CEventRateModel::SBucketStats::SBucketStats(core_t::TTime startTime)

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -1125,8 +1125,8 @@ bool CEventRatePopulationModel::fill(model_t::EFeature feature,
 }
 
 void CEventRatePopulationModel::addAnnotation(core_t::TTime time,
-                                 CAnnotation::EEvent type,
-                                 const std::string& annotation) {
+                                              CAnnotation::EEvent type,
+                                              const std::string& annotation) {
     m_CurrentBucketStats.s_Annotations.emplace_back(
         time, type, annotation, this->dataGatherer().searchKey().detectorIndex(), EMPTY_STRING,
         EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING);

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -1124,6 +1124,14 @@ bool CEventRatePopulationModel::fill(model_t::EFeature feature,
     return true;
 }
 
+void CEventRatePopulationModel::addAnnotation(core_t::TTime time,
+                                 CAnnotation::EEvent type,
+                                 const std::string& annotation) {
+    m_CurrentBucketStats.s_Annotations.emplace_back(
+        time, type, annotation, this->dataGatherer().searchKey().detectorIndex(), EMPTY_STRING,
+        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING);
+}
+
 ////////// CEventRatePopulationModel::SBucketStats Implementation //////////
 
 CEventRatePopulationModel::SBucketStats::SBucketStats(core_t::TTime startTime)

--- a/lib/model/CMetricModel.cc
+++ b/lib/model/CMetricModel.cc
@@ -760,6 +760,14 @@ void CMetricModel::fill(model_t::EFeature feature,
     }
 }
 
+void CMetricModel::addAnnotation(core_t::TTime time,
+                                 CAnnotation::EEvent type,
+                                 const std::string& annotation) {
+    m_CurrentBucketStats.s_Annotations.emplace_back(
+        time, type, annotation, this->dataGatherer().searchKey().detectorIndex(), EMPTY_STRING,
+        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING);
+}
+
 ////////// CMetricModel::SBucketStats Implementation //////////
 
 CMetricModel::SBucketStats::SBucketStats(core_t::TTime startTime)

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -1025,6 +1025,14 @@ bool CMetricPopulationModel::fill(model_t::EFeature feature,
     return true;
 }
 
+void CMetricPopulationModel::addAnnotation(core_t::TTime time,
+                                 CAnnotation::EEvent type,
+                                 const std::string& annotation) {
+    m_CurrentBucketStats.s_Annotations.emplace_back(
+        time, type, annotation, this->dataGatherer().searchKey().detectorIndex(), EMPTY_STRING,
+        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING);
+}
+
 ////////// CMetricPopulationModel::SBucketStats Implementation //////////
 
 CMetricPopulationModel::SBucketStats::SBucketStats(core_t::TTime startTime)

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -1026,8 +1026,8 @@ bool CMetricPopulationModel::fill(model_t::EFeature feature,
 }
 
 void CMetricPopulationModel::addAnnotation(core_t::TTime time,
-                                 CAnnotation::EEvent type,
-                                 const std::string& annotation) {
+                                           CAnnotation::EEvent type,
+                                           const std::string& annotation) {
     m_CurrentBucketStats.s_Annotations.emplace_back(
         time, type, annotation, this->dataGatherer().searchKey().detectorIndex(), EMPTY_STRING,
         EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING);

--- a/lib/model/unittest/Mocks.cc
+++ b/lib/model/unittest/Mocks.cc
@@ -205,6 +205,12 @@ void CMockModel::mockTimeSeriesModels(TMathsModelUPtrVec&& models) {
     m_Models = std::move(models);
 }
 
+void CMockModel::addAnnotation(core_t::TTime,
+                               CAnnotation::EEvent ,
+                               const std::string& ) {
+    // do nothing
+}
+
 CMemoryUsageEstimator* CMockModel::memoryUsageEstimator() const {
     return nullptr;
 }

--- a/lib/model/unittest/Mocks.cc
+++ b/lib/model/unittest/Mocks.cc
@@ -205,9 +205,7 @@ void CMockModel::mockTimeSeriesModels(TMathsModelUPtrVec&& models) {
     m_Models = std::move(models);
 }
 
-void CMockModel::addAnnotation(core_t::TTime,
-                               CAnnotation::EEvent ,
-                               const std::string& ) {
+void CMockModel::addAnnotation(core_t::TTime, CAnnotation::EEvent, const std::string&) {
     // do nothing
 }
 

--- a/lib/model/unittest/Mocks.h
+++ b/lib/model/unittest/Mocks.h
@@ -127,9 +127,6 @@ public:
 
     void mockTimeSeriesModels(TMathsModelUPtrVec&& model);
 
-protected:
-    void addAnnotation(core_t::TTime, CAnnotation::EEvent type, const std::string& annotation) override;
-
 private:
     using TDouble1Vec = CAnomalyDetectorModel::TDouble1Vec;
     using TSizeSizeTimeTriple = core::CTriple<std::size_t, std::size_t, core_t::TTime>;
@@ -146,6 +143,7 @@ private:
     const model::CInterimBucketCorrector& interimValueCorrector() const override;
     void doSkipSampling(core_t::TTime startTime, core_t::TTime endTime) override;
     CMemoryUsageEstimator* memoryUsageEstimator() const override;
+    void addAnnotation(core_t::TTime, CAnnotation::EEvent type, const std::string& annotation) override;
 
 private:
     bool m_IsPopulation;

--- a/lib/model/unittest/Mocks.h
+++ b/lib/model/unittest/Mocks.h
@@ -127,6 +127,9 @@ public:
 
     void mockTimeSeriesModels(TMathsModelUPtrVec&& model);
 
+protected:
+    void addAnnotation(core_t::TTime, CAnnotation::EEvent type, const std::string& annotation) override;
+
 private:
     using TDouble1Vec = CAnomalyDetectorModel::TDouble1Vec;
     using TSizeSizeTimeTriple = core::CTriple<std::size_t, std::size_t, core_t::TTime>;


### PR DESCRIPTION
This PR adds a simple protected interface to add annotations to the model. It is factored out of #2695 for a simpler review.

This functionality will be unit-tested in #2695, where the new `addAnnotation` function will be used.