### PR TITLE
Remove debug line that was printing out huge tensors causing timeouts in QA

### DIFF
--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -76,7 +76,7 @@ torch::Tensor infer(torch::jit::script::Module& module_,
         } else {
             auto outputTensor = output.toTensor();
             if (outputTensor.dim() == 0) { // If the output is a scaler, we need to reshape it into a 1D tensor
-                all.push_back(std::move(outputTensor.reshape({1, 1})));
+                all.push_back(outputTensor.reshape({1, 1}));
             } else {
                 all.push_back(std::move(outputTensor));
             }

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -69,7 +69,7 @@ torch::Tensor infer(torch::jit::script::Module& module_,
         }
 
         auto output = module_.forward(inputs);
-        LOG_DEBUG(<< "output_" << i << ": " << output);
+
         if (output.isTuple()) {
             // For transformers the result tensor is the first element in a tuple.
             all.push_back(output.toTuple()->elements()[0].toTensor());


### PR DESCRIPTION
The recent change to support zero dimensional tensors was failing in QA tests, and the root cause was this debug line which printed out each of the results, which can be quite large for some models. 

I aslo removed std::move from the reshape because it was causing compile time warnings, but that wasn't the cause of this problem.

This issue only affected QA so it is a non-issue