### PR TITLE
[ML] Remove dependency on macos_x86_64 build step

### DIFF
--- a/.buildkite/pipelines/create_dra.yml.sh
+++ b/.buildkite/pipelines/create_dra.yml.sh
@@ -17,7 +17,6 @@ steps:
     depends_on:
         - "build_test_linux-aarch64-RelWithDebInfo"
         - "build_test_linux-x86_64-RelWithDebInfo"
-        - "build_test_macos-x86_64-RelWithDebInfo"
         - "build_test_macos-aarch64-RelWithDebInfo"
         - "build_test_Windows-x86_64-RelWithDebInfo"
 


### PR DESCRIPTION
Remove the dependency on the macOS x86 build (as it no longer exists) allowing the DRA upload step to proceed