### PR TITLE
[ML] Fix forecasting parameters initialization for large models (#2759)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -39,6 +39,12 @@
 
 * Allow for pytorch_inference results to include zero-dimensional tensors.
 
+== {es} version 8.15.4
+
+=== Bug Fixes
+
+* Fix parameter initialization for large forecasting models. (See {ml-pull}2759[#2759].)
+
 == {es} version 8.15.2
 
 === Enhancements

--- a/lib/model/CForecastModelPersist.cc
+++ b/lib/model/CForecastModelPersist.cc
@@ -128,11 +128,7 @@ bool CForecastModelPersist::CRestore::nextModel(TMathsModelPtr& model,
                     m_ModelParams.s_MaximumTimeToTestForChange};
 
                 maths::common::SModelRestoreParams params{
-                    modelParams,
-                    maths::common::STimeSeriesDecompositionRestoreParams{
-                        m_ModelParams.s_DecayRate, m_ModelParams.s_BucketLength,
-                        m_ModelParams.s_ComponentSize,
-                        m_ModelParams.distributionRestoreParams(dataType)},
+                    modelParams, m_ModelParams.decompositionRestoreParams(dataType),
                     m_ModelParams.distributionRestoreParams(dataType)};
 
                 auto serialiserOperator =

--- a/lib/model/unittest/CForecastModelPersistTest.cc
+++ b/lib/model/unittest/CForecastModelPersistTest.cc
@@ -18,6 +18,7 @@
 #include <maths/time_series/CTimeSeriesDecomposition.h>
 #include <maths/time_series/CTimeSeriesModel.h>
 
+#include <model/CAnomalyDetectorModelConfig.h>
 #include <model/CForecastModelPersist.h>
 
 #include <test/BoostTestPointerOutput.h>
@@ -39,8 +40,9 @@ BOOST_AUTO_TEST_CASE(testPersistAndRestore) {
     params.s_DecayRate = 0.001;
     params.s_LearnRate = 1.0;
     params.s_MinimumTimeToDetectChange = 6 * core::constants::HOUR;
-    params.s_MaximumTimeToTestForChange = core::constants::DAY;
-    maths::time_series::CTimeSeriesDecomposition trend(params.s_DecayRate, bucketLength);
+    double trendDecayRate{CAnomalyDetectorModelConfig::trendDecayRate(
+        params.s_DecayRate, bucketLength)};
+    maths::time_series::CTimeSeriesDecomposition trend(trendDecayRate, bucketLength);
 
     maths::common::CNormalMeanPrecConjugate prior{
         maths::common::CNormalMeanPrecConjugate::nonInformativePrior(


### PR DESCRIPTION
We fix initialization of the decayRate parameter when models have to spill to disk