### PR TITLE
[ML] Correct filter regex for Staging builds

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -217,11 +217,7 @@ spec:
         BUILD_SNAPSHOT: "false"
       pipeline_file: .buildkite/branch.json.py
       provider_settings:
-        filter_condition: 'build.branch =~ /^[0-9]+\.[0-9]+\$/ ||
-
-          build.branch =~ /^([0-9]+\.){2}[0-9]+\$/
-
-          '
+        filter_condition: 'build.branch =~ /^[0-9]+\.[0-9]+$$/ || build.branch =~ /^([0-9]+\.){2}[0-9]+$$/'
         filter_enabled: true
         trigger_mode: code
       repository: elastic/ml-cpp


### PR DESCRIPTION
Triggering a Staging build via a Github webhook
requires a slight tweak to the branch filter regular expression.

Tested by briefly modifying the regex in Buildkite pipeline settings and pushing an empty commit to the `8.15` branch. Checking the Staging pipeline in Buildkite shows that a build was indeed triggered, see - https://buildkite.com/elastic/ml-cpp-staging-builds/builds/111

Relates #2717 