### PR TITLE
[ML] Fix failing testFileIoIsGood test on mac x86

### DIFF
--- a/lib/api/unittest/CIoManagerTest.cc
+++ b/lib/api/unittest/CIoManagerTest.cc
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_SUITE(CIoManagerTest)
 namespace {
 
 const std::uint32_t SLEEP_TIME_MS{100};
-const std::uint32_t PAUSE_TIME_MS{10};
+const std::uint32_t PAUSE_TIME_MS{40};
 const std::size_t MAX_ATTEMPTS{100};
 const std::size_t TEST_SIZE{10000};
 const char TEST_CHAR{'a'};


### PR DESCRIPTION
Bump a test thread timeout to increase the chance of successfully reading from a test file on slower machines.

Prior to this change the `CIoManagerTest/testFileIoIsGood` test has been failing approx 5 - 15 pct of the time. Testing the change with this script

```
testFailures=0; for i in {1..1000}; do ../../../cmake-build-relwithdebinfo/test/lib/api/unittest/ml_test_api --run_test=CIoManagerTest/testFileIoGood; if [ $? != 0 ]; then ((++testFailures)); fi; done; echo $testFailures
```

echoes `0` upon completion.