### PR TITLE
[8.15][ML] QA tests on specific branch and version (#2742)

### DIFF
--- a/.buildkite/ml_pipeline/config.py
+++ b/.buildkite/ml_pipeline/config.py
@@ -25,6 +25,38 @@ class Config:
             if self.run_qa_tests:
                 self.action = "build"
 
+        # If the ACTION is set to "run_qa_tests" then set some optional variables governing the ES branch to build, the
+        # stack version to set and the subset of QA tests to run, depending on whether appropriate variables are set in
+        # the environment.
+        if self.run_qa_tests:
+            if "GITHUB_PR_COMMENT_VAR_BRANCH" in os.environ:
+                os.environ["ES_BRANCH"] = os.environ["GITHUB_PR_COMMENT_VAR_BRANCH"]
+
+            if "GITHUB_PR_COMMENT_VAR_VERSION" in os.environ:
+                os.environ["STACK_VERSION"] = os.environ["GITHUB_PR_COMMENT_VAR_VERSION"]
+
+            if "GITHUB_PR_COMMENT_VAR_ARGS" in os.environ:
+                os.environ["QAF_TESTS_TO_RUN"] = os.environ["GITHUB_PR_COMMENT_VAR_ARGS"]
+
+        # If the GITHUB_PR_COMMENT_VAR_ARCH environment variable is set then   attemot to parse it
+        # into comma separated values. If the values are one or both of "aarch64" or "x86_64" then set the member
+        # variables self.build_aarch64, self.build_x86_64 accordingly. These values will be used to restrict the build
+        # jobs to a particular achitecture.
+        if "GITHUB_PR_COMMENT_VAR_ARCH" in os.environ:
+            csv_arch = os.environ["GITHUB_PR_COMMENT_VAR_ARCH"]
+            for each in [ x.strip().lower() for x in csv_arch.split(",")]:
+                if each == "aarch64":
+                    self.build_aarch64 = "--build-aarch64"
+                elif each == "x86_64":
+                    self.build_x86_64 = "--build-x86_64"
+        else:
+            self.build_aarch64 = "--build-aarch64"
+            self.build_x86_64 = "--build-x86_64"
+
+        # If the GITHUB_PR_COMMENT_VAR_PLATFORM environment variable is set to a non-empty string then attemot to parse it
+        # into comma separated values. If the values are one or a combination of "windows", "mac(os)", "linux"  then set the member
+        # variables self.build_windows, self.build_macos, self.build_linux accordingly. These values will be used to restrict the build
+        # jobs to a particular platform.
         if "GITHUB_PR_COMMENT_VAR_PLATFORM" in os.environ:
             csv_platform = os.environ["GITHUB_PR_COMMENT_VAR_PLATFORM"]
             for each in [ x.strip().lower() for x in csv_platform.split(",")]:

--- a/.buildkite/pipelines/run_qa_tests.yml.sh
+++ b/.buildkite/pipelines/run_qa_tests.yml.sh
@@ -24,5 +24,17 @@ steps:
     build:
       message: "${BUILDKITE_MESSAGE}"
       env:
-        QAF_TESTS_TO_RUN: "ml_cpp_pr"
+        QAF_TESTS_TO_RUN: "${QAF_TESTS_TO_RUN:-ml_cpp_pr}"
 EOL
+
+if [ "${ES_BRANCH}" != "" ]; then
+cat <<EOL
+        ES_BRANCH: "${ES_BRANCH}"
+EOL
+fi
+
+if [ "${STACK_VERSION}" != "" ]; then
+cat <<EOL
+        STACK_VERSION: "${STACK_VERSION}"
+EOL
+fi

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -9,7 +9,7 @@
       "commit_status_context": "ml-cpp-ci",
       "build_on_commit": true,
       "build_on_comment": true,
-      "trigger_comment_regex": "^(?:(?:buildkite +)(?<action>build|debug|run_qa_tests) *(?: *on *(?<platform>(?:[ ,]*(?:windows|linux|mac(os)?))+))?)$",
+      "trigger_comment_regex": "^(?:(?:buildkite +)(?<action>build|debug|run_qa_tests|run_pytorch_tests)(=(?<args>(?:[^ ]+)))? *(?: for ES_BRANCH=(?<branch>([.0-9a-zA-Z]+)))? *(?:with STACK_VERSION=(?<version>([.0-9]+)))? *(?: *on *(?<platform>(?:[ ,]*(?:windows|linux|mac(os)?))+))?) *(?<arch>(?:[, ]*aarch64|x86_64)+)?$",
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "skip_ci_labels": ["skip-ci", "jenkins-ci", ">test-mute", ">docs"],
       "skip_target_branches": ["6.8", "7.11", "7.12"],


### PR DESCRIPTION
Enable being able to specify a particular ES branch and stack version when running QA tests on a PR. The syntax of the GitHub comment to do this is, e.g.:

```
buildkite run_qa_tests for ES_BRANCH=8.x with STACK_VERSION=8.16.0
```

Backports #2742