### PR TITLE
[8.18][ML] Windows 2022: Upgrade PyTorch to version 2.5.1 (#2799)

### DIFF
--- a/build-setup/windows.md
+++ b/build-setup/windows.md
@@ -193,7 +193,7 @@ On the "Advanced Options" screen, check "Install for all users" and "Add Python 
 
 For the time being, do not take advantage of the option on the final installer screen to reconfigure the machine to allow paths longer than 260 characters.  We still support Windows versions that do not have this option.
 
-### PyTorch 2.5.0
+### PyTorch 2.5.1
 
 (This step requires a lot of memory. It failed on a machine with 12GB of RAM. It just about fitted on a 20GB machine. 32GB RAM is recommended.)
 
@@ -209,7 +209,7 @@ Next, in a Git bash shell run:
 
 ```
 cd /c/tools
-git clone --depth=1 --branch=v2.5.0 https://github.com/pytorch/pytorch.git
+git clone --depth=1 --branch=v2.5.1 https://github.com/pytorch/pytorch.git
 cd pytorch
 git submodule sync
 git submodule update --init --recursive
@@ -265,7 +265,7 @@ set USE_QNNPACK=OFF
 set USE_PYTORCH_QNNPACK=OFF
 set USE_XNNPACK=OFF
 set MSVC_Z7_OVERRIDE=OFF
-set PYTORCH_BUILD_VERSION=2.5.0
+set PYTORCH_BUILD_VERSION=2.5.1
 set PYTORCH_BUILD_NUMBER=1
 python setup.py install
 ```

--- a/dev-tools/download_windows_deps.ps1
+++ b/dev-tools/download_windows_deps.ps1
@@ -9,11 +9,11 @@
 # limitation.
 #
 $ErrorActionPreference="Stop"
-$Archive="usr-x86_64-windows-2016-14.zip"
+$Archive="usr-x86_64-windows-2016-15.zip"
 $Destination="C:\"
-# If PyTorch is not version 2.5.0 then we need the latest download
+# If PyTorch is not version 2.5.1 then we need the latest download
 if (!(Test-Path "$Destination\usr\local\include\pytorch\torch\csrc\api\include\torch\version.h") -Or
-    !(Select-String -Path "$Destination\usr\local\include\pytorch\torch\csrc\api\include\torch\version.h" -Pattern "2.5.0" -Quiet)) {
+    !(Select-String -Path "$Destination\usr\local\include\pytorch\torch\csrc\api\include\torch\version.h" -Pattern "2.5.1" -Quiet)) {
     Remove-Item "$Destination\usr" -Recurse -Force -ErrorAction Ignore
     $ZipSource="https://storage.googleapis.com/elastic-ml-public/dependencies/$Archive"
     $ZipDestination="$Env:TEMP\$Archive"

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -32,7 +32,7 @@
 
 === Enhancements
 
-* Update the PyTorch library to version 2.5.0. (See {ml-pull}2783[#2783], {ml-pull}2778[#2778].)
+* Update the PyTorch library to version 2.5.1. (See {ml-pull}2783[#2783], {ml-pull}2799[#2799].)
 * Upgrade Boost libraries to version 1.86. (See {ml-pull}2780[#2780], {ml-pull}2779[#2779].)
 * Drop support for macOS Intel builds. (See {ml-pull}2795[#2795].)
 


### PR DESCRIPTION
Update docs and configuration to refer to PyTorch 2.5.1

Backports #2799 