### PR TITLE
[8.16][ML] Increase the upper limits for the Boost.JSON SAX parser (#2809)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,12 @@
 
 //=== Regressions
 
+== {es} version 8.16.4
+
+=== Bug Fixes
+
+* Increase the upper limits for the Boost.JSON SAX parser. (See {ml-pull}2809[#2809].)
+
 == {es} version 8.16.0
 
 === Enhancements

--- a/include/core/BoostJsonConstants.h
+++ b/include/core/BoostJsonConstants.h
@@ -13,6 +13,7 @@
 #define INCLUDED_ml_core_CBoostJsonConstants_h
 
 #include <cstddef>
+#include <limits>
 
 namespace ml {
 namespace core {
@@ -21,16 +22,16 @@ namespace boost_json_constants {
 // Constants that set upper limits for Boost.JSON SAX style parsing
 
 // The maximum number of elements allowed in an object
-constexpr std::size_t MAX_OBJECT_SIZE = 1'000'000;
+constexpr std::size_t MAX_OBJECT_SIZE = std::numeric_limits<std::size_t>::max();
 
 // The maximum number of elements allowed in an array
-constexpr std::size_t MAX_ARRAY_SIZE = 1'000'000;
+constexpr std::size_t MAX_ARRAY_SIZE = std::numeric_limits<std::size_t>::max();
 
 // The maximum number of characters allowed in a key
-constexpr std::size_t MAX_KEY_SIZE = 1 << 10;
+constexpr std::size_t MAX_KEY_SIZE = std::numeric_limits<std::size_t>::max();
 
 // The maximum number of characters allowed in a string
-constexpr std::size_t MAX_STRING_SIZE = 1 << 30;
+constexpr std::size_t MAX_STRING_SIZE = std::numeric_limits<std::size_t>::max();
 }
 }
 }


### PR DESCRIPTION
The maximum size limits for several features of the Boost.JSON SAX style parser are currently set to arbitrary "largeish" values. This PR increases those upper limits to be as large as possible.

Closes #2808
Backports #2809