### PR TITLE
[ML] Remove 8.14 branch from build schedule

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -156,7 +156,7 @@ spec:
         build_branches: true
         build_pull_request_forks: false
         cancel_deleted_branch_builds: true
-        filter_condition: build.branch == "main" || build.branch == "8.15" || build.branch == "8.14" || build.branch == "7.17"
+        filter_condition: build.branch == "main" || build.branch == "8.15" || build.branch == "7.17"
         filter_enabled: true
         publish_blocked_as_pending: true
         publish_commit_status: false
@@ -166,12 +166,8 @@ spec:
       schedules:
         Daily 7_17:
           branch: '7.17'
-          cronline: 30 03 * * *
-          message: Daily SNAPSHOT build for 7.17 
-        Daily 8_14:
-          branch: '8.14'
           cronline: 30 02 * * *
-          message: Daily SNAPSHOT build for 8.14
+          message: Daily SNAPSHOT build for 7.17 
         Daily 8_15:
           branch: '8.15'
           cronline: 30 01 * * *


### PR DESCRIPTION
Now that 8.15.0 is out support for 8.14 has ended.