### PR TITLE
[ML] Rebuild Docker image for nightly pytorch latest builds

### DIFF
--- a/dev-tools/docker/README.md
+++ b/dev-tools/docker/README.md
@@ -20,7 +20,7 @@ same tag - pytorch_viable_strict - for the image.
 
 ## Repository: ml-linux-dependency-builder
 
-### Latest version: 3
+### Latest version: 4
 
 ### Comments
 A Docker image that can be used to compile the dependencies of

--- a/dev-tools/docker/build_linux_dependency_builder_image.sh
+++ b/dev-tools/docker/build_linux_dependency_builder_image.sh
@@ -35,7 +35,7 @@ sleep 5
 HOST=docker.elastic.co
 ACCOUNT=ml-dev
 REPOSITORY=ml-linux-dependency-builder
-VERSION=3
+VERSION=4
 
 set -e
 

--- a/dev-tools/docker/pytorch_linux_image/Dockerfile
+++ b/dev-tools/docker/pytorch_linux_image/Dockerfile
@@ -9,7 +9,7 @@
 # limitation.
 #
 
-FROM docker.elastic.co/ml-dev/ml-linux-dependency-builder:3 AS builder
+FROM docker.elastic.co/ml-dev/ml-linux-dependency-builder:4 AS builder
 
 LABEL maintainer="Ed Savage <ed.savage@elastic.co>"
 


### PR DESCRIPTION
Update Docker configs/version numbers in order that the nightly pytorch_latest builds pickup the latest base image changes - e.g. `Boost 1.86.0`.

The base image `docker.elastic.co/ml-dev/ml-linux-build:33` contains the `Boost 1.86.0` libraries required by the `ml-cpp` code, but the latest dependency builder image `docker.elastic.co/ml-dev/ml-linux-dependency-builder:3` built on top of it does not. To solve the issue bump the dependency builder version number to `4` and rebuild the docker image.

See https://buildkite.com/elastic/ml-cpp-pr-builds/builds/1396