### PR TITLE
[8.18][ML] macOS ARM: Upgrade PyTorch to version 2.5.1 (#2798)

### DIFF
--- a/3rd_party/licenses/pytorch-INFO.csv
+++ b/3rd_party/licenses/pytorch-INFO.csv
@@ -1,2 +1,2 @@
 name,version,revision,url,license,copyright,sourceURL
-PyTorch,2.5.0,32f585d9346e316e554c8d9bf7548af9f62141fc,https://pytorch.org,BSD-3-Clause,,
+PyTorch,2.5.1,a8d6afb511a69687bbb2b7e88a3cf67917e1697e,https://pytorch.org,BSD-3-Clause,,

--- a/build-setup/macos.md
+++ b/build-setup/macos.md
@@ -127,7 +127,7 @@ Download the graphical installer for Python 3.10.9 from <https://www.python.org/
 
 Install using all the default options.  When the installer completes a Finder window pops up.  Double click the `Install Certificates.command` file in this folder to install the SSL certificates Python needs.
 
-### PyTorch 2.5.0
+### PyTorch 2.5.1
 
 PyTorch requires that certain Python modules are installed.  To install them:
 
@@ -138,7 +138,7 @@ sudo /Library/Frameworks/Python.framework/Versions/3.10/bin/pip3.10 install nump
 Then obtain the PyTorch code:
 
 ```
-git clone --depth=1 --branch=v2.5.0 https://github.com/pytorch/pytorch.git
+git clone --depth=1 --branch=v2.5.1 https://github.com/pytorch/pytorch.git
 cd pytorch
 git submodule sync
 git submodule update --init --recursive
@@ -252,7 +252,7 @@ export DNNL_TARGET_ARCH=AARCH64
 export USE_MKLDNN=ON
 export USE_QNNPACK=OFF
 export USE_PYTORCH_QNNPACK=OFF
-export PYTORCH_BUILD_VERSION=2.5.0
+export PYTORCH_BUILD_VERSION=2.5.1
 export PYTORCH_BUILD_NUMBER=1
 /Library/Frameworks/Python.framework/Versions/3.10/bin/python3.10 setup.py install
 ```

--- a/dev-tools/download_macos_deps.sh
+++ b/dev-tools/download_macos_deps.sh
@@ -28,7 +28,7 @@ case `uname -m` in
         ARCHIVE=local-x86_64-apple-macosx12.0-1.tar.bz2
         ;;
     arm64)
-        ARCHIVE=local-arm64-apple-macosx11.1-11.tar.bz2
+        ARCHIVE=local-arm64-apple-macosx11.1-12.tar.bz2
         ;;
 
     *)

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -32,7 +32,7 @@
 
 === Enhancements
 
-* Update the PyTorch library to version 2.5.1. (See {ml-pull}2783[#2783], {ml-pull}2799[#2799].)
+* Update the PyTorch library to version 2.5.1. (See {ml-pull}2783[#2798], {ml-pull}2799[#2799].)
 * Upgrade Boost libraries to version 1.86. (See {ml-pull}2780[#2780], {ml-pull}2779[#2779].)
 * Drop support for macOS Intel builds. (See {ml-pull}2795[#2795].)
 


### PR DESCRIPTION
Update docs and build scripts to refer to PyTorch v2.5.1

Backports #2798