### PR TITLE
[8.18][ML] Update location of boost libraries repo (#2829)

### DIFF
--- a/build-setup/linux.md
+++ b/build-setup/linux.md
@@ -173,7 +173,7 @@ to install.
 
 ### Boost 1.86.0
 
-Download version 1.86.0 of Boost from <https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2>. You must get this exact version, as the Machine Learning build system requires it.
+Download version 1.86.0 of Boost from <https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2>. You must get this exact version, as the Machine Learning build system requires it.
 
 Assuming you chose the `.bz2` version, extract it to a temporary directory:
 

--- a/build-setup/macos.md
+++ b/build-setup/macos.md
@@ -68,7 +68,7 @@ at the command prompt.
 
 ### Boost 1.86.0
 
-Download version 1.86.0 of Boost from <https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2>. You must get this exact version, as the Machine Learning build system requires it.
+Download version 1.86.0 of Boost from <https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2>. You must get this exact version, as the Machine Learning build system requires it.
 
 Assuming you chose the `.bz2` version, extract it to a temporary directory:
 

--- a/build-setup/windows.md
+++ b/build-setup/windows.md
@@ -121,7 +121,7 @@ nmake install
 
 ### Boost 1.86.0
 
-Download version 1.86.0 of Boost from <https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2> . You must get this exact version, as the Machine Learning build system requires it.
+Download version 1.86.0 of Boost from <https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2> . You must get this exact version, as the Machine Learning build system requires it.
 
 Assuming you chose the `.bz2` version, extract it in a Git bash shell using the GNU tar that comes with Git for Windows, e.g.:
 

--- a/dev-tools/docker/linux_aarch64_native_image/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_image/Dockerfile
@@ -78,7 +78,7 @@ RUN \
 # Build Boost
 RUN \
   cd ${build_dir} && \
-  wget --quiet -O - https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2 | tar jxf - && \
+  wget --quiet -O - https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2 | tar jxf - && \
   cd boost_1_86_0 && \
   ./bootstrap.sh --without-libraries=context --without-libraries=coroutine --without-libraries=graph_parallel --without-libraries=mpi --without-libraries=python --without-icu && \
   sed -i -e 's/{13ul/{3ul, 13ul/' boost/unordered/detail/prime_fmod.hpp&& \

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -78,7 +78,7 @@ RUN \
 # Build Boost
 RUN \
   cd ${build_dir} && \
-  wget --quiet -O - https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2 | tar jxf - && \
+  wget --quiet -O - https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2 | tar jxf - && \
   cd boost_1_86_0 && \
   ./bootstrap.sh --without-libraries=context --without-libraries=coroutine --without-libraries=graph_parallel --without-libraries=mpi --without-libraries=python --without-icu && \
   sed -i -e 's/{13ul/{3ul, 13ul/' boost/unordered/detail/prime_fmod.hpp && \


### PR DESCRIPTION
The Boost repository is no longer hosted by jfrog. Update scripts, docs, Dockerfiles etc to reference the new location.

Backports #2829 