### PR TITLE
[ML] Update location of boost libraries repo

### DIFF
--- a/.ci/orka/third_party_deps.sh
+++ b/.ci/orka/third_party_deps.sh
@@ -22,7 +22,7 @@ unset CPLUS_INCLUDE_PATH
 unset LIBRARY_PATH
 
 # Build and install boost 1.86.0
-curl -L https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2 | tar xjf - && \
+curl -L https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2 | tar xjf - && \
 cd boost_1_86_0 && \
 ./bootstrap.sh --with-toolset=clang --without-libraries=context --without-libraries=coroutine --without-libraries=graph_parallel --without-libraries=mpi --without-libraries=python --without-icu && \
 sed -i -e 's/{13ul/{3ul, 13ul/' boost/unordered/detail/prime_fmod.hpp

--- a/build-setup/linux.md
+++ b/build-setup/linux.md
@@ -177,7 +177,7 @@ to install.
 
 ### Boost 1.86.0
 
-Download version 1.86.0 of Boost from <https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2>. You must get this exact version, as the Machine Learning build system requires it.
+Download version 1.86.0 of Boost from <https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2>. You must get this exact version, as the Machine Learning build system requires it.
 
 Assuming you chose the `.bz2` version, extract it to a temporary directory:
 

--- a/build-setup/macos.md
+++ b/build-setup/macos.md
@@ -87,7 +87,7 @@ process.
 
 ### Boost 1.86.0
 
-Download version 1.86.0 of Boost from <https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2>. You must get this exact version, as the Machine Learning build system requires it.
+Download version 1.86.0 of Boost from <https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2>. You must get this exact version, as the Machine Learning build system requires it.
 
 Assuming you chose the `.bz2` version, extract it to a temporary directory:
 

--- a/build-setup/windows.md
+++ b/build-setup/windows.md
@@ -131,7 +131,7 @@ nmake install
 
 ### Boost 1.86.0
 
-Download version 1.86.0 of Boost from <https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2> . You must get this exact version, as the Machine Learning build system requires it.
+Download version 1.86.0 of Boost from <https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2> . You must get this exact version, as the Machine Learning build system requires it.
 
 Assuming you chose the `.bz2` version, extract it in a Git bash shell using the GNU tar that comes with Git for Windows, e.g.:
 

--- a/dev-tools/build_windows_third_party_deps.ps1
+++ b/dev-tools/build_windows_third_party_deps.ps1
@@ -68,7 +68,7 @@ Write-Host "--- Done Installing libxml2 2.9.14"
 Write-Host "--- Installing boost 1.86.0"
 cd c:\tools
 $Archive="boost_1_86_0.tar.bz2"
-$ZipSource="https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/$Archive"
+$ZipSource="https://archives.boost.io/main/release/1.86.0/source/$Archive"
 $ZipDestination="\tools\$Archive"
 (New-Object Net.WebClient).DownloadFile($ZipSource, $ZipDestination)
 C:\Progra~1\git\bin\bash.exe -c "tar jxvf boost_1_86_0.tar.bz2"

--- a/dev-tools/docker/linux_aarch64_native_image/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_image/Dockerfile
@@ -83,7 +83,7 @@ RUN \
 # Build Boost
 RUN \
   cd ${build_dir} && \
-  wget --quiet -O - https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2 | tar jxf - && \
+  wget --quiet -O - https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2 | tar jxf - && \
   cd boost_1_86_0 && \
   ./bootstrap.sh --without-libraries=context,coroutine,graph_parallel,mpi,python --without-icu && \
   sed -i -e 's/{13ul/{3ul, 13ul/' boost/unordered/detail/prime_fmod.hpp && \

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -83,7 +83,7 @@ RUN \
 # Build Boost
 RUN \
   cd ${build_dir} && \
-  wget --quiet -O - https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2 | tar jxf - && \
+  wget --quiet -O - https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2 | tar jxf - && \
   cd boost_1_86_0 && \
   ./bootstrap.sh --without-libraries=context,coroutine,graph_parallel,mpi,python --without-icu && \
   sed -i -e 's/{13ul/{3ul, 13ul/' boost/unordered/detail/prime_fmod.hpp && \

--- a/dev-tools/docker/ubuntu_devbox/Dockerfile
+++ b/dev-tools/docker/ubuntu_devbox/Dockerfile
@@ -83,14 +83,14 @@ RUN \
 # Build Boost
 RUN \
   cd ${build_dir} && \
-  wget --quiet -O - https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2 | tar jxf - && \
-  cd boost_1_83_0 && \
+  wget --quiet -O - https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2 | tar jxf - && \
+  cd boost_1_86_0 && \
   ./bootstrap.sh --without-libraries=context --without-libraries=coroutine --without-libraries=graph_parallel --without-libraries=mpi --without-libraries=python --without-icu && \
   sed -i -e 's|(13ul)(29ul)(53ul)(97ul)(193ul)(389ul)(769ul)(1543ul)(3079ul)(6151ul)( \\|(3ul)(13ul)(29ul)(53ul)(97ul)(193ul)(389ul)(769ul)(1543ul)(3079ul)(6151ul)(       \\|' boost/unordered/detail/prime_fmod.hpp && \
   ./b2 -j`nproc` --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=BOOST_LOG_WITHOUT_DEBUG_OUTPUT define=BOOST_LOG_WITHOUT_EVENT_LOG define=BOOST_LOG_WITHOUT_SYSLOG define=BOOST_LOG_WITHOUT_IPC define=_FORTIFY_SOURCE=2 cxxflags='-std=gnu++17 -fstack-protector -msse4.2 -mfpmath=sse' cflags='-D__STDC_FORMAT_MACROS' linkflags='-std=gnu++17 -Wl,-z,relro -Wl,-z,now' && \
   ./b2 install --prefix=/usr/local/gcc133 --layout=versioned --disable-icu pch=off optimization=speed inlining=full define=BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS define=BOOST_LOG_WITHOUT_DEBUG_OUTPUT define=BOOST_LOG_WITHOUT_EVENT_LOG define=BOOST_LOG_WITHOUT_SYSLOG define=BOOST_LOG_WITHOUT_IPC define=_FORTIFY_SOURCE=2 cxxflags='-std=gnu++17 -fstack-protector -msse4.2 -mfpmath=sse' cflags='-D__STDC_FORMAT_MACROS' linkflags='-std=gnu++17 -Wl,-z,relro -Wl,-z,now' && \
   cd .. && \
-  rm -rf boost_1_83_0
+  rm -rf boost_1_86_0
 
 # Build patchelf
 RUN \
@@ -165,7 +165,7 @@ ENV PATH=/usr/local/gcc133/bin:/usr/bin:/bin:/usr/sbin:/sbin
 # If the PyTorch branch is changed also update PYTORCH_BUILD_VERSION
 RUN \
   cd ${build_dir} && \
-  git -c advice.detachedHead=false clone --depth=1 --branch=v2.3.1 https://github.com/pytorch/pytorch.git && \
+  git -c advice.detachedHead=false clone --depth=1 --branch=v2.5.1 https://github.com/pytorch/pytorch.git && \
   cd pytorch && \
   git submodule sync && \
   git submodule update --init --recursive && \
@@ -179,7 +179,7 @@ RUN \
   export USE_QNNPACK=OFF && \
   export USE_PYTORCH_QNNPACK=OFF && \
   export USE_XNNPACK=OFF && \
-  export PYTORCH_BUILD_VERSION=2.3.1 && \
+  export PYTORCH_BUILD_VERSION=2.5.1 && \
   export PYTORCH_BUILD_NUMBER=1 && \
   export MAX_JOBS=10 && \
   /usr/local/bin/python3.12 setup.py install

--- a/dev-tools/docker/ubuntu_devbox/Dockerfile.8.11
+++ b/dev-tools/docker/ubuntu_devbox/Dockerfile.8.11
@@ -76,7 +76,7 @@ RUN \
 # Build Boost
 RUN \
   cd ${build_dir} && \
-  wget --quiet -O - https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/boost_1_77_0.tar.bz2 | tar jxf - && \
+  wget --quiet -O - https://archives.boost.io/release/1.77.0/source/boost_1_77_0.tar.bz2 | tar jxf - && \
   cd boost_1_77_0 && \
   ./bootstrap.sh --without-libraries=context --without-libraries=coroutine --without-libraries=graph_parallel --without-libraries=mpi --without-libraries=python --without-icu && \
   sed -i -e 's|(17ul)(29ul)(37ul)(53ul)(67ul)(79ul)( \\|(3ul)(17ul)(29ul)(37ul)(53ul)(67ul)(79ul)(       \\|' boost/unordered/detail/implementation.hpp && \

--- a/dev-tools/docker/ubuntu_devbox/Dockerfile.8.16
+++ b/dev-tools/docker/ubuntu_devbox/Dockerfile.8.16
@@ -76,7 +76,7 @@ RUN \
 # Build Boost
 RUN \
   cd ${build_dir} && \
-  wget --quiet -O - https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2 | tar jxf - && \
+  wget --quiet -O - https://archives.boost.io/release/1.83.0/source/boost_1_83_0.tar.bz2 | tar jxf - && \
   cd boost_1_83_0 && \
   ./bootstrap.sh --without-libraries=context --without-libraries=coroutine --without-libraries=graph_parallel --without-libraries=mpi --without-libraries=python --without-icu && \
   sed -i -e 's|(13ul)(29ul)(53ul)(97ul)(193ul)(389ul)(769ul)(1543ul)(3079ul)(6151ul)( \\|(3ul)(13ul)(29ul)(53ul)(97ul)(193ul)(389ul)(769ul)(1543ul)(3079ul)(6151ul)(       \\|' boost/unordered/detail/prime_fmod.hpp && \


### PR DESCRIPTION
The Boost repository is no longer hosted by jfrog. Update scripts, docs, Dockerfiles etc to reference the new location.