### PR TITLE
[ML] Change time shift sign for intuitive configuration (#2737)

### DIFF
--- a/lib/model/CDetectionRule.cc
+++ b/lib/model/CDetectionRule.cc
@@ -87,7 +87,12 @@ void CDetectionRule::addTimeShift(core_t::TTime timeShift) {
             timeShiftApplied.end()) {
             // When the callback is executed, the model is already in the correct time
             // interval. Hence, we need to shift the time right away.
-            model.shiftTime(time, timeShift);
+            // IMPLEMENTATION DECISION: We apply the negative amount of time shift to the
+            // model. This is because the time shift is applied to the model's frame of reference
+            // and not the global time. This allows a more intuitive configuration from the user's
+            // perspective: in spring we move the clock forward, and the time shift is positive, in
+            // autumn we move the clock backward, and the time shift is negative.
+            model.shiftTime(time, -timeShift);
             timeShiftApplied.emplace_back(&model);
         }
     });

--- a/lib/model/unittest/CDetectionRuleTest.cc
+++ b/lib/model/unittest/CDetectionRuleTest.cc
@@ -1020,8 +1020,8 @@ BOOST_FIXTURE_TEST_CASE(testRuleTimeShiftShouldShiftTimeSeriesModelState, CTestF
         rule.executeCallback(*model, timestamp);
 
         // the time series model should have been shifted by specified amount.
-        BOOST_TEST_REQUIRE(trendModel.lastValueTime() == lastValueTime + timeShiftInSecs);
-        BOOST_TEST_REQUIRE(trendModel.timeShift() == timeShiftInSecs);
+        BOOST_TEST_REQUIRE(trendModel.lastValueTime() == lastValueTime - timeShiftInSecs);
+        BOOST_TEST_REQUIRE(trendModel.timeShift() == -timeShiftInSecs);
 
         // and an annotation should have been added to the model
         BOOST_TEST_REQUIRE(annotations.size() == numAnnotationsBeforeShift + 1);
@@ -1091,8 +1091,8 @@ BOOST_FIXTURE_TEST_CASE(testTwoTimeShiftRuleShouldShiftTwice, CTestFixture) {
     // the values after the second time should be the sum of two rules.
     timestamp += timeShift1; // simulate the time has moved forward by the time shift
     rule2.executeCallback(*model, timestamp);
-    BOOST_TEST_REQUIRE(trendModel.lastValueTime() == lastValueTimeAfterFirstShift + timeShift2);
-    BOOST_TEST_REQUIRE(trendModel.timeShift() == timeShift1 + timeShift2);
+    BOOST_TEST_REQUIRE(trendModel.lastValueTime() == lastValueTimeAfterFirstShift - timeShift2);
+    BOOST_TEST_REQUIRE(trendModel.timeShift() == -(timeShift1 + timeShift2));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The way the application of the force_time_shift custom rule was configured before, is to specify the amount of time the model's frame of reference should shift.

This is counter-intuitive for the users since when they need to move their clock forward in spring, they would be expected to specify force_time_shift by -3600, aka backward.

This PR switches the sign inside the C++ implementation and allows a more intuitive configuration.

I marked it as a non-issue since the functionality has not yet been released.