### PR TITLE
[backport 8.15.2] Change result writing to allow for a single value

### DIFF
--- a/bin/pytorch_inference/CResultWriter.cc
+++ b/bin/pytorch_inference/CResultWriter.cc
@@ -136,6 +136,9 @@ std::string CResultWriter::createInnerResult(const ::torch::Tensor& results) {
             case 2:
                 this->writePrediction<2>(results, jsonWriter);
                 break;
+            case 1:
+                this->writePrediction<1>(results, jsonWriter);
+                break;
             default: {
                 std::ostringstream ss;
                 ss << "Cannot convert results tensor of size [" << sizes << ']';

--- a/bin/pytorch_inference/CResultWriter.h
+++ b/bin/pytorch_inference/CResultWriter.h
@@ -191,6 +191,24 @@ private:
         jsonWriter.onObjectEnd();
     }
 
+    //! Write a 1D inference result
+    template<typename T>
+    void writeInferenceResults(const ::torch::TensorAccessor<T, 1UL>& accessor,
+                               TStringBufWriter& jsonWriter) {
+
+        jsonWriter.onKey(RESULT);
+        jsonWriter.onObjectBegin();
+        jsonWriter.onKey(INFERENCE);
+        // The Java side requires a 3D array, so wrap the 1D result in an
+        // extra outer array twice.
+        jsonWriter.onArrayBegin();
+        jsonWriter.onArrayBegin();
+        this->writeTensor(accessor, jsonWriter);
+        jsonWriter.onArrayEnd();
+        jsonWriter.onArrayEnd();
+        jsonWriter.onObjectEnd();
+    }
+
 private:
     core::CJsonOutputStreamWrapper m_WrappedOutputStream;
 };

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -69,11 +69,17 @@ torch::Tensor infer(torch::jit::script::Module& module_,
         }
 
         auto output = module_.forward(inputs);
+        LOG_DEBUG(<< "output_" << i << ": " << output);
         if (output.isTuple()) {
             // For transformers the result tensor is the first element in a tuple.
             all.push_back(output.toTuple()->elements()[0].toTensor());
         } else {
-            all.push_back(output.toTensor());
+            auto outputTensor = output.toTensor();
+            if (outputTensor.dim() == 0) { // If the output is a scaler, we need to reshape it into a 1D tensor
+                all.push_back(std::move(outputTensor.reshape({1, 1})));
+            } else {
+                all.push_back(std::move(outputTensor));
+            }
         }
 
         inputs.clear();

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -69,14 +69,13 @@ torch::Tensor infer(torch::jit::script::Module& module_,
         }
 
         auto output = module_.forward(inputs);
-        LOG_DEBUG(<< "output_" << i << ": " << output);
         if (output.isTuple()) {
             // For transformers the result tensor is the first element in a tuple.
             all.push_back(output.toTuple()->elements()[0].toTensor());
         } else {
             auto outputTensor = output.toTensor();
             if (outputTensor.dim() == 0) { // If the output is a scaler, we need to reshape it into a 1D tensor
-                all.push_back(std::move(outputTensor.reshape({1, 1})));
+                all.push_back(outputTensor.reshape({1, 1}));
             } else {
                 all.push_back(std::move(outputTensor));
             }

--- a/bin/pytorch_inference/unittest/CResultWriterTest.cc
+++ b/bin/pytorch_inference/unittest/CResultWriterTest.cc
@@ -80,6 +80,18 @@ BOOST_AUTO_TEST_CASE(testCreateInnerInferenceResult) {
     BOOST_REQUIRE_EQUAL(expected, innerPortion);
 }
 
+BOOST_AUTO_TEST_CASE(testCreateInnerInferenceResultFor1DimensionalResult) {
+    std::ostringstream output;
+    ml::torch::CResultWriter resultWriter{output};
+    ::torch::Tensor tensor{::torch::ones({1})};
+    std::string innerPortion{resultWriter.createInnerResult(tensor)};
+    std::string expected = "\"result\":{\"inference\":"
+                           "[[[1]]]}";
+    LOG_INFO(<< "expected: " << expected);
+    LOG_INFO(<< "actual: " << innerPortion);
+    BOOST_REQUIRE_EQUAL(expected, innerPortion);
+}
+
 BOOST_AUTO_TEST_CASE(testWrapAndWriteInferenceResult) {
     std::string innerPortion{
         "\"result\":{\"inference\":"

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,12 @@
 
 //=== Regressions
 
+== {es} version 8.15.2
+
+=== Bug Fixes
+
+* Allow for pytorch_inference results to include zero-dimensional tensors.
+
 == {es} version 8.15.1
 
 === Enhancements


### PR DESCRIPTION
backport of https://github.com/elastic/ml-cpp/pull/2720