### PR TITLE
[ML] Fix for CKMeansOnlineTest compilation errors

### DIFF
--- a/lib/maths/common/unittest/CKMeansOnlineTest.cc
+++ b/lib/maths/common/unittest/CKMeansOnlineTest.cc
@@ -205,8 +205,9 @@ BOOST_AUTO_TEST_CASE(testDeduplicate) {
                         0.0);
     CKMeansOnlineForTest<TVector2>::deduplicate(points);
     BOOST_REQUIRE_EQUAL(1, points.size());
-    BOOST_ASSERT(TFloatVector2{0.0} ==
-                 maths::common::CBasicStatistics::mean(points[0].first));
+    BOOST_REQUIRE_EQUAL(TFloatVector2{0.0},
+                        static_cast<const TFloatVector2&>(
+                            maths::common::CBasicStatistics::mean(points[0].first)));
     BOOST_REQUIRE_EQUAL(4.0, maths::common::CBasicStatistics::count(points[0].first));
     BOOST_REQUIRE_EQUAL(0.0, points[0].second);
     points.clear();
@@ -222,16 +223,19 @@ BOOST_AUTO_TEST_CASE(testDeduplicate) {
                         0.0);
     CKMeansOnlineForTest<TVector2>::deduplicate(points);
     BOOST_REQUIRE_EQUAL(3, points.size());
-    BOOST_ASSERT(TFloatVector2{0.0} ==
-                 maths::common::CBasicStatistics::mean(points[0].first));
+    BOOST_REQUIRE_EQUAL(TFloatVector2{0.0},
+                        static_cast<const TFloatVector2&>(
+                            maths::common::CBasicStatistics::mean(points[0].first)));
     BOOST_REQUIRE_EQUAL(1.0, maths::common::CBasicStatistics::count(points[0].first));
     BOOST_REQUIRE_EQUAL(0.0, points[0].second);
-    BOOST_ASSERT(TFloatVector2{1.0} ==
-                 maths::common::CBasicStatistics::mean(points[1].first));
+    BOOST_REQUIRE_EQUAL(TFloatVector2{1.0},
+                        static_cast<const TFloatVector2&>(
+                            maths::common::CBasicStatistics::mean(points[1].first)));
     BOOST_REQUIRE_EQUAL(2.0, maths::common::CBasicStatistics::count(points[1].first));
     BOOST_REQUIRE_EQUAL(0.0, points[1].second);
-    BOOST_ASSERT(TFloatVector2{2.0} ==
-                 maths::common::CBasicStatistics::mean(points[2].first));
+    BOOST_REQUIRE_EQUAL(TFloatVector2{2.0},
+                        static_cast<const TFloatVector2&>(
+                            maths::common::CBasicStatistics::mean(points[2].first)));
     BOOST_REQUIRE_EQUAL(1.0, maths::common::CBasicStatistics::count(points[2].first));
     BOOST_REQUIRE_EQUAL(0.0, points[2].second);
     points.clear();
@@ -259,16 +263,19 @@ BOOST_AUTO_TEST_CASE(testDeduplicate) {
         CKMeansOnlineForTest<TVector2>::deduplicate(points);
 
         BOOST_REQUIRE_EQUAL(3, points.size());
-        BOOST_ASSERT(TFloatVector2{0.0} ==
-                     maths::common::CBasicStatistics::mean(points[0].first));
+        BOOST_REQUIRE_EQUAL(TFloatVector2{0.0},
+                            static_cast<const TFloatVector2&>(
+                                maths::common::CBasicStatistics::mean(points[0].first)));
         BOOST_REQUIRE_EQUAL(10.0,
                             maths::common::CBasicStatistics::count(points[0].first));
-        BOOST_ASSERT(TFloatVector2{1.0} ==
-                     maths::common::CBasicStatistics::mean(points[1].first));
+        BOOST_REQUIRE_EQUAL(TFloatVector2{1.0},
+                            static_cast<const TFloatVector2&>(
+                                maths::common::CBasicStatistics::mean(points[1].first)));
         BOOST_REQUIRE_EQUAL(7.0,
                             maths::common::CBasicStatistics::count(points[1].first));
-        BOOST_ASSERT(TFloatVector2{2.0} ==
-                     maths::common::CBasicStatistics::mean(points[2].first));
+        BOOST_REQUIRE_EQUAL(TFloatVector2{2.0},
+                            static_cast<const TFloatVector2&>(
+                                maths::common::CBasicStatistics::mean(points[2].first)));
         BOOST_REQUIRE_EQUAL(6.0,
                             maths::common::CBasicStatistics::count(points[2].first));
 


### PR DESCRIPTION
CKMeansOnlineTest fails to build on mac and windows (a previous attempted fix was insufficient for debug builds). 

This PR provides the correct fix for those compilation errors.