### PR TITLE
[ML] Correct the reference to a Buildkite step name

### DIFF
--- a/.buildkite/pipelines/create_dra.yml.sh
+++ b/.buildkite/pipelines/create_dra.yml.sh
@@ -17,7 +17,7 @@ steps:
     depends_on:
         - "build_test_linux-aarch64-RelWithDebInfo"
         - "build_test_linux-x86_64-RelWithDebInfo"
-        - "build_macos_x86_64_cross-RelWithDebInfo"
+        - "build_test_macos-x86_64-RelWithDebInfo"
         - "build_test_macos-aarch64-RelWithDebInfo"
         - "build_test_Windows-x86_64-RelWithDebInfo"
 


### PR DESCRIPTION
Refer to `build_test_macos-x86_64-RelWithDebInfo` instead of `build_macos_x86_64_cross-RelWithDebInfo`

Labelling as `>non-issue` as this is purely related to CI builds.