### PR TITLE
[ML] Install Java 21 on AWS EC2 using yum

### DIFF
--- a/.buildkite/pipelines/run_es_tests_aarch64.yml.sh
+++ b/.buildkite/pipelines/run_es_tests_aarch64.yml.sh
@@ -13,7 +13,9 @@ steps:
   - label: "Java :java: Integration Tests for aarch64 :hammer:"
     key: "java_integration_tests_aarch64"
     command:
-      - 'sudo mkdir -p /usr/lib/jvm/amazon-corretto-21 && wget -O - https://corretto.aws/downloads/latest/amazon-corretto-21-aarch64-linux-jdk.tar.gz | sudo tar xzf - -C /usr/lib/jvm/amazon-corretto-21 --strip=1'
+      - 'sudo rpm --import https://yum.corretto.aws/corretto.key'
+      - 'sudo curl -L -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo'
+      - 'sudo yum install java-21-amazon-corretto-devel'
       - 'buildkite-agent artifact download "build/*" . --step build_test_linux-aarch64-RelWithDebInfo'
       - '.buildkite/scripts/steps/run_es_tests.sh || (cd ../elasticsearch && find x-pack -name logs | xargs tar cvzf logs.tgz && buildkite-agent artifact upload logs.tgz && false)'
     depends_on: "build_test_linux-aarch64-RelWithDebInfo"
@@ -24,7 +26,6 @@ steps:
       diskSizeGb: 100
       diskName: '/dev/xvda'
     env:
-      JAVA_HOME: "/usr/lib/jvm/amazon-corretto-21"
       IVY_REPO: "../ivy"
       GRADLE_JVM_OPTS: "-Dorg.gradle.jvmargs=-Xmx16g"
     notify:

--- a/.buildkite/pipelines/run_es_tests_aarch64.yml.sh
+++ b/.buildkite/pipelines/run_es_tests_aarch64.yml.sh
@@ -15,7 +15,7 @@ steps:
     command:
       - 'sudo rpm --import https://yum.corretto.aws/corretto.key'
       - 'sudo curl -L -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo'
-      - 'sudo yum install java-21-amazon-corretto-devel'
+      - 'sudo yum install -y java-21-amazon-corretto-devel'
       - 'buildkite-agent artifact download "build/*" . --step build_test_linux-aarch64-RelWithDebInfo'
       - '.buildkite/scripts/steps/run_es_tests.sh || (cd ../elasticsearch && find x-pack -name logs | xargs tar cvzf logs.tgz && buildkite-agent artifact upload logs.tgz && false)'
     depends_on: "build_test_linux-aarch64-RelWithDebInfo"

--- a/.buildkite/pipelines/run_es_tests_x86_64.yml.sh
+++ b/.buildkite/pipelines/run_es_tests_x86_64.yml.sh
@@ -15,7 +15,7 @@ steps:
     command:
       - 'sudo rpm --import https://yum.corretto.aws/corretto.key'
       - 'sudo curl -L -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo'
-      - 'sudo yum install java-21-amazon-corretto-devel'
+      - 'sudo yum install -y java-21-amazon-corretto-devel'
       - 'buildkite-agent artifact download "build/*" . --step build_test_linux-x86_64-RelWithDebInfo'
       - '.buildkite/scripts/steps/run_es_tests.sh || (cd ../elasticsearch && find x-pack -name logs | xargs tar cvzf logs.tgz && buildkite-agent artifact upload logs.tgz && false)'
     depends_on: "build_test_linux-x86_64-RelWithDebInfo"

--- a/.buildkite/pipelines/run_es_tests_x86_64.yml.sh
+++ b/.buildkite/pipelines/run_es_tests_x86_64.yml.sh
@@ -13,7 +13,9 @@ steps:
   - label: "Java :java: Integration Tests for x86_64 :hammer:"
     key: "java_integration_tests_x86_64"
     command:
-      - 'sudo mkdir -p /usr/lib/jvm/amazon-corretto-21 && wget -O - https://corretto.aws/downloads/latest/amazon-corretto-21-x64-linux-jdk.tar.gz | sudo tar xzf - -C /usr/lib/jvm/amazon-corretto-21 --strip=1'
+      - 'sudo rpm --import https://yum.corretto.aws/corretto.key'
+      - 'sudo curl -L -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo'
+      - 'sudo yum install java-21-amazon-corretto-devel'
       - 'buildkite-agent artifact download "build/*" . --step build_test_linux-x86_64-RelWithDebInfo'
       - '.buildkite/scripts/steps/run_es_tests.sh || (cd ../elasticsearch && find x-pack -name logs | xargs tar cvzf logs.tgz && buildkite-agent artifact upload logs.tgz && false)'
     depends_on: "build_test_linux-x86_64-RelWithDebInfo"
@@ -24,7 +26,6 @@ steps:
       diskSizeGb: 100
       diskName: '/dev/xvda'
     env:
-      JAVA_HOME: "/usr/lib/jvm/amazon-corretto-21"
       IVY_REPO: "../ivy"
       GRADLE_JVM_OPTS: "-Dorg.gradle.jvmargs=-Xmx16g"
     notify:


### PR DESCRIPTION
The recommended method of installing Java 21 on AWS EC2 instances is to use `yum` to install `java-21-amazon-corretto`. This does require a bit of pre-configuration however, as detailed here - https://docs.aws.amazon.com/corretto/latest/corretto-21-ug/generic-linux-install.html#rpm-linux-install-instruct

This PR replaces the ad-hoc installation of Java 21 (using `curl` etc.) in #2727 with the recommended method.