### PR TITLE
[ML] Permit 8.15 builds to be triggered by GH activity

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -156,7 +156,7 @@ spec:
         build_branches: true
         build_pull_request_forks: false
         cancel_deleted_branch_builds: true
-        filter_condition: build.branch == "main" || build.branch == "8.x" || build.branch == "8.16" || build.branch == "7.17"
+        filter_condition: build.branch == "main" || build.branch == "8.x" || build.branch == "8.16" || build.branch == "8.15" ||  build.branch == "7.17"
         filter_enabled: true
         publish_blocked_as_pending: true
         publish_commit_status: false


### PR DESCRIPTION
Allow the 8.15 branch to be included in snapshot builds upon GitHub activity, as well as daily schedule.

Changes are required only to be merged to `main`, hence labelling as `v9.0.0` .