### PR TITLE
[ML] Trigger a "staging" build on merge to branch

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -219,7 +219,7 @@ spec:
 
           '
         filter_enabled: true
-        trigger_mode: none
+        trigger_mode: code
       repository: elastic/ml-cpp
       skip_intermediate_builds: true
       teams:


### PR DESCRIPTION
This PR addresses the timeliness of the `ml-cpp` "Staging" (release) builds.

With this change a Buildkite Staging build will be triggered each time a code change is merged to a branch matching the filter condition, i.e. branches names consisting of two or three groups of numbers separated by dots. 

Up until now we have relied upon human processes to trigger these types of builds. However this approach does allow scope to fail.

It it is not necessary to perform Staging builds any more frequently than upon code change. This is due to the fact that the same code is incorporated into Snapshot builds, that are built daily, regardless of code change (in order to run a frequent barrage of tests).


