### PR TITLE
[ML] Update build configurations for Elasticsearch 9.1.0 and adjust cron schedules for daily builds

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -156,7 +156,7 @@ spec:
         build_branches: true
         build_pull_request_forks: false
         cancel_deleted_branch_builds: true
-        filter_condition: build.branch == "main" || build.branch == "8.x" || build.branch == "8.18" || build.branch == "8.17" || build.branch == "8.16" ||  build.branch == "7.17"
+        filter_condition: build.branch == "main" || build.branch == "9.0" || build.branch == "8.x" || build.branch == "8.18" || build.branch == "8.17" || build.branch == "8.16" ||  build.branch == "7.17"
         filter_enabled: true
         publish_blocked_as_pending: true
         publish_commit_status: false
@@ -166,24 +166,28 @@ spec:
       schedules:
         Daily 7_17:
           branch: '7.17'
-          cronline: 30 05 * * *
+          cronline: 30 06 * * *
           message: Daily SNAPSHOT build for 7.17
         Daily 8_16:
           branch: '8.16'
-          cronline: 30 04 * * *
+          cronline: 30 05 * * *
           message: Daily SNAPSHOT build for 8.16
         Daily 8_17:
           branch: '8.17'
-          cronline: 30 03 * * *
+          cronline: 30 04 * * *
           message: Daily SNAPSHOT build for 8.17
         Daily 8_18:
           branch: '8.18'
-          cronline: 30 02 * * *
+          cronline: 30 03 * * *
           message: Daily SNAPSHOT build for 8.18
         Daily 8_x:
           branch: '8.x'
-          cronline: 30 01 * * *
+          cronline: 30 02 * * *
           message: Daily SNAPSHOT build for 8.x
+        Daily 9.0:
+          branch: 9.0
+          cronline: 30 01 * * *
+          message: Daily SNAPSHOT build for 9.0
         Daily main:
           branch: main
           cronline: 30 00 * * *

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.daemon=false
 
-elasticsearchVersion=9.0.0
+elasticsearchVersion=9.1.0
 
 artifactName=ml-cpp
 


### PR DESCRIPTION
Update the Elasticsearch version to 9.1.0 and modify cron schedules for daily builds to add support for the new version.