### PR TITLE
[ML] Fixing force time shift logic

### DIFF
--- a/include/api/CDetectionRulesJsonParser.h
+++ b/include/api/CDetectionRulesJsonParser.h
@@ -11,7 +11,6 @@
 #ifndef INCLUDED_ml_api_CDetectionRulesJsonParser_h
 #define INCLUDED_ml_api_CDetectionRulesJsonParser_h
 
-#include <boost/json/object.hpp>
 #include <core/CLogger.h>
 #include <core/CPatternSet.h>
 

--- a/include/model/CDetectionRule.h
+++ b/include/model/CDetectionRule.h
@@ -12,6 +12,8 @@
 #ifndef INCLUDED_ml_model_CDetectionRule_h
 #define INCLUDED_ml_model_CDetectionRule_h
 
+#include <core/CoreTypes.h>
+
 #include <model/CRuleCondition.h>
 #include <model/CRuleScope.h>
 #include <model/ImportExport.h>
@@ -36,7 +38,7 @@ class MODEL_EXPORT CDetectionRule {
 
 public:
     using TRuleConditionVec = std::vector<CRuleCondition>;
-    using TCallback = std::function<void(CAnomalyDetectorModel&)>;
+    using TCallback = std::function<void(CAnomalyDetectorModel&, core_t::TTime)>;
 
     //! Rule actions can apply to skip results, skip model updates, evaluate callback
     //! function or several of the actions.

--- a/lib/model/CCountingModel.cc
+++ b/lib/model/CCountingModel.cc
@@ -376,7 +376,7 @@ void CCountingModel::shiftTime(core_t::TTime time, core_t::TTime shift) {
     // bucket corrector needs to be shifted.
     m_InterimBucketCorrector->shiftTime(time, shift);
     this->addAnnotation(time, CAnnotation::E_ModelChange,
-                        "Shifted time by " + std::to_string(shift) + " seconds");
+                        "Counting model shifted time by " + std::to_string(shift) + " seconds");
 }
 
 double CCountingModel::attributeFrequency(std::size_t /*cid*/) const {

--- a/lib/model/CDetectionRule.cc
+++ b/lib/model/CDetectionRule.cc
@@ -78,7 +78,8 @@ void CDetectionRule::executeCallback(CAnomalyDetectorModel& model, core_t::TTime
 }
 
 void CDetectionRule::addTimeShift(core_t::TTime timeShift) {
-    this->setCallback([ timeShift, timeShiftApplied = false ](CAnomalyDetectorModel & model, core_t::TTime time) mutable {
+    this->setCallback([ timeShift, timeShiftApplied = false ](
+        CAnomalyDetectorModel & model, core_t::TTime time) mutable {
         if (timeShiftApplied == false) {
             // When the callback is executed, the model is already in the correct time
             // interval. Hence, we need to shift the time right away.

--- a/lib/model/CDetectionRule.cc
+++ b/lib/model/CDetectionRule.cc
@@ -9,7 +9,7 @@
  * limitation.
  */
 
-#include <core/CTimeUtils.h>
+#include <core/CoreTypes.h>
 
 #include <model/CAnomalyDetectorModel.h>
 #include <model/CDetectionRule.h>
@@ -73,17 +73,16 @@ void CDetectionRule::executeCallback(CAnomalyDetectorModel& model, core_t::TTime
                 return;
             }
         }
-        m_Callback(model);
+        m_Callback(model, time);
     }
 }
 
 void CDetectionRule::addTimeShift(core_t::TTime timeShift) {
-    this->setCallback([ timeShift, timeShiftApplied = false ](CAnomalyDetectorModel & model) mutable {
+    this->setCallback([ timeShift, timeShiftApplied = false ](CAnomalyDetectorModel & model, core_t::TTime time) mutable {
         if (timeShiftApplied == false) {
             // When the callback is executed, the model is already in the correct time
             // interval. Hence, we need to shift the time right away.
-            core_t::TTime now = core::CTimeUtils::now();
-            model.shiftTime(now, timeShift);
+            model.shiftTime(time, timeShift);
             timeShiftApplied = true;
         }
     });

--- a/lib/model/CDetectionRule.cc
+++ b/lib/model/CDetectionRule.cc
@@ -9,8 +9,8 @@
  * limitation.
  */
 
-#include <core/CoreTypes.h>
 #include <core/CSmallVector.h>
+#include <core/CoreTypes.h>
 
 #include <model/CAnomalyDetectorModel.h>
 #include <model/CDetectionRule.h>

--- a/lib/model/CEventRatePopulationModel.cc
+++ b/lib/model/CEventRatePopulationModel.cc
@@ -1138,6 +1138,9 @@ void CEventRatePopulationModel::shiftTime(core_t::TTime time, core_t::TTime shif
             model->shiftTime(time, shift);
         }
     }
+
+    this->addAnnotation(time, CAnnotation::E_ModelChange,
+                        "Model shifted time by " + std::to_string(shift) + " seconds");
 }
 
 ////////// CEventRatePopulationModel::SBucketStats Implementation //////////

--- a/lib/model/CIndividualModel.cc
+++ b/lib/model/CIndividualModel.cc
@@ -651,7 +651,7 @@ void CIndividualModel::shiftTime(core_t::TTime time, core_t::TTime shift) {
         }
     }
     this->addAnnotation(time, CAnnotation::E_ModelChange,
-                        "Shifted time by " + std::to_string(shift) + " seconds");
+                        "Model shifted time by " + std::to_string(shift) + " seconds");
 }
 }
 }

--- a/lib/model/CMetricPopulationModel.cc
+++ b/lib/model/CMetricPopulationModel.cc
@@ -1040,7 +1040,7 @@ void CMetricPopulationModel::shiftTime(core_t::TTime time, core_t::TTime shift) 
         }
     }
     this->addAnnotation(time, CAnnotation::E_ModelChange,
-                        "Shifted time by " + std::to_string(shift) + " seconds");
+                        "Model shifted time by " + std::to_string(shift) + " seconds");
 }
 
 ////////// CMetricPopulationModel::SBucketStats Implementation //////////


### PR DESCRIPTION
When performing a time shift callback, what should be the time at which the shift should be applied? 

The original implementation was using `now()` which would work fine for live data, but not for backtesting. This PR changes this behavior. Now, we use the first timestamp when the detection rules have passed the conditions test. 

Also, previous implementation missed the fact that each detector configuration is associated with two detectors: a simple counting detector and a specialized detector (e.g. metric). This means, that the same rule should shift two different models. Hence, I modified the logic responsible for making sure that every model is shifted only once.

The functionality was not released yet, hence I mark it as a non-issue.