### PR TITLE
[8.16][ML] Fix a few address sanitizer issues (#2738)

### DIFF
--- a/cmake/variables.cmake
+++ b/cmake/variables.cmake
@@ -160,7 +160,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set(CMAKE_CXX_FLAGS_RELEASE "/O2 /D NDEBUG /D EXCLUDE_TRACE_LOGGING /Qfast_transcendentals /Qvec-report:1")
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/Zi /O2 /D NDEBUG /D EXCLUDE_TRACE_LOGGING /Qfast_transcendentals /Qvec-report:1")
   set(CMAKE_CXX_FLAGS_DEBUG "/Zi /Od /RTC1")
-  set(CMAKE_CXX_FLAGS_SANITIZER "/fsanitize=address /Zi" CACHE STRING
+  set(CMAKE_CXX_FLAGS_SANITIZER "/fsanitize=address /O2 /Zi" CACHE STRING
           "Flags used by the C++ compiler during sanitizer builds."
           FORCE)
   set(CMAKE_EXE_LINKER_FLAGS_SANITIZER "")
@@ -173,7 +173,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -DEXCLUDE_TRACE_LOGGING -Wdisabled-optimization -D_FORTIFY_SOURCE=2")
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -O3 -DNDEBUG -DEXCLUDE_TRACE_LOGGING -Wdisabled-optimization -D_FORTIFY_SOURCE=2")
   set(CMAKE_CXX_FLAGS_DEBUG "-g")
-  set(CMAKE_CXX_FLAGS_SANITIZER "-fsanitize=address -g -fno-omit-frame-pointer" CACHE STRING
+  set(CMAKE_CXX_FLAGS_SANITIZER "-fsanitize=address -g -O3 -fno-omit-frame-pointer" CACHE STRING
           "Flags used by the C++ compiler during sanitizer builds."
           FORCE)
 endif()
@@ -182,7 +182,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -DEXCLUDE_TRACE_LOGGING")
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -O3 -DNDEBUG -DEXCLUDE_TRACE_LOGGING")
   set(CMAKE_CXX_FLAGS_DEBUG "-g")
-  set(CMAKE_CXX_FLAGS_SANITIZER "-fsanitize=address -g -fno-omit-frame-pointer" CACHE STRING
+  set(CMAKE_CXX_FLAGS_SANITIZER "-fsanitize=address -g -O3 -fno-omit-frame-pointer" CACHE STRING
           "Flags used by the C++ compiler during sanitizer builds."
           FORCE)
   mark_as_advanced(

--- a/lib/api/unittest/CJsonOutputWriterTest.cc
+++ b/lib/api/unittest/CJsonOutputWriterTest.cc
@@ -1010,6 +1010,7 @@ BOOST_AUTO_TEST_CASE(testGeoResultsWrite) {
     std::string functionDescription("lat_long(location)");
     ml::api::CHierarchicalResultsWriter::TOptionalStrOptionalStrPrDoublePrVec influences;
     std::string emptyString;
+    std::string mean_function("mean");
     // The output writer won't close the JSON structures until is is destroyed
     {
         std::ostringstream sstream;
@@ -1099,8 +1100,8 @@ BOOST_AUTO_TEST_CASE(testGeoResultsWrite) {
             ml::api::CHierarchicalResultsWriter::SResults result(
                 ml::api::CHierarchicalResultsWriter::E_Result, partitionFieldName,
                 partitionFieldValue, byFieldName, byFieldValue,
-                correlatedByFieldValue, 1, "mean", functionDescription, 2.24,
-                79, typical, actual, 10.0, 10.0, 0.5, 0.0, fieldName,
+                correlatedByFieldValue, 1, mean_function, functionDescription,
+                2.24, 79, typical, actual, 10.0, 10.0, 0.5, 0.0, fieldName,
                 influences, false, true, 1, 1, EMPTY_STRING_LIST, {});
             BOOST_TEST_REQUIRE(writer.acceptResult(result));
             BOOST_TEST_REQUIRE(writer.endOutputBatch(false, 1U));

--- a/lib/maths/analytics/unittest/CBoostedTreeTest.cc
+++ b/lib/maths/analytics/unittest/CBoostedTreeTest.cc
@@ -488,8 +488,8 @@ BOOST_AUTO_TEST_CASE(testEdgeCases) {
 
     auto frame = core::makeMainStorageDataFrame(cols).first;
 
-    fillDataFrame(5, 0, 2, {{1.0}, {1.0}, {1.0}, {1.0}, {1.0}},
-                  {0.0, 0.0, 0.0, 0.0, 0.0}, [](const TRowRef&) { return 1.0; }, *frame);
+    fillDataFrame(5, 0, 2, {{1.0, 1.0, 1.0, 1.0, 1.0}}, {0.0, 0.0, 0.0, 0.0, 0.0},
+                  [](const TRowRef&) { return 1.0; }, *frame);
 
     BOOST_REQUIRE_NO_THROW(maths::analytics::CBoostedTreeFactory::constructFromParameters(
                                1, std::make_unique<maths::analytics::boosted_tree::CMse>())

--- a/lib/maths/time_series/CTrendComponent.cc
+++ b/lib/maths/time_series/CTrendComponent.cc
@@ -310,10 +310,15 @@ void CTrendComponent::shiftLevel(double shift,
     double magnitude{shifts[last] - shifts[next - 1]};
     if (m_TimeOfLastLevelChange != UNSET_TIME) {
         double dt{static_cast<double>(time - m_TimeOfLastLevelChange)};
-        double value{static_cast<double>(
-            common::CBasicStatistics::mean(values[segments[next] - 1]))};
-        m_ProbabilityOfLevelChangeModel.addTrainingDataPoint(LEVEL_CHANGE_LABEL,
-                                                             {{dt}, {value}});
+        if (values.size() > segments[next] - 1) {
+            double value{static_cast<double>(
+                common::CBasicStatistics::mean(values[segments[next] - 1]))};
+            m_ProbabilityOfLevelChangeModel.addTrainingDataPoint(LEVEL_CHANGE_LABEL,
+                                                                 {{dt}, {value}});
+        } else {
+            LOG_DEBUG(<< "Size mis-match reading from values. Length = "
+                      << values.size() << ", requested index = " << segments[next] - 1);
+        }
     }
     m_TimeOfLastLevelChange = time;
     for (std::size_t i = segments[last]; i < values.size(); ++i, time += bucketLength) {

--- a/lib/maths/time_series/unittest/CCalendarCyclicTestTest.cc
+++ b/lib/maths/time_series/unittest/CCalendarCyclicTestTest.cc
@@ -528,7 +528,7 @@ BOOST_AUTO_TEST_CASE(testLongBuckets) {
         TDoubleVec error;
         for (core_t::TTime time = 0, i = 0; time <= end; time += DAY) {
             rng.generateNormalSamples(0.0, 9.0, 1, error);
-            if (time >= months[i] && time < months[i] + DAY) {
+            if (time >= months[i] && time < months[i] + DAY && i < months.size() - 1) {
                 error[0] += 20.0;
                 ++i;
             }


### PR DESCRIPTION
Fix a few issues picked up by the address sanitizer. These are mostly related to unit tests, including one that leads to an occasional crash on Windows - #2651, and also:

* Fix a heap-buffer-overflow in test case Address Sanitizer picked up a heap-buffer-overflow in `CBoostedTreeTest/testEdgeCases`. Rework the test slightly to avoid it.

* Optimize code when running the Address Sanitizer Add the `O3` flag to those used for compiling with the Address Sanitizer enabled. In most cases this is sufficient and cuts the run time significantly.

Backports #2738 