### PR TITLE
[8.16][ML] Add CMake config to integrate gperftools (#2713)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,26 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   install(FILES ${CMAKE_BINARY_DIR}/Info.plist DESTINATION ${CMAKE_INSTALL_PREFIX})
 endif()
 
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  if(NOT LINK_TCMALLOC)
+    set(LINK_TCMALLOC FALSE)
+  endif()
+  if(NOT LINK_PROFILER)
+    set(LINK_PROFILER FALSE)
+  endif()
+else()
+  if(LINK_TCMALLOC)
+    message(WARNING "Not linking libtcmalloc on ${CMAKE_SYSTEM_NAME}")
+    set(LINK_TCMALLOC FALSE)
+    unset(LINK_TCMALLOC CACHE)
+  endif()
+  if(LINK_PROFILER)
+    message(WARNING "Not linking libprofiler on ${CMAKE_SYSTEM_NAME}")
+    set(LINK_PROFILER FALSE)
+    unset(LINK_PROFILER CACHE)
+  endif()
+endif()
+
 message(STATUS "CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}")
 
 include_directories(SYSTEM ${ML_SYSTEM_INCLUDE_DIRECTORIES})
@@ -87,3 +107,11 @@ add_subdirectory(devlib)
 # Add a target to build Doxygen generated documentation
 # if the doxygen executable can be found
 ml_doxygen(${CMAKE_SOURCE_DIR}/build/doxygen)
+
+if (LINK_TCMALLOC)
+  unset(LINK_TCMALLOC CACHE)
+endif()
+
+if (LINK_PROFILER)
+  unset(LINK_PROFILER CACHE)
+endif()

--- a/bin/autodetect/CMakeLists.txt
+++ b/bin/autodetect/CMakeLists.txt
@@ -22,6 +22,16 @@ set(ML_LINK_LIBRARIES
   MlVer
   )
 
+if (LINK_TCMALLOC)
+  message(AUTHOR_WARNING "Linking libtcmalloc. Build is not for production release.")
+  list(APPEND ML_LINK_LIBRARIES tcmalloc)
+endif ()
+
+if (LINK_PROFILER)
+  message(AUTHOR_WARNING "Linking libprofiler. Build is not for production release.")
+  list(APPEND ML_LINK_LIBRARIES profiler)
+endif ()
+
 ml_add_executable(autodetect
   CCmdLineParser.cc
   )

--- a/bin/pytorch_inference/CMakeLists.txt
+++ b/bin/pytorch_inference/CMakeLists.txt
@@ -21,6 +21,16 @@ set(ML_LINK_LIBRARIES
   ${C10_LIB}
   )
 
+if (LINK_TCMALLOC)
+  message(AUTHOR_WARNING "Linking libtcmalloc. Build is not for production release.")
+  list(APPEND ML_LINK_LIBRARIES tcmalloc)
+endif ()
+
+if (LINK_PROFILER)
+  message(AUTHOR_WARNING "Linking libprofiler. Build is not for production release.")
+  list(APPEND ML_LINK_LIBRARIES profiler)
+endif ()
+
 ml_add_executable(pytorch_inference
   CBufferedIStreamAdapter.cc
   CCmdLineParser.cc


### PR DESCRIPTION
Add options to link in libprofiler and/or libtcmalloc to autodetact and pytorch_inference. For Linux builds only. Not for production releases.

Backports #2713