### PR TITLE
[ML] Increase timeout for macOS debug builds

### DIFF
--- a/.buildkite/pipelines/build_macos.json.py
+++ b/.buildkite/pipelines/build_macos.json.py
@@ -73,7 +73,7 @@ def main(args):
     for arch, build_type in product(archs, cur_build_types):
         pipeline_steps.append({
             "label": f"Build & test :cpp: for MacOS-{arch}-{build_type} :macos:",
-            "timeout_in_minutes": "240",
+            "timeout_in_minutes": "300",
             "agents": agents[arch],
             "commands": [
               f'if [[ "{args.action}" == "debug" ]]; then export ML_DEBUG=1; fi',


### PR DESCRIPTION
The macOS x86_64 debug build has been timing out recently (since migrating to building on Orka instances). Bump the timeout for all macOS builds by another hour.