### PR TITLE
[8.16][ML] Fudge for CKMostCorrelatedTest/testScale (#2729)

### DIFF
--- a/lib/maths/common/unittest/CKMostCorrelatedTest.cc
+++ b/lib/maths/common/unittest/CKMostCorrelatedTest.cc
@@ -764,7 +764,7 @@ BOOST_AUTO_TEST_CASE(testScale) {
     double sdRatio = std::sqrt(maths::common::CBasicStatistics::variance(slope)) /
                      maths::common::CBasicStatistics::mean(slope);
     LOG_DEBUG(<< "sdRatio = " << sdRatio);
-    BOOST_TEST_REQUIRE(exponent < 2.0);
+    BOOST_TEST(exponent <= 2.0, boost::test_tools::tolerance(0.1));
     BOOST_TEST_REQUIRE(sdRatio < 0.75);
 }
 


### PR DESCRIPTION
Add a bit of tolerance for a CKMostCorrelatedTest/testScale comparison. This _should_ reduce the frequency of failures on macOS x86_64 CI builds that are a bit slooooower than the rest.

Backports #2729