### PR TITLE
[7.17][ML] Migrate to S3 bucket in elastic-dev AWS account for 3rd party dependencies (#2703)

### DIFF
--- a/dev-tools/docker/linux_aarch64_cross_image/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_cross_image/Dockerfile
@@ -24,7 +24,7 @@ RUN \
 RUN \
   mkdir -p /usr/local/sysroot-aarch64-linux-gnu/usr && \
   cd /usr/local/sysroot-aarch64-linux-gnu/usr && \
-  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/usr-aarch64-linux-gnu-1.tar.bz2 | tar jxf - && \
+  wget --quiet -O - https://s3-eu-west-2.amazonaws.com/ml-cpp-artifacts/dependencies/usr-aarch64-linux-gnu-1.tar.bz2 | tar jxf - && \
   cd .. && \
   ln -s usr/lib lib && \
   ln -s usr/lib64 lib64

--- a/dev-tools/docker/macosx_image/Dockerfile
+++ b/dev-tools/docker/macosx_image/Dockerfile
@@ -34,8 +34,8 @@ RUN \
 RUN \
   mkdir -p /usr/local/sysroot-x86_64-apple-macosx10.11/usr && \
   cd /usr/local/sysroot-x86_64-apple-macosx10.11/usr && \
-  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/usr-x86_64-apple-macosx10.11-3.tar.bz2 | tar jxf - && \
-  wget --quiet -O - https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/xcode-x86_64-apple-macosx10.11-1.tar.bz2 | tar jxf -
+  wget --quiet -O - https://s3-eu-west-2.amazonaws.com/ml-cpp-artifacts/dependencies/usr-x86_64-apple-macosx10.11-3.tar.bz2 | tar jxf - && \
+  wget --quiet -O - https://s3-eu-west-2.amazonaws.com/ml-cpp-artifacts/dependencies/xcode-x86_64-apple-macosx10.11-1.tar.bz2 | tar jxf -
 
 # Build cctools-port
 RUN \

--- a/dev-tools/download_macos_deps.sh
+++ b/dev-tools/download_macos_deps.sh
@@ -35,7 +35,7 @@ case `uname -m` in
 
 esac
 
-URL="https://s3-eu-west-1.amazonaws.com/prelert-artifacts/dependencies/$ARCHIVE"
+URL="https://s3-eu-west-2.amazonaws.com/ml-cpp-artifacts/dependencies/$ARCHIVE"
 
 echo "Downloading dependencies from $URL"
 cd "$TMPDIR" && curl -s -S --retry 5 -O "$URL"


### PR DESCRIPTION

Handle the migration to a new S3 bucket in 2 stages:

1. Migrate the 3rd party dependencies that the ml-cpp builds require to the new S3 bucket (this PR)
2. In a follow up PR. Update where the built `ml-cpp` artifacts get written to. Because this step will also require updating references in e.g. the `elasticsearch` repo some coordination is required. A good approach may be to:
  * update the `ml-cpp` scripts to briefly store the artifacts in both the old `prelert-artifacts` bucket and also in the new `ml-cpp-artifacts` bucket
  * update the `elasticsearch` repo appropriately to refer to the new bucket.
  * finally remove all references to the `prelert-artifacts` bucket from the `ml-cpp` repo.

Backports #2703