### PR TITLE
Correct version PyTorch upgraded in changelog

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -35,11 +35,13 @@
 * Allow the user to force a detector to shift time series state by a specific amount.
   (See {ml-pull}2695[#2695].)
 
-== {es} version 8.15.1
+== {es} version 8.15.2
 
 === Enhancements
 
 * Update the Pytorch library to version 2.3.1. (See {ml-pull}2688[#2688].)
+
+== {es} version 8.15.1
 
 == {es} version 8.15.0
 


### PR DESCRIPTION
The PyTorch upgrade did not make into 8.15.1 #2688 it will now be in the 8.15.2 build