### PR TITLE
[8.18][ML] Upgrade to PyTorch 2.5.0 on Windows 2016 builds (#2783)

### DIFF
--- a/3rd_party/licenses/pytorch-INFO.csv
+++ b/3rd_party/licenses/pytorch-INFO.csv
@@ -1,2 +1,2 @@
 name,version,revision,url,license,copyright,sourceURL
-PyTorch,2.3.1,63d5e9221bedd1546b7d364b5ce4171547db12a9,https://pytorch.org,BSD-3-Clause,,
+PyTorch,2.5.0,32f585d9346e316e554c8d9bf7548af9f62141fc,https://pytorch.org,BSD-3-Clause,,

--- a/build-setup/windows.md
+++ b/build-setup/windows.md
@@ -193,7 +193,7 @@ On the "Advanced Options" screen, check "Install for all users" and "Add Python 
 
 For the time being, do not take advantage of the option on the final installer screen to reconfigure the machine to allow paths longer than 260 characters.  We still support Windows versions that do not have this option.
 
-### PyTorch 2.3.1
+### PyTorch 2.5.0
 
 (This step requires a lot of memory. It failed on a machine with 12GB of RAM. It just about fitted on a 20GB machine. 32GB RAM is recommended.)
 
@@ -209,7 +209,7 @@ Next, in a Git bash shell run:
 
 ```
 cd /c/tools
-git clone --depth=1 --branch=v2.3.1 https://github.com/pytorch/pytorch.git
+git clone --depth=1 --branch=v2.5.0 https://github.com/pytorch/pytorch.git
 cd pytorch
 git submodule sync
 git submodule update --init --recursive
@@ -265,7 +265,7 @@ set USE_QNNPACK=OFF
 set USE_PYTORCH_QNNPACK=OFF
 set USE_XNNPACK=OFF
 set MSVC_Z7_OVERRIDE=OFF
-set PYTORCH_BUILD_VERSION=2.3.1
+set PYTORCH_BUILD_VERSION=2.5.0
 set PYTORCH_BUILD_NUMBER=1
 python setup.py install
 ```

--- a/dev-tools/download_windows_deps.ps1
+++ b/dev-tools/download_windows_deps.ps1
@@ -9,11 +9,11 @@
 # limitation.
 #
 $ErrorActionPreference="Stop"
-$Archive="usr-x86_64-windows-2016-13.zip"
+$Archive="usr-x86_64-windows-2016-14.zip"
 $Destination="C:\"
-# If PyTorch is not version 2.3.1 then we need the latest download
+# If PyTorch is not version 2.5.0 then we need the latest download
 if (!(Test-Path "$Destination\usr\local\include\pytorch\torch\csrc\api\include\torch\version.h") -Or
-    !(Select-String -Path "$Destination\usr\local\include\pytorch\torch\csrc\api\include\torch\version.h" -Pattern "2.3.1" -Quiet)) {
+    !(Select-String -Path "$Destination\usr\local\include\pytorch\torch\csrc\api\include\torch\version.h" -Pattern "2.5.0" -Quiet)) {
     Remove-Item "$Destination\usr" -Recurse -Force -ErrorAction Ignore
     $ZipSource="https://storage.googleapis.com/elastic-ml-public/dependencies/$Archive"
     $ZipDestination="$Env:TEMP\$Archive"

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,12 @@
 
 //=== Regressions
 
+== {es} version 8.18.0
+
+=== Enhancements
+
+* Update the PyTorch library to version 2.5.0. (See {ml-pull}2783[#2783].)
+
 == {es} version 8.16.0
 
 === Enhancements


### PR DESCRIPTION
Update build scripts and docs to refer to PyTorch 2.5.0

Note the slightly different procedure between the Windows 2022 and 2016 builds.

Backports #2783