### PR TITLE
[ML] Refactor tests that use CDataGatherer constructor

### DIFF
--- a/lib/model/unittest/CDetectionRuleTest.cc
+++ b/lib/model/unittest/CDetectionRuleTest.cc
@@ -49,8 +49,7 @@ using namespace model;
 namespace {
 
 using TFeatureVec = std::vector<model_t::EFeature>;
-using TStrVec = std::vector<std::string>;
-using TMockModelPtr = std::unique_ptr<model::CMockModel>;
+using TMockModelPtr = std::unique_ptr<CMockModel>;
 
 const std::string EMPTY_STRING;
 }
@@ -61,39 +60,35 @@ protected:
 };
 
 BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
-    core_t::TTime bucketLength = 100;
-    core_t::TTime startTime = 100;
-    SModelParams params(bucketLength);
-    CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
+    constexpr core_t::TTime bucketLength = 100;
+    constexpr core_t::TTime startTime = 100;
+    const SModelParams params(bucketLength);
+    constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
 
     TFeatureVec features;
     features.push_back(model_t::E_PopulationMeanByPersonAndAttribute);
-    std::string partitionFieldName("partition");
-    std::string partitionFieldValue("par_1");
-    std::string personFieldName("over");
-    std::string attributeFieldName("by");
-    CSearchKey key(0, function_t::E_PopulationMetricMean, false, model_t::E_XF_None,
+    std::string const partitionFieldName("partition");
+    std::string const partitionFieldValue("par_1");
+    std::string const personFieldName("over");
+    std::string const attributeFieldName("by");
+    CSearchKey const key(0, function_t::E_PopulationMetricMean, false, model_t::E_XF_None,
                    "", attributeFieldName, personFieldName, partitionFieldName);
-    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-    //     model_t::E_PopulationMetric, model_t::E_None, params, EMPTY_STRING,
-    //     partitionFieldValue, personFieldName, attributeFieldName, EMPTY_STRING,
-    // TStrVec{}, key, features, startTime, 0));
-    auto gathererPtr = model::CDataGathererBuilder(model_t::E_PopulationMetric,
-                                                   features, params, key, 0)
+    auto gathererPtr = CDataGathererBuilder(model_t::E_PopulationMetric,
+                                                   features, params, key, startTime)
                            .partitionFieldValue(partitionFieldValue)
                            .personFieldName(personFieldName)
                            .attributeFieldName(attributeFieldName)
                            .buildSharedPtr();
 
-    std::string person1("p1");
+    std::string const person1("p1");
     bool added = false;
     gathererPtr->addPerson(person1, m_ResourceMonitor, added);
-    std::string person2("p2");
+    std::string const person2("p2");
     gathererPtr->addPerson(person2, m_ResourceMonitor, added);
-    std::string attr11("a1_1");
-    std::string attr12("a1_2");
-    std::string attr21("a2_1");
-    std::string attr22("a2_2");
+    std::string const attr11("a1_1");
+    std::string const attr12("a1_2");
+    std::string const attr21("a2_1");
+    std::string const attr22("a2_2");
     gathererPtr->addAttribute(attr11, m_ResourceMonitor, added);
     gathererPtr->addAttribute(attr12, m_ResourceMonitor, added);
     gathererPtr->addAttribute(attr21, m_ResourceMonitor, added);
@@ -101,14 +96,14 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
 
     CMockModel model(params, gathererPtr, influenceCalculators);
     model.mockPopulation(true);
-    CAnomalyDetectorModel::TDouble1Vec actual(1, 4.99);
+    CAnomalyDetectorModel::TDouble1Vec const actual(1, 4.99);
     model.mockAddBucketValue(model_t::E_PopulationMeanByPersonAndAttribute, 0, 0, 100, actual);
     model.mockAddBucketValue(model_t::E_PopulationMeanByPersonAndAttribute, 0, 1, 100, actual);
     model.mockAddBucketValue(model_t::E_PopulationMeanByPersonAndAttribute, 1, 2, 100, actual);
     model.mockAddBucketValue(model_t::E_PopulationMeanByPersonAndAttribute, 1, 3, 100, actual);
 
     for (auto filterType : {CRuleScope::E_Include, CRuleScope::E_Exclude}) {
-        std::string filterJson("[\"a1_1\",\"a2_2\"]");
+        std::string const filterJson(R"(["a1_1","a2_2"])");
         core::CPatternSet valueFilter;
         valueFilter.initFromJson(filterJson);
 
@@ -120,7 +115,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
         }
 
         bool isInclude = filterType == CRuleScope::E_Include;
-        model_t::CResultType resultType(model_t::CResultType::E_Final);
+        model_t::CResultType const resultType(model_t::CResultType::E_Final);
 
         BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
                                       model_t::E_PopulationMeanByPersonAndAttribute,
@@ -137,7 +132,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
     }
 
     for (auto filterType : {CRuleScope::E_Include, CRuleScope::E_Exclude}) {
-        std::string filterJson("[\"a1*\"]");
+        std::string const filterJson("[\"a1*\"]");
         core::CPatternSet valueFilter;
         valueFilter.initFromJson(filterJson);
 
@@ -149,7 +144,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
         }
 
         bool isInclude = filterType == CRuleScope::E_Include;
-        model_t::CResultType resultType(model_t::CResultType::E_Final);
+        model_t::CResultType const resultType(model_t::CResultType::E_Final);
 
         BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
                                       model_t::E_PopulationMeanByPersonAndAttribute,
@@ -166,7 +161,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
     }
 
     for (auto filterType : {CRuleScope::E_Include, CRuleScope::E_Exclude}) {
-        std::string filterJson("[\"*2\"]");
+        std::string const filterJson("[\"*2\"]");
         core::CPatternSet valueFilter;
         valueFilter.initFromJson(filterJson);
 
@@ -178,7 +173,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
         }
 
         bool isInclude = filterType == CRuleScope::E_Include;
-        model_t::CResultType resultType(model_t::CResultType::E_Final);
+        model_t::CResultType const resultType(model_t::CResultType::E_Final);
 
         BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
                                       model_t::E_PopulationMeanByPersonAndAttribute,
@@ -195,7 +190,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
     }
 
     for (auto filterType : {CRuleScope::E_Include, CRuleScope::E_Exclude}) {
-        std::string filterJson("[\"*1*\"]");
+        std::string const filterJson("[\"*1*\"]");
         core::CPatternSet valueFilter;
         valueFilter.initFromJson(filterJson);
 
@@ -207,7 +202,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
         }
 
         bool isInclude = filterType == CRuleScope::E_Include;
-        model_t::CResultType resultType(model_t::CResultType::E_Final);
+        model_t::CResultType const resultType(model_t::CResultType::E_Final);
 
         BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
                                       model_t::E_PopulationMeanByPersonAndAttribute,
@@ -224,7 +219,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
     }
 
     for (auto filterType : {CRuleScope::E_Include, CRuleScope::E_Exclude}) {
-        std::string filterJson("[\"p2\"]");
+        std::string const filterJson("[\"p2\"]");
         core::CPatternSet valueFilter;
         valueFilter.initFromJson(filterJson);
 
@@ -236,7 +231,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
         }
 
         bool isInclude = filterType == CRuleScope::E_Include;
-        model_t::CResultType resultType(model_t::CResultType::E_Final);
+        model_t::CResultType const resultType(model_t::CResultType::E_Final);
 
         BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
                                       model_t::E_PopulationMeanByPersonAndAttribute,
@@ -253,7 +248,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
     }
 
     for (auto filterType : {CRuleScope::E_Include, CRuleScope::E_Exclude}) {
-        std::string filterJson("[\"par_1\"]");
+        std::string const filterJson("[\"par_1\"]");
         core::CPatternSet valueFilter;
         valueFilter.initFromJson(filterJson);
 
@@ -265,7 +260,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
         }
 
         bool isInclude = filterType == CRuleScope::E_Include;
-        model_t::CResultType resultType(model_t::CResultType::E_Final);
+        model_t::CResultType const resultType(model_t::CResultType::E_Final);
 
         BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
                                       model_t::E_PopulationMeanByPersonAndAttribute,
@@ -282,7 +277,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
     }
 
     for (auto filterType : {CRuleScope::E_Include, CRuleScope::E_Exclude}) {
-        std::string filterJson("[\"par_2\"]");
+        std::string const filterJson("[\"par_2\"]");
         core::CPatternSet valueFilter;
         valueFilter.initFromJson(filterJson);
 
@@ -294,7 +289,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
         }
 
         bool isInclude = filterType == CRuleScope::E_Include;
-        model_t::CResultType resultType(model_t::CResultType::E_Final);
+        model_t::CResultType const resultType(model_t::CResultType::E_Final);
 
         BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
                                       model_t::E_PopulationMeanByPersonAndAttribute,
@@ -312,28 +307,25 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalActualCondition, CTestFixture) {
-    core_t::TTime bucketLength = 100;
-    core_t::TTime startTime = 100;
-    CSearchKey key;
-    SModelParams params(bucketLength);
-    CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
+    constexpr core_t::TTime bucketLength = 100;
+    constexpr core_t::TTime startTime = 100;
+    CSearchKey const key;
+    SModelParams const params(bucketLength);
+    CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec const influenceCalculators;
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualMeanByPerson);
-    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-    //     model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-    //     EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
-    CAnomalyDetectorModel::TDataGathererPtr gathererPtr =
-        model::CDataGathererBuilder(model_t::E_Metric, features, params, key, 0).buildSharedPtr();
+    auto const gathererPtr =
+        CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime).buildSharedPtr();
 
-    std::string person1("p1");
+    std::string const person1("p1");
     bool addedPerson = false;
     gathererPtr->addPerson(person1, m_ResourceMonitor, addedPerson);
 
     CMockModel model(params, gathererPtr, influenceCalculators);
-    CAnomalyDetectorModel::TDouble1Vec actual100(1, 4.99);
-    CAnomalyDetectorModel::TDouble1Vec actual200(1, 5.00);
-    CAnomalyDetectorModel::TDouble1Vec actual300(1, 5.01);
+    CAnomalyDetectorModel::TDouble1Vec const actual100(1, 4.99);
+    CAnomalyDetectorModel::TDouble1Vec const actual200(1, 5.00);
+    CAnomalyDetectorModel::TDouble1Vec const actual300(1, 5.01);
     model.mockAddBucketValue(model_t::E_IndividualMeanByPerson, 0, 0, 100, actual100);
     model.mockAddBucketValue(model_t::E_IndividualMeanByPerson, 0, 0, 200, actual200);
     model.mockAddBucketValue(model_t::E_IndividualMeanByPerson, 0, 0, 300, actual300);
@@ -348,7 +340,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalActualCondition, CTestFixture) {
         CDetectionRule rule;
         rule.addCondition(condition);
 
-        model_t::CResultType resultType(model_t::CResultType::E_Final);
+        model_t::CResultType const resultType(model_t::CResultType::E_Final);
 
         BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
                                       model_t::E_IndividualMeanByPerson,
@@ -371,7 +363,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalActualCondition, CTestFixture) {
         CDetectionRule rule;
         rule.addCondition(condition);
 
-        model_t::CResultType resultType(model_t::CResultType::E_Final);
+        model_t::CResultType const resultType(model_t::CResultType::E_Final);
 
         BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
                                       model_t::E_IndividualMeanByPerson,
@@ -393,7 +385,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalActualCondition, CTestFixture) {
         CDetectionRule rule;
         rule.addCondition(condition);
 
-        model_t::CResultType resultType(model_t::CResultType::E_Final);
+        model_t::CResultType const resultType(model_t::CResultType::E_Final);
 
         BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
                                       model_t::E_IndividualMeanByPerson,
@@ -415,7 +407,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalActualCondition, CTestFixture) {
         CDetectionRule rule;
         rule.addCondition(condition);
 
-        model_t::CResultType resultType(model_t::CResultType::E_Final);
+        model_t::CResultType const resultType(model_t::CResultType::E_Final);
 
         BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
                                       model_t::E_IndividualMeanByPerson,
@@ -430,34 +422,31 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalActualCondition, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalTypicalCondition, CTestFixture) {
-    core_t::TTime bucketLength = 100;
-    core_t::TTime startTime = 100;
-    CSearchKey key;
-    SModelParams params(bucketLength);
-    CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
+    constexpr core_t::TTime bucketLength = 100;
+    constexpr core_t::TTime startTime = 100;
+    CSearchKey const key;
+    SModelParams const params(bucketLength);
+    CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec const influenceCalculators;
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualMeanByPerson);
-    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-    //     model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-    //     EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
     auto gathererPtr =
-        model::CDataGathererBuilder(model_t::E_Metric, features, params, key, 0).buildSharedPtr();
+        CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime).buildSharedPtr();
 
-    std::string person1("p1");
+    std::string const person1("p1");
     bool addedPerson = false;
     gathererPtr->addPerson(person1, m_ResourceMonitor, addedPerson);
 
     CMockModel model(params, gathererPtr, influenceCalculators);
-    CAnomalyDetectorModel::TDouble1Vec actual100(1, 4.99);
-    CAnomalyDetectorModel::TDouble1Vec actual200(1, 5.00);
-    CAnomalyDetectorModel::TDouble1Vec actual300(1, 5.01);
+    CAnomalyDetectorModel::TDouble1Vec const actual100(1, 4.99);
+    CAnomalyDetectorModel::TDouble1Vec const actual200(1, 5.00);
+    CAnomalyDetectorModel::TDouble1Vec const actual300(1, 5.01);
     model.mockAddBucketValue(model_t::E_IndividualMeanByPerson, 0, 0, 100, actual100);
     model.mockAddBucketValue(model_t::E_IndividualMeanByPerson, 0, 0, 200, actual200);
     model.mockAddBucketValue(model_t::E_IndividualMeanByPerson, 0, 0, 300, actual300);
-    CAnomalyDetectorModel::TDouble1Vec typical100(1, 44.99);
-    CAnomalyDetectorModel::TDouble1Vec typical200(1, 45.00);
-    CAnomalyDetectorModel::TDouble1Vec typical300(1, 45.01);
+    CAnomalyDetectorModel::TDouble1Vec const typical100(1, 44.99);
+    CAnomalyDetectorModel::TDouble1Vec const typical200(1, 45.00);
+    CAnomalyDetectorModel::TDouble1Vec const typical300(1, 45.01);
     model.mockAddBucketBaselineMean(model_t::E_IndividualMeanByPerson, 0, 0, 100, typical100);
     model.mockAddBucketBaselineMean(model_t::E_IndividualMeanByPerson, 0, 0, 200, typical200);
     model.mockAddBucketBaselineMean(model_t::E_IndividualMeanByPerson, 0, 0, 300, typical300);
@@ -472,7 +461,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalTypicalCondition, CTestFixture) {
         CDetectionRule rule;
         rule.addCondition(condition);
 
-        model_t::CResultType resultType(model_t::CResultType::E_Final);
+        model_t::CResultType const resultType(model_t::CResultType::E_Final);
 
         BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
                                       model_t::E_IndividualMeanByPerson,
@@ -495,7 +484,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalTypicalCondition, CTestFixture) {
         CDetectionRule rule;
         rule.addCondition(condition);
 
-        model_t::CResultType resultType(model_t::CResultType::E_Final);
+        model_t::CResultType const resultType(model_t::CResultType::E_Final);
 
         BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
                                       model_t::E_IndividualMeanByPerson,
@@ -510,43 +499,40 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalTypicalCondition, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalDiffAbsCondition, CTestFixture) {
-    core_t::TTime bucketLength = 100;
-    core_t::TTime startTime = 100;
-    CSearchKey key;
-    SModelParams params(bucketLength);
-    CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
+    constexpr core_t::TTime bucketLength = 100;
+    constexpr core_t::TTime startTime = 100;
+    CSearchKey const key;
+    SModelParams const params(bucketLength);
+    CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec const influenceCalculators;
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualMeanByPerson);
-    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-    //     model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-    //     EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
-    CAnomalyDetectorModel::TDataGathererPtr gathererPtr =
-        model::CDataGathererBuilder(model_t::E_Metric, features, params, key, 0).buildSharedPtr();
+    auto gathererPtr =
+        CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime).buildSharedPtr();
 
-    std::string person1("p1");
+    std::string const person1("p1");
     bool addedPerson = false;
     gathererPtr->addPerson(person1, m_ResourceMonitor, addedPerson);
 
     CMockModel model(params, gathererPtr, influenceCalculators);
-    CAnomalyDetectorModel::TDouble1Vec actual100(1, 8.9);
-    CAnomalyDetectorModel::TDouble1Vec actual200(1, 9.0);
-    CAnomalyDetectorModel::TDouble1Vec actual300(1, 9.1);
-    CAnomalyDetectorModel::TDouble1Vec actual400(1, 10.9);
-    CAnomalyDetectorModel::TDouble1Vec actual500(1, 11.0);
-    CAnomalyDetectorModel::TDouble1Vec actual600(1, 11.1);
+    CAnomalyDetectorModel::TDouble1Vec const actual100(1, 8.9);
+    CAnomalyDetectorModel::TDouble1Vec const actual200(1, 9.0);
+    CAnomalyDetectorModel::TDouble1Vec const actual300(1, 9.1);
+    CAnomalyDetectorModel::TDouble1Vec const actual400(1, 10.9);
+    CAnomalyDetectorModel::TDouble1Vec const actual500(1, 11.0);
+    CAnomalyDetectorModel::TDouble1Vec const actual600(1, 11.1);
     model.mockAddBucketValue(model_t::E_IndividualMeanByPerson, 0, 0, 100, actual100);
     model.mockAddBucketValue(model_t::E_IndividualMeanByPerson, 0, 0, 200, actual200);
     model.mockAddBucketValue(model_t::E_IndividualMeanByPerson, 0, 0, 300, actual300);
     model.mockAddBucketValue(model_t::E_IndividualMeanByPerson, 0, 0, 400, actual400);
     model.mockAddBucketValue(model_t::E_IndividualMeanByPerson, 0, 0, 500, actual500);
     model.mockAddBucketValue(model_t::E_IndividualMeanByPerson, 0, 0, 600, actual600);
-    CAnomalyDetectorModel::TDouble1Vec typical100(1, 10.0);
-    CAnomalyDetectorModel::TDouble1Vec typical200(1, 10.0);
-    CAnomalyDetectorModel::TDouble1Vec typical300(1, 10.0);
-    CAnomalyDetectorModel::TDouble1Vec typical400(1, 10.0);
-    CAnomalyDetectorModel::TDouble1Vec typical500(1, 10.0);
-    CAnomalyDetectorModel::TDouble1Vec typical600(1, 10.0);
+    CAnomalyDetectorModel::TDouble1Vec const typical100(1, 10.0);
+    CAnomalyDetectorModel::TDouble1Vec const typical200(1, 10.0);
+    CAnomalyDetectorModel::TDouble1Vec const typical300(1, 10.0);
+    CAnomalyDetectorModel::TDouble1Vec const typical400(1, 10.0);
+    CAnomalyDetectorModel::TDouble1Vec const typical500(1, 10.0);
+    CAnomalyDetectorModel::TDouble1Vec const typical600(1, 10.0);
     model.mockAddBucketBaselineMean(model_t::E_IndividualMeanByPerson, 0, 0, 100, typical100);
     model.mockAddBucketBaselineMean(model_t::E_IndividualMeanByPerson, 0, 0, 200, typical200);
     model.mockAddBucketBaselineMean(model_t::E_IndividualMeanByPerson, 0, 0, 300, typical300);
@@ -564,7 +550,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalDiffAbsCondition, CTestFixture) {
         CDetectionRule rule;
         rule.addCondition(condition);
 
-        model_t::CResultType resultType(model_t::CResultType::E_Final);
+        model_t::CResultType const resultType(model_t::CResultType::E_Final);
 
         BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
                                       model_t::E_IndividualMeanByPerson,
@@ -596,7 +582,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalDiffAbsCondition, CTestFixture) {
         CDetectionRule rule;
         rule.addCondition(condition);
 
-        model_t::CResultType resultType(model_t::CResultType::E_Final);
+        model_t::CResultType const resultType(model_t::CResultType::E_Final);
 
         BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
                                       model_t::E_IndividualMeanByPerson,
@@ -628,11 +614,8 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNoActualValueAvailable, CTestFixture) {
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualMeanByPerson);
-    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-    //     model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-    //     EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
     CAnomalyDetectorModel::TDataGathererPtr gathererPtr =
-        model::CDataGathererBuilder(model_t::E_Metric, features, params, key, 0).buildSharedPtr();
+        CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime).buildSharedPtr();
 
     std::string person1("p1");
     bool addedPerson = false;
@@ -670,7 +653,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenDifferentSeriesAndIndividualModel, CTestFi
     features.push_back(model_t::E_IndividualMeanByPerson);
     std::string personFieldName("series");
     CAnomalyDetectorModel::TDataGathererPtr gathererPtr =
-        model::CDataGathererBuilder(model_t::E_Metric, features, params, key, 0)
+        CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime)
             .personFieldName(personFieldName)
             .buildSharedPtr();
 
@@ -719,12 +702,8 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenDifferentSeriesAndPopulationModel, CTestFi
     features.push_back(model_t::E_PopulationMeanByPersonAndAttribute);
     std::string personFieldName("over");
     std::string attributeFieldName("by");
-    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-    //     model_t::E_PopulationMetric, model_t::E_None, params, EMPTY_STRING,
-    //     EMPTY_STRING, personFieldName, attributeFieldName, EMPTY_STRING,
-    //     TStrVec{}, key, features, startTime, 0));
-    auto gathererPtr = model::CDataGathererBuilder(model_t::E_PopulationMetric,
-                                                   features, params, key, 0)
+    auto gathererPtr = CDataGathererBuilder(model_t::E_PopulationMetric,
+                                                   features, params, key, startTime)
                            .personFieldName(personFieldName)
                            .attributeFieldName(attributeFieldName)
                            .buildSharedPtr();
@@ -789,11 +768,8 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenMultipleConditions, CTestFixture) {
     TFeatureVec features;
     features.push_back(model_t::E_IndividualMeanByPerson);
     std::string personFieldName("series");
-    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-    //     model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, personFieldName,
-    //     EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
     CAnomalyDetectorModel::TDataGathererPtr gathererPtr =
-        model::CDataGathererBuilder(model_t::E_Metric, features, params, key, 0)
+        CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime)
             .personFieldName(personFieldName)
             .buildSharedPtr();
 
@@ -899,11 +875,8 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenTimeCondition, CTestFixture) {
     std::string personFieldName("series");
     CSearchKey key(0, function_t::E_IndividualMetricMean, false, model_t::E_XF_None,
                    "", personFieldName, EMPTY_STRING, partitionFieldName);
-    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-    //     model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, personFieldName,
-    //     EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
     auto gathererPtr =
-        model::CDataGathererBuilder(model_t::E_Metric, features, params, key, 0)
+        CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime)
             .personFieldName(personFieldName)
             .buildSharedPtr();
     CMockModel model(params, gathererPtr, influenceCalculators);
@@ -944,11 +917,8 @@ BOOST_FIXTURE_TEST_CASE(testRuleActions, CTestFixture) {
     std::string personFieldName("series");
     CSearchKey key(0, function_t::E_IndividualMetricMean, false, model_t::E_XF_None,
                    "", personFieldName, EMPTY_STRING, partitionFieldName);
-    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-    //     model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, personFieldName,
-    //     EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
     auto gathererPtr =
-        model::CDataGathererBuilder(model_t::E_Metric, features, params, key, 0)
+        CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime)
             .personFieldName(personFieldName)
             .buildSharedPtr();
     CMockModel model(params, gathererPtr, influenceCalculators);
@@ -975,7 +945,7 @@ BOOST_FIXTURE_TEST_CASE(testRuleActions, CTestFixture) {
                                   model_t::E_IndividualMeanByPerson, resultType,
                                   0, 0, 100));
 
-    rule.action(static_cast<CDetectionRule::ERuleAction>(3));
+    rule.action(3);
     BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model, model_t::E_IndividualMeanByPerson,
                                   resultType, 0, 0, 100));
     BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipModelUpdate, model,
@@ -983,20 +953,17 @@ BOOST_FIXTURE_TEST_CASE(testRuleActions, CTestFixture) {
                                   0, 0, 100));
 }
 
-TMockModelPtr initializeModel(ml::model::CResourceMonitor& resourceMonitor) {
+static TMockModelPtr initializeModel(CResourceMonitor& resourceMonitor) {
     core_t::TTime bucketLength{600};
-    model::SModelParams params{bucketLength};
-    model::CSearchKey key;
+    SModelParams params{bucketLength};
+    CSearchKey key;
     model_t::TFeatureVec features;
     // Initialize mock model
-    model::CAnomalyDetectorModel::TDataGathererPtr gatherer;
+    CAnomalyDetectorModel::TDataGathererPtr gatherer;
 
     features.assign(1, model_t::E_IndividualSumByBucketAndPerson);
 
-    // gatherer = std::make_shared<model::CDataGatherer>(
-    //     model_t::analysisCategory(features[0]), model_t::E_None, params, EMPTY_STRING,
-    //     EMPTY_STRING, "p", EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, 0, 0);
-    gatherer = model::CDataGathererBuilder(model_t::analysisCategory(features[0]),
+    gatherer = CDataGathererBuilder(analysisCategory(features[0]),
                                            features, params, key, 0)
                    .personFieldName("p")
                    .buildSharedPtr();
@@ -1004,7 +971,7 @@ TMockModelPtr initializeModel(ml::model::CResourceMonitor& resourceMonitor) {
     bool addedPerson{false};
     gatherer->addPerson(person, resourceMonitor, addedPerson);
 
-    TMockModelPtr model{new model::CMockModel(
+    TMockModelPtr model{new CMockModel(
         params, gatherer, {/* we don't care about influence */})};
 
     maths::time_series::CTimeSeriesDecomposition trend;
@@ -1012,10 +979,10 @@ TMockModelPtr initializeModel(ml::model::CResourceMonitor& resourceMonitor) {
         maths::common::CNormalMeanPrecConjugate::nonInformativePrior(maths_t::E_ContinuousData)};
     maths::common::CModelParams timeSeriesModelParams{
         bucketLength, 1.0, 0.001, 0.2, 6 * core::constants::HOUR, 24 * core::constants::HOUR};
-    std::unique_ptr<maths::time_series::CUnivariateTimeSeriesModel> timeSeriesModel =
+    auto timeSeriesModel =
         std::make_unique<maths::time_series::CUnivariateTimeSeriesModel>(
             timeSeriesModelParams, 0, trend, prior);
-    model::CMockModel::TMathsModelUPtrVec models;
+    CMockModel::TMathsModelUPtrVec models;
     models.emplace_back(std::move(timeSeriesModel));
     model->mockTimeSeriesModels(std::move(models));
     return model;
@@ -1027,7 +994,7 @@ BOOST_FIXTURE_TEST_CASE(testRuleTimeShiftShouldShiftTimeSeriesModelState, CTestF
     test::CRandomNumbers::TDoubleVec timeShifts;
     rng.generateUniformSamples(-3600, 3600, 10, timeShifts);
 
-    for (auto timeShift : timeShifts) {
+    for (const auto timeShift : timeShifts) {
         core_t::TTime timeShiftInSecs{static_cast<core_t::TTime>(timeShift)};
         TMockModelPtr model{initializeModel(m_ResourceMonitor)};
         // Capture state before the rule is applied
@@ -1036,11 +1003,11 @@ BOOST_FIXTURE_TEST_CASE(testRuleTimeShiftShouldShiftTimeSeriesModelState, CTestF
                 static_cast<const maths::time_series::CUnivariateTimeSeriesModel*>(
                     model->model(0))
                     ->trendModel());
-        core_t::TTime lastValueTime = trendModel.lastValueTime();
+        const core_t::TTime lastValueTime = trendModel.lastValueTime();
         const auto& annotations = model->annotations();
-        std::size_t numAnnotationsBeforeShift = annotations.size();
+        const std::size_t numAnnotationsBeforeShift = annotations.size();
 
-        core_t::TTime timestamp{100};
+        constexpr core_t::TTime timestamp{100};
         CRuleCondition conditionGte;
         conditionGte.appliesTo(CRuleCondition::E_Time);
         conditionGte.op(CRuleCondition::E_GTE);
@@ -1063,9 +1030,9 @@ BOOST_FIXTURE_TEST_CASE(testRuleTimeShiftShouldShiftTimeSeriesModelState, CTestF
 
 BOOST_FIXTURE_TEST_CASE(testRuleTimeShiftShouldNotApplyTwice, CTestFixture) {
     // Test that if a rule has already been applied, it should not be applied again.
-    core_t::TTime timeShift{3600};
+    constexpr core_t::TTime timeShift{3600};
 
-    TMockModelPtr model{initializeModel(m_ResourceMonitor)};
+    const TMockModelPtr model{initializeModel(m_ResourceMonitor)};
     const auto& trendModel = static_cast<const maths::time_series::CTimeSeriesDecomposition&>(
         static_cast<const maths::time_series::CUnivariateTimeSeriesModel*>(model->model(0))
             ->trendModel());
@@ -1094,10 +1061,10 @@ BOOST_FIXTURE_TEST_CASE(testRuleTimeShiftShouldNotApplyTwice, CTestFixture) {
 
 BOOST_FIXTURE_TEST_CASE(testTwoTimeShiftRuleShouldShiftTwice, CTestFixture) {
     // Test that if two rules are applied, the time series model should be shifted twice.
-    core_t::TTime timeShift1{3600};
-    core_t::TTime timeShift2{7200};
+    constexpr core_t::TTime timeShift1{3600};
+    constexpr core_t::TTime timeShift2{7200};
 
-    TMockModelPtr model{initializeModel(m_ResourceMonitor)};
+    const TMockModelPtr model{initializeModel(m_ResourceMonitor)};
     const auto& trendModel = static_cast<const maths::time_series::CTimeSeriesDecomposition&>(
         static_cast<const maths::time_series::CUnivariateTimeSeriesModel*>(model->model(0))
             ->trendModel());
@@ -1114,7 +1081,7 @@ BOOST_FIXTURE_TEST_CASE(testTwoTimeShiftRuleShouldShiftTwice, CTestFixture) {
     rule1.addTimeShift(timeShift1);
     rule1.executeCallback(*model, timestamp);
 
-    core_t::TTime lastValueTimeAfterFirstShift = trendModel.lastValueTime();
+    const core_t::TTime lastValueTimeAfterFirstShift = trendModel.lastValueTime();
 
     CDetectionRule rule2;
     rule2.addCondition(conditionGte);
@@ -1187,7 +1154,7 @@ BOOST_FIXTURE_TEST_CASE(testChecksum, CTestFixture) {
     rule2 = rule1;
 
     // Modify the scope of rule2
-    std::string fieldName = "user";
+    const std::string fieldName = "user";
     core::CPatternSet valueFilter;
     valueFilter.initFromPatternList({"admin"});
     rule2.includeScope(fieldName, valueFilter);

--- a/lib/model/unittest/CDetectionRuleTest.cc
+++ b/lib/model/unittest/CDetectionRuleTest.cc
@@ -63,25 +63,22 @@ TMockModelPtr initializeModel(CResourceMonitor& resourceMonitor) {
 
     features.assign(1, model_t::E_IndividualSumByBucketAndPerson);
 
-    gatherer = CDataGathererBuilder(analysisCategory(features[0]),
-                                           features, params, key, 0)
+    gatherer = CDataGathererBuilder(analysisCategory(features[0]), features, params, key, 0)
                    .personFieldName("p")
                    .buildSharedPtr();
     std::string const person("p1");
     bool addedPerson{false};
     gatherer->addPerson(person, resourceMonitor, addedPerson);
 
-    TMockModelPtr model{new CMockModel(
-        params, gatherer, {/* we don't care about influence */})};
+    TMockModelPtr model{new CMockModel(params, gatherer, {/* we don't care about influence */})};
 
     maths::time_series::CTimeSeriesDecomposition const trend;
     maths::common::CNormalMeanPrecConjugate const prior{
         maths::common::CNormalMeanPrecConjugate::nonInformativePrior(maths_t::E_ContinuousData)};
     maths::common::CModelParams const timeSeriesModelParams{
         bucketLength, 1.0, 0.001, 0.2, 6 * core::constants::HOUR, 24 * core::constants::HOUR};
-    auto timeSeriesModel =
-        std::make_unique<maths::time_series::CUnivariateTimeSeriesModel>(
-            timeSeriesModelParams, 0, trend, prior);
+    auto timeSeriesModel = std::make_unique<maths::time_series::CUnivariateTimeSeriesModel>(
+        timeSeriesModelParams, 0, trend, prior);
     CMockModel::TMathsModelUPtrVec models;
     models.emplace_back(std::move(timeSeriesModel));
     model->mockTimeSeriesModels(std::move(models));
@@ -107,9 +104,9 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
     std::string const personFieldName("over");
     std::string const attributeFieldName("by");
     CSearchKey const key(0, function_t::E_PopulationMetricMean, false, model_t::E_XF_None,
-                   "", attributeFieldName, personFieldName, partitionFieldName);
+                         "", attributeFieldName, personFieldName, partitionFieldName);
     auto gathererPtr = CDataGathererBuilder(model_t::E_PopulationMetric,
-                                                   features, params, key, startTime)
+                                            features, params, key, startTime)
                            .partitionFieldValue(partitionFieldValue)
                            .personFieldName(personFieldName)
                            .attributeFieldName(attributeFieldName)
@@ -349,7 +346,8 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalActualCondition, CTestFixture) {
     constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
 
     TFeatureVec const features{model_t::E_IndividualMeanByPerson};
-    auto gathererPtr = CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime).buildSharedPtr();
+    auto gathererPtr = CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime)
+                           .buildSharedPtr();
 
     std::string const person1("p1");
     bool addedPerson = false;
@@ -363,7 +361,8 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalActualCondition, CTestFixture) {
     model.mockAddBucketValue(model_t::E_IndividualMeanByPerson, 0, 0, 200, actual200);
     model.mockAddBucketValue(model_t::E_IndividualMeanByPerson, 0, 0, 300, actual300);
 
-    auto testRule = [&](CRuleCondition::ERuleConditionOperator op, double value, bool expected100, bool expected200, bool expected300) {
+    auto testRule = [&](CRuleCondition::ERuleConditionOperator op, double value,
+                        bool expected100, bool expected200, bool expected300) {
         CRuleCondition condition;
         condition.appliesTo(CRuleCondition::E_Actual);
         condition.op(op);
@@ -373,9 +372,15 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalActualCondition, CTestFixture) {
 
         model_t::CResultType const resultType(model_t::CResultType::E_Final);
 
-        BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model, model_t::E_IndividualMeanByPerson, resultType, 0, 0, 100) == expected100);
-        BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model, model_t::E_IndividualMeanByPerson, resultType, 0, 0, 200) == expected200);
-        BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model, model_t::E_IndividualMeanByPerson, resultType, 0, 0, 300) == expected300);
+        BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
+                                      model_t::E_IndividualMeanByPerson,
+                                      resultType, 0, 0, 100) == expected100);
+        BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
+                                      model_t::E_IndividualMeanByPerson,
+                                      resultType, 0, 0, 200) == expected200);
+        BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
+                                      model_t::E_IndividualMeanByPerson,
+                                      resultType, 0, 0, 300) == expected300);
     };
 
     testRule(CRuleCondition::E_LT, 5.0, true, false, false);
@@ -392,7 +397,8 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalTypicalCondition, CTestFixture) {
     constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
 
     TFeatureVec const features{model_t::E_IndividualMeanByPerson};
-    auto gathererPtr = CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime).buildSharedPtr();
+    auto gathererPtr = CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime)
+                           .buildSharedPtr();
 
     const std::string person1("p1");
     bool addedPerson = false;
@@ -412,7 +418,8 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalTypicalCondition, CTestFixture) {
     model.mockAddBucketBaselineMean(model_t::E_IndividualMeanByPerson, 0, 0, 200, typical200);
     model.mockAddBucketBaselineMean(model_t::E_IndividualMeanByPerson, 0, 0, 300, typical300);
 
-    auto testRule = [&](CRuleCondition::ERuleConditionOperator op, double value, bool expected100, bool expected200, bool expected300) {
+    auto testRule = [&](CRuleCondition::ERuleConditionOperator op, double value,
+                        bool expected100, bool expected200, bool expected300) {
         CRuleCondition condition;
         condition.appliesTo(CRuleCondition::E_Typical);
         condition.op(op);
@@ -422,9 +429,15 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalTypicalCondition, CTestFixture) {
 
         const model_t::CResultType resultType(model_t::CResultType::E_Final);
 
-        BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model, model_t::E_IndividualMeanByPerson, resultType, 0, 0, 100) == expected100);
-        BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model, model_t::E_IndividualMeanByPerson, resultType, 0, 0, 200) == expected200);
-        BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model, model_t::E_IndividualMeanByPerson, resultType, 0, 0, 300) == expected300);
+        BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
+                                      model_t::E_IndividualMeanByPerson,
+                                      resultType, 0, 0, 100) == expected100);
+        BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
+                                      model_t::E_IndividualMeanByPerson,
+                                      resultType, 0, 0, 200) == expected200);
+        BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
+                                      model_t::E_IndividualMeanByPerson,
+                                      resultType, 0, 0, 300) == expected300);
     };
 
     testRule(CRuleCondition::E_LT, 45.0, true, false, false);
@@ -432,49 +445,53 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalTypicalCondition, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalDiffAbsCondition, CTestFixture) {
-            constexpr core_t::TTime bucketLength = 100;
-            constexpr core_t::TTime startTime = 100;
-            const CSearchKey key;
-            const SModelParams params(bucketLength);
-            constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
+    constexpr core_t::TTime bucketLength = 100;
+    constexpr core_t::TTime startTime = 100;
+    const CSearchKey key;
+    const SModelParams params(bucketLength);
+    constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
 
-            TFeatureVec const features{model_t::E_IndividualMeanByPerson};
-            auto gathererPtr = CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime).buildSharedPtr();
+    TFeatureVec const features{model_t::E_IndividualMeanByPerson};
+    auto gathererPtr = CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime)
+                           .buildSharedPtr();
 
-            const std::string person1("p1");
-            bool addedPerson = false;
-            gathererPtr->addPerson(person1, m_ResourceMonitor, addedPerson);
+    const std::string person1("p1");
+    bool addedPerson = false;
+    gathererPtr->addPerson(person1, m_ResourceMonitor, addedPerson);
 
-            CMockModel model(params, gathererPtr, influenceCalculators);
-            const std::vector<CAnomalyDetectorModel::TDouble1Vec> actuals{
-                {8.9}, {9.0}, {9.1}, {10.9}, {11.0}, {11.1}};
-            const std::vector<CAnomalyDetectorModel::TDouble1Vec> typicals(6, {10.0});
+    CMockModel model(params, gathererPtr, influenceCalculators);
+    const std::vector<CAnomalyDetectorModel::TDouble1Vec> actuals{
+        {8.9}, {9.0}, {9.1}, {10.9}, {11.0}, {11.1}};
+    const std::vector<CAnomalyDetectorModel::TDouble1Vec> typicals(6, {10.0});
 
-            for (size_t i = 0; i < actuals.size(); ++i) {
-                model.mockAddBucketValue(model_t::E_IndividualMeanByPerson, 0, 0, 100 * (i + 1), actuals[i]);
-                model.mockAddBucketBaselineMean(model_t::E_IndividualMeanByPerson, 0, 0, 100 * (i + 1), typicals[i]);
-            }
+    for (size_t i = 0; i < actuals.size(); ++i) {
+        model.mockAddBucketValue(model_t::E_IndividualMeanByPerson, 0, 0,
+                                 100 * (i + 1), actuals[i]);
+        model.mockAddBucketBaselineMean(model_t::E_IndividualMeanByPerson, 0, 0,
+                                        100 * (i + 1), typicals[i]);
+    }
 
-            auto testRule = [&](CRuleCondition::ERuleConditionOperator op, double value, const std::vector<bool>& expected) {
-                CRuleCondition condition;
-                condition.appliesTo(CRuleCondition::E_DiffFromTypical);
-                condition.op(op);
-                condition.value(value);
-                CDetectionRule rule;
-                rule.addCondition(condition);
+    auto testRule = [&](CRuleCondition::ERuleConditionOperator op, double value,
+                        const std::vector<bool>& expected) {
+        CRuleCondition condition;
+        condition.appliesTo(CRuleCondition::E_DiffFromTypical);
+        condition.op(op);
+        condition.value(value);
+        CDetectionRule rule;
+        rule.addCondition(condition);
 
-                const model_t::CResultType resultType(model_t::CResultType::E_Final);
+        const model_t::CResultType resultType(model_t::CResultType::E_Final);
 
-                for (size_t i = 0; i < expected.size(); ++i) {
-                    BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
-                                                  model_t::E_IndividualMeanByPerson,
-                                                  resultType, 0, 0, 100 * (i + 1)) == expected[i]);
-                }
-            };
-
-            testRule(CRuleCondition::E_LT, 1.0, {false, false, true, true, false, false});
-            testRule(CRuleCondition::E_GT, 1.0, {true, false, false, false, false, true});
+        for (size_t i = 0; i < expected.size(); ++i) {
+            BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
+                                          model_t::E_IndividualMeanByPerson, resultType,
+                                          0, 0, 100 * (i + 1)) == expected[i]);
         }
+    };
+
+    testRule(CRuleCondition::E_LT, 1.0, {false, false, true, true, false, false});
+    testRule(CRuleCondition::E_GT, 1.0, {true, false, false, false, false, true});
+}
 
 BOOST_FIXTURE_TEST_CASE(testApplyGivenNoActualValueAvailable, CTestFixture) {
     constexpr core_t::TTime bucketLength = 100;
@@ -575,7 +592,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenDifferentSeriesAndPopulationModel, CTestFi
     std::string const personFieldName("over");
     std::string const attributeFieldName("by");
     auto gathererPtr = CDataGathererBuilder(model_t::E_PopulationMetric,
-                                                   features, params, key, startTime)
+                                            features, params, key, startTime)
                            .personFieldName(personFieldName)
                            .attributeFieldName(attributeFieldName)
                            .buildSharedPtr();
@@ -631,59 +648,62 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenDifferentSeriesAndPopulationModel, CTestFi
 }
 
 BOOST_FIXTURE_TEST_CASE(testApplyGivenMultipleConditions, CTestFixture) {
-        constexpr core_t::TTime bucketLength = 100;
-        constexpr core_t::TTime startTime = 100;
-        const CSearchKey key;
-        const SModelParams params(bucketLength);
-        constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
+    constexpr core_t::TTime bucketLength = 100;
+    constexpr core_t::TTime startTime = 100;
+    const CSearchKey key;
+    const SModelParams params(bucketLength);
+    constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
 
-        TFeatureVec const features{model_t::E_IndividualMeanByPerson};
-        const std::string personFieldName("series");
-        auto gathererPtr = CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime)
-                               .personFieldName(personFieldName)
-                               .buildSharedPtr();
+    TFeatureVec const features{model_t::E_IndividualMeanByPerson};
+    const std::string personFieldName("series");
+    auto gathererPtr = CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime)
+                           .personFieldName(personFieldName)
+                           .buildSharedPtr();
 
-        const std::string person1("p1");
-        bool addedPerson = false;
-        gathererPtr->addPerson(person1, m_ResourceMonitor, addedPerson);
+    const std::string person1("p1");
+    bool addedPerson = false;
+    gathererPtr->addPerson(person1, m_ResourceMonitor, addedPerson);
 
-        CMockModel model(params, gathererPtr, influenceCalculators);
-        const CAnomalyDetectorModel::TDouble1Vec p1Actual{10.0};
-        model.mockAddBucketValue(model_t::E_IndividualMeanByPerson, 0, 0, 100, p1Actual);
+    CMockModel model(params, gathererPtr, influenceCalculators);
+    const CAnomalyDetectorModel::TDouble1Vec p1Actual{10.0};
+    model.mockAddBucketValue(model_t::E_IndividualMeanByPerson, 0, 0, 100, p1Actual);
 
-        auto testRule = [&](const CRuleCondition& condition1, const CRuleCondition& condition2, bool expected) {
-            CDetectionRule rule;
-            rule.addCondition(condition1);
-            rule.addCondition(condition2);
+    auto testRule = [&](const CRuleCondition& condition1,
+                        const CRuleCondition& condition2, bool expected) {
+        CDetectionRule rule;
+        rule.addCondition(condition1);
+        rule.addCondition(condition2);
 
-            const model_t::CResultType resultType(model_t::CResultType::E_Final);
-            BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model, model_t::E_IndividualMeanByPerson, resultType, 0, 0, 100) == expected);
-        };
+        const model_t::CResultType resultType(model_t::CResultType::E_Final);
+        BOOST_TEST_REQUIRE(rule.apply(CDetectionRule::E_SkipResult, model,
+                                      model_t::E_IndividualMeanByPerson,
+                                      resultType, 0, 0, 100) == expected);
+    };
 
-        CRuleCondition condition1;
-        condition1.appliesTo(CRuleCondition::E_Actual);
-        condition1.op(CRuleCondition::E_LT);
-        condition1.value(9.0);
+    CRuleCondition condition1;
+    condition1.appliesTo(CRuleCondition::E_Actual);
+    condition1.op(CRuleCondition::E_LT);
+    condition1.value(9.0);
 
-        CRuleCondition condition2;
-        condition2.appliesTo(CRuleCondition::E_Actual);
-        condition2.op(CRuleCondition::E_LT);
-        condition2.value(9.5);
+    CRuleCondition condition2;
+    condition2.appliesTo(CRuleCondition::E_Actual);
+    condition2.op(CRuleCondition::E_LT);
+    condition2.value(9.5);
 
-        testRule(condition1, condition2, false);
+    testRule(condition1, condition2, false);
 
-        condition1.value(11.0);
-        condition2.value(9.5);
-        testRule(condition1, condition2, false);
+    condition1.value(11.0);
+    condition2.value(9.5);
+    testRule(condition1, condition2, false);
 
-        condition1.value(9.0);
-        condition2.value(10.5);
-        testRule(condition1, condition2, false);
+    condition1.value(9.0);
+    condition2.value(10.5);
+    testRule(condition1, condition2, false);
 
-        condition1.value(12.0);
-        condition2.value(10.5);
-        testRule(condition1, condition2, true);
-    }
+    condition1.value(12.0);
+    condition2.value(10.5);
+    testRule(condition1, condition2, true);
+}
 
 BOOST_FIXTURE_TEST_CASE(testApplyGivenTimeCondition, CTestFixture) {
     constexpr core_t::TTime bucketLength = 100;
@@ -697,10 +717,9 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenTimeCondition, CTestFixture) {
     std::string const personFieldName("series");
     CSearchKey const key(0, function_t::E_IndividualMetricMean, false, model_t::E_XF_None,
                          "", personFieldName, EMPTY_STRING, partitionFieldName);
-    auto gathererPtr =
-        CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime)
-            .personFieldName(personFieldName)
-            .buildSharedPtr();
+    auto gathererPtr = CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime)
+                           .personFieldName(personFieldName)
+                           .buildSharedPtr();
     CMockModel const model(params, gathererPtr, influenceCalculators);
     CRuleCondition conditionGte;
     conditionGte.appliesTo(CRuleCondition::E_Time);
@@ -739,10 +758,9 @@ BOOST_FIXTURE_TEST_CASE(testRuleActions, CTestFixture) {
     std::string const personFieldName("series");
     CSearchKey const key(0, function_t::E_IndividualMetricMean, false, model_t::E_XF_None,
                          "", personFieldName, EMPTY_STRING, partitionFieldName);
-    auto gathererPtr =
-        CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime)
-            .personFieldName(personFieldName)
-            .buildSharedPtr();
+    auto gathererPtr = CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime)
+                           .personFieldName(personFieldName)
+                           .buildSharedPtr();
     CMockModel const model(params, gathererPtr, influenceCalculators);
     CRuleCondition conditionGte;
     conditionGte.appliesTo(CRuleCondition::E_Time);
@@ -774,8 +792,6 @@ BOOST_FIXTURE_TEST_CASE(testRuleActions, CTestFixture) {
                                   model_t::E_IndividualMeanByPerson, resultType,
                                   0, 0, 100));
 }
-
-
 
 BOOST_FIXTURE_TEST_CASE(testRuleTimeShiftShouldShiftTimeSeriesModelState, CTestFixture) {
 

--- a/lib/model/unittest/CDetectionRuleTest.cc
+++ b/lib/model/unittest/CDetectionRuleTest.cc
@@ -31,6 +31,7 @@
 #include <test/CRandomNumbers.h>
 
 #include "Mocks.h"
+#include "ModelTestHelpers.h"
 
 #include <boost/test/tools/interface.hpp>
 #include <boost/test/unit_test.hpp>
@@ -73,10 +74,16 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
     std::string attributeFieldName("by");
     CSearchKey key(0, function_t::E_PopulationMetricMean, false, model_t::E_XF_None,
                    "", attributeFieldName, personFieldName, partitionFieldName);
-    CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-        model_t::E_PopulationMetric, model_t::E_None, params, EMPTY_STRING,
-        partitionFieldValue, personFieldName, attributeFieldName, EMPTY_STRING,
-        TStrVec{}, key, features, startTime, 0));
+    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
+    //     model_t::E_PopulationMetric, model_t::E_None, params, EMPTY_STRING,
+    //     partitionFieldValue, personFieldName, attributeFieldName, EMPTY_STRING,
+    // TStrVec{}, key, features, startTime, 0));
+    auto gathererPtr = model::CDataGathererBuilder(model_t::E_PopulationMetric,
+                                                   features, params, key, 0)
+                           .partitionFieldValue(partitionFieldValue)
+                           .personFieldName(personFieldName)
+                           .attributeFieldName(attributeFieldName)
+                           .buildSharedPtr();
 
     std::string person1("p1");
     bool added = false;
@@ -313,9 +320,11 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalActualCondition, CTestFixture) {
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualMeanByPerson);
-    CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-        model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-        EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
+    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
+    //     model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+    //     EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
+    CAnomalyDetectorModel::TDataGathererPtr gathererPtr =
+        model::CDataGathererBuilder(model_t::E_Metric, features, params, key, 0).buildSharedPtr();
 
     std::string person1("p1");
     bool addedPerson = false;
@@ -429,9 +438,11 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalTypicalCondition, CTestFixture) {
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualMeanByPerson);
-    CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-        model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-        EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
+    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
+    //     model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+    //     EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
+    auto gathererPtr =
+        model::CDataGathererBuilder(model_t::E_Metric, features, params, key, 0).buildSharedPtr();
 
     std::string person1("p1");
     bool addedPerson = false;
@@ -507,9 +518,11 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalDiffAbsCondition, CTestFixture) {
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualMeanByPerson);
-    CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-        model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-        EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
+    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
+    //     model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+    //     EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
+    CAnomalyDetectorModel::TDataGathererPtr gathererPtr =
+        model::CDataGathererBuilder(model_t::E_Metric, features, params, key, 0).buildSharedPtr();
 
     std::string person1("p1");
     bool addedPerson = false;
@@ -615,9 +628,11 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNoActualValueAvailable, CTestFixture) {
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualMeanByPerson);
-    CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-        model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-        EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
+    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
+    //     model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+    //     EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
+    CAnomalyDetectorModel::TDataGathererPtr gathererPtr =
+        model::CDataGathererBuilder(model_t::E_Metric, features, params, key, 0).buildSharedPtr();
 
     std::string person1("p1");
     bool addedPerson = false;
@@ -654,9 +669,10 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenDifferentSeriesAndIndividualModel, CTestFi
     TFeatureVec features;
     features.push_back(model_t::E_IndividualMeanByPerson);
     std::string personFieldName("series");
-    CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-        model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, personFieldName,
-        EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
+    CAnomalyDetectorModel::TDataGathererPtr gathererPtr =
+        model::CDataGathererBuilder(model_t::E_Metric, features, params, key, 0)
+            .personFieldName(personFieldName)
+            .buildSharedPtr();
 
     std::string person1("p1");
     bool addedPerson = false;
@@ -703,11 +719,15 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenDifferentSeriesAndPopulationModel, CTestFi
     features.push_back(model_t::E_PopulationMeanByPersonAndAttribute);
     std::string personFieldName("over");
     std::string attributeFieldName("by");
-    CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-        model_t::E_PopulationMetric, model_t::E_None, params, EMPTY_STRING,
-        EMPTY_STRING, personFieldName, attributeFieldName, EMPTY_STRING,
-        TStrVec{}, key, features, startTime, 0));
-
+    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
+    //     model_t::E_PopulationMetric, model_t::E_None, params, EMPTY_STRING,
+    //     EMPTY_STRING, personFieldName, attributeFieldName, EMPTY_STRING,
+    //     TStrVec{}, key, features, startTime, 0));
+    auto gathererPtr = model::CDataGathererBuilder(model_t::E_PopulationMetric,
+                                                   features, params, key, 0)
+                           .personFieldName(personFieldName)
+                           .attributeFieldName(attributeFieldName)
+                           .buildSharedPtr();
     std::string person1("p1");
     bool added = false;
     gathererPtr->addPerson(person1, m_ResourceMonitor, added);
@@ -769,9 +789,13 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenMultipleConditions, CTestFixture) {
     TFeatureVec features;
     features.push_back(model_t::E_IndividualMeanByPerson);
     std::string personFieldName("series");
-    CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-        model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, personFieldName,
-        EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
+    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
+    //     model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, personFieldName,
+    //     EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
+    CAnomalyDetectorModel::TDataGathererPtr gathererPtr =
+        model::CDataGathererBuilder(model_t::E_Metric, features, params, key, 0)
+            .personFieldName(personFieldName)
+            .buildSharedPtr();
 
     std::string person1("p1");
     bool addedPerson = false;
@@ -875,10 +899,13 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenTimeCondition, CTestFixture) {
     std::string personFieldName("series");
     CSearchKey key(0, function_t::E_IndividualMetricMean, false, model_t::E_XF_None,
                    "", personFieldName, EMPTY_STRING, partitionFieldName);
-    CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-        model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, personFieldName,
-        EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
-
+    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
+    //     model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, personFieldName,
+    //     EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
+    auto gathererPtr =
+        model::CDataGathererBuilder(model_t::E_Metric, features, params, key, 0)
+            .personFieldName(personFieldName)
+            .buildSharedPtr();
     CMockModel model(params, gathererPtr, influenceCalculators);
     CRuleCondition conditionGte;
     conditionGte.appliesTo(CRuleCondition::E_Time);
@@ -917,10 +944,13 @@ BOOST_FIXTURE_TEST_CASE(testRuleActions, CTestFixture) {
     std::string personFieldName("series");
     CSearchKey key(0, function_t::E_IndividualMetricMean, false, model_t::E_XF_None,
                    "", personFieldName, EMPTY_STRING, partitionFieldName);
-    CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-        model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, personFieldName,
-        EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
-
+    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
+    //     model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, personFieldName,
+    //     EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
+    auto gathererPtr =
+        model::CDataGathererBuilder(model_t::E_Metric, features, params, key, 0)
+            .personFieldName(personFieldName)
+            .buildSharedPtr();
     CMockModel model(params, gathererPtr, influenceCalculators);
     CRuleCondition conditionGte;
     conditionGte.appliesTo(CRuleCondition::E_Time);
@@ -963,10 +993,13 @@ TMockModelPtr initializeModel(ml::model::CResourceMonitor& resourceMonitor) {
 
     features.assign(1, model_t::E_IndividualSumByBucketAndPerson);
 
-    gatherer = std::make_shared<model::CDataGatherer>(
-        model_t::analysisCategory(features[0]), model_t::E_None, params, EMPTY_STRING,
-        EMPTY_STRING, "p", EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, 0, 0);
-
+    // gatherer = std::make_shared<model::CDataGatherer>(
+    //     model_t::analysisCategory(features[0]), model_t::E_None, params, EMPTY_STRING,
+    //     EMPTY_STRING, "p", EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, 0, 0);
+    gatherer = model::CDataGathererBuilder(model_t::analysisCategory(features[0]),
+                                           features, params, key, 0)
+                   .personFieldName("p")
+                   .buildSharedPtr();
     std::string person("p1");
     bool addedPerson{false};
     gatherer->addPerson(person, resourceMonitor, addedPerson);

--- a/lib/model/unittest/CDetectionRuleTest.cc
+++ b/lib/model/unittest/CDetectionRuleTest.cc
@@ -165,7 +165,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
     }
 
     for (auto filterType : {CRuleScope::E_Include, CRuleScope::E_Exclude}) {
-        std::string const filterJson("[\"a1*\"]");
+        std::string const filterJson(R"(["a1*"])");
         core::CPatternSet valueFilter;
         valueFilter.initFromJson(filterJson);
 
@@ -194,7 +194,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
     }
 
     for (auto filterType : {CRuleScope::E_Include, CRuleScope::E_Exclude}) {
-        std::string const filterJson("[\"*2\"]");
+        std::string const filterJson(R"(["*2"])");
         core::CPatternSet valueFilter;
         valueFilter.initFromJson(filterJson);
 
@@ -223,7 +223,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
     }
 
     for (auto filterType : {CRuleScope::E_Include, CRuleScope::E_Exclude}) {
-        std::string const filterJson("[\"*1*\"]");
+        std::string const filterJson(R"(["*1*"])");
         core::CPatternSet valueFilter;
         valueFilter.initFromJson(filterJson);
 
@@ -252,7 +252,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
     }
 
     for (auto filterType : {CRuleScope::E_Include, CRuleScope::E_Exclude}) {
-        std::string const filterJson("[\"p2\"]");
+        std::string const filterJson(R"(["p2"])");
         core::CPatternSet valueFilter;
         valueFilter.initFromJson(filterJson);
 
@@ -281,7 +281,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
     }
 
     for (auto filterType : {CRuleScope::E_Include, CRuleScope::E_Exclude}) {
-        std::string const filterJson("[\"par_1\"]");
+        std::string const filterJson(R"(["par_1"])");
         core::CPatternSet valueFilter;
         valueFilter.initFromJson(filterJson);
 
@@ -310,7 +310,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
     }
 
     for (auto filterType : {CRuleScope::E_Include, CRuleScope::E_Exclude}) {
-        std::string const filterJson("[\"par_2\"]");
+        std::string const filterJson(R"(["par_2"])");
         core::CPatternSet valueFilter;
         valueFilter.initFromJson(filterJson);
 
@@ -561,7 +561,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenDifferentSeriesAndIndividualModel, CTestFi
 
     CDetectionRule rule;
 
-    std::string const filterJson("[\"p1\"]");
+    std::string const filterJson(R"(["p1"])");
     core::CPatternSet valueFilter;
     valueFilter.initFromJson(filterJson);
     rule.includeScope(personFieldName, valueFilter);

--- a/lib/model/unittest/CDetectionRuleTest.cc
+++ b/lib/model/unittest/CDetectionRuleTest.cc
@@ -70,7 +70,8 @@ TMockModelPtr initializeModel(CResourceMonitor& resourceMonitor) {
     bool addedPerson{false};
     gatherer->addPerson(person, resourceMonitor, addedPerson);
 
-    TMockModelPtr model{new CMockModel(params, gatherer, {/* we don't care about influence */})};
+    constexpr CMockModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators; //we don't care about influence
+    auto model = std::make_unique<CMockModel>(params, gatherer, influenceCalculators);
 
     maths::time_series::CTimeSeriesDecomposition const trend;
     maths::common::CNormalMeanPrecConjugate const prior{

--- a/lib/model/unittest/CDetectionRuleTest.cc
+++ b/lib/model/unittest/CDetectionRuleTest.cc
@@ -70,7 +70,7 @@ TMockModelPtr initializeModel(CResourceMonitor& resourceMonitor) {
     bool addedPerson{false};
     gatherer->addPerson(person, resourceMonitor, addedPerson);
 
-    constexpr CMockModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators; //we don't care about influence
+    const CMockModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators; //we don't care about influence
     auto model = std::make_unique<CMockModel>(params, gatherer, influenceCalculators);
 
     maths::time_series::CTimeSeriesDecomposition const trend;
@@ -96,7 +96,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenScope, CTestFixture) {
     constexpr core_t::TTime bucketLength = 100;
     constexpr core_t::TTime startTime = 100;
     const SModelParams params(bucketLength);
-    constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
+    const CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
 
     TFeatureVec features;
     features.push_back(model_t::E_PopulationMeanByPersonAndAttribute);
@@ -344,7 +344,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalActualCondition, CTestFixture) {
     constexpr core_t::TTime startTime = 100;
     CSearchKey const key;
     SModelParams const params(bucketLength);
-    constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
+    const CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
 
     TFeatureVec const features{model_t::E_IndividualMeanByPerson};
     auto gathererPtr = CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime)
@@ -395,7 +395,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalTypicalCondition, CTestFixture) {
     constexpr core_t::TTime startTime = 100;
     const CSearchKey key;
     const SModelParams params(bucketLength);
-    constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
+    const CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
 
     TFeatureVec const features{model_t::E_IndividualMeanByPerson};
     auto gathererPtr = CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime)
@@ -450,7 +450,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNumericalDiffAbsCondition, CTestFixture) {
     constexpr core_t::TTime startTime = 100;
     const CSearchKey key;
     const SModelParams params(bucketLength);
-    constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
+    const CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
 
     TFeatureVec const features{model_t::E_IndividualMeanByPerson};
     auto gathererPtr = CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime)
@@ -499,7 +499,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenNoActualValueAvailable, CTestFixture) {
     constexpr core_t::TTime startTime = 100;
     CSearchKey const key;
     SModelParams const params(bucketLength);
-    constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
+    const CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualMeanByPerson);
@@ -537,7 +537,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenDifferentSeriesAndIndividualModel, CTestFi
     constexpr core_t::TTime startTime = 100;
     CSearchKey const key;
     SModelParams const params(bucketLength);
-    constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
+    const CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualMeanByPerson);
@@ -586,7 +586,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenDifferentSeriesAndPopulationModel, CTestFi
     constexpr core_t::TTime startTime = 100;
     CSearchKey const key;
     SModelParams const params(bucketLength);
-    constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
+    const CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
 
     TFeatureVec features;
     features.push_back(model_t::E_PopulationMeanByPersonAndAttribute);
@@ -653,7 +653,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenMultipleConditions, CTestFixture) {
     constexpr core_t::TTime startTime = 100;
     const CSearchKey key;
     const SModelParams params(bucketLength);
-    constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
+    const CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
 
     TFeatureVec const features{model_t::E_IndividualMeanByPerson};
     const std::string personFieldName("series");
@@ -710,7 +710,7 @@ BOOST_FIXTURE_TEST_CASE(testApplyGivenTimeCondition, CTestFixture) {
     constexpr core_t::TTime bucketLength = 100;
     constexpr core_t::TTime startTime = 100;
     SModelParams const params(bucketLength);
-    constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
+    const CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualMeanByPerson);
@@ -751,7 +751,7 @@ BOOST_FIXTURE_TEST_CASE(testRuleActions, CTestFixture) {
     constexpr core_t::TTime bucketLength = 100;
     constexpr core_t::TTime startTime = 100;
     SModelParams const params(bucketLength);
-    constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
+    const CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualMeanByPerson);

--- a/lib/model/unittest/CEventRateDataGathererTest.cc
+++ b/lib/model/unittest/CEventRateDataGathererTest.cc
@@ -343,7 +343,7 @@ void testGathererMultipleSeries(const core_t::TTime startTime,
     addArrival(gatherer, resourceMonitor, startTime + 2, gatherer.personName(4));
     addArrival(gatherer, resourceMonitor, startTime + 3, gatherer.personName(4));
 
-    constexpr TSizeUInt64PrVec personCounts;
+    const TSizeUInt64PrVec personCounts;
 
     TFeatureSizeFeatureDataPrVecPrVec featureData;
     gatherer.featureData(startTime, bucketLength, featureData);
@@ -1423,14 +1423,15 @@ protected:
     // Helper to sort influence values (when needed) using the ordering defined in maths::common.
     static void sortInfluenceValues(SEventRateFeatureData& featureData) {
         for (auto& influenceGroup : featureData.s_InfluenceValues) {
-            std::ranges::sort(influenceGroup, maths::common::COrderings::SFirstLess());
+            std::sort(influenceGroup.begin(), influenceGroup.end(),
+                      maths::common::COrderings::SFirstLess());
         }
     }
 
     // ----- Block 1: Distinct Count with NO influences -----
     static void testDistinctCountNoInfluence() {
         // Create an empty (constexpr) vector of optional strings.
-        constexpr TOptionalStrVec influencers{};
+        const TOptionalStrVec influencers{};
 
         CUniqueStringFeatureData data;
         // Initially, no strings have been inserted.
@@ -1487,8 +1488,9 @@ protected:
 
         SEventRateFeatureData featureData(0);
         data.populateDistinctCountFeatureData(featureData);
-        std::ranges::sort(featureData.s_InfluenceValues[0],
-                          maths::common::COrderings::SFirstLess());
+        std::sort(featureData.s_InfluenceValues[0].begin(),
+                  featureData.s_InfluenceValues[0].end(),
+                  maths::common::COrderings::SFirstLess());
         BOOST_REQUIRE_EQUAL(std::string("3, [[(inf1, ([2], 1)), (inf2, ([2], 1)), (inf3, ([1], 1))]]"),
                             featureData.print());
     }
@@ -1521,8 +1523,9 @@ protected:
         SEventRateFeatureData featureData(0);
         data.populateDistinctCountFeatureData(featureData);
         for (std::size_t i = 0; i < 2; i++) {
-            std::ranges::sort(featureData.s_InfluenceValues[i],
-                              maths::common::COrderings::SFirstLess());
+            std::sort(featureData.s_InfluenceValues[i].begin(),
+                      featureData.s_InfluenceValues[i].end(),
+                      maths::common::COrderings::SFirstLess());
         }
         BOOST_REQUIRE_EQUAL(std::string("3, [[(inf1, ([2], 1)), (inf2, ([2], 1))], [(inf_v2, ([1], 1)), (inf_v3, ([2], 1))]]"),
                             featureData.print());
@@ -1530,7 +1533,7 @@ protected:
 
     // ----- Block 4: Info Content with NO influences -----
     static void testInfoContentNoInfluence() {
-        constexpr TOptionalStrVec influencers{}; // empty
+        const TOptionalStrVec influencers{}; // empty
         CUniqueStringFeatureData data;
         verifyInfoContentFeature(data, "0");
 
@@ -1582,8 +1585,9 @@ protected:
 
         SEventRateFeatureData featureData(0);
         data.populateInfoContentFeatureData(featureData);
-        std::ranges::sort(featureData.s_InfluenceValues[0],
-                          maths::common::COrderings::SFirstLess());
+        std::sort(featureData.s_InfluenceValues[0].begin(),
+                  featureData.s_InfluenceValues[0].end(),
+                  maths::common::COrderings::SFirstLess());
         BOOST_REQUIRE_EQUAL(std::string("18, [[(inf1, ([16], 1)), (inf2, ([16], 1)), (inf3, ([12], 1))]]"),
                             featureData.print());
     }
@@ -1616,8 +1620,9 @@ protected:
         SEventRateFeatureData featureData(0);
         data.populateInfoContentFeatureData(featureData);
         for (std::size_t i = 0; i < 2; i++) {
-            std::ranges::sort(featureData.s_InfluenceValues[i],
-                              maths::common::COrderings::SFirstLess());
+            std::sort(featureData.s_InfluenceValues[i].begin(),
+                      featureData.s_InfluenceValues[i].end(),
+                      maths::common::COrderings::SFirstLess());
         }
         BOOST_REQUIRE_EQUAL(std::string("18, [[(inf1, ([16], 1)), (inf2, ([16], 1))], [(inf_v2, ([12], 1)), (inf_v3, ([16], 1))]]"),
                             featureData.print());
@@ -1714,13 +1719,12 @@ protected:
         auto builder = CDataGathererBuilder(model_t::E_EventRate, features,
                                             params, key, startTime);
         if (useAttribute) {
-            auto tempBuilder =
-                builder.gathererType(model_t::E_PopulationEventRate).attributeFieldName("att");
-            return tempBuilder.build();
+            return builder.gathererType(model_t::E_PopulationEventRate)
+                .attributeFieldName("att")
+                .build();
         }
         if (!isPopulation) {
-            auto tempBuilder = builder.personFieldName("person");
-            return tempBuilder.build();
+            return builder.personFieldName("person").build();
         }
         return builder.build();
     }

--- a/lib/model/unittest/CEventRateDataGathererTest.cc
+++ b/lib/model/unittest/CEventRateDataGathererTest.cc
@@ -211,8 +211,7 @@ void importCsvData(CDataGatherer& gatherer,
                    CResourceMonitor& resourceMonitor,
                    const std::string& filename,
                    const TSizeVec& fields) {
-    using TifstreamPtr = std::shared_ptr<std::ifstream>;
-    TifstreamPtr ifs(new std::ifstream(filename.c_str()));
+    auto ifs(std::make_shared<std::ifstream>(filename.c_str()));
     BOOST_TEST_REQUIRE(ifs->is_open());
 
     core::CRegex regex;
@@ -888,9 +887,6 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderFinalResult, CTestFixture) {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualNonZeroCountByBucketAndPerson);
         features.push_back(model_t::E_IndividualTotalBucketCountByPerson);
-        // CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-        //                        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-        //                        EMPTY_STRING, {}, key, features, startTime, 0);
         CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
                                                       params, key, startTime)
                                      .build();

--- a/lib/model/unittest/CEventRateDataGathererTest.cc
+++ b/lib/model/unittest/CEventRateDataGathererTest.cc
@@ -63,8 +63,6 @@ namespace {
 const CSearchKey key;
 const std::string EMPTY_STRING;
 
-
-
 std::size_t addPerson(CDataGatherer& gatherer,
                       CResourceMonitor& resourceMonitor,
                       const std::string& p,
@@ -138,7 +136,7 @@ void addArrival(CDataGatherer& gatherer,
     CDataGatherer::TStrCPtrVec fieldValues;
     fieldValues.push_back(&person);
 
-    for (const auto & influencer : influencers) {
+    for (const auto& influencer : influencers) {
         fieldValues.push_back(&influencer);
     }
 
@@ -168,7 +166,8 @@ void testInfluencerPerFeature(const model_t::EFeature feature,
     features.push_back(feature);
     TStrVec influencerFieldNames;
     influencerFieldNames.emplace_back("IF1");
-    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime)
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                  params, key, startTime)
                                  .influenceFieldNames(influencerFieldNames)
                                  .valueFieldName(valueField)
                                  .build();
@@ -401,7 +400,8 @@ BOOST_FIXTURE_TEST_CASE(testLatencyPersist, CTestFixture) {
         // Create a gatherer, no influences
         TFeatureVec features;
         features.push_back(model_t::E_IndividualUniqueCountByBucketAndPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime)
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                      params, key, startTime)
                                      .personFieldName("program")
                                      .valueFieldName("file")
                                      .build();
@@ -420,7 +420,8 @@ BOOST_FIXTURE_TEST_CASE(testLatencyPersist, CTestFixture) {
         TStrVec influencers;
         influencers.emplace_back("user");
         features.push_back(model_t::E_IndividualUniqueCountByBucketAndPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime)
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                      params, key, startTime)
                                      .personFieldName("program")
                                      .valueFieldName("file")
                                      .build();
@@ -438,7 +439,8 @@ BOOST_FIXTURE_TEST_CASE(testLatencyPersist, CTestFixture) {
         // Create a gatherer, no influences
         TFeatureVec features;
         features.push_back(model_t::E_IndividualNonZeroCountByBucketAndPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime)
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                      params, key, startTime)
                                      .personFieldName("program")
                                      .build();
         TSizeVec fields;
@@ -455,7 +457,8 @@ BOOST_FIXTURE_TEST_CASE(testLatencyPersist, CTestFixture) {
         TStrVec influencers;
         influencers.emplace_back("user");
         features.push_back(model_t::E_IndividualNonZeroCountByBucketAndPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime)
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                      params, key, startTime)
                                      .personFieldName("program")
                                      .influenceFieldNames(influencers)
                                      .build();
@@ -492,9 +495,9 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeries, CTestFixture) {
         10000 // sentinel
     };
 
-    std::array const expectedPersonCounts{std::string("[(0, 6)]"), std::string("[(0, 3)]"),
-                            std::string("[(0, 2)]"), std::string("[(0, 0)]"),
-                            std::string("[(0, 3)]")};
+    std::array const expectedPersonCounts{
+        std::string("[(0, 6)]"), std::string("[(0, 3)]"), std::string("[(0, 2)]"),
+        std::string("[(0, 0)]"), std::string("[(0, 3)]")};
 
     std::array const expectedPersonNonZeroCounts{
         std::string("[(0, 6)]"), std::string("[(0, 3)]"),
@@ -510,7 +513,9 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeries, CTestFixture) {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
         features.push_back(model_t::E_IndividualMinByPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                      params, key, startTime)
+                                     .build();
         BOOST_TEST_REQUIRE(!gatherer.isPopulation());
         BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p"));
 
@@ -554,7 +559,9 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeries, CTestFixture) {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualNonZeroCountByBucketAndPerson);
         features.push_back(model_t::E_IndividualTotalBucketCountByPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                      params, key, startTime)
+                                     .build();
         BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p"));
 
         core_t::TTime time = startTime;
@@ -592,7 +599,9 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeries, CTestFixture) {
     {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualIndicatorOfBucketPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                      params, key, startTime)
+                                     .build();
         BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p"));
 
         core_t::TTime time = startTime;
@@ -630,7 +639,7 @@ BOOST_FIXTURE_TEST_CASE(testMultipleSeries, CTestFixture) {
     constexpr core_t::TTime startTime = 0;
     constexpr core_t::TTime bucketLength = 600;
 
-    const std::vector<core_t::TTime>  data1 = {
+    const std::vector<core_t::TTime> data1 = {
         1,    15,   180, 190, 400,
         550, // bucket 1
         600,  799,
@@ -662,10 +671,13 @@ BOOST_FIXTURE_TEST_CASE(testMultipleSeries, CTestFixture) {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
 
-        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
-        testGathererMultipleSeries(STestTimes{.s_StartTime=startTime, .s_BucketLength=bucketLength},
-                                   STestData{.data1=data1, .data2=data2}, expectedPersonCounts,
-                                   params, bucketLength, gatherer, m_ResourceMonitor);
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                      params, key, startTime)
+                                     .build();
+        testGathererMultipleSeries(
+            STestTimes{.s_StartTime = startTime, .s_BucketLength = bucketLength},
+            STestData{.data1 = data1, .data2 = data2}, expectedPersonCounts,
+            params, bucketLength, gatherer, m_ResourceMonitor);
 
         BOOST_REQUIRE_EQUAL(1, gatherer.numberByFieldValues());
     }
@@ -674,7 +686,9 @@ BOOST_FIXTURE_TEST_CASE(testMultipleSeries, CTestFixture) {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
 
-        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                      params, key, startTime)
+                                     .build();
         testGathererMultipleSeries(startTime, bucketLength, gatherer, m_ResourceMonitor);
 
         BOOST_REQUIRE_EQUAL(2, gatherer.numberByFieldValues());
@@ -695,7 +709,9 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
     features.push_back(model_t::E_IndividualLowCountsByBucketAndPerson);
     features.push_back(model_t::E_IndividualHighCountsByBucketAndPerson);
     const SModelParams params(bucketLength);
-    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                  params, key, startTime)
+                                 .build();
     BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p1"));
     BOOST_REQUIRE_EQUAL(1, addPerson(gatherer, m_ResourceMonitor, "p2"));
     BOOST_REQUIRE_EQUAL(2, addPerson(gatherer, m_ResourceMonitor, "p3"));
@@ -719,7 +735,9 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         peopleToRemove.push_back(1);
         gatherer.recyclePeople(peopleToRemove);
 
-        CDataGatherer expectedGatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
+        CDataGatherer expectedGatherer =
+            CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime)
+                .build();
         BOOST_REQUIRE_EQUAL(0, addPerson(expectedGatherer, m_ResourceMonitor, "p3"));
         BOOST_REQUIRE_EQUAL(1, addPerson(expectedGatherer, m_ResourceMonitor, "p4"));
         BOOST_REQUIRE_EQUAL(2, addPerson(expectedGatherer, m_ResourceMonitor, "p5"));
@@ -727,7 +745,8 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         BOOST_REQUIRE_EQUAL(4, addPerson(expectedGatherer, m_ResourceMonitor, "p7"));
         BOOST_REQUIRE_EQUAL(5, addPerson(expectedGatherer, m_ResourceMonitor, "p8"));
 
-        constexpr std::array<core_t::TTime, 6>  expectedCounts = {5, 2, 0, 5, 7, 10};
+        constexpr std::array<core_t::TTime, 6> expectedCounts = {5, 2, 0,
+                                                                 5, 7, 10};
         for (std::size_t i = 0; i < std::size(expectedCounts); ++i) {
             for (core_t::TTime time = 0; time < expectedCounts[i]; ++time) {
                 addArrival(expectedGatherer, m_ResourceMonitor,
@@ -746,7 +765,9 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         peopleToRemove.push_back(7);
         gatherer.recyclePeople(peopleToRemove);
 
-        CDataGatherer expectedGatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
+        CDataGatherer expectedGatherer =
+            CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime)
+                .build();
         BOOST_REQUIRE_EQUAL(0, addPerson(expectedGatherer, m_ResourceMonitor, "p3"));
         BOOST_REQUIRE_EQUAL(1, addPerson(expectedGatherer, m_ResourceMonitor, "p6"));
         BOOST_REQUIRE_EQUAL(2, addPerson(expectedGatherer, m_ResourceMonitor, "p7"));
@@ -770,7 +791,9 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         peopleToRemove.push_back(6);
         gatherer.recyclePeople(peopleToRemove);
 
-        const CDataGatherer  expectedGatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
+        const CDataGatherer expectedGatherer =
+            CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime)
+                .build();
 
         LOG_DEBUG(<< "checksum          = " << gatherer.checksum());
         LOG_DEBUG(<< "expected checksum = " << expectedGatherer.checksum());
@@ -794,11 +817,12 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderFinalResult, CTestFixture) {
     constexpr core_t::TTime startTime = 0;
     constexpr core_t::TTime bucketLength = 600;
     constexpr std::size_t latencyBuckets(3);
-    constexpr core_t::TTime latencyTime = bucketLength * static_cast<core_t::TTime>(latencyBuckets);
+    constexpr core_t::TTime latencyTime =
+        bucketLength * static_cast<core_t::TTime>(latencyBuckets);
     SModelParams params(bucketLength);
     params.s_LatencyBuckets = latencyBuckets;
 
-    const std::array<core_t::TTime, 15>  data = {
+    const std::array<core_t::TTime, 15> data = {
         1, 180, 1200, 190, 400,
         600, // bucket 1, 2 & 3
         550, 799, 1199,
@@ -827,7 +851,9 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderFinalResult, CTestFixture) {
     {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                      params, key, startTime)
+                                     .build();
         addPerson(gatherer, m_ResourceMonitor, "p");
 
         core_t::TTime time = startTime;
@@ -865,7 +891,9 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderFinalResult, CTestFixture) {
         // CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
         //                        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
         //                        EMPTY_STRING, {}, key, features, startTime, 0);
-        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                      params, key, startTime)
+                                     .build();
         BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p"));
 
         core_t::TTime time = startTime;
@@ -903,7 +931,9 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderFinalResult, CTestFixture) {
     {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualIndicatorOfBucketPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                      params, key, startTime)
+                                     .build();
 
         BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p"));
 
@@ -942,7 +972,7 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderInterimResult, CTestFixture) {
     SModelParams params(bucketLength);
     params.s_LatencyBuckets = latencyBuckets;
 
-    constexpr std::array<core_t::TTime,8> data = {
+    constexpr std::array<core_t::TTime, 8> data = {
         1, 1200,
         600, // bucket 1, 3 & 2
         1199,
@@ -955,7 +985,9 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderInterimResult, CTestFixture) {
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                  params, key, startTime)
+                                 .build();
 
     addPerson(gatherer, m_ResourceMonitor, "p");
     TFeatureSizeFeatureDataPrVecPrVec featureData;
@@ -1067,7 +1099,8 @@ BOOST_FIXTURE_TEST_CASE(testMultipleSeriesOutOfOrderFinalResult, CTestFixture) {
     constexpr core_t::TTime startTime = 0;
     constexpr core_t::TTime bucketLength = 600;
     constexpr std::size_t latencyBuckets(3);
-    constexpr core_t::TTime latencyTime = bucketLength * static_cast<core_t::TTime>(latencyBuckets);
+    constexpr core_t::TTime latencyTime =
+        bucketLength * static_cast<core_t::TTime>(latencyBuckets);
     SModelParams params(bucketLength);
     params.s_LatencyBuckets = latencyBuckets;
 
@@ -1099,17 +1132,22 @@ BOOST_FIXTURE_TEST_CASE(testMultipleSeriesOutOfOrderFinalResult, CTestFixture) {
             std::string("[(0, 3), (1, 6)]")};
         TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                      params, key, startTime)
+                                     .build();
 
-        testGathererMultipleSeries(STestTimes{.s_StartTime=startTime, .s_BucketLength=bucketLength},
-                                   STestData{.data1=data1, .data2=data2}, expectedPersonCounts,
-                                   params, latencyTime, gatherer, m_ResourceMonitor);
+        testGathererMultipleSeries(
+            STestTimes{.s_StartTime = startTime, .s_BucketLength = bucketLength},
+            STestData{.data1 = data1, .data2 = data2}, expectedPersonCounts,
+            params, latencyTime, gatherer, m_ResourceMonitor);
     }
 
     {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                      params, key, startTime)
+                                     .build();
 
         testGathererMultipleSeries(startTime, bucketLength, gatherer, m_ResourceMonitor);
     }
@@ -1122,14 +1160,16 @@ BOOST_FIXTURE_TEST_CASE(testArrivalBeforeLatencyWindowIsIgnored, CTestFixture) {
     SModelParams params(bucketLength);
     params.s_LatencyBuckets = latencyBuckets;
 
-    constexpr std::array<core_t::TTime,2> data = {
+    constexpr std::array<core_t::TTime, 2> data = {
         1800, // Bucket 4, thus bucket 1's values are already out of latency window
         1     // Bucket 1
     };
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                  params, key, startTime)
+                                 .build();
 
     addPerson(gatherer, m_ResourceMonitor, "p");
 
@@ -1161,7 +1201,7 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenSingleSeries, CTestFixture) {
     SModelParams params(bucketLength);
     params.s_LatencyBuckets = latencyBuckets;
 
-    constexpr std::array<core_t::TTime,6> data = {
+    constexpr std::array<core_t::TTime, 6> data = {
         100,
         300, // Bucket 1
         600, 800,
@@ -1171,7 +1211,9 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenSingleSeries, CTestFixture) {
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                  params, key, startTime)
+                                 .build();
 
     addPerson(gatherer, m_ResourceMonitor, "p");
 
@@ -1225,7 +1267,9 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenMultipleSeries, CTestFixture) {
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                  params, key, startTime)
+                                 .build();
 
     addPerson(gatherer, m_ResourceMonitor, "p1");
     addPerson(gatherer, m_ResourceMonitor, "p2");
@@ -1275,7 +1319,9 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenBucketNotAvailable, CTestFixture) {
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                  params, key, startTime)
+                                 .build();
     addPerson(gatherer, m_ResourceMonitor, "p");
 
     addArrival(gatherer, m_ResourceMonitor, 1200, "p");
@@ -1287,7 +1333,7 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenBucketNotAvailable, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testInfluencerBucketStatistics, CTestFixture) {
-    constexpr std::array<core_t::TTime,15> data = {
+    constexpr std::array<core_t::TTime, 15> data = {
         1, 15, 180, 190, 400,
         550, // bucket 1
         600, 799,
@@ -1364,7 +1410,7 @@ protected:
     // Helper that creates a SEventRateFeatureData object, populates it using the distinct count method,
     // and checks that its print() output matches the expected value.
     static void verifyDistinctCountFeature(const CUniqueStringFeatureData& data,
-                                    const std::string& expected) {
+                                           const std::string& expected) {
         SEventRateFeatureData featureData(0);
         data.populateDistinctCountFeatureData(featureData);
         BOOST_REQUIRE_EQUAL(expected, featureData.print());
@@ -1372,7 +1418,7 @@ protected:
 
     // Similar helper for the info-content feature data.
     static void verifyInfoContentFeature(const CUniqueStringFeatureData& data,
-                                  const std::string& expected) {
+                                         const std::string& expected) {
         SEventRateFeatureData featureData(0);
         data.populateInfoContentFeatureData(featureData);
         BOOST_REQUIRE_EQUAL(expected, featureData.print());
@@ -1414,7 +1460,7 @@ protected:
             data.populateDistinctCountFeatureData(featureData);
             BOOST_REQUIRE_EQUAL(std::max(static_cast<std::uint64_t>(3),
                                          static_cast<std::uint64_t>(i)),
-                                  featureData.s_Count);
+                                featureData.s_Count);
         }
     }
 
@@ -1506,9 +1552,12 @@ protected:
             data.insert(ss.str(), influencers);
             SEventRateFeatureData featureData(0);
             data.populateInfoContentFeatureData(featureData);
-            BOOST_TEST_REQUIRE((featureData.s_Count - 12) >= std::max(static_cast<std::uint64_t>(3),
+            BOOST_TEST_REQUIRE((featureData.s_Count - 12) >=
+                               std::max(static_cast<std::uint64_t>(3),
                                         static_cast<std::uint64_t>(i)));
-            BOOST_TEST_REQUIRE((featureData.s_Count - 12) <= std::max(static_cast<std::uint64_t>(3), static_cast<std::uint64_t>(i)) * 3);
+            BOOST_TEST_REQUIRE(
+                (featureData.s_Count - 12) <=
+                std::max(static_cast<std::uint64_t>(3), static_cast<std::uint64_t>(i)) * 3);
         }
     }
 
@@ -1573,7 +1622,7 @@ protected:
         data.populateInfoContentFeatureData(featureData);
         for (std::size_t i = 0; i < 2; i++) {
             std::ranges::sort(featureData.s_InfluenceValues[i],
-                      maths::common::COrderings::SFirstLess());
+                              maths::common::COrderings::SFirstLess());
         }
         BOOST_REQUIRE_EQUAL(std::string("18, [[(inf1, ([16], 1)), (inf2, ([16], 1))], [(inf_v2, ([12], 1)), (inf_v3, ([16], 1))]]"),
                             featureData.print());
@@ -1589,11 +1638,12 @@ protected:
 
         TFeatureVec features;
         features.push_back(model_t::E_IndividualUniqueCountByBucketAndPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime)
-            .personFieldName("P")
-            .valueFieldName("V")
-            .influenceFieldNames({"INF"})
-            .build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features,
+                                                      params, key, startTime)
+                                     .personFieldName("P")
+                                     .valueFieldName("V")
+                                     .influenceFieldNames({"INF"})
+                                     .build();
 
         BOOST_TEST_REQUIRE(!gatherer.isPopulation());
         BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p", "v", 1));
@@ -1611,10 +1661,14 @@ protected:
         testPersistence(params, gatherer, model_t::E_EventRate);
 
         // Add data (some out-of-order) for distinct strings.
-        addArrival(gatherer, m_ResourceMonitor, time - (2 * bucketLength), "p", "stringOne", "inf1");
-        addArrival(gatherer, m_ResourceMonitor, time - (2 * bucketLength), "p", "stringTwo", "inf2");
-        addArrival(gatherer, m_ResourceMonitor, time - (1 * bucketLength), "p", "stringThree", "inf3");
-        addArrival(gatherer, m_ResourceMonitor, time - (1 * bucketLength), "p", "stringFour", "inf1");
+        addArrival(gatherer, m_ResourceMonitor, time - (2 * bucketLength), "p",
+                   "stringOne", "inf1");
+        addArrival(gatherer, m_ResourceMonitor, time - (2 * bucketLength), "p",
+                   "stringTwo", "inf2");
+        addArrival(gatherer, m_ResourceMonitor, time - (1 * bucketLength), "p",
+                   "stringThree", "inf3");
+        addArrival(gatherer, m_ResourceMonitor, time - (1 * bucketLength), "p",
+                   "stringFour", "inf1");
         addArrival(gatherer, m_ResourceMonitor, time, "p", "stringFive", "inf2");
         addArrival(gatherer, m_ResourceMonitor, time, "p", "stringSix", "inf3");
         testPersistence(params, gatherer, model_t::E_EventRate);
@@ -1630,7 +1684,6 @@ BOOST_FIXTURE_TEST_CASE(testDistinctStrings, CDistinctStringsTestFixture) {
     testInfoContentMultipleInfluence();
     testLatencyBucketsDistinctStrings();
 }
-
 
 class CDiurnalTestFixture : public CTestFixture {
 protected:
@@ -1650,7 +1703,8 @@ protected:
 
     // Compute the expected count.
     // If isDay is true, the modulo is 86400 (day), otherwise 604800 (week).
-    static std::uint64_t computeExpected(const core_t::TTime time, const std::uint64_t addition,
+    static std::uint64_t computeExpected(const core_t::TTime time,
+                                         const std::uint64_t addition,
                                          const bool isDay) {
         return static_cast<std::uint64_t>(time % (isDay ? 86400 : 604800)) + addition;
     }
@@ -1658,16 +1712,18 @@ protected:
     // Build a gatherer based on the features, parameters, start time, and type.
     // When useAttribute is true the attribute field is set (for population tests).
     static CDataGatherer createGatherer(const TFeatureVec& features,
-                                 const SModelParams& params,
-                                 core_t::TTime startTime,
-                                 bool isPopulation,
-                                 bool useAttribute = false) {
-        auto builder = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime);
+                                        const SModelParams& params,
+                                        core_t::TTime startTime,
+                                        bool isPopulation,
+                                        bool useAttribute = false) {
+        auto builder = CDataGathererBuilder(model_t::E_EventRate, features,
+                                            params, key, startTime);
         if (useAttribute) {
             auto tempBuilder =
                 builder.gathererType(model_t::E_PopulationEventRate).attributeFieldName("att");
             return tempBuilder.build();
-        } if (!isPopulation) {
+        }
+        if (!isPopulation) {
             auto tempBuilder = builder.personFieldName("person");
             return tempBuilder.build();
         }
@@ -1676,9 +1732,9 @@ protected:
 
     // Verify that the gatherer contains the proper features.
     static void verifyGathererFeatures(const CDataGatherer& gatherer,
-                                const TFeatureVec& features,
-                                model_t::EFeature expectedFeature,
-                                bool isPopulation) {
+                                       const TFeatureVec& features,
+                                       model_t::EFeature expectedFeature,
+                                       bool isPopulation) {
         BOOST_REQUIRE_EQUAL(1, gatherer.numberFeatures());
         for (std::size_t i = 0; i < features.size(); ++i) {
             BOOST_REQUIRE_EQUAL(features[i], gatherer.feature(i));
@@ -1705,9 +1761,7 @@ protected:
     //  - TFeatureSizeFeatureDataPrVecPrVec for tests by person,
     //  - TFeatureSizeSizePrFeatureDataPrVecPrVec for tests over person.
     template<typename FeatureDataT>
-    void verifyFeatureData(const CDataGatherer& gatherer,
-                           core_t::TTime time,
-                           std::uint64_t expectedCount) {
+    void verifyFeatureData(const CDataGatherer& gatherer, core_t::TTime time, std::uint64_t expectedCount) {
         FeatureDataT featureData;
         gatherer.featureData(time, BUCKET_LENGTH, featureData);
         BOOST_REQUIRE_EQUAL(1, featureData.size());
@@ -1728,50 +1782,44 @@ protected:
 
         // Arrival 1: time + 0
         addArrivalHelper(gatherer, time + 0, useAttribute);
-        verifyFeatureData<FeatureDataT>(gatherer, time,
-                                        computeExpected(time, 0, isDay));
+        verifyFeatureData<FeatureDataT>(gatherer, time, computeExpected(time, 0, isDay));
 
         // Arrival 2: time + 100, expected additional count of 50.
         addArrivalHelper(gatherer, time + 100, useAttribute);
-        verifyFeatureData<FeatureDataT>(gatherer, time,
-                                        computeExpected(time, 50, isDay));
+        verifyFeatureData<FeatureDataT>(gatherer, time, computeExpected(time, 50, isDay));
 
         time += BUCKET_LENGTH;
         // Arrival 3: new bucket, time + 0.
         addArrivalHelper(gatherer, time + 0, useAttribute);
-        verifyFeatureData<FeatureDataT>(gatherer, time,
-                                        computeExpected(time, 0, isDay));
+        verifyFeatureData<FeatureDataT>(gatherer, time, computeExpected(time, 0, isDay));
 
         // Arrival 4: time + 200, expected additional count of 100.
         addArrivalHelper(gatherer, time + 200, useAttribute);
-        verifyFeatureData<FeatureDataT>(gatherer, time,
-                                        computeExpected(time, 100, isDay));
+        verifyFeatureData<FeatureDataT>(gatherer, time, computeExpected(time, 100, isDay));
 
         time += BUCKET_LENGTH;
         // Arrival 5: time + 0.
         addArrivalHelper(gatherer, time + 0, useAttribute);
-        verifyFeatureData<FeatureDataT>(gatherer, time,
-                                        computeExpected(time, 0, isDay));
+        verifyFeatureData<FeatureDataT>(gatherer, time, computeExpected(time, 0, isDay));
 
         // Arrival 6: time + 300, expected additional count of 150.
         addArrivalHelper(gatherer, time + 300, useAttribute);
-        verifyFeatureData<FeatureDataT>(gatherer, time,
-                                        computeExpected(time, 150, isDay));
+        verifyFeatureData<FeatureDataT>(gatherer, time, computeExpected(time, 150, isDay));
 
         // Check latency: go back two buckets.
         time -= BUCKET_LENGTH * 2;
         addArrivalHelper(gatherer, time + 200, useAttribute);
-        verifyFeatureData<FeatureDataT>(gatherer, time,
-                                        computeExpected(time, 100, isDay));
+        verifyFeatureData<FeatureDataT>(gatherer, time, computeExpected(time, 100, isDay));
 
         time += BUCKET_LENGTH;
         addArrivalHelper(gatherer, time + 400, useAttribute);
-        verifyFeatureData<FeatureDataT>(gatherer, time,
-                                        computeExpected(time, 200, isDay));
+        verifyFeatureData<FeatureDataT>(gatherer, time, computeExpected(time, 200, isDay));
     }
 
     // Verify summary information for the gatherer.
-    static void verifyGathererSummary(const CDataGatherer& gatherer, bool isPopulation, bool useAttribute) {
+    static void verifyGathererSummary(const CDataGatherer& gatherer,
+                                      bool isPopulation,
+                                      bool useAttribute) {
         if (isPopulation) {
             if (useAttribute) {
                 BOOST_REQUIRE_EQUAL(1, gatherer.numberActivePeople());
@@ -1791,10 +1839,12 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CDiurnalTestFixture) {
         // Test: time_of_day by person
         LOG_DEBUG(<< "Testing time_of_day by person");
         SModelParams const params = createParams();
-        TFeatureVec const features{ model_t::E_IndividualTimeOfDayByBucketAndPerson };
+        TFeatureVec const features{model_t::E_IndividualTimeOfDayByBucketAndPerson};
         CDataGatherer gatherer = createGatherer(features, params, START_TIME, false);
-        verifyGathererFeatures(gatherer, features, model_t::E_IndividualTimeOfDayByBucketAndPerson, false);
-        runTestSequence<TFeatureSizeFeatureDataPrVecPrVec>(gatherer, /*isDay=*/true, /*useAttribute=*/false);
+        verifyGathererFeatures(gatherer, features,
+                               model_t::E_IndividualTimeOfDayByBucketAndPerson, false);
+        runTestSequence<TFeatureSizeFeatureDataPrVecPrVec>(gatherer, /*isDay=*/true,
+                                                           /*useAttribute=*/false);
         verifyGathererSummary(gatherer, false, false);
         testPersistence(params, gatherer, model_t::E_EventRate);
     }
@@ -1802,10 +1852,12 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CDiurnalTestFixture) {
         // Test: time_of_week by person
         LOG_DEBUG(<< "Testing time_of_week by person");
         SModelParams const params = createParams();
-        TFeatureVec const features{ model_t::E_IndividualTimeOfWeekByBucketAndPerson };
+        TFeatureVec const features{model_t::E_IndividualTimeOfWeekByBucketAndPerson};
         CDataGatherer gatherer = createGatherer(features, params, START_TIME, false);
-        verifyGathererFeatures(gatherer, features, model_t::E_IndividualTimeOfWeekByBucketAndPerson, false);
-        runTestSequence<TFeatureSizeFeatureDataPrVecPrVec>(gatherer, /*isDay=*/false, /*useAttribute=*/false);
+        verifyGathererFeatures(gatherer, features,
+                               model_t::E_IndividualTimeOfWeekByBucketAndPerson, false);
+        runTestSequence<TFeatureSizeFeatureDataPrVecPrVec>(
+            gatherer, /*isDay=*/false, /*useAttribute=*/false);
         verifyGathererSummary(gatherer, false, false);
         testPersistence(params, gatherer, model_t::E_EventRate);
     }
@@ -1813,10 +1865,13 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CDiurnalTestFixture) {
         // Test: time_of_week over person (with attribute)
         LOG_DEBUG(<< "Testing time_of_week over person");
         SModelParams const params = createParams();
-        TFeatureVec const features{ model_t::E_PopulationTimeOfWeekByBucketPersonAndAttribute };
-        CDataGatherer gatherer = createGatherer(features, params, START_TIME, true, /*useAttribute=*/true);
-        verifyGathererFeatures(gatherer, features, model_t::E_PopulationTimeOfWeekByBucketPersonAndAttribute, true);
-        runTestSequence<TFeatureSizeSizePrFeatureDataPrVecPrVec>(gatherer, /*isDay=*/false, /*useAttribute=*/true);
+        TFeatureVec const features{model_t::E_PopulationTimeOfWeekByBucketPersonAndAttribute};
+        CDataGatherer gatherer = createGatherer(features, params, START_TIME,
+                                                true, /*useAttribute=*/true);
+        verifyGathererFeatures(gatherer, features, model_t::E_PopulationTimeOfWeekByBucketPersonAndAttribute,
+                               true);
+        runTestSequence<TFeatureSizeSizePrFeatureDataPrVecPrVec>(
+            gatherer, /*isDay=*/false, /*useAttribute=*/true);
         verifyGathererSummary(gatherer, true, true);
         testPersistence(params, gatherer, model_t::E_EventRate);
     }
@@ -1824,10 +1879,13 @@ BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CDiurnalTestFixture) {
         // Test: time_of_day over person (with attribute)
         LOG_DEBUG(<< "Testing time_of_day over person");
         SModelParams const params = createParams();
-        TFeatureVec const features{ model_t::E_PopulationTimeOfDayByBucketPersonAndAttribute };
-        CDataGatherer gatherer = createGatherer(features, params, START_TIME, true, /*useAttribute=*/true);
-        verifyGathererFeatures(gatherer, features, model_t::E_PopulationTimeOfDayByBucketPersonAndAttribute, true);
-        runTestSequence<TFeatureSizeSizePrFeatureDataPrVecPrVec>(gatherer, /*isDay=*/true, /*useAttribute=*/true);
+        TFeatureVec const features{model_t::E_PopulationTimeOfDayByBucketPersonAndAttribute};
+        CDataGatherer gatherer = createGatherer(features, params, START_TIME,
+                                                true, /*useAttribute=*/true);
+        verifyGathererFeatures(gatherer, features, model_t::E_PopulationTimeOfDayByBucketPersonAndAttribute,
+                               true);
+        runTestSequence<TFeatureSizeSizePrFeatureDataPrVecPrVec>(
+            gatherer, /*isDay=*/true, /*useAttribute=*/true);
         verifyGathererSummary(gatherer, true, true);
         testPersistence(params, gatherer, model_t::E_EventRate);
     }

--- a/lib/model/unittest/CEventRateDataGathererTest.cc
+++ b/lib/model/unittest/CEventRateDataGathererTest.cc
@@ -61,16 +61,71 @@ using TStrCPtrVec = CBucketGatherer::TStrCPtrVec;
 namespace {
 
 const CSearchKey key;
-const std::string EMPTY_STRING("");
+const std::string EMPTY_STRING;
+
+class CDataGathererBuilder {
+public:
+    CDataGathererBuilder(const TFeatureVec& features, const SModelParams& params, const CSearchKey& searchKey,
+                         const core_t::TTime startTime
+    ): m_Features(features), m_Params(params),  m_StartTime(startTime), m_SearchKey(searchKey) {}
+
+    CDataGatherer build() const {
+        return {m_GathererType, m_SummaryMode, m_Params, m_SummaryCountFieldName,
+                             m_PartitionFieldValue, m_PersonFieldName, m_AttributeFieldName,
+                             m_ValueFieldName, m_InfluenceFieldNames, m_SearchKey, m_Features,
+                             m_StartTime, m_SampleCountOverride};
+    }
+
+    CDataGathererBuilder& personFieldName(const std::string& personFieldName) {
+        m_PersonFieldName = personFieldName;
+        return *this;
+    }
+
+    CDataGathererBuilder& valueFieldName(const std::string& valueFieldName) {
+        m_ValueFieldName = valueFieldName;
+        return *this;
+    }
+
+    CDataGathererBuilder& influenceFieldNames(const TStrVec& influenceFieldName) {
+        m_InfluenceFieldNames = influenceFieldName;
+        return *this;
+    }
+
+    CDataGathererBuilder& attributeFieldName(const std::string& attributeFieldName) {
+        m_AttributeFieldName = attributeFieldName;
+        return *this;
+    }
+
+    CDataGathererBuilder& gathererType(model_t::EAnalysisCategory gathererType) {
+        m_GathererType = gathererType;
+        return *this;
+    }
+
+private:
+    const TFeatureVec& m_Features;
+    const SModelParams& m_Params;
+    core_t::TTime m_StartTime;
+    const CSearchKey& m_SearchKey;
+    model_t::EAnalysisCategory m_GathererType{model_t::E_EventRate};
+    model_t::ESummaryMode m_SummaryMode{model_t::E_None};
+    std::string m_SummaryCountFieldName{EMPTY_STRING};
+    std::string m_PartitionFieldValue{EMPTY_STRING};
+    std::string m_PersonFieldName{EMPTY_STRING};
+    std::string m_AttributeFieldName{EMPTY_STRING};
+    std::string m_ValueFieldName{EMPTY_STRING};
+    TStrVec m_InfluenceFieldNames;
+    int m_SampleCountOverride{0};
+
+};
 
 std::size_t addPerson(CDataGatherer& gatherer,
                       CResourceMonitor& resourceMonitor,
                       const std::string& p,
                       const std::string& v = EMPTY_STRING,
-                      std::size_t numInfluencers = 0) {
+                      const std::size_t numInfluencers = 0) {
     CDataGatherer::TStrCPtrVec person;
     person.push_back(&p);
-    std::string i("i");
+    std::string const i("i");
     for (std::size_t j = 0; j < numInfluencers; ++j) {
         person.push_back(&i);
     }
@@ -84,7 +139,7 @@ std::size_t addPerson(CDataGatherer& gatherer,
 
 void addArrival(CDataGatherer& gatherer,
                 CResourceMonitor& resourceMonitor,
-                core_t::TTime time,
+                const core_t::TTime time,
                 const std::string& person) {
     CDataGatherer::TStrCPtrVec fieldValues;
     fieldValues.push_back(&person);
@@ -97,7 +152,7 @@ void addArrival(CDataGatherer& gatherer,
 
 void addArrival(CDataGatherer& gatherer,
                 CResourceMonitor& resourceMonitor,
-                core_t::TTime time,
+                const core_t::TTime time,
                 const std::string& person,
                 const std::string& attribute) {
     CDataGatherer::TStrCPtrVec fieldValues;
@@ -112,7 +167,7 @@ void addArrival(CDataGatherer& gatherer,
 
 void addArrival(CDataGatherer& gatherer,
                 CResourceMonitor& resourceMonitor,
-                core_t::TTime time,
+                const core_t::TTime time,
                 const std::string& person,
                 const std::string& value,
                 const std::string& influencer) {
@@ -129,15 +184,15 @@ void addArrival(CDataGatherer& gatherer,
 
 void addArrival(CDataGatherer& gatherer,
                 CResourceMonitor& resourceMonitor,
-                core_t::TTime time,
+                const core_t::TTime time,
                 const std::string& person,
                 const TStrVec& influencers,
                 const std::string& value) {
     CDataGatherer::TStrCPtrVec fieldValues;
     fieldValues.push_back(&person);
 
-    for (std::size_t i = 0; i < influencers.size(); ++i) {
-        fieldValues.push_back(&influencers[i]);
+    for (const auto & influencer : influencers) {
+        fieldValues.push_back(&influencer);
     }
 
     if (!value.empty()) {
@@ -150,7 +205,7 @@ void addArrival(CDataGatherer& gatherer,
     gatherer.addArrival(fieldValues, eventData, resourceMonitor);
 }
 
-void testInfluencerPerFeature(model_t::EFeature feature,
+void testInfluencerPerFeature(const model_t::EFeature feature,
                               const TTimeVec& data,
                               const TStrVecVec& influencers,
                               const TStrVec& expected,
@@ -158,17 +213,19 @@ void testInfluencerPerFeature(model_t::EFeature feature,
                               CResourceMonitor& resourceMonitor) {
     LOG_DEBUG(<< " *** testing " << model_t::print(feature) << " ***");
 
-    const core_t::TTime startTime = 0;
-    const core_t::TTime bucketLength = 600;
-    SModelParams params(bucketLength);
+    constexpr core_t::TTime startTime = 0;
+    constexpr core_t::TTime bucketLength = 600;
+    SModelParams const params(bucketLength);
 
     TFeatureVec features;
     features.push_back(feature);
     TStrVec influencerFieldNames;
-    influencerFieldNames.push_back("IF1");
-    CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params, EMPTY_STRING,
-                           EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, valueField,
-                           influencerFieldNames, key, features, startTime, 0);
+    influencerFieldNames.emplace_back("IF1");
+    CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime)
+                                 .influenceFieldNames(influencerFieldNames)
+                                 .valueFieldName(valueField)
+                                 .build();
+
     BOOST_TEST_REQUIRE(!gatherer.isPopulation());
     BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, resourceMonitor, "p", valueField, 1));
 
@@ -230,8 +287,8 @@ void importCsvData(CDataGatherer& gatherer,
         CDataGatherer::TStrCPtrVec fieldValues;
         CEventData data;
         data.time(time);
-        for (std::size_t i = 0; i < fields.size(); i++) {
-            fieldValues.push_back(&tokens[fields[i]]);
+        for (const auto field : fields) {
+            fieldValues.push_back(&tokens[field]);
         }
         gatherer.addArrival(fieldValues, data, resourceMonitor);
     }
@@ -250,7 +307,7 @@ struct STestData {
 
 void testGathererMultipleSeries(const STestTimes& testTimes,
                                 const STestData& testData,
-                                std::vector<std::string> expectedPersonCounts,
+                                const std::vector<std::string>& expectedPersonCounts,
                                 const SModelParams& params,
                                 core_t::TTime upperLimit,
                                 CDataGatherer& gatherer,
@@ -264,9 +321,9 @@ void testGathererMultipleSeries(const STestTimes& testTimes,
 
     core_t::TTime time = startTime;
 
-    std::size_t i1 = 0u;
-    std::size_t i2 = 0u;
-    std::size_t j = 0u;
+    std::size_t i1 = 0U;
+    std::size_t i2 = 0U;
+    std::size_t j = 0U;
     for (;;) {
         for (/**/; j < 5 && std::min(testData.data1[i1], testData.data2[i2]) >= time + upperLimit;
              time += bucketLength, ++j) {
@@ -312,7 +369,7 @@ void testGathererMultipleSeries(const STestTimes& testTimes,
     BOOST_TEST_REQUIRE(!gatherer.personId("p2", pid));
 
     TFeatureSizeFeatureDataPrVecPrVec featureData;
-    gatherer.featureData(startTime + 4 * bucketLength, bucketLength, featureData);
+    gatherer.featureData(startTime + (4 * bucketLength), bucketLength, featureData);
     LOG_DEBUG(<< "featureData = " << featureData);
     BOOST_REQUIRE_EQUAL(1, featureData.size());
     BOOST_REQUIRE_EQUAL(model_t::E_IndividualCountByBucketAndPerson,
@@ -341,7 +398,7 @@ void testGathererMultipleSeries(const core_t::TTime startTime,
     addArrival(gatherer, resourceMonitor, startTime + 2, gatherer.personName(4));
     addArrival(gatherer, resourceMonitor, startTime + 3, gatherer.personName(4));
 
-    TSizeUInt64PrVec personCounts;
+    constexpr TSizeUInt64PrVec personCounts;
 
     TFeatureSizeFeatureDataPrVecPrVec featureData;
     gatherer.featureData(startTime, bucketLength, featureData);
@@ -387,9 +444,9 @@ protected:
 };
 
 BOOST_FIXTURE_TEST_CASE(testLatencyPersist, CTestFixture) {
-    core_t::TTime bucketLength = 3600;
-    core_t::TTime latency = 5 * bucketLength;
-    core_t::TTime startTime = 1420192800;
+    constexpr core_t::TTime bucketLength = 3600;
+    constexpr core_t::TTime latency = 5 * bucketLength;
+    constexpr core_t::TTime startTime = 1420192800;
     SModelParams params(bucketLength);
     params.configureLatency(latency, bucketLength);
 
@@ -397,9 +454,10 @@ BOOST_FIXTURE_TEST_CASE(testLatencyPersist, CTestFixture) {
         // Create a gatherer, no influences
         TFeatureVec features;
         features.push_back(model_t::E_IndividualUniqueCountByBucketAndPerson);
-        CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, "program", EMPTY_STRING,
-                               "file", {}, key, features, startTime, 0);
+        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime)
+                                     .personFieldName("program")
+                                     .valueFieldName("file")
+                                     .build();
         TSizeVec fields;
         fields.push_back(2);
         fields.push_back(1);
@@ -413,11 +471,12 @@ BOOST_FIXTURE_TEST_CASE(testLatencyPersist, CTestFixture) {
         // Create a gatherer, with influences
         TFeatureVec features;
         TStrVec influencers;
-        influencers.push_back("user");
+        influencers.emplace_back("user");
         features.push_back(model_t::E_IndividualUniqueCountByBucketAndPerson);
-        CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, "program", EMPTY_STRING,
-                               "file", influencers, key, features, startTime, 0);
+        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime)
+                                     .personFieldName("program")
+                                     .valueFieldName("file")
+                                     .build();
         TSizeVec fields;
         fields.push_back(2);
         fields.push_back(3);
@@ -432,9 +491,9 @@ BOOST_FIXTURE_TEST_CASE(testLatencyPersist, CTestFixture) {
         // Create a gatherer, no influences
         TFeatureVec features;
         features.push_back(model_t::E_IndividualNonZeroCountByBucketAndPerson);
-        CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, "program", EMPTY_STRING,
-                               EMPTY_STRING, {}, key, features, startTime, 0);
+        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime)
+                                     .personFieldName("program")
+                                     .build();
         TSizeVec fields;
         fields.push_back(2);
 
@@ -447,11 +506,13 @@ BOOST_FIXTURE_TEST_CASE(testLatencyPersist, CTestFixture) {
         // Create a gatherer, with influences
         TFeatureVec features;
         TStrVec influencers;
-        influencers.push_back("user");
+        influencers.emplace_back("user");
         features.push_back(model_t::E_IndividualNonZeroCountByBucketAndPerson);
-        CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params, EMPTY_STRING,
-                               EMPTY_STRING, "program", EMPTY_STRING, EMPTY_STRING,
-                               influencers, key, features, startTime, 0);
+        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime)
+                                     .personFieldName("program")
+                                     .influenceFieldNames(influencers)
+                                     .build();
+
         TSizeVec fields;
         fields.push_back(2);
         fields.push_back(3);
@@ -467,11 +528,11 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeries, CTestFixture) {
 
     // Test that the various statistics come back as we expect.
 
-    const core_t::TTime startTime = 0;
-    const core_t::TTime bucketLength = 600;
-    SModelParams params(bucketLength);
+    constexpr core_t::TTime startTime = 0;
+    constexpr core_t::TTime bucketLength = 600;
+    SModelParams const params(bucketLength);
 
-    core_t::TTime data[] = {
+    constexpr std::array<core_t::TTime, 15> data = {
         1, 15, 180, 190, 400,
         550, // bucket 1
         600, 799,
@@ -484,15 +545,15 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeries, CTestFixture) {
         10000 // sentinel
     };
 
-    std::string expectedPersonCounts[] = {
-        std::string("[(0, 6)]"), std::string("[(0, 3)]"), std::string("[(0, 2)]"),
-        std::string("[(0, 0)]"), std::string("[(0, 3)]")};
+    std::array const expectedPersonCounts{std::string("[(0, 6)]"), std::string("[(0, 3)]"),
+                            std::string("[(0, 2)]"), std::string("[(0, 0)]"),
+                            std::string("[(0, 3)]")};
 
-    std::string expectedPersonNonZeroCounts[] = {
+    std::array const expectedPersonNonZeroCounts{
         std::string("[(0, 6)]"), std::string("[(0, 3)]"),
         std::string("[(0, 2)]"), std::string("[]"), std::string("[(0, 3)]")};
 
-    std::string expectedPersonIndicator[] = {
+    std::array const expectedPersonIndicator{
         std::string("[(0, 1)]"), std::string("[(0, 1)]"),
         std::string("[(0, 1)]"), std::string("[]"), std::string("[(0, 1)]")};
 
@@ -502,9 +563,7 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeries, CTestFixture) {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
         features.push_back(model_t::E_IndividualMinByPerson);
-        CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                               EMPTY_STRING, {}, key, features, startTime, 0);
+        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
         BOOST_TEST_REQUIRE(!gatherer.isPopulation());
         BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p"));
 
@@ -548,9 +607,7 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeries, CTestFixture) {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualNonZeroCountByBucketAndPerson);
         features.push_back(model_t::E_IndividualTotalBucketCountByPerson);
-        CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                               EMPTY_STRING, {}, key, features, startTime, 0);
+        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
         BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p"));
 
         core_t::TTime time = startTime;
@@ -584,13 +641,11 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeries, CTestFixture) {
         }
     }
 
-    // Test test person indicator by bucket.
+    // Test person indicator by bucket.
     {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualIndicatorOfBucketPerson);
-        CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                               EMPTY_STRING, {}, key, features, startTime, 0);
+        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
         BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p"));
 
         core_t::TTime time = startTime;
@@ -625,10 +680,10 @@ BOOST_FIXTURE_TEST_CASE(testMultipleSeries, CTestFixture) {
     // Test that the various statistics come back as we expect
     // for multiple people.
 
-    const core_t::TTime startTime = 0;
-    const core_t::TTime bucketLength = 600;
+    constexpr core_t::TTime startTime = 0;
+    constexpr core_t::TTime bucketLength = 600;
 
-    std::vector<core_t::TTime> data1 = {
+    const std::vector<core_t::TTime>  data1 = {
         1,    15,   180, 190, 400,
         550, // bucket 1
         600,  799,
@@ -640,7 +695,7 @@ BOOST_FIXTURE_TEST_CASE(testMultipleSeries, CTestFixture) {
         2490, // bucket 5
         10000 // sentinel
     };
-    std::vector<core_t::TTime> data2 = {
+    const std::vector<core_t::TTime> data2 = {
         1,    5,    15,   25,   180,  190,  400, 550, // bucket 1
         600,  605,  609,  799,  1199,                 // bucket 2
         1200, 1250, 1255, 1256, 1300, 1400,           // bucket 3
@@ -649,23 +704,20 @@ BOOST_FIXTURE_TEST_CASE(testMultipleSeries, CTestFixture) {
         10000                                         // sentinel
     };
 
-    std::vector<std::string> expectedPersonCounts = {
+    const std::vector expectedPersonCounts = {
         std::string("[(0, 6), (1, 8)]"), std::string("[(0, 3), (1, 5)]"),
         std::string("[(0, 2), (1, 6)]"), std::string("[(0, 1), (1, 2)]"),
         std::string("[(0, 3), (1, 6)]")};
 
-    SModelParams params(bucketLength);
+    const SModelParams params(bucketLength);
 
     {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
 
-        CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                               EMPTY_STRING, {}, KEY, features, startTime, 0);
-
-        testGathererMultipleSeries(STestTimes{startTime, bucketLength},
-                                   STestData{data1, data2}, expectedPersonCounts,
+        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+        testGathererMultipleSeries(STestTimes{.s_StartTime=startTime, .s_BucketLength=bucketLength},
+                                   STestData{.data1=data1, .data2=data2}, expectedPersonCounts,
                                    params, bucketLength, gatherer, m_ResourceMonitor);
 
         BOOST_REQUIRE_EQUAL(1, gatherer.numberByFieldValues());
@@ -675,10 +727,7 @@ BOOST_FIXTURE_TEST_CASE(testMultipleSeries, CTestFixture) {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
 
-        CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                               EMPTY_STRING, {}, key, features, startTime, 0);
-
+        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
         testGathererMultipleSeries(startTime, bucketLength, gatherer, m_ResourceMonitor);
 
         BOOST_REQUIRE_EQUAL(2, gatherer.numberByFieldValues());
@@ -688,8 +737,8 @@ BOOST_FIXTURE_TEST_CASE(testMultipleSeries, CTestFixture) {
 BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
     // Test various combinations of removed people.
 
-    const core_t::TTime startTime = 0;
-    const core_t::TTime bucketLength = 600;
+    constexpr core_t::TTime startTime = 0;
+    constexpr core_t::TTime bucketLength = 600;
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualCountByBucketAndPerson);
@@ -698,10 +747,8 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
     features.push_back(model_t::E_IndividualIndicatorOfBucketPerson);
     features.push_back(model_t::E_IndividualLowCountsByBucketAndPerson);
     features.push_back(model_t::E_IndividualHighCountsByBucketAndPerson);
-    SModelParams params(bucketLength);
-    CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                           EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                           EMPTY_STRING, {}, key, features, startTime, 0);
+    const SModelParams params(bucketLength);
+    CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
     BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p1"));
     BOOST_REQUIRE_EQUAL(1, addPerson(gatherer, m_ResourceMonitor, "p2"));
     BOOST_REQUIRE_EQUAL(2, addPerson(gatherer, m_ResourceMonitor, "p3"));
@@ -711,7 +758,7 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
     BOOST_REQUIRE_EQUAL(6, addPerson(gatherer, m_ResourceMonitor, "p7"));
     BOOST_REQUIRE_EQUAL(7, addPerson(gatherer, m_ResourceMonitor, "p8"));
 
-    core_t::TTime counts[] = {0, 3, 5, 2, 0, 5, 7, 10};
+    constexpr std::array<core_t::TTime, 8> counts = {0, 3, 5, 2, 0, 5, 7, 10};
     for (std::size_t i = 0; i < std::size(counts); ++i) {
         for (core_t::TTime time = 0; time < counts[i]; ++time) {
             addArrival(gatherer, m_ResourceMonitor, startTime + time,
@@ -725,10 +772,7 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         peopleToRemove.push_back(1);
         gatherer.recyclePeople(peopleToRemove);
 
-        CDataGatherer expectedGatherer(model_t::E_EventRate, model_t::E_None,
-                                       params, EMPTY_STRING, EMPTY_STRING,
-                                       EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                                       {}, key, features, startTime, 0);
+        CDataGatherer expectedGatherer = CDataGathererBuilder(features, params, key, startTime).build();
         BOOST_REQUIRE_EQUAL(0, addPerson(expectedGatherer, m_ResourceMonitor, "p3"));
         BOOST_REQUIRE_EQUAL(1, addPerson(expectedGatherer, m_ResourceMonitor, "p4"));
         BOOST_REQUIRE_EQUAL(2, addPerson(expectedGatherer, m_ResourceMonitor, "p5"));
@@ -736,7 +780,7 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         BOOST_REQUIRE_EQUAL(4, addPerson(expectedGatherer, m_ResourceMonitor, "p7"));
         BOOST_REQUIRE_EQUAL(5, addPerson(expectedGatherer, m_ResourceMonitor, "p8"));
 
-        core_t::TTime expectedCounts[] = {5, 2, 0, 5, 7, 10};
+        constexpr std::array<core_t::TTime, 6>  expectedCounts = {5, 2, 0, 5, 7, 10};
         for (std::size_t i = 0; i < std::size(expectedCounts); ++i) {
             for (core_t::TTime time = 0; time < expectedCounts[i]; ++time) {
                 addArrival(expectedGatherer, m_ResourceMonitor,
@@ -755,15 +799,12 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         peopleToRemove.push_back(7);
         gatherer.recyclePeople(peopleToRemove);
 
-        CDataGatherer expectedGatherer(model_t::E_EventRate, model_t::E_None,
-                                       params, EMPTY_STRING, EMPTY_STRING,
-                                       EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                                       {}, key, features, startTime, 0);
+        CDataGatherer expectedGatherer = CDataGathererBuilder(features, params, key, startTime).build();
         BOOST_REQUIRE_EQUAL(0, addPerson(expectedGatherer, m_ResourceMonitor, "p3"));
         BOOST_REQUIRE_EQUAL(1, addPerson(expectedGatherer, m_ResourceMonitor, "p6"));
         BOOST_REQUIRE_EQUAL(2, addPerson(expectedGatherer, m_ResourceMonitor, "p7"));
 
-        core_t::TTime expectedCounts[] = {5, 5, 7};
+        constexpr std::array<core_t::TTime, 3> expectedCounts = {5, 5, 7};
         for (std::size_t i = 0; i < std::size(expectedCounts); ++i) {
             for (core_t::TTime time = 0; time < expectedCounts[i]; ++time) {
                 addArrival(expectedGatherer, m_ResourceMonitor,
@@ -782,10 +823,7 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         peopleToRemove.push_back(6);
         gatherer.recyclePeople(peopleToRemove);
 
-        CDataGatherer expectedGatherer(model_t::E_EventRate, model_t::E_None,
-                                       params, EMPTY_STRING, EMPTY_STRING,
-                                       EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                                       {}, key, features, startTime, 0);
+        const CDataGatherer  expectedGatherer = CDataGathererBuilder(features, params, key, startTime).build();
 
         LOG_DEBUG(<< "checksum          = " << gatherer.checksum());
         LOG_DEBUG(<< "expected checksum = " << expectedGatherer.checksum());
@@ -806,14 +844,14 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderFinalResult, CTestFixture) {
 
     // Test that the various statistics come back as we expect.
 
-    const core_t::TTime startTime = 0;
-    const core_t::TTime bucketLength = 600;
-    std::size_t latencyBuckets(3);
-    core_t::TTime latencyTime = bucketLength * static_cast<core_t::TTime>(latencyBuckets);
+    constexpr core_t::TTime startTime = 0;
+    constexpr core_t::TTime bucketLength = 600;
+    constexpr std::size_t latencyBuckets(3);
+    constexpr core_t::TTime latencyTime = bucketLength * static_cast<core_t::TTime>(latencyBuckets);
     SModelParams params(bucketLength);
     params.s_LatencyBuckets = latencyBuckets;
 
-    core_t::TTime data[] = {
+    const std::array<core_t::TTime, 15>  data = {
         1, 180, 1200, 190, 400,
         600, // bucket 1, 2 & 3
         550, 799, 1199,
@@ -825,15 +863,15 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderFinalResult, CTestFixture) {
         10000 // sentinel
     };
 
-    std::string expectedPersonCounts[] = {
+    constexpr std::array expectedPersonCounts = {
         std::string("[(0, 6)]"), std::string("[(0, 3)]"), std::string("[(0, 2)]"),
         std::string("[(0, 0)]"), std::string("[(0, 3)]")};
 
-    std::string expectedPersonNonZeroCounts[] = {
+    constexpr std::array expectedPersonNonZeroCounts = {
         std::string("[(0, 6)]"), std::string("[(0, 3)]"),
         std::string("[(0, 2)]"), std::string("[]"), std::string("[(0, 3)]")};
 
-    std::string expectedPersonIndicator[] = {
+    constexpr std::array expectedPersonIndicator = {
         std::string("[(0, 1)]"), std::string("[(0, 1)]"),
         std::string("[(0, 1)]"), std::string("[]"), std::string("[(0, 1)]")};
 
@@ -842,9 +880,10 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderFinalResult, CTestFixture) {
     {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-        CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                               EMPTY_STRING, {}, key, features, startTime, 0);
+        // CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
+        //                        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+        //                        EMPTY_STRING, {}, key, features, startTime, 0);
+        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
         addPerson(gatherer, m_ResourceMonitor, "p");
 
         core_t::TTime time = startTime;
@@ -879,9 +918,10 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderFinalResult, CTestFixture) {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualNonZeroCountByBucketAndPerson);
         features.push_back(model_t::E_IndividualTotalBucketCountByPerson);
-        CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                               EMPTY_STRING, {}, key, features, startTime, 0);
+        // CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
+        //                        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+        //                        EMPTY_STRING, {}, key, features, startTime, 0);
+        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
         BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p"));
 
         core_t::TTime time = startTime;
@@ -915,13 +955,12 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderFinalResult, CTestFixture) {
         }
     }
 
-    // Test test person indicator by bucket.
+    // Test person indicator by bucket.
     {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualIndicatorOfBucketPerson);
-        CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                               EMPTY_STRING, {}, key, features, startTime, 0);
+        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+
         BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p"));
 
         core_t::TTime time = startTime;
@@ -953,13 +992,13 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderFinalResult, CTestFixture) {
 
 BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderInterimResult, CTestFixture) {
 
-    const core_t::TTime startTime = 0;
-    const core_t::TTime bucketLength = 600;
-    std::size_t latencyBuckets(3);
+    constexpr core_t::TTime startTime = 0;
+    constexpr core_t::TTime bucketLength = 600;
+    constexpr std::size_t latencyBuckets(3);
     SModelParams params(bucketLength);
     params.s_LatencyBuckets = latencyBuckets;
 
-    core_t::TTime data[] = {
+    constexpr std::array<core_t::TTime,8> data = {
         1, 1200,
         600, // bucket 1, 3 & 2
         1199,
@@ -972,9 +1011,8 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderInterimResult, CTestFixture) {
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-    CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                           EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                           EMPTY_STRING, {}, key, features, startTime, 0);
+    CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+
     addPerson(gatherer, m_ResourceMonitor, "p");
     TFeatureSizeFeatureDataPrVecPrVec featureData;
 
@@ -1082,14 +1120,14 @@ BOOST_FIXTURE_TEST_CASE(testMultipleSeriesOutOfOrderFinalResult, CTestFixture) {
     // Test that the various statistics come back as we expect
     // for multiple people.
 
-    const core_t::TTime startTime = 0;
-    const core_t::TTime bucketLength = 600;
-    std::size_t latencyBuckets(3);
-    core_t::TTime latencyTime = bucketLength * static_cast<core_t::TTime>(latencyBuckets);
+    constexpr core_t::TTime startTime = 0;
+    constexpr core_t::TTime bucketLength = 600;
+    constexpr std::size_t latencyBuckets(3);
+    constexpr core_t::TTime latencyTime = bucketLength * static_cast<core_t::TTime>(latencyBuckets);
     SModelParams params(bucketLength);
     params.s_LatencyBuckets = latencyBuckets;
 
-    std::vector<core_t::TTime> data1 = {
+    const std::vector<core_t::TTime> data1 = {
         1,    15,   1200, 190, 400,
         550, // bucket 1, 2 & 3
         600,  1250,
@@ -1101,7 +1139,7 @@ BOOST_FIXTURE_TEST_CASE(testMultipleSeriesOutOfOrderFinalResult, CTestFixture) {
         2490, // bucket 4 & 5
         10000 // sentinel
     };
-    std::vector<core_t::TTime> data2 = {
+    const std::vector<core_t::TTime> data2 = {
         1250, 5,    15,   600,  180,  190,  400, 550, // bucket 1, 2 & 3
         25,   605,  609,  799,  1199,                 // bucket 1 & 2
         1200, 1,    1255, 1950, 1400,                 // bucket 1, 3 & 4
@@ -1110,52 +1148,45 @@ BOOST_FIXTURE_TEST_CASE(testMultipleSeriesOutOfOrderFinalResult, CTestFixture) {
         10000                                         // sentinel
     };
 
-    std::vector<std::string> expectedPersonCounts = {
-        std::string("[(0, 6), (1, 8)]"), std::string("[(0, 3), (1, 5)]"),
-        std::string("[(0, 2), (1, 6)]"), std::string("[(0, 1), (1, 2)]"),
-        std::string("[(0, 3), (1, 6)]")};
-
     {
+        const std::vector expectedPersonCounts = {
+            std::string("[(0, 6), (1, 8)]"), std::string("[(0, 3), (1, 5)]"),
+            std::string("[(0, 2), (1, 6)]"), std::string("[(0, 1), (1, 2)]"),
+            std::string("[(0, 3), (1, 6)]")};
         TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-        CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                               EMPTY_STRING, {}, key, features, startTime, 0);
+        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
 
-        testGathererMultipleSeries(STestTimes{startTime, bucketLength},
-                                   STestData{data1, data2}, expectedPersonCounts,
+        testGathererMultipleSeries(STestTimes{.s_StartTime=startTime, .s_BucketLength=bucketLength},
+                                   STestData{.data1=data1, .data2=data2}, expectedPersonCounts,
                                    params, latencyTime, gatherer, m_ResourceMonitor);
     }
 
     {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-
-        CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                               EMPTY_STRING, {}, key, features, startTime, 0);
+        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
 
         testGathererMultipleSeries(startTime, bucketLength, gatherer, m_ResourceMonitor);
     }
 }
 
 BOOST_FIXTURE_TEST_CASE(testArrivalBeforeLatencyWindowIsIgnored, CTestFixture) {
-    const core_t::TTime startTime = 0;
-    const core_t::TTime bucketLength = 600;
-    std::size_t latencyBuckets(2);
+    constexpr core_t::TTime startTime = 0;
+    constexpr core_t::TTime bucketLength = 600;
+    constexpr std::size_t latencyBuckets(2);
     SModelParams params(bucketLength);
     params.s_LatencyBuckets = latencyBuckets;
 
-    core_t::TTime data[] = {
-        1800, // Bucket 4, thus bucket 1 values are already out of latency window
+    constexpr std::array<core_t::TTime,2> data = {
+        1800, // Bucket 4, thus bucket 1's values are already out of latency window
         1     // Bucket 1
     };
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-    CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                           EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                           EMPTY_STRING, {}, key, features, startTime, 0);
+    CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+
     addPerson(gatherer, m_ResourceMonitor, "p");
 
     addArrival(gatherer, m_ResourceMonitor, data[0], "p");
@@ -1180,13 +1211,13 @@ BOOST_FIXTURE_TEST_CASE(testArrivalBeforeLatencyWindowIsIgnored, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testResetBucketGivenSingleSeries, CTestFixture) {
-    const core_t::TTime startTime = 0;
-    const core_t::TTime bucketLength = 600;
-    std::size_t latencyBuckets(2);
+    constexpr core_t::TTime startTime = 0;
+    constexpr core_t::TTime bucketLength = 600;
+    constexpr std::size_t latencyBuckets(2);
     SModelParams params(bucketLength);
     params.s_LatencyBuckets = latencyBuckets;
 
-    core_t::TTime data[] = {
+    constexpr std::array<core_t::TTime,6> data = {
         100,
         300, // Bucket 1
         600, 800,
@@ -1196,13 +1227,12 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenSingleSeries, CTestFixture) {
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-    CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                           EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                           EMPTY_STRING, {}, key, features, startTime, 0);
+    CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+
     addPerson(gatherer, m_ResourceMonitor, "p");
 
-    for (std::size_t i = 0; i < std::size(data); ++i) {
-        addArrival(gatherer, m_ResourceMonitor, data[i], "p");
+    for (const auto i : data) {
+        addArrival(gatherer, m_ResourceMonitor, i, "p");
     }
 
     TFeatureSizeFeatureDataPrVecPrVec featureData;
@@ -1235,13 +1265,13 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenSingleSeries, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testResetBucketGivenMultipleSeries, CTestFixture) {
-    const core_t::TTime startTime = 0;
-    const core_t::TTime bucketLength = 600;
-    std::size_t latencyBuckets(2);
+    constexpr core_t::TTime startTime = 0;
+    constexpr core_t::TTime bucketLength = 600;
+    constexpr std::size_t latencyBuckets(2);
     SModelParams params(bucketLength);
     params.s_LatencyBuckets = latencyBuckets;
 
-    core_t::TTime data[] = {
+    constexpr std::array<core_t::TTime, 6> data = {
         100,
         300, // Bucket 1
         600, 800,
@@ -1251,17 +1281,16 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenMultipleSeries, CTestFixture) {
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-    CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                           EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                           EMPTY_STRING, {}, key, features, startTime, 0);
+    CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+
     addPerson(gatherer, m_ResourceMonitor, "p1");
     addPerson(gatherer, m_ResourceMonitor, "p2");
     addPerson(gatherer, m_ResourceMonitor, "p3");
 
-    for (std::size_t i = 0; i < std::size(data); ++i) {
-        addArrival(gatherer, m_ResourceMonitor, data[i], "p1");
-        addArrival(gatherer, m_ResourceMonitor, data[i], "p2");
-        addArrival(gatherer, m_ResourceMonitor, data[i], "p3");
+    for (const auto i : data) {
+        addArrival(gatherer, m_ResourceMonitor, i, "p1");
+        addArrival(gatherer, m_ResourceMonitor, i, "p2");
+        addArrival(gatherer, m_ResourceMonitor, i, "p3");
     }
 
     TFeatureSizeFeatureDataPrVecPrVec featureData;
@@ -1294,17 +1323,15 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenMultipleSeries, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testResetBucketGivenBucketNotAvailable, CTestFixture) {
-    const core_t::TTime startTime = 0;
-    const core_t::TTime bucketLength = 600;
-    std::size_t latencyBuckets(1);
+    constexpr core_t::TTime startTime = 0;
+    constexpr core_t::TTime bucketLength = 600;
+    constexpr std::size_t latencyBuckets(1);
     SModelParams params(bucketLength);
     params.s_LatencyBuckets = latencyBuckets;
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-    CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                           EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                           EMPTY_STRING, {}, key, features, startTime, 0);
+    CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
     addPerson(gatherer, m_ResourceMonitor, "p");
 
     addArrival(gatherer, m_ResourceMonitor, 1200, "p");
@@ -1316,7 +1343,7 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenBucketNotAvailable, CTestFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(testInfluencerBucketStatistics, CTestFixture) {
-    core_t::TTime data[] = {
+    constexpr std::array<core_t::TTime,15> data = {
         1, 15, 180, 190, 400,
         550, // bucket 1
         600, 799,
@@ -1328,41 +1355,35 @@ BOOST_FIXTURE_TEST_CASE(testInfluencerBucketStatistics, CTestFixture) {
         2490, // bucket 5
         10000 // sentinel
     };
-    TTimeVec dataVec(data, &data[15]);
+    const TTimeVec dataVec(data.begin(), data.end());
 
-    TStrVecVec influencers(14, TStrVec(1, "i"));
+    const TStrVecVec influencers(14, TStrVec(1, "i"));
 
-    std::string expectedPersonCounts[] = {
+    const TStrVec expectedPersonCountsVec{
         std::string("[(0, 6, [[(i, ([6], 1))]])]"),
         std::string("[(0, 3, [[(i, ([3], 1))]])]"),
         std::string("[(0, 2, [[(i, ([2], 1))]])]"), std::string("[(0, 0, [[]])]"),
         std::string("[(0, 3, [[(i, ([3], 1))]])]")};
-    TStrVec expectedPersonCountsVec(&expectedPersonCounts[0], &expectedPersonCounts[5]);
 
-    std::string expectedPersonNonZeroCounts[] = {
+    const TStrVec expectedPersonNonZeroCountsVec{
         std::string("[(0, 6, [[(i, ([6], 1))]])]"),
         std::string("[(0, 3, [[(i, ([3], 1))]])]"),
         std::string("[(0, 2, [[(i, ([2], 1))]])]"), std::string("[]"),
         std::string("[(0, 3, [[(i, ([3], 1))]])]")};
-    TStrVec expectedPersonNonZeroCountsVec(&expectedPersonNonZeroCounts[0],
-                                           &expectedPersonNonZeroCounts[5]);
 
-    std::string expectedPersonIndicator[] = {
+    const TStrVec expectedPersonIndicatorVec{
         std::string("[(0, 1, [[(i, ([1], 1))]])]"),
         std::string("[(0, 1, [[(i, ([1], 1))]])]"),
         std::string("[(0, 1, [[(i, ([1], 1))]])]"), std::string("[]"),
         std::string("[(0, 1, [[(i, ([1], 1))]])]")};
-    TStrVec expectedPersonIndicatorVec(&expectedPersonIndicator[0],
-                                       &expectedPersonIndicator[5]);
 
-    TStrVec expectedArrivalTimeVec(6, std::string("[]"));
+    const TStrVec expectedArrivalTimeVec(6, std::string("[]"));
 
-    std::string expectedInfoContent[] = {
+    const TStrVec expectedInfoContentVec{
         std::string("[(0, 13, [[(i, ([13], 1))]])]"),
         std::string("[(0, 13, [[(i, ([13], 1))]])]"),
         std::string("[(0, 13, [[(i, ([13], 1))]])]"), std::string("[]"),
         std::string("[(0, 13, [[(i, ([13], 1))]])]")};
-    TStrVec expectedInfoContentVec(&expectedInfoContent[0], &expectedInfoContent[5]);
 
     testInfluencerPerFeature(model_t::E_IndividualCountByBucketAndPerson, dataVec,
                              influencers, expectedPersonCountsVec, "", m_ResourceMonitor);
@@ -1390,68 +1411,175 @@ BOOST_FIXTURE_TEST_CASE(testInfluencerBucketStatistics, CTestFixture) {
                              "value", m_ResourceMonitor);
 }
 
-BOOST_FIXTURE_TEST_CASE(testDistinctStrings, CTestFixture) {
+class CDistinctStringsTestFixture : public CTestFixture {
+protected:
+    // Type aliases for convenience.
     using TOptionalStr = std::optional<std::string>;
     using TOptionalStrVec = std::vector<TOptionalStr>;
 
-    // Test the SUniqueStringFeatureData struct
-    {
-        // Check adding values with no influences gives the correct count
-        // for distinct_count
-        CUniqueStringFeatureData data;
-        TOptionalStrVec influencers;
+    // Helper that creates a SEventRateFeatureData object, populates it using the distinct count method,
+    // and checks that its print() output matches the expected value.
+    static void verifyDistinctCountFeature(const CUniqueStringFeatureData& data,
+                                    const std::string& expected) {
+        SEventRateFeatureData featureData(0);
+        data.populateDistinctCountFeatureData(featureData);
+        BOOST_REQUIRE_EQUAL(expected, featureData.print());
+    }
 
-        {
-            SEventRateFeatureData featureData(0);
-            data.populateDistinctCountFeatureData(featureData);
-            BOOST_REQUIRE_EQUAL(std::string("0"), featureData.print());
+    // Similar helper for the info-content feature data.
+    static void verifyInfoContentFeature(const CUniqueStringFeatureData& data,
+                                  const std::string& expected) {
+        SEventRateFeatureData featureData(0);
+        data.populateInfoContentFeatureData(featureData);
+        BOOST_REQUIRE_EQUAL(expected, featureData.print());
+    }
+
+    // Helper to sort influence values (when needed) using the ordering defined in maths::common.
+    static void sortInfluenceValues(SEventRateFeatureData& featureData) {
+        for (auto& influenceGroup : featureData.s_InfluenceValues) {
+            std::ranges::sort(influenceGroup, maths::common::COrderings::SFirstLess());
         }
+    }
 
+    // ----- Block 1: Distinct Count with NO influences -----
+    static void testDistinctCountNoInfluence() {
+        // Create an empty (constexpr) vector of optional strings.
+        constexpr TOptionalStrVec influencers{};
+
+        CUniqueStringFeatureData data;
+        // Initially, no strings have been inserted.
+        verifyDistinctCountFeature(data, "0");
+
+        // Insert "str1" repeatedly and verify that distinct count remains "1"
         for (std::size_t i = 0; i < 100; ++i) {
             data.insert("str1", influencers);
-            SEventRateFeatureData featureData(0);
-            data.populateDistinctCountFeatureData(featureData);
-            BOOST_REQUIRE_EQUAL(std::string("1"), featureData.print());
+            verifyDistinctCountFeature(data, "1");
         }
+        // Insert "str2" and "str3" repeatedly so that eventually the distinct count becomes "3"
         for (std::size_t i = 0; i < 100; ++i) {
             data.insert("str2", influencers);
             data.insert("str3", influencers);
-            SEventRateFeatureData featureData(0);
-            data.populateDistinctCountFeatureData(featureData);
-            BOOST_REQUIRE_EQUAL(std::string("3"), featureData.print());
+            verifyDistinctCountFeature(data, "3");
         }
+        // For additional inserts, check that the internal count equals max(3, i)
         for (std::size_t i = 1; i < 100; ++i) {
             std::stringstream ss;
             ss << "str" << i;
             data.insert(ss.str(), influencers);
             SEventRateFeatureData featureData(0);
             data.populateDistinctCountFeatureData(featureData);
-            BOOST_REQUIRE_EQUAL(std::max(std::uint64_t(3), std::uint64_t(i)),
-                                featureData.s_Count);
+            BOOST_REQUIRE_EQUAL(std::max(static_cast<std::uint64_t>(3),
+                                         static_cast<std::uint64_t>(i)),
+                                  featureData.s_Count);
         }
     }
-    {
-        // Check we can add influencers now - just 1
-        // First with a non-present value
+
+    // ----- Block 2: Distinct Count with a SINGLE influencer -----
+    static void testDistinctCountSingleInfluence() {
+        TOptionalStrVec influencers;
+        influencers.emplace_back(); // initially, the optional is not set
+
         CUniqueStringFeatureData data;
+        data.insert("str1", influencers);
+        verifyDistinctCountFeature(data, "1, [[]]");
+
+        // Now set the influencer value.
+        influencers.back() = "inf1";
+        data.insert("str1", influencers);
+        verifyDistinctCountFeature(data, "1, [[(inf1, ([1], 1))]]");
+
+        // Insert additional values.
+        data.insert("str2", influencers);
+        data.insert("str2", influencers);
+        data.insert("str2", influencers);
+        data.insert("str2", influencers);
+        influencers.back() = "inf2";
+        data.insert("str1", influencers);
+        data.insert("str3", influencers);
+        influencers.back() = "inf3";
+        data.insert("str3", influencers);
+
+        SEventRateFeatureData featureData(0);
+        data.populateDistinctCountFeatureData(featureData);
+        std::ranges::sort(featureData.s_InfluenceValues[0],
+                          maths::common::COrderings::SFirstLess());
+        BOOST_REQUIRE_EQUAL(std::string("3, [[(inf1, ([2], 1)), (inf2, ([2], 1)), (inf3, ([1], 1))]]"),
+                            featureData.print());
+    }
+
+    // ----- Block 3: Distinct Count with MULTIPLE influencers -----
+    static void testDistinctCountMultipleInfluence() {
+        TOptionalStrVec influencers;
+        influencers.emplace_back();
+        influencers.emplace_back();
+
+        CUniqueStringFeatureData data;
+        data.insert("str1", influencers);
+        data.insert("str2", influencers);
+        data.insert("str1", influencers);
+        verifyDistinctCountFeature(data, "2, [[], []]");
+
+        influencers[0] = "inf1";
+        data.insert("str1", influencers);
+        data.insert("str2", influencers);
+        verifyDistinctCountFeature(data, "2, [[(inf1, ([2], 1))], []]");
+
+        influencers[1] = "inf_v2";
+        data.insert("str2", influencers);
+        influencers[0] = "inf2";
+        influencers[1] = "inf_v3";
+        data.insert("str3", influencers);
+        data.insert("str1", influencers);
+        data.insert("str3", influencers);
+
+        SEventRateFeatureData featureData(0);
+        data.populateDistinctCountFeatureData(featureData);
+        for (std::size_t i = 0; i < 2; i++) {
+            std::ranges::sort(featureData.s_InfluenceValues[i],
+                              maths::common::COrderings::SFirstLess());
+        }
+        BOOST_REQUIRE_EQUAL(std::string("3, [[(inf1, ([2], 1)), (inf2, ([2], 1))], [(inf_v2, ([1], 1)), (inf_v3, ([2], 1))]]"),
+                            featureData.print());
+    }
+
+    // ----- Block 4: Info Content with NO influences -----
+    static void testInfoContentNoInfluence() {
+        constexpr TOptionalStrVec influencers{}; // empty
+        CUniqueStringFeatureData data;
+        verifyInfoContentFeature(data, "0");
+
+        data.insert("str1", influencers);
+        verifyInfoContentFeature(data, "12");
+
+        data.insert("str2", influencers);
+        data.insert("str3", influencers);
+        verifyInfoContentFeature(data, "18");
+
+        // For further inserts, ensure the info content count (offset by 12) is within expected bounds.
+        for (std::size_t i = 1; i < 100; ++i) {
+            std::stringstream ss;
+            ss << "str" << i;
+            data.insert(ss.str(), influencers);
+            SEventRateFeatureData featureData(0);
+            data.populateInfoContentFeatureData(featureData);
+            BOOST_TEST_REQUIRE((featureData.s_Count - 12) >= std::max(static_cast<std::uint64_t>(3),
+                                        static_cast<std::uint64_t>(i)));
+            BOOST_TEST_REQUIRE((featureData.s_Count - 12) <= std::max(static_cast<std::uint64_t>(3), static_cast<std::uint64_t>(i)) * 3);
+        }
+    }
+
+    // ----- Block 5: Info Content with a SINGLE influencer -----
+    static void testInfoContentSingleInfluence() {
         TOptionalStrVec influencers;
         influencers.emplace_back();
 
+        CUniqueStringFeatureData data;
         data.insert("str1", influencers);
-        {
-            SEventRateFeatureData featureData(0);
-            data.populateDistinctCountFeatureData(featureData);
-            BOOST_REQUIRE_EQUAL(std::string("1, [[]]"), featureData.print());
-        }
+        verifyInfoContentFeature(data, "12, [[]]");
 
         influencers.back() = "inf1";
         data.insert("str1", influencers);
-        {
-            SEventRateFeatureData featureData(0);
-            data.populateDistinctCountFeatureData(featureData);
-            BOOST_REQUIRE_EQUAL(std::string("1, [[(inf1, ([1], 1))]]"),
-                                featureData.print());
-        }
+        verifyInfoContentFeature(data, "12, [[(inf1, ([12], 1))]]");
 
         data.insert("str2", influencers);
         data.insert("str2", influencers);
@@ -1462,209 +1590,69 @@ BOOST_FIXTURE_TEST_CASE(testDistinctStrings, CTestFixture) {
         data.insert("str3", influencers);
         influencers.back() = "inf3";
         data.insert("str3", influencers);
-        {
-            SEventRateFeatureData featureData(0);
-            data.populateDistinctCountFeatureData(featureData);
 
-            std::sort(featureData.s_InfluenceValues[0].begin(),
-                      featureData.s_InfluenceValues[0].end(),
-                      maths::common::COrderings::SFirstLess());
-
-            BOOST_REQUIRE_EQUAL(std::string("3, [[(inf1, ([2], 1)), (inf2, ([2], 1)), (inf3, ([1], 1))]]"),
-                                featureData.print());
-        }
+        SEventRateFeatureData featureData(0);
+        data.populateInfoContentFeatureData(featureData);
+        std::sort(featureData.s_InfluenceValues[0].begin(),
+                  featureData.s_InfluenceValues[0].end(),
+                  maths::common::COrderings::SFirstLess());
+        BOOST_REQUIRE_EQUAL(std::string("18, [[(inf1, ([16], 1)), (inf2, ([16], 1)), (inf3, ([12], 1))]]"),
+                            featureData.print());
     }
 
-    {
-        // Check we can add more than one influencer
-        CUniqueStringFeatureData data;
+    // ----- Block 6: Info Content with MULTIPLE influencers -----
+    static void testInfoContentMultipleInfluence() {
         TOptionalStrVec influencers;
         influencers.emplace_back();
         influencers.emplace_back();
 
+        CUniqueStringFeatureData data;
         data.insert("str1", influencers);
         data.insert("str2", influencers);
         data.insert("str1", influencers);
-        {
-            SEventRateFeatureData featureData(0);
-            data.populateDistinctCountFeatureData(featureData);
-            BOOST_REQUIRE_EQUAL(std::string("2, [[], []]"), featureData.print());
-        }
+        verifyInfoContentFeature(data, "16, [[], []]");
 
         influencers[0] = "inf1";
         data.insert("str1", influencers);
         data.insert("str2", influencers);
-        {
-            SEventRateFeatureData featureData(0);
-            data.populateDistinctCountFeatureData(featureData);
-            BOOST_REQUIRE_EQUAL(std::string("2, [[(inf1, ([2], 1))], []]"),
-                                featureData.print());
-        }
-        influencers[1] = "inf_v2";
+        verifyInfoContentFeature(data, "16, [[(inf1, ([16], 1))], []]");
 
+        influencers[1] = "inf_v2";
         data.insert("str2", influencers);
         influencers[0] = "inf2";
         influencers[1] = "inf_v3";
         data.insert("str3", influencers);
         data.insert("str1", influencers);
         data.insert("str3", influencers);
-        {
-            SEventRateFeatureData featureData(0);
-            data.populateDistinctCountFeatureData(featureData);
-            for (std::size_t i = 0; i < 2; i++) {
-                std::sort(featureData.s_InfluenceValues[i].begin(),
-                          featureData.s_InfluenceValues[i].end(),
-                          maths::common::COrderings::SFirstLess());
-            }
-            BOOST_REQUIRE_EQUAL(std::string("3, [[(inf1, ([2], 1)), (inf2, ([2], 1))], [(inf_v2, ([1], 1)), (inf_v3, ([2], 1))]]"),
-                                featureData.print());
-        }
-    }
-    {
-        // Now test info_content - compressed strings
-        // Check adding values with no influences gives the correct count
-        CUniqueStringFeatureData data;
-        TOptionalStrVec influencers;
 
-        {
-            SEventRateFeatureData featureData(0);
-            data.populateInfoContentFeatureData(featureData);
-            BOOST_REQUIRE_EQUAL(std::string("0"), featureData.print());
-        }
-
-        {
-            data.insert("str1", influencers);
-            SEventRateFeatureData featureData(0);
-            data.populateInfoContentFeatureData(featureData);
-            BOOST_REQUIRE_EQUAL(std::string("12"), featureData.print());
-        }
-
-        {
-            data.insert("str2", influencers);
-            data.insert("str3", influencers);
-            SEventRateFeatureData featureData(0);
-            data.populateInfoContentFeatureData(featureData);
-            BOOST_REQUIRE_EQUAL(std::string("18"), featureData.print());
-        }
-
-        for (std::size_t i = 1; i < 100; ++i) {
-            std::stringstream ss;
-            ss << "str" << i;
-            data.insert(ss.str(), influencers);
-            SEventRateFeatureData featureData(0);
-            data.populateInfoContentFeatureData(featureData);
-            BOOST_TEST_REQUIRE((featureData.s_Count - 12) >=
-                               std::max(std::uint64_t(3), std::uint64_t(i)));
-            BOOST_TEST_REQUIRE((featureData.s_Count - 12) <=
-                               std::max(std::uint64_t(3), std::uint64_t(i)) * 3);
-        }
-    }
-    {
-        // Check we can add influencers now - just 1
-        // First with a non-present value
-        CUniqueStringFeatureData data;
-        TOptionalStrVec influencers;
-        influencers.emplace_back();
-
-        data.insert("str1", influencers);
-        {
-            SEventRateFeatureData featureData(0);
-            data.populateInfoContentFeatureData(featureData);
-            BOOST_REQUIRE_EQUAL(std::string("12, [[]]"), featureData.print());
-        }
-
-        influencers.back() = "inf1";
-        data.insert("str1", influencers);
-        {
-            SEventRateFeatureData featureData(0);
-            data.populateInfoContentFeatureData(featureData);
-            BOOST_REQUIRE_EQUAL(std::string("12, [[(inf1, ([12], 1))]]"),
-                                featureData.print());
-        }
-
-        data.insert("str2", influencers);
-        data.insert("str2", influencers);
-        data.insert("str2", influencers);
-        data.insert("str2", influencers);
-        influencers.back() = "inf2";
-        data.insert("str1", influencers);
-        data.insert("str3", influencers);
-        influencers.back() = "inf3";
-        data.insert("str3", influencers);
-        {
-            SEventRateFeatureData featureData(0);
-            data.populateInfoContentFeatureData(featureData);
-
-            std::sort(featureData.s_InfluenceValues[0].begin(),
-                      featureData.s_InfluenceValues[0].end(),
+        SEventRateFeatureData featureData(0);
+        data.populateInfoContentFeatureData(featureData);
+        for (std::size_t i = 0; i < 2; i++) {
+            std::ranges::sort(featureData.s_InfluenceValues[i],
                       maths::common::COrderings::SFirstLess());
-
-            BOOST_REQUIRE_EQUAL(std::string("18, [[(inf1, ([16], 1)), (inf2, ([16], 1)), (inf3, ([12], 1))]]"),
-                                featureData.print());
         }
+        BOOST_REQUIRE_EQUAL(std::string("18, [[(inf1, ([16], 1)), (inf2, ([16], 1))], [(inf_v2, ([12], 1)), (inf_v3, ([16], 1))]]"),
+                            featureData.print());
     }
-    {
-        // Check we can add more than one influencer
-        CUniqueStringFeatureData data;
-        TOptionalStrVec influencers;
-        influencers.emplace_back();
-        influencers.emplace_back();
 
-        data.insert("str1", influencers);
-        data.insert("str2", influencers);
-        data.insert("str1", influencers);
-        {
-            SEventRateFeatureData featureData(0);
-            data.populateInfoContentFeatureData(featureData);
-            BOOST_REQUIRE_EQUAL(std::string("16, [[], []]"), featureData.print());
-        }
-
-        influencers[0] = "inf1";
-        data.insert("str1", influencers);
-        data.insert("str2", influencers);
-        {
-            SEventRateFeatureData featureData(0);
-            data.populateInfoContentFeatureData(featureData);
-            BOOST_REQUIRE_EQUAL(std::string("16, [[(inf1, ([16], 1))], []]"),
-                                featureData.print());
-        }
-        influencers[1] = "inf_v2";
-
-        data.insert("str2", influencers);
-        influencers[0] = "inf2";
-        influencers[1] = "inf_v3";
-        data.insert("str3", influencers);
-        data.insert("str1", influencers);
-        data.insert("str3", influencers);
-        {
-            SEventRateFeatureData featureData(0);
-            data.populateInfoContentFeatureData(featureData);
-            for (std::size_t i = 0; i < 2; i++) {
-                std::sort(featureData.s_InfluenceValues[i].begin(),
-                          featureData.s_InfluenceValues[i].end(),
-                          maths::common::COrderings::SFirstLess());
-            }
-            BOOST_REQUIRE_EQUAL(std::string("18, [[(inf1, ([16], 1)), (inf2, ([16], 1))], [(inf_v2, ([12], 1)), (inf_v3, ([16], 1))]]"),
-                                featureData.print());
-        }
-    }
-    {
-        // Check that we can add distinct strings in latency buckets and restore them
-        core_t::TTime bucketLength(1800);
-        core_t::TTime startTime(1432733400);
-        std::size_t latencyBuckets(3);
+    // ----- Block 7: Distinct Strings in Latency Buckets -----
+    void testLatencyBucketsDistinctStrings() {
+        constexpr core_t::TTime bucketLength = 1800;
+        constexpr core_t::TTime startTime = 1432733400;
+        constexpr std::size_t latencyBuckets = 3;
         SModelParams params(bucketLength);
         params.s_LatencyBuckets = latencyBuckets;
 
         TFeatureVec features;
         features.push_back(model_t::E_IndividualUniqueCountByBucketAndPerson);
-        CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, "P", EMPTY_STRING,
-                               "V", {"INF"}, key, features, startTime, 0);
+        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime)
+            .personFieldName("P")
+            .valueFieldName("V")
+            .influenceFieldNames({"INF"})
+            .build();
 
         BOOST_TEST_REQUIRE(!gatherer.isPopulation());
         BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p", "v", 1));
-
         BOOST_REQUIRE_EQUAL(1, gatherer.numberFeatures());
         for (std::size_t i = 0; i < 1; ++i) {
             BOOST_REQUIRE_EQUAL(features[i], gatherer.feature(i));
@@ -1674,520 +1662,229 @@ BOOST_FIXTURE_TEST_CASE(testDistinctStrings, CTestFixture) {
         BOOST_REQUIRE_EQUAL(1, gatherer.numberActivePeople());
         BOOST_REQUIRE_EQUAL(1, gatherer.numberByFieldValues());
         BOOST_REQUIRE_EQUAL(std::string("p"), gatherer.personName(0));
-        core_t::TTime time = startTime;
-
+        constexpr core_t::TTime time = startTime;
         BOOST_REQUIRE_EQUAL(bucketLength, gatherer.bucketLength());
         testPersistence(params, gatherer, model_t::E_EventRate);
 
-        // Add data, some of which will be out of order
-        addArrival(gatherer, m_ResourceMonitor, time - (2 * bucketLength), "p",
-                   "stringOne", "inf1");
-        addArrival(gatherer, m_ResourceMonitor, time - (2 * bucketLength), "p",
-                   "stringTwo", "inf2");
-        addArrival(gatherer, m_ResourceMonitor, time - (1 * bucketLength), "p",
-                   "stringThree", "inf3");
-        addArrival(gatherer, m_ResourceMonitor, time - (1 * bucketLength), "p",
-                   "stringFour", "inf1");
+        // Add data (some out-of-order) for distinct strings.
+        addArrival(gatherer, m_ResourceMonitor, time - (2 * bucketLength), "p", "stringOne", "inf1");
+        addArrival(gatherer, m_ResourceMonitor, time - (2 * bucketLength), "p", "stringTwo", "inf2");
+        addArrival(gatherer, m_ResourceMonitor, time - (1 * bucketLength), "p", "stringThree", "inf3");
+        addArrival(gatherer, m_ResourceMonitor, time - (1 * bucketLength), "p", "stringFour", "inf1");
         addArrival(gatherer, m_ResourceMonitor, time, "p", "stringFive", "inf2");
         addArrival(gatherer, m_ResourceMonitor, time, "p", "stringSix", "inf3");
         testPersistence(params, gatherer, model_t::E_EventRate);
     }
+};
+
+BOOST_FIXTURE_TEST_CASE(testDistinctStrings, CDistinctStringsTestFixture) {
+    testDistinctCountNoInfluence();
+    testDistinctCountSingleInfluence();
+    testDistinctCountMultipleInfluence();
+    testInfoContentNoInfluence();
+    testInfoContentSingleInfluence();
+    testInfoContentMultipleInfluence();
+    testLatencyBucketsDistinctStrings();
 }
 
-BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CTestFixture) {
-    const std::string person("p");
-    const std::string attribute("a");
-    const std::string emptyString("");
+
+class CDiurnalTestFixture : public CTestFixture {
+protected:
+    // Common constants.
+    static constexpr core_t::TTime BUCKET_LENGTH{3600};
+    static constexpr core_t::TTime START_TIME{1432731600};
+    static constexpr std::size_t LATENCY_BUCKETS{3};
+    const std::string PERSON{"p"};
+    const std::string ATTRIBUTE{"a"};
+
+    // Create and initialize the model parameters.
+    static SModelParams createParams() {
+        SModelParams params(BUCKET_LENGTH);
+        params.s_LatencyBuckets = LATENCY_BUCKETS;
+        return params;
+    }
+
+    // Compute the expected count.
+    // If isDay is true, the modulo is 86400 (day), otherwise 604800 (week).
+    static std::uint64_t computeExpected(const core_t::TTime time, const std::uint64_t addition,
+                                         const bool isDay) {
+        return static_cast<std::uint64_t>(time % (isDay ? 86400 : 604800)) + addition;
+    }
+
+    // Build a gatherer based on the features, parameters, start time, and type.
+    // When useAttribute is true the attribute field is set (for population tests).
+    static CDataGatherer createGatherer(const TFeatureVec& features,
+                                 const SModelParams& params,
+                                 core_t::TTime startTime,
+                                 bool isPopulation,
+                                 bool useAttribute = false) {
+        auto builder = CDataGathererBuilder(features, params, key, startTime);
+        if (useAttribute) {
+            auto tempBuilder =
+                builder.gathererType(model_t::E_PopulationEventRate).attributeFieldName("att");
+            return tempBuilder.build();
+        } if (!isPopulation) {
+            auto tempBuilder = builder.personFieldName("person");
+            return tempBuilder.build();
+        }
+        return builder.build();
+    }
+
+    // Verify that the gatherer contains the proper features.
+    static void verifyGathererFeatures(const CDataGatherer& gatherer,
+                                const TFeatureVec& features,
+                                model_t::EFeature expectedFeature,
+                                bool isPopulation) {
+        BOOST_REQUIRE_EQUAL(1, gatherer.numberFeatures());
+        for (std::size_t i = 0; i < features.size(); ++i) {
+            BOOST_REQUIRE_EQUAL(features[i], gatherer.feature(i));
+        }
+        BOOST_TEST_REQUIRE(gatherer.hasFeature(expectedFeature));
+        if (isPopulation) {
+            BOOST_TEST_REQUIRE(gatherer.isPopulation());
+        } else {
+            BOOST_TEST_REQUIRE(!gatherer.isPopulation());
+        }
+    }
+
+    // Helper to add an arrival with or without an attribute.
+    void addArrivalHelper(CDataGatherer& gatherer, core_t::TTime t, bool useAttribute) {
+        if (useAttribute) {
+            addArrival(gatherer, m_ResourceMonitor, t, PERSON, ATTRIBUTE);
+        } else {
+            addArrival(gatherer, m_ResourceMonitor, t, PERSON);
+        }
+    }
+
+    // Template to verify the feature data.
+    // FeatureDataT is one of:
+    //  - TFeatureSizeFeatureDataPrVecPrVec for tests by person,
+    //  - TFeatureSizeSizePrFeatureDataPrVecPrVec for tests over person.
+    template<typename FeatureDataT>
+    void verifyFeatureData(const CDataGatherer& gatherer,
+                           core_t::TTime time,
+                           std::uint64_t expectedCount) {
+        FeatureDataT featureData;
+        gatherer.featureData(time, BUCKET_LENGTH, featureData);
+        BOOST_REQUIRE_EQUAL(1, featureData.size());
+        BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
+        BOOST_REQUIRE_EQUAL(expectedCount, featureData[0].second[0].second.s_Count);
+    }
+
+    // Run a sequence of arrivals and verifications.
+    // The isDay flag selects the modulo (day or week), and useAttribute toggles between
+    // person-only and attribute-including arrivals.
+    template<typename FeatureDataT>
+    void runTestSequence(CDataGatherer& gatherer, bool isDay, bool useAttribute) {
+        core_t::TTime time = START_TIME;
+
+        // Check bucket length and persistence.
+        BOOST_REQUIRE_EQUAL(BUCKET_LENGTH, gatherer.bucketLength());
+        testPersistence(createParams(), gatherer, model_t::E_EventRate);
+
+        // Arrival 1: time + 0
+        addArrivalHelper(gatherer, time + 0, useAttribute);
+        verifyFeatureData<FeatureDataT>(gatherer, time,
+                                        computeExpected(time, 0, isDay));
+
+        // Arrival 2: time + 100, expected additional count of 50.
+        addArrivalHelper(gatherer, time + 100, useAttribute);
+        verifyFeatureData<FeatureDataT>(gatherer, time,
+                                        computeExpected(time, 50, isDay));
+
+        time += BUCKET_LENGTH;
+        // Arrival 3: new bucket, time + 0.
+        addArrivalHelper(gatherer, time + 0, useAttribute);
+        verifyFeatureData<FeatureDataT>(gatherer, time,
+                                        computeExpected(time, 0, isDay));
+
+        // Arrival 4: time + 200, expected additional count of 100.
+        addArrivalHelper(gatherer, time + 200, useAttribute);
+        verifyFeatureData<FeatureDataT>(gatherer, time,
+                                        computeExpected(time, 100, isDay));
+
+        time += BUCKET_LENGTH;
+        // Arrival 5: time + 0.
+        addArrivalHelper(gatherer, time + 0, useAttribute);
+        verifyFeatureData<FeatureDataT>(gatherer, time,
+                                        computeExpected(time, 0, isDay));
+
+        // Arrival 6: time + 300, expected additional count of 150.
+        addArrivalHelper(gatherer, time + 300, useAttribute);
+        verifyFeatureData<FeatureDataT>(gatherer, time,
+                                        computeExpected(time, 150, isDay));
+
+        // Check latency: go back two buckets.
+        time -= BUCKET_LENGTH * 2;
+        addArrivalHelper(gatherer, time + 200, useAttribute);
+        verifyFeatureData<FeatureDataT>(gatherer, time,
+                                        computeExpected(time, 100, isDay));
+
+        time += BUCKET_LENGTH;
+        addArrivalHelper(gatherer, time + 400, useAttribute);
+        verifyFeatureData<FeatureDataT>(gatherer, time,
+                                        computeExpected(time, 200, isDay));
+    }
+
+    // Verify summary information for the gatherer.
+    static void verifyGathererSummary(const CDataGatherer& gatherer, bool isPopulation, bool useAttribute) {
+        if (isPopulation) {
+            if (useAttribute) {
+                BOOST_REQUIRE_EQUAL(1, gatherer.numberActivePeople());
+                BOOST_REQUIRE_EQUAL(1, gatherer.numberActiveAttributes());
+                BOOST_REQUIRE_EQUAL(std::string("a"), gatherer.attributeName(0));
+            }
+        } else {
+            BOOST_REQUIRE_EQUAL(1, gatherer.numberActivePeople());
+            BOOST_REQUIRE_EQUAL(std::string("p"), gatherer.personName(0));
+        }
+        BOOST_REQUIRE_EQUAL(1, gatherer.numberByFieldValues());
+    }
+};
+
+BOOST_FIXTURE_TEST_CASE(testDiurnalFeatures, CDiurnalTestFixture) {
     {
-        // Check that we can add time-of-day events and gather them correctly
+        // Test: time_of_day by person
         LOG_DEBUG(<< "Testing time_of_day by person");
-
-        core_t::TTime bucketLength(3600);
-        core_t::TTime startTime(1432731600);
-        std::size_t latencyBuckets(3);
-        SModelParams params(bucketLength);
-        params.s_LatencyBuckets = latencyBuckets;
-
-        TFeatureVec features;
-        features.push_back(model_t::E_IndividualTimeOfDayByBucketAndPerson);
-        CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, "person", EMPTY_STRING,
-                               EMPTY_STRING, {}, key, features, startTime, 0);
-
-        BOOST_TEST_REQUIRE(!gatherer.isPopulation());
-
-        BOOST_REQUIRE_EQUAL(1, gatherer.numberFeatures());
-        for (std::size_t i = 0; i < 1; ++i) {
-            BOOST_REQUIRE_EQUAL(features[i], gatherer.feature(i));
-        }
-        BOOST_TEST_REQUIRE(gatherer.hasFeature(model_t::E_IndividualTimeOfDayByBucketAndPerson));
-
-        core_t::TTime time = startTime;
-
-        BOOST_REQUIRE_EQUAL(bucketLength, gatherer.bucketLength());
-        testPersistence(params, gatherer, model_t::E_EventRate);
-
-        // Add some data, and check that we get the right numbers out of the featureData
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 0, person);
-
-            TFeatureSizeFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 86400),
-                                featureData[0].second[0].second.s_Count);
-        }
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 100, person);
-
-            TFeatureSizeFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 50),
-                                featureData[0].second[0].second.s_Count);
-        }
-        time += bucketLength;
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 0, person);
-
-            TFeatureSizeFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 86400),
-                                featureData[0].second[0].second.s_Count);
-        }
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 200, person);
-
-            TFeatureSizeFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 100),
-                                featureData[0].second[0].second.s_Count);
-        }
-        time += bucketLength;
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 0, person);
-
-            TFeatureSizeFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 86400),
-                                featureData[0].second[0].second.s_Count);
-        }
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 300, person);
-
-            TFeatureSizeFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 150),
-                                featureData[0].second[0].second.s_Count);
-        }
-
-        // Check latency by going backwards in time
-        time -= bucketLength * 2;
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 200, person);
-
-            TFeatureSizeFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 100),
-                                featureData[0].second[0].second.s_Count);
-        }
-        time += bucketLength;
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 400, person);
-
-            TFeatureSizeFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 200),
-                                featureData[0].second[0].second.s_Count);
-        }
-
-        BOOST_REQUIRE_EQUAL(1, gatherer.numberActivePeople());
-        BOOST_REQUIRE_EQUAL(1, gatherer.numberByFieldValues());
-        BOOST_REQUIRE_EQUAL(std::string("p"), gatherer.personName(0));
+        SModelParams const params = createParams();
+        TFeatureVec const features{ model_t::E_IndividualTimeOfDayByBucketAndPerson };
+        CDataGatherer gatherer = createGatherer(features, params, START_TIME, false);
+        verifyGathererFeatures(gatherer, features, model_t::E_IndividualTimeOfDayByBucketAndPerson, false);
+        runTestSequence<TFeatureSizeFeatureDataPrVecPrVec>(gatherer, /*isDay=*/true, /*useAttribute=*/false);
+        verifyGathererSummary(gatherer, false, false);
         testPersistence(params, gatherer, model_t::E_EventRate);
     }
     {
-        // Check that we can add time-of-week events and gather them correctly
+        // Test: time_of_week by person
         LOG_DEBUG(<< "Testing time_of_week by person");
-
-        core_t::TTime bucketLength(3600);
-        core_t::TTime startTime(1432731600);
-        std::size_t latencyBuckets(3);
-        SModelParams params(bucketLength);
-        params.s_LatencyBuckets = latencyBuckets;
-
-        TFeatureVec features;
-        features.push_back(model_t::E_IndividualTimeOfWeekByBucketAndPerson);
-        CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, "person", EMPTY_STRING,
-                               EMPTY_STRING, {}, key, features, startTime, 0);
-
-        BOOST_TEST_REQUIRE(!gatherer.isPopulation());
-
-        BOOST_REQUIRE_EQUAL(1, gatherer.numberFeatures());
-        for (std::size_t i = 0; i < 1; ++i) {
-            BOOST_REQUIRE_EQUAL(features[i], gatherer.feature(i));
-        }
-        BOOST_TEST_REQUIRE(gatherer.hasFeature(model_t::E_IndividualTimeOfWeekByBucketAndPerson));
-
-        core_t::TTime time = startTime;
-
-        BOOST_REQUIRE_EQUAL(bucketLength, gatherer.bucketLength());
-        testPersistence(params, gatherer, model_t::E_EventRate);
-
-        // Add some data, and check that we get the right numbers out of the featureData
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 0, person);
-
-            TFeatureSizeFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 604800),
-                                featureData[0].second[0].second.s_Count);
-        }
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 100, person);
-
-            TFeatureSizeFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 50),
-                                featureData[0].second[0].second.s_Count);
-        }
-        time += bucketLength;
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 0, person);
-
-            TFeatureSizeFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 604800),
-                                featureData[0].second[0].second.s_Count);
-        }
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 200, person);
-
-            TFeatureSizeFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 100),
-                                featureData[0].second[0].second.s_Count);
-        }
-        time += bucketLength;
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 0, person);
-
-            TFeatureSizeFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 604800),
-                                featureData[0].second[0].second.s_Count);
-        }
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 300, person);
-
-            TFeatureSizeFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 150),
-                                featureData[0].second[0].second.s_Count);
-        }
-
-        // Check latency by going backwards in time
-        time -= bucketLength * 2;
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 200, person);
-
-            TFeatureSizeFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 100),
-                                featureData[0].second[0].second.s_Count);
-        }
-        time += bucketLength;
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 400, person);
-
-            TFeatureSizeFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 200),
-                                featureData[0].second[0].second.s_Count);
-        }
-
-        BOOST_REQUIRE_EQUAL(1, gatherer.numberActivePeople());
-        BOOST_REQUIRE_EQUAL(1, gatherer.numberByFieldValues());
-        BOOST_REQUIRE_EQUAL(std::string("p"), gatherer.personName(0));
+        SModelParams const params = createParams();
+        TFeatureVec const features{ model_t::E_IndividualTimeOfWeekByBucketAndPerson };
+        CDataGatherer gatherer = createGatherer(features, params, START_TIME, false);
+        verifyGathererFeatures(gatherer, features, model_t::E_IndividualTimeOfWeekByBucketAndPerson, false);
+        runTestSequence<TFeatureSizeFeatureDataPrVecPrVec>(gatherer, /*isDay=*/false, /*useAttribute=*/false);
+        verifyGathererSummary(gatherer, false, false);
         testPersistence(params, gatherer, model_t::E_EventRate);
     }
     {
-        // Check that we can add time-of-week events and gather them correctly
+        // Test: time_of_week over person (with attribute)
         LOG_DEBUG(<< "Testing time_of_week over person");
-
-        core_t::TTime bucketLength(3600);
-        core_t::TTime startTime(1432731600);
-        std::size_t latencyBuckets(3);
-        SModelParams params(bucketLength);
-        params.s_LatencyBuckets = latencyBuckets;
-
-        TFeatureVec features;
-        features.push_back(model_t::E_PopulationTimeOfWeekByBucketPersonAndAttribute);
-        CDataGatherer gatherer(model_t::E_PopulationEventRate, model_t::E_None,
-                               params, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                               "att", EMPTY_STRING, {}, key, features, startTime, 0);
-
-        BOOST_TEST_REQUIRE(gatherer.isPopulation());
-
-        BOOST_REQUIRE_EQUAL(1, gatherer.numberFeatures());
-        for (std::size_t i = 0; i < 1; ++i) {
-            BOOST_REQUIRE_EQUAL(features[i], gatherer.feature(i));
-        }
-        BOOST_TEST_REQUIRE(gatherer.hasFeature(
-            model_t::E_PopulationTimeOfWeekByBucketPersonAndAttribute));
-
-        core_t::TTime time = startTime;
-
-        BOOST_REQUIRE_EQUAL(bucketLength, gatherer.bucketLength());
-        testPersistence(params, gatherer, model_t::E_EventRate);
-
-        // Add some data, and check that we get the right numbers out of the featureData
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 0, person, attribute);
-
-            TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 604800),
-                                featureData[0].second[0].second.s_Count);
-        }
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 100, person, attribute);
-
-            TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 50),
-                                featureData[0].second[0].second.s_Count);
-        }
-        time += bucketLength;
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 0, person, attribute);
-
-            TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 604800),
-                                featureData[0].second[0].second.s_Count);
-        }
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 200, person, attribute);
-
-            TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 100),
-                                featureData[0].second[0].second.s_Count);
-        }
-        time += bucketLength;
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 0, person, attribute);
-
-            TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 604800),
-                                featureData[0].second[0].second.s_Count);
-        }
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 300, person, attribute);
-
-            TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 150),
-                                featureData[0].second[0].second.s_Count);
-        }
-
-        // Check latency by going backwards in time
-        time -= bucketLength * 2;
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 200, person, attribute);
-
-            TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 100),
-                                featureData[0].second[0].second.s_Count);
-        }
-        time += bucketLength;
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 400, person, attribute);
-
-            TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 604800) + 200),
-                                featureData[0].second[0].second.s_Count);
-        }
-
-        BOOST_REQUIRE_EQUAL(1, gatherer.numberActivePeople());
-        BOOST_REQUIRE_EQUAL(1, gatherer.numberActiveAttributes());
-        BOOST_REQUIRE_EQUAL(1, gatherer.numberByFieldValues());
-        BOOST_REQUIRE_EQUAL(std::string("a"), gatherer.attributeName(0));
+        SModelParams const params = createParams();
+        TFeatureVec const features{ model_t::E_PopulationTimeOfWeekByBucketPersonAndAttribute };
+        CDataGatherer gatherer = createGatherer(features, params, START_TIME, true, /*useAttribute=*/true);
+        verifyGathererFeatures(gatherer, features, model_t::E_PopulationTimeOfWeekByBucketPersonAndAttribute, true);
+        runTestSequence<TFeatureSizeSizePrFeatureDataPrVecPrVec>(gatherer, /*isDay=*/false, /*useAttribute=*/true);
+        verifyGathererSummary(gatherer, true, true);
         testPersistence(params, gatherer, model_t::E_EventRate);
     }
     {
-        // Check that we can add time-of-day events and gather them correctly
+        // Test: time_of_day over person (with attribute)
         LOG_DEBUG(<< "Testing time_of_day over person");
-
-        core_t::TTime bucketLength(3600);
-        core_t::TTime startTime(1432731600);
-        std::size_t latencyBuckets(3);
-        SModelParams params(bucketLength);
-        params.s_LatencyBuckets = latencyBuckets;
-
-        TFeatureVec features;
-        features.push_back(model_t::E_PopulationTimeOfDayByBucketPersonAndAttribute);
-        CDataGatherer gatherer(model_t::E_PopulationEventRate, model_t::E_None,
-                               params, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                               "att", EMPTY_STRING, {}, key, features, startTime, 0);
-
-        BOOST_TEST_REQUIRE(gatherer.isPopulation());
-
-        BOOST_REQUIRE_EQUAL(1, gatherer.numberFeatures());
-        for (std::size_t i = 0; i < 1; ++i) {
-            BOOST_REQUIRE_EQUAL(features[i], gatherer.feature(i));
-        }
-        BOOST_TEST_REQUIRE(gatherer.hasFeature(
-            model_t::E_PopulationTimeOfDayByBucketPersonAndAttribute));
-
-        core_t::TTime time = startTime;
-
-        BOOST_REQUIRE_EQUAL(bucketLength, gatherer.bucketLength());
-        testPersistence(params, gatherer, model_t::E_EventRate);
-
-        // Add some data, and check that we get the right numbers out of the featureData
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 0, person, attribute);
-
-            TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 86400),
-                                featureData[0].second[0].second.s_Count);
-        }
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 100, person, attribute);
-
-            TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 50),
-                                featureData[0].second[0].second.s_Count);
-        }
-        time += bucketLength;
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 0, person, attribute);
-
-            TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 86400),
-                                featureData[0].second[0].second.s_Count);
-        }
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 200, person, attribute);
-
-            TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 100),
-                                featureData[0].second[0].second.s_Count);
-        }
-        time += bucketLength;
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 0, person, attribute);
-
-            TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t(time % 86400),
-                                featureData[0].second[0].second.s_Count);
-        }
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 300, person, attribute);
-
-            TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 150),
-                                featureData[0].second[0].second.s_Count);
-        }
-
-        // Check latency by going backwards in time
-        time -= bucketLength * 2;
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 200, person, attribute);
-
-            TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 100),
-                                featureData[0].second[0].second.s_Count);
-        }
-        time += bucketLength;
-        {
-            addArrival(gatherer, m_ResourceMonitor, time + 400, person, attribute);
-
-            TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
-            gatherer.featureData(time, bucketLength, featureData);
-            BOOST_REQUIRE_EQUAL(1, featureData.size());
-            BOOST_REQUIRE_EQUAL(1, featureData[0].second.size());
-            BOOST_REQUIRE_EQUAL(std::uint64_t((time % 86400) + 200),
-                                featureData[0].second[0].second.s_Count);
-        }
-
-        BOOST_REQUIRE_EQUAL(1, gatherer.numberActivePeople());
-        BOOST_REQUIRE_EQUAL(1, gatherer.numberActiveAttributes());
-        BOOST_REQUIRE_EQUAL(1, gatherer.numberByFieldValues());
-        BOOST_REQUIRE_EQUAL(std::string("a"), gatherer.attributeName(0));
+        SModelParams const params = createParams();
+        TFeatureVec const features{ model_t::E_PopulationTimeOfDayByBucketPersonAndAttribute };
+        CDataGatherer gatherer = createGatherer(features, params, START_TIME, true, /*useAttribute=*/true);
+        verifyGathererFeatures(gatherer, features, model_t::E_PopulationTimeOfDayByBucketPersonAndAttribute, true);
+        runTestSequence<TFeatureSizeSizePrFeatureDataPrVecPrVec>(gatherer, /*isDay=*/true, /*useAttribute=*/true);
+        verifyGathererSummary(gatherer, true, true);
         testPersistence(params, gatherer, model_t::E_EventRate);
     }
 }

--- a/lib/model/unittest/CEventRateDataGathererTest.cc
+++ b/lib/model/unittest/CEventRateDataGathererTest.cc
@@ -1586,9 +1586,8 @@ protected:
 
         SEventRateFeatureData featureData(0);
         data.populateInfoContentFeatureData(featureData);
-        std::sort(featureData.s_InfluenceValues[0].begin(),
-                  featureData.s_InfluenceValues[0].end(),
-                  maths::common::COrderings::SFirstLess());
+        std::ranges::sort(featureData.s_InfluenceValues[0],
+                          maths::common::COrderings::SFirstLess());
         BOOST_REQUIRE_EQUAL(std::string("18, [[(inf1, ([16], 1)), (inf2, ([16], 1)), (inf3, ([12], 1))]]"),
                             featureData.print());
     }

--- a/lib/model/unittest/CEventRateDataGathererTest.cc
+++ b/lib/model/unittest/CEventRateDataGathererTest.cc
@@ -833,15 +833,15 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderFinalResult, CTestFixture) {
         10000 // sentinel
     };
 
-    constexpr std::array expectedPersonCounts = {
+    const std::array expectedPersonCounts = {
         std::string("[(0, 6)]"), std::string("[(0, 3)]"), std::string("[(0, 2)]"),
         std::string("[(0, 0)]"), std::string("[(0, 3)]")};
 
-    constexpr std::array expectedPersonNonZeroCounts = {
+    const std::array expectedPersonNonZeroCounts = {
         std::string("[(0, 6)]"), std::string("[(0, 3)]"),
         std::string("[(0, 2)]"), std::string("[]"), std::string("[(0, 3)]")};
 
-    constexpr std::array expectedPersonIndicator = {
+    const std::array expectedPersonIndicator = {
         std::string("[(0, 1)]"), std::string("[(0, 1)]"),
         std::string("[(0, 1)]"), std::string("[]"), std::string("[(0, 1)]")};
 

--- a/lib/model/unittest/CEventRateDataGathererTest.cc
+++ b/lib/model/unittest/CEventRateDataGathererTest.cc
@@ -63,60 +63,7 @@ namespace {
 const CSearchKey key;
 const std::string EMPTY_STRING;
 
-class CDataGathererBuilder {
-public:
-    CDataGathererBuilder(const TFeatureVec& features, const SModelParams& params, const CSearchKey& searchKey,
-                         const core_t::TTime startTime
-    ): m_Features(features), m_Params(params),  m_StartTime(startTime), m_SearchKey(searchKey) {}
 
-    CDataGatherer build() const {
-        return {m_GathererType, m_SummaryMode, m_Params, m_SummaryCountFieldName,
-                             m_PartitionFieldValue, m_PersonFieldName, m_AttributeFieldName,
-                             m_ValueFieldName, m_InfluenceFieldNames, m_SearchKey, m_Features,
-                             m_StartTime, m_SampleCountOverride};
-    }
-
-    CDataGathererBuilder& personFieldName(const std::string& personFieldName) {
-        m_PersonFieldName = personFieldName;
-        return *this;
-    }
-
-    CDataGathererBuilder& valueFieldName(const std::string& valueFieldName) {
-        m_ValueFieldName = valueFieldName;
-        return *this;
-    }
-
-    CDataGathererBuilder& influenceFieldNames(const TStrVec& influenceFieldName) {
-        m_InfluenceFieldNames = influenceFieldName;
-        return *this;
-    }
-
-    CDataGathererBuilder& attributeFieldName(const std::string& attributeFieldName) {
-        m_AttributeFieldName = attributeFieldName;
-        return *this;
-    }
-
-    CDataGathererBuilder& gathererType(model_t::EAnalysisCategory gathererType) {
-        m_GathererType = gathererType;
-        return *this;
-    }
-
-private:
-    const TFeatureVec& m_Features;
-    const SModelParams& m_Params;
-    core_t::TTime m_StartTime;
-    const CSearchKey& m_SearchKey;
-    model_t::EAnalysisCategory m_GathererType{model_t::E_EventRate};
-    model_t::ESummaryMode m_SummaryMode{model_t::E_None};
-    std::string m_SummaryCountFieldName{EMPTY_STRING};
-    std::string m_PartitionFieldValue{EMPTY_STRING};
-    std::string m_PersonFieldName{EMPTY_STRING};
-    std::string m_AttributeFieldName{EMPTY_STRING};
-    std::string m_ValueFieldName{EMPTY_STRING};
-    TStrVec m_InfluenceFieldNames;
-    int m_SampleCountOverride{0};
-
-};
 
 std::size_t addPerson(CDataGatherer& gatherer,
                       CResourceMonitor& resourceMonitor,
@@ -221,7 +168,7 @@ void testInfluencerPerFeature(const model_t::EFeature feature,
     features.push_back(feature);
     TStrVec influencerFieldNames;
     influencerFieldNames.emplace_back("IF1");
-    CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime)
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime)
                                  .influenceFieldNames(influencerFieldNames)
                                  .valueFieldName(valueField)
                                  .build();
@@ -454,7 +401,7 @@ BOOST_FIXTURE_TEST_CASE(testLatencyPersist, CTestFixture) {
         // Create a gatherer, no influences
         TFeatureVec features;
         features.push_back(model_t::E_IndividualUniqueCountByBucketAndPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime)
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime)
                                      .personFieldName("program")
                                      .valueFieldName("file")
                                      .build();
@@ -473,7 +420,7 @@ BOOST_FIXTURE_TEST_CASE(testLatencyPersist, CTestFixture) {
         TStrVec influencers;
         influencers.emplace_back("user");
         features.push_back(model_t::E_IndividualUniqueCountByBucketAndPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime)
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime)
                                      .personFieldName("program")
                                      .valueFieldName("file")
                                      .build();
@@ -491,7 +438,7 @@ BOOST_FIXTURE_TEST_CASE(testLatencyPersist, CTestFixture) {
         // Create a gatherer, no influences
         TFeatureVec features;
         features.push_back(model_t::E_IndividualNonZeroCountByBucketAndPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime)
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime)
                                      .personFieldName("program")
                                      .build();
         TSizeVec fields;
@@ -508,7 +455,7 @@ BOOST_FIXTURE_TEST_CASE(testLatencyPersist, CTestFixture) {
         TStrVec influencers;
         influencers.emplace_back("user");
         features.push_back(model_t::E_IndividualNonZeroCountByBucketAndPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime)
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime)
                                      .personFieldName("program")
                                      .influenceFieldNames(influencers)
                                      .build();
@@ -563,7 +510,7 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeries, CTestFixture) {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
         features.push_back(model_t::E_IndividualMinByPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
         BOOST_TEST_REQUIRE(!gatherer.isPopulation());
         BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p"));
 
@@ -607,7 +554,7 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeries, CTestFixture) {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualNonZeroCountByBucketAndPerson);
         features.push_back(model_t::E_IndividualTotalBucketCountByPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
         BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p"));
 
         core_t::TTime time = startTime;
@@ -645,7 +592,7 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeries, CTestFixture) {
     {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualIndicatorOfBucketPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
         BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p"));
 
         core_t::TTime time = startTime;
@@ -715,7 +662,7 @@ BOOST_FIXTURE_TEST_CASE(testMultipleSeries, CTestFixture) {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
 
-        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
         testGathererMultipleSeries(STestTimes{.s_StartTime=startTime, .s_BucketLength=bucketLength},
                                    STestData{.data1=data1, .data2=data2}, expectedPersonCounts,
                                    params, bucketLength, gatherer, m_ResourceMonitor);
@@ -727,7 +674,7 @@ BOOST_FIXTURE_TEST_CASE(testMultipleSeries, CTestFixture) {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
 
-        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
         testGathererMultipleSeries(startTime, bucketLength, gatherer, m_ResourceMonitor);
 
         BOOST_REQUIRE_EQUAL(2, gatherer.numberByFieldValues());
@@ -748,7 +695,7 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
     features.push_back(model_t::E_IndividualLowCountsByBucketAndPerson);
     features.push_back(model_t::E_IndividualHighCountsByBucketAndPerson);
     const SModelParams params(bucketLength);
-    CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
     BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p1"));
     BOOST_REQUIRE_EQUAL(1, addPerson(gatherer, m_ResourceMonitor, "p2"));
     BOOST_REQUIRE_EQUAL(2, addPerson(gatherer, m_ResourceMonitor, "p3"));
@@ -772,7 +719,7 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         peopleToRemove.push_back(1);
         gatherer.recyclePeople(peopleToRemove);
 
-        CDataGatherer expectedGatherer = CDataGathererBuilder(features, params, key, startTime).build();
+        CDataGatherer expectedGatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
         BOOST_REQUIRE_EQUAL(0, addPerson(expectedGatherer, m_ResourceMonitor, "p3"));
         BOOST_REQUIRE_EQUAL(1, addPerson(expectedGatherer, m_ResourceMonitor, "p4"));
         BOOST_REQUIRE_EQUAL(2, addPerson(expectedGatherer, m_ResourceMonitor, "p5"));
@@ -799,7 +746,7 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         peopleToRemove.push_back(7);
         gatherer.recyclePeople(peopleToRemove);
 
-        CDataGatherer expectedGatherer = CDataGathererBuilder(features, params, key, startTime).build();
+        CDataGatherer expectedGatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
         BOOST_REQUIRE_EQUAL(0, addPerson(expectedGatherer, m_ResourceMonitor, "p3"));
         BOOST_REQUIRE_EQUAL(1, addPerson(expectedGatherer, m_ResourceMonitor, "p6"));
         BOOST_REQUIRE_EQUAL(2, addPerson(expectedGatherer, m_ResourceMonitor, "p7"));
@@ -823,7 +770,7 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         peopleToRemove.push_back(6);
         gatherer.recyclePeople(peopleToRemove);
 
-        const CDataGatherer  expectedGatherer = CDataGathererBuilder(features, params, key, startTime).build();
+        const CDataGatherer  expectedGatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
 
         LOG_DEBUG(<< "checksum          = " << gatherer.checksum());
         LOG_DEBUG(<< "expected checksum = " << expectedGatherer.checksum());
@@ -880,10 +827,7 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderFinalResult, CTestFixture) {
     {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-        // CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
-        //                        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-        //                        EMPTY_STRING, {}, key, features, startTime, 0);
-        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
         addPerson(gatherer, m_ResourceMonitor, "p");
 
         core_t::TTime time = startTime;
@@ -921,7 +865,7 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderFinalResult, CTestFixture) {
         // CDataGatherer gatherer(model_t::E_EventRate, model_t::E_None, params,
         //                        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
         //                        EMPTY_STRING, {}, key, features, startTime, 0);
-        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
         BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p"));
 
         core_t::TTime time = startTime;
@@ -959,7 +903,7 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderFinalResult, CTestFixture) {
     {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualIndicatorOfBucketPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
 
         BOOST_REQUIRE_EQUAL(0, addPerson(gatherer, m_ResourceMonitor, "p"));
 
@@ -1011,7 +955,7 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrderInterimResult, CTestFixture) {
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-    CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
 
     addPerson(gatherer, m_ResourceMonitor, "p");
     TFeatureSizeFeatureDataPrVecPrVec featureData;
@@ -1155,7 +1099,7 @@ BOOST_FIXTURE_TEST_CASE(testMultipleSeriesOutOfOrderFinalResult, CTestFixture) {
             std::string("[(0, 3), (1, 6)]")};
         TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
 
         testGathererMultipleSeries(STestTimes{.s_StartTime=startTime, .s_BucketLength=bucketLength},
                                    STestData{.data1=data1, .data2=data2}, expectedPersonCounts,
@@ -1165,7 +1109,7 @@ BOOST_FIXTURE_TEST_CASE(testMultipleSeriesOutOfOrderFinalResult, CTestFixture) {
     {
         TFeatureVec features;
         features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
 
         testGathererMultipleSeries(startTime, bucketLength, gatherer, m_ResourceMonitor);
     }
@@ -1185,7 +1129,7 @@ BOOST_FIXTURE_TEST_CASE(testArrivalBeforeLatencyWindowIsIgnored, CTestFixture) {
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-    CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
 
     addPerson(gatherer, m_ResourceMonitor, "p");
 
@@ -1227,7 +1171,7 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenSingleSeries, CTestFixture) {
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-    CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
 
     addPerson(gatherer, m_ResourceMonitor, "p");
 
@@ -1281,7 +1225,7 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenMultipleSeries, CTestFixture) {
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-    CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
 
     addPerson(gatherer, m_ResourceMonitor, "p1");
     addPerson(gatherer, m_ResourceMonitor, "p2");
@@ -1331,7 +1275,7 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenBucketNotAvailable, CTestFixture) {
 
     TFeatureVec features;
     features.push_back(model_t::E_IndividualCountByBucketAndPerson);
-    CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime).build();
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime).build();
     addPerson(gatherer, m_ResourceMonitor, "p");
 
     addArrival(gatherer, m_ResourceMonitor, 1200, "p");
@@ -1645,7 +1589,7 @@ protected:
 
         TFeatureVec features;
         features.push_back(model_t::E_IndividualUniqueCountByBucketAndPerson);
-        CDataGatherer gatherer = CDataGathererBuilder(features, params, key, startTime)
+        CDataGatherer gatherer = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime)
             .personFieldName("P")
             .valueFieldName("V")
             .influenceFieldNames({"INF"})
@@ -1718,7 +1662,7 @@ protected:
                                  core_t::TTime startTime,
                                  bool isPopulation,
                                  bool useAttribute = false) {
-        auto builder = CDataGathererBuilder(features, params, key, startTime);
+        auto builder = CDataGathererBuilder(model_t::E_EventRate, features, params, key, startTime);
         if (useAttribute) {
             auto tempBuilder =
                 builder.gathererType(model_t::E_PopulationEventRate).attributeFieldName("att");

--- a/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
+++ b/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
@@ -24,6 +24,8 @@
 #include <test/BoostTestCloseAbsolute.h>
 #include <test/CRandomNumbers.h>
 
+#include "ModelTestHelpers.h"
+
 #include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -236,9 +238,11 @@ BOOST_FIXTURE_TEST_CASE(testAttributeCounts, CTestFixture) {
     features.push_back(model_t::E_PopulationCountByBucketPersonAndAttribute);
     features.push_back(model_t::E_PopulationUniquePersonCountByAttribute);
     SModelParams params(bucketLength);
-    CDataGatherer dataGatherer(model_t::E_PopulationEventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                               EMPTY_STRING, {}, searchKey, features, startTime, 0);
+    // CDataGatherer dataGatherer(model_t::E_PopulationEventRate, model_t::E_None, params,
+    //                            EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+    //                            EMPTY_STRING, {}, searchKey, features, startTime, 0);
+    CDataGatherer dataGatherer = CDataGathererBuilder(model_t::E_PopulationEventRate,
+                                                  features, params, searchKey, startTime).build();
     BOOST_TEST_REQUIRE(dataGatherer.isPopulation());
 
     BOOST_REQUIRE_EQUAL(startTime, dataGatherer.currentBucketStartTime());
@@ -348,10 +352,11 @@ BOOST_FIXTURE_TEST_CASE(testAttributeIndicator, CTestFixture) {
     CDataGatherer::TFeatureVec features;
     features.push_back(model_t::E_PopulationIndicatorOfBucketPersonAndAttribute);
     SModelParams params(bucketLength);
-    CDataGatherer dataGatherer(model_t::E_PopulationEventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                               EMPTY_STRING, {}, searchKey, features, startTime, 0);
-
+    // CDataGatherer dataGatherer(model_t::E_PopulationEventRate, model_t::E_None, params,
+    //                            EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+    //                            EMPTY_STRING, {}, searchKey, features, startTime, 0);
+    CDataGatherer dataGatherer = CDataGathererBuilder(model_t::E_PopulationEventRate,
+                                                  features, params, searchKey, startTime).build();
     core_t::TTime time = startTime;
     for (std::size_t i = 0; i < numberBuckets; ++i, time += bucketLength) {
         TMessageVec messages;
@@ -407,10 +412,11 @@ BOOST_FIXTURE_TEST_CASE(testUniqueValueCounts, CTestFixture) {
     CDataGatherer::TFeatureVec features;
     features.push_back(model_t::E_PopulationUniqueCountByBucketPersonAndAttribute);
     SModelParams params(bucketLength);
-    CDataGatherer dataGatherer(model_t::E_PopulationEventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                               "value", {}, searchKey, features, startTime, 0);
-
+    // CDataGatherer dataGatherer(model_t::E_PopulationEventRate, model_t::E_None, params,
+    //                            EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+    //                            "value", {}, searchKey, features, startTime, 0);
+    CDataGatherer dataGatherer = CDataGathererBuilder(model_t::E_PopulationEventRate,
+                                                  features, params, searchKey, startTime).valueFieldName("value").build();
     core_t::TTime time = startTime;
     for (std::size_t i = 0; i < numberBuckets; ++i, time += bucketLength) {
         TMessageVec messages;
@@ -475,10 +481,10 @@ BOOST_FIXTURE_TEST_CASE(testCompressedLength, CTestFixture) {
     CDataGatherer::TFeatureVec features;
     features.push_back(model_t::E_PopulationInfoContentByBucketPersonAndAttribute);
     SModelParams params(bucketLength);
-    CDataGatherer dataGatherer(model_t::E_PopulationEventRate, model_t::E_None, params,
-                               EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                               "value", {}, searchKey, features, startTime, 0);
-
+    CDataGatherer dataGatherer = CDataGathererBuilder(model_t::E_PopulationEventRate,
+                                                       features, params, searchKey, startTime)
+                                      .valueFieldName("value")
+                                      .build();
     core_t::TTime time = startTime;
     for (std::size_t i = 0; i < numberBuckets; ++i, time += bucketLength) {
         TMessageVec messages;
@@ -564,9 +570,11 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
     CDataGatherer::TFeatureVec features;
     features.push_back(model_t::E_PopulationCountByBucketPersonAndAttribute);
     SModelParams params(bucketLength);
-    CDataGatherer gatherer(model_t::E_PopulationEventRate, model_t::E_None, params,
-                           EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                           EMPTY_STRING, {}, searchKey, features, startTime, 0);
+    // CDataGatherer gatherer(model_t::E_PopulationEventRate, model_t::E_None, params,
+    //                        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+    //                        EMPTY_STRING, {}, searchKey, features, startTime, 0);
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_PopulationEventRate,
+                                                  features, params, searchKey, startTime).build();
     core_t::TTime bucketStart = startTime;
     for (std::size_t i = 0; i < numberBuckets; ++i, bucketStart += bucketLength) {
         TMessageVec messages;
@@ -686,10 +694,11 @@ BOOST_FIXTURE_TEST_CASE(testRemoveAttributes, CTestFixture) {
     features.push_back(model_t::E_PopulationCountByBucketPersonAndAttribute);
     features.push_back(model_t::E_PopulationUniquePersonCountByAttribute);
     SModelParams params(bucketLength);
-    CDataGatherer gatherer(model_t::E_PopulationEventRate, model_t::E_None, params,
-                           EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                           EMPTY_STRING, {}, searchKey, features, startTime, 0);
-
+    // CDataGatherer gatherer(model_t::E_PopulationEventRate, model_t::E_None, params,
+    //                        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+    //                        EMPTY_STRING, {}, searchKey, features, startTime, 0);
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_PopulationEventRate,
+                                                  features, params, searchKey, startTime).build();
     TMessageVec messages;
     generateTestMessages(rng, startTime, bucketLength, messages);
 
@@ -816,11 +825,12 @@ BOOST_FIXTURE_TEST_CASE(testPersistence, CTestFixture) {
         features.push_back(model_t::E_PopulationCountByBucketPersonAndAttribute);
         features.push_back(model_t::E_PopulationUniquePersonCountByAttribute);
         SModelParams params(bucketLength);
-        CDataGatherer origDataGatherer(model_t::E_PopulationEventRate, model_t::E_None,
-                                       params, EMPTY_STRING, EMPTY_STRING,
-                                       EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                                       {}, searchKey, features, startTime, 0);
-
+        // CDataGatherer origDataGatherer(model_t::E_PopulationEventRate, model_t::E_None,
+        //                                params, EMPTY_STRING, EMPTY_STRING,
+        //                                EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+        //                                {}, searchKey, features, startTime, 0);
+        CDataGatherer origDataGatherer = CDataGathererBuilder(model_t::E_PopulationEventRate,
+                                                  features, params, searchKey, startTime).build();
         TMessageVec messages;
         generateTestMessages(rng, startTime, bucketLength, messages);
 
@@ -839,11 +849,12 @@ BOOST_FIXTURE_TEST_CASE(testPersistence, CTestFixture) {
         CDataGatherer::TFeatureVec features;
         features.push_back(model_t::E_PopulationInfoContentByBucketPersonAndAttribute);
         SModelParams params(bucketLength);
-        CDataGatherer dataGatherer(model_t::E_PopulationEventRate, model_t::E_None,
-                                   params, EMPTY_STRING, EMPTY_STRING,
-                                   EMPTY_STRING, EMPTY_STRING, "value", {},
-                                   searchKey, features, startTime, 0);
-
+        // CDataGatherer dataGatherer(model_t::E_PopulationEventRate, model_t::E_None,
+        //                            params, EMPTY_STRING, EMPTY_STRING,
+        //                            EMPTY_STRING, EMPTY_STRING, "value", {},
+        //                            searchKey, features, startTime, 0);
+        CDataGatherer dataGatherer = CDataGathererBuilder(model_t::E_PopulationEventRate,
+                                                  features, params, searchKey, startTime).valueFieldName("value").build();
         core_t::TTime time = startTime;
         for (std::size_t i = 0; i < numberBuckets; ++i, time += bucketLength) {
             TMessageVec messages;

--- a/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
+++ b/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
@@ -292,8 +292,9 @@ BOOST_FIXTURE_TEST_CASE(testAttributeCounts, CTestFixture) {
         BOOST_REQUIRE_EQUAL(expectedAttributePeople.size(), peoplePerAttribute.size());
         TSizeSizePrFeatureDataPrVec expectedPeoplePerAttribute;
         for (std::size_t j = 0; j < peoplePerAttribute.size(); ++j) {
-            expectedPeoplePerAttribute.emplace_back(std::make_pair(
-                std::make_pair(static_cast<size_t>(0), j), expectedAttributePeople[j].size()));
+            expectedPeoplePerAttribute.emplace_back(
+                std::make_pair(std::make_pair(static_cast<size_t>(0), j),
+                               expectedAttributePeople[j].size()));
         }
         BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(expectedPeoplePerAttribute),
                             core::CContainerPrinter::print(peoplePerAttribute));
@@ -524,10 +525,10 @@ BOOST_FIXTURE_TEST_CASE(testCompressedLength, CTestFixture) {
             const TStrSet& uniqueValues = bucketPeopleCategorie.second;
 
             core::CDeflator compressor(false);
-BOOST_REQUIRE_EQUAL(
-                        uniqueValues.size(),
-                        static_cast<size_t>(std::ranges::count_if(
-                            uniqueValues, std::bind_front(&core::CCompressUtil::addString, &compressor))));
+            BOOST_REQUIRE_EQUAL(uniqueValues.size(),
+                                static_cast<size_t>(std::ranges::count_if(
+                                    uniqueValues, std::bind_front(&core::CCompressUtil::addString,
+                                                                  &compressor))));
             std::size_t length(0);
             BOOST_TEST_REQUIRE(compressor.length(true, length));
             expectedBucketCompressedLengthPerPerson[key] = length;
@@ -768,7 +769,7 @@ BOOST_FIXTURE_TEST_CASE(testRemoveAttributes, CTestFixture) {
 
 namespace {
 void testPersistDataGatherer(const CDataGatherer& origDataGatherer,
-                                    const SModelParams& params) {
+                             const SModelParams& params) {
     std::ostringstream origJson;
     core::CJsonStatePersistInserter::persist(
         origJson, std::bind_front(&CDataGatherer::acceptPersistInserter, &origDataGatherer));
@@ -792,8 +793,6 @@ void testPersistDataGatherer(const CDataGatherer& origDataGatherer,
     BOOST_REQUIRE_EQUAL(origJson.str(), newJson.str());
 }
 }
-
-
 
 BOOST_FIXTURE_TEST_CASE(testPersistence, CTestFixture) {
     constexpr core_t::TTime startTime = 1367280000;

--- a/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
+++ b/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
@@ -25,10 +25,10 @@
 
 #include "ModelTestHelpers.h"
 
-#include <algorithm>
 #include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include <algorithm>
 #include <memory>
 #include <set>
 #include <utility>

--- a/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
+++ b/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
@@ -316,11 +316,11 @@ BOOST_FIXTURE_TEST_CASE(testAttributeCounts, CTestFixture) {
 
     TStrVec const categories = allCategories();
     TSizeVec attributeIds;
-    for (const auto& categorie : categories) {
+    for (const auto& category : categories) {
         std::size_t cid;
-        BOOST_TEST_REQUIRE(dataGatherer.attributeId(categorie, cid));
+        BOOST_TEST_REQUIRE(dataGatherer.attributeId(category, cid));
         attributeIds.push_back(cid);
-        BOOST_REQUIRE_EQUAL(expectedAttributeOrder[categorie], cid);
+        BOOST_REQUIRE_EQUAL(expectedAttributeOrder[category], cid);
     }
     LOG_DEBUG(<< "attribute ids = " << attributeIds);
     LOG_DEBUG(<< "expected attribute ids = " << expectedAttributeOrder);

--- a/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
+++ b/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
@@ -292,8 +292,8 @@ BOOST_FIXTURE_TEST_CASE(testAttributeCounts, CTestFixture) {
         TSizeSizePrFeatureDataPrVec expectedPeoplePerAttribute;
         for (std::size_t j = 0; j < peoplePerAttribute.size(); ++j) {
             expectedPeoplePerAttribute.emplace_back(
-                std::make_pair(std::make_pair(static_cast<size_t>(0), j),
-                               expectedAttributePeople[j].size()));
+                std::make_pair(static_cast<size_t>(0), j),
+                expectedAttributePeople[j].size());
         }
         BOOST_REQUIRE_EQUAL(core::CContainerPrinter::print(expectedPeoplePerAttribute),
                             core::CContainerPrinter::print(peoplePerAttribute));

--- a/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
+++ b/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
@@ -242,7 +242,8 @@ BOOST_FIXTURE_TEST_CASE(testAttributeCounts, CTestFixture) {
     //                            EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
     //                            EMPTY_STRING, {}, searchKey, features, startTime, 0);
     CDataGatherer dataGatherer = CDataGathererBuilder(model_t::E_PopulationEventRate,
-                                                  features, params, searchKey, startTime).build();
+                                                      features, params, searchKey, startTime)
+                                     .build();
     BOOST_TEST_REQUIRE(dataGatherer.isPopulation());
 
     BOOST_REQUIRE_EQUAL(startTime, dataGatherer.currentBucketStartTime());
@@ -356,7 +357,8 @@ BOOST_FIXTURE_TEST_CASE(testAttributeIndicator, CTestFixture) {
     //                            EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
     //                            EMPTY_STRING, {}, searchKey, features, startTime, 0);
     CDataGatherer dataGatherer = CDataGathererBuilder(model_t::E_PopulationEventRate,
-                                                  features, params, searchKey, startTime).build();
+                                                      features, params, searchKey, startTime)
+                                     .build();
     core_t::TTime time = startTime;
     for (std::size_t i = 0; i < numberBuckets; ++i, time += bucketLength) {
         TMessageVec messages;
@@ -416,7 +418,9 @@ BOOST_FIXTURE_TEST_CASE(testUniqueValueCounts, CTestFixture) {
     //                            EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
     //                            "value", {}, searchKey, features, startTime, 0);
     CDataGatherer dataGatherer = CDataGathererBuilder(model_t::E_PopulationEventRate,
-                                                  features, params, searchKey, startTime).valueFieldName("value").build();
+                                                      features, params, searchKey, startTime)
+                                     .valueFieldName("value")
+                                     .build();
     core_t::TTime time = startTime;
     for (std::size_t i = 0; i < numberBuckets; ++i, time += bucketLength) {
         TMessageVec messages;
@@ -482,9 +486,9 @@ BOOST_FIXTURE_TEST_CASE(testCompressedLength, CTestFixture) {
     features.push_back(model_t::E_PopulationInfoContentByBucketPersonAndAttribute);
     SModelParams params(bucketLength);
     CDataGatherer dataGatherer = CDataGathererBuilder(model_t::E_PopulationEventRate,
-                                                       features, params, searchKey, startTime)
-                                      .valueFieldName("value")
-                                      .build();
+                                                      features, params, searchKey, startTime)
+                                     .valueFieldName("value")
+                                     .build();
     core_t::TTime time = startTime;
     for (std::size_t i = 0; i < numberBuckets; ++i, time += bucketLength) {
         TMessageVec messages;
@@ -574,7 +578,8 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
     //                        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
     //                        EMPTY_STRING, {}, searchKey, features, startTime, 0);
     CDataGatherer gatherer = CDataGathererBuilder(model_t::E_PopulationEventRate,
-                                                  features, params, searchKey, startTime).build();
+                                                  features, params, searchKey, startTime)
+                                 .build();
     core_t::TTime bucketStart = startTime;
     for (std::size_t i = 0; i < numberBuckets; ++i, bucketStart += bucketLength) {
         TMessageVec messages;
@@ -698,7 +703,8 @@ BOOST_FIXTURE_TEST_CASE(testRemoveAttributes, CTestFixture) {
     //                        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
     //                        EMPTY_STRING, {}, searchKey, features, startTime, 0);
     CDataGatherer gatherer = CDataGathererBuilder(model_t::E_PopulationEventRate,
-                                                  features, params, searchKey, startTime).build();
+                                                  features, params, searchKey, startTime)
+                                 .build();
     TMessageVec messages;
     generateTestMessages(rng, startTime, bucketLength, messages);
 
@@ -829,8 +835,10 @@ BOOST_FIXTURE_TEST_CASE(testPersistence, CTestFixture) {
         //                                params, EMPTY_STRING, EMPTY_STRING,
         //                                EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
         //                                {}, searchKey, features, startTime, 0);
-        CDataGatherer origDataGatherer = CDataGathererBuilder(model_t::E_PopulationEventRate,
-                                                  features, params, searchKey, startTime).build();
+        CDataGatherer origDataGatherer =
+            CDataGathererBuilder(model_t::E_PopulationEventRate, features,
+                                 params, searchKey, startTime)
+                .build();
         TMessageVec messages;
         generateTestMessages(rng, startTime, bucketLength, messages);
 
@@ -853,8 +861,11 @@ BOOST_FIXTURE_TEST_CASE(testPersistence, CTestFixture) {
         //                            params, EMPTY_STRING, EMPTY_STRING,
         //                            EMPTY_STRING, EMPTY_STRING, "value", {},
         //                            searchKey, features, startTime, 0);
-        CDataGatherer dataGatherer = CDataGathererBuilder(model_t::E_PopulationEventRate,
-                                                  features, params, searchKey, startTime).valueFieldName("value").build();
+        CDataGatherer dataGatherer =
+            CDataGathererBuilder(model_t::E_PopulationEventRate, features,
+                                 params, searchKey, startTime)
+                .valueFieldName("value")
+                .build();
         core_t::TTime time = startTime;
         for (std::size_t i = 0; i < numberBuckets; ++i, time += bucketLength) {
             TMessageVec messages;

--- a/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
+++ b/lib/model/unittest/CEventRatePopulationDataGathererTest.cc
@@ -270,13 +270,11 @@ BOOST_FIXTURE_TEST_CASE(testAttributeCounts, CTestFixture) {
             ++expectedAttributeCounts[std::make_pair(pid, cid)];
             expectedAttributePeople[cid].insert(pid);
             if (expectedAttributeOrder
-                    .insert(TStrSizeMap::value_type(message.s_Attribute, attributeOrder))
+                    .try_emplace(message.s_Attribute, attributeOrder)
                     .second) {
                 ++attributeOrder;
             }
-            if (expectedPeopleOrder
-                    .insert(TStrSizeMap::value_type(message.s_Person, personOrder))
-                    .second) {
+            if (expectedPeopleOrder.try_emplace(message.s_Person, personOrder).second) {
                 ++personOrder;
             }
         }
@@ -360,7 +358,7 @@ BOOST_FIXTURE_TEST_CASE(testAttributeIndicator, CTestFixture) {
         generateTestMessages(rng, time, bucketLength, messages);
 
         TSizeSizePrUInt64Map expectedAttributeIndicator;
-        for (auto& message : messages) {
+        for (auto const& message : messages) {
             addArrival(message.s_Time, message.s_Person, message.s_Attribute,
                        dataGatherer, m_ResourceMonitor);
 
@@ -421,7 +419,7 @@ BOOST_FIXTURE_TEST_CASE(testUniqueValueCounts, CTestFixture) {
         TSizeSizePrUInt64Map expectedUniqueCounts;
 
         TSizeSizeSetMap bucketPeopleCategories;
-        for (auto& message : messages) {
+        for (auto const& message : messages) {
             std::ostringstream ss;
             ss << "thing"
                << "_" << time << "_" << i;
@@ -487,7 +485,7 @@ BOOST_FIXTURE_TEST_CASE(testCompressedLength, CTestFixture) {
         generateTestMessages(rng, time, bucketLength, messages);
 
         TSizeStrSetMap bucketPeopleCategories;
-        for (auto& message : messages) {
+        for (auto const& message : messages) {
             addArrival(message.s_Time, message.s_Person, "attribute",
                        message.s_Attribute, dataGatherer, m_ResourceMonitor);
 
@@ -520,7 +518,7 @@ BOOST_FIXTURE_TEST_CASE(testCompressedLength, CTestFixture) {
                             bucketCompressedLengthPerPerson.size());
 
         TSizeSizePrUInt64Map expectedBucketCompressedLengthPerPerson;
-        for (auto& bucketPeopleCategorie : bucketPeopleCategories) {
+        for (auto const& bucketPeopleCategorie : bucketPeopleCategories) {
             TSizeSizePr const key(bucketPeopleCategorie.first, 0);
             const TStrSet& uniqueValues = bucketPeopleCategorie.second;
 
@@ -569,7 +567,7 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
     for (std::size_t i = 0; i < numberBuckets; ++i, bucketStart += bucketLength) {
         TMessageVec messages;
         generateTestMessages(rng, bucketStart, bucketLength, messages);
-        for (auto& message : messages) {
+        for (auto const& message : messages) {
             addArrival(message.s_Time, message.s_Person, message.s_Attribute,
                        gatherer, m_ResourceMonitor);
         }
@@ -598,7 +596,7 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
     {
         TSizeUInt64PrVec nonZeroCounts;
         gatherer.personNonZeroCounts(bucketStart - bucketLength, nonZeroCounts);
-        for (auto& nonZeroCount : nonZeroCounts) {
+        for (auto const& nonZeroCount : nonZeroCounts) {
             if (!std::ranges::binary_search(peopleToRemove, nonZeroCount.first)) {
                 const std::string& name = gatherer.personName(nonZeroCount.first);
                 expectedNonZeroCounts[name] = static_cast<size_t>(nonZeroCount.second);
@@ -613,7 +611,7 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         TStrFeatureDataPrVec expected;
         TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
         gatherer.featureData(bucketStart - bucketLength, bucketLength, featureData);
-        for (auto& i : featureData) {
+        for (auto const& i : featureData) {
             const TSizeSizePrFeatureDataPrVec& data = i.second;
             for (const auto& j : data) {
                 if (!std::ranges::binary_search(peopleToRemove, j.first.first)) {
@@ -640,7 +638,7 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
     TStrSizeMap actualNonZeroCounts;
     TSizeUInt64PrVec nonZeroCounts;
     gatherer.personNonZeroCounts(bucketStart - bucketLength, nonZeroCounts);
-    for (auto& nonZeroCount : nonZeroCounts) {
+    for (auto const& nonZeroCount : nonZeroCounts) {
         const std::string& name = gatherer.personName(nonZeroCount.first);
         actualNonZeroCounts[name] = static_cast<size_t>(nonZeroCount.second);
     }
@@ -655,7 +653,7 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         TStrFeatureDataPrVec actual;
         TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
         gatherer.featureData(bucketStart - bucketLength, bucketLength, featureData);
-        for (auto& i : featureData) {
+        for (auto const& i : featureData) {
             const TSizeSizePrFeatureDataPrVec& data = i.second;
             for (const auto& j : data) {
                 std::string const key = model_t::print(i.first) + " " +
@@ -688,7 +686,7 @@ BOOST_FIXTURE_TEST_CASE(testRemoveAttributes, CTestFixture) {
     generateTestMessages(rng, startTime, bucketLength, messages);
 
     constexpr core_t::TTime bucketStart = startTime;
-    for (auto& message : messages) {
+    for (auto const& message : messages) {
         addArrival(message.s_Time, message.s_Person, message.s_Attribute,
                    gatherer, m_ResourceMonitor);
     }
@@ -720,7 +718,7 @@ BOOST_FIXTURE_TEST_CASE(testRemoveAttributes, CTestFixture) {
         TStrFeatureDataPrVec expected;
         TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
         gatherer.featureData(bucketStart, bucketLength, featureData);
-        for (auto& i : featureData) {
+        for (auto const& i : featureData) {
             const TSizeSizePrFeatureDataPrVec& data = i.second;
             for (const auto& j : data) {
                 if (!std::ranges::binary_search(attributesToRemove, j.first.second)) {
@@ -751,7 +749,7 @@ BOOST_FIXTURE_TEST_CASE(testRemoveAttributes, CTestFixture) {
         TStrFeatureDataPrVec actual;
         TFeatureSizeSizePrFeatureDataPrVecPrVec featureData;
         gatherer.featureData(bucketStart, bucketLength, featureData);
-        for (auto& i : featureData) {
+        for (auto const& i : featureData) {
             const TSizeSizePrFeatureDataPrVec& data = i.second;
             for (const auto& j : data) {
                 std::string const key = model_t::print(i.first) + " " +
@@ -812,7 +810,7 @@ BOOST_FIXTURE_TEST_CASE(testPersistence, CTestFixture) {
         TMessageVec messages;
         generateTestMessages(rng, startTime, bucketLength, messages);
 
-        for (auto& message : messages) {
+        for (auto const& message : messages) {
             addArrival(message.s_Time, message.s_Person, message.s_Attribute,
                        origDataGatherer, m_ResourceMonitor);
         }
@@ -837,7 +835,7 @@ BOOST_FIXTURE_TEST_CASE(testPersistence, CTestFixture) {
             TMessageVec messages;
             generateTestMessages(rng, time, bucketLength, messages);
 
-            for (auto& message : messages) {
+            for (auto const& message : messages) {
                 addArrival(message.s_Time, message.s_Person, "attribute",
                            message.s_Attribute, dataGatherer, m_ResourceMonitor);
 

--- a/lib/model/unittest/CHierarchicalResultsTest.cc
+++ b/lib/model/unittest/CHierarchicalResultsTest.cc
@@ -332,7 +332,7 @@ public:
             LOG_DEBUG(<< "leaf = " << probabilities.s_Name);
 
             std::vector<int> detectors;
-            for (const auto & [ detector, _ ] : probabilities.s_Probabilities) {
+            for (const auto & [ detector, p ] : probabilities.s_Probabilities) {
                 detectors.push_back(detector);
             }
 

--- a/lib/model/unittest/CHierarchicalResultsTest.cc
+++ b/lib/model/unittest/CHierarchicalResultsTest.cc
@@ -437,7 +437,8 @@ BOOST_AUTO_TEST_CASE(testBreadthFirstVisit) {
 
     static const std::string FUNC("min");
 
-    static constexpr ml::model::function_t::EFunction function(ml::model::function_t::E_IndividualMetricMin);
+    static constexpr ml::model::function_t::EFunction function(
+        ml::model::function_t::E_IndividualMetricMin);
 
     addResult(1, false, FUNC, function, PART1, part1, PERS, pers1, VAL1, 0.1, results);
     addResult(1, false, FUNC, function, PART1, part1, PERS, pers2, VAL1, 0.1, results);
@@ -500,7 +501,8 @@ BOOST_AUTO_TEST_CASE(testDepthFirstVisit) {
 
     static const std::string FUNC("max");
 
-    static constexpr ml::model::function_t::EFunction function(ml::model::function_t::E_IndividualMetricMax);
+    static constexpr ml::model::function_t::EFunction function(
+        ml::model::function_t::E_IndividualMetricMax);
 
     addResult(1, false, FUNC, function, PART1, part1, PERS, pers1, VAL1, 0.1, results);
     addResult(1, false, FUNC, function, PART1, part1, PERS, pers2, VAL1, 0.1, results);
@@ -759,7 +761,8 @@ BOOST_AUTO_TEST_CASE(testBuildHierarchyGivenPartitionsWithSinglePersonFieldValue
 
 BOOST_AUTO_TEST_CASE(testBasicVisitor) {
     static const std::string FUNC("max");
-    static constexpr ml::model::function_t::EFunction function(ml::model::function_t::E_IndividualMetricMax);
+    static constexpr ml::model::function_t::EFunction function(
+        ml::model::function_t::E_IndividualMetricMax);
 
     // Test by and over
     {
@@ -981,7 +984,8 @@ BOOST_AUTO_TEST_CASE(testAggregator) {
     double score = 0.0;
     double probability = 1.0;
     static const std::string FUNC("max");
-    static constexpr ml::model::function_t::EFunction function(ml::model::function_t::E_IndividualMetricMax);
+    static constexpr ml::model::function_t::EFunction function(
+        ml::model::function_t::E_IndividualMetricMax);
 
     // Test by.
     {
@@ -1138,7 +1142,8 @@ BOOST_AUTO_TEST_CASE(testInfluence) {
         model::CAnomalyDetectorModelConfig::defaultConfig();
     model::CHierarchicalResultsAggregator aggregator(modelConfig);
     std::string const FUNC("max");
-    static constexpr ml::model::function_t::EFunction function(ml::model::function_t::E_IndividualMetricMax);
+    static constexpr ml::model::function_t::EFunction function(
+        ml::model::function_t::E_IndividualMetricMax);
 
     std::string i2("i2");
     std::string i1("i1");
@@ -1303,7 +1308,8 @@ BOOST_AUTO_TEST_CASE(testScores) {
     CCheckScores checkScores;
     static const std::string MAX("max");
     static const std::string RARE("rare");
-    static constexpr ml::model::function_t::EFunction function(ml::model::function_t::E_IndividualMetricMax);
+    static constexpr ml::model::function_t::EFunction function(
+        ml::model::function_t::E_IndividualMetricMax);
 
     // Test vanilla by / over.
     {
@@ -1431,7 +1437,8 @@ BOOST_AUTO_TEST_CASE(testWriter) {
     CWriteConsistencyChecker writeConsistencyChecker(limits);
 
     static const std::string FUNC("max");
-    static constexpr ml::model::function_t::EFunction function(ml::model::function_t::E_IndividualMetricMax);
+    static constexpr ml::model::function_t::EFunction function(
+        ml::model::function_t::E_IndividualMetricMax);
 
     // Test complex.
     {
@@ -1517,21 +1524,21 @@ BOOST_AUTO_TEST_CASE(testNormalizer) {
     model::CLimits l;
     model::CHierarchicalResultsNormalizer normalizer(l, modelConfig);
     static const std::string FUNC("max");
-    static constexpr ml::model::function_t::EFunction function(ml::model::function_t::E_IndividualMetricMax);
+    static constexpr ml::model::function_t::EFunction function(
+        ml::model::function_t::E_IndividualMetricMax);
 
     // Not using TRUE and FALSE as they clash with Windows macros
 
-    const std::array<std::array<std::string, 7>, 9> fields = {{
-            {"1", FALSE_STR, PNF1, pn11, PF2, p21, EMPTY_STRING},
-            {"1", FALSE_STR, PNF1, pn11, PF2, p22, EMPTY_STRING},
-            {"1", FALSE_STR, PNF1, pn11, PF2, p23, EMPTY_STRING},
-            {"2", TRUE_STR, PNF1, pn12, PF1, p11, EMPTY_STRING},
-            {"2", TRUE_STR, PNF1, pn12, PF1, p12, EMPTY_STRING},
-            {"2", TRUE_STR, PNF1, pn12, PF1, p13, EMPTY_STRING},
-            {"3", FALSE_STR, PNF2, pn21, PF1, p11, EMPTY_STRING},
-            {"3", FALSE_STR, PNF2, pn22, PF1, p12, EMPTY_STRING},
-            {"3", FALSE_STR, PNF2, pn23, PF1, p13, EMPTY_STRING}
-        }};
+    const std::array<std::array<std::string, 7>, 9> fields = {
+        {{"1", FALSE_STR, PNF1, pn11, PF2, p21, EMPTY_STRING},
+         {"1", FALSE_STR, PNF1, pn11, PF2, p22, EMPTY_STRING},
+         {"1", FALSE_STR, PNF1, pn11, PF2, p23, EMPTY_STRING},
+         {"2", TRUE_STR, PNF1, pn12, PF1, p11, EMPTY_STRING},
+         {"2", TRUE_STR, PNF1, pn12, PF1, p12, EMPTY_STRING},
+         {"2", TRUE_STR, PNF1, pn12, PF1, p13, EMPTY_STRING},
+         {"3", FALSE_STR, PNF2, pn21, PF1, p11, EMPTY_STRING},
+         {"3", FALSE_STR, PNF2, pn22, PF1, p12, EMPTY_STRING},
+         {"3", FALSE_STR, PNF2, pn23, PF1, p13, EMPTY_STRING}}};
     TStrNormalizerPtrMap expectedNormalizers;
     expectedNormalizers.emplace(
         "r", std::make_shared<model::CAnomalyScore::CNormalizer>(modelConfig));
@@ -1770,19 +1777,19 @@ BOOST_AUTO_TEST_CASE(testDetectorEqualizing) {
         static constexpr ml::model::function_t::EFunction function(
             ml::model::function_t::E_IndividualMetricMax);
 
-        const std::array<std::array<std::string, 7>, 12> fields = {{
-            {"0", FALSE_STR, PNF1, pn11, PF1, p11, EMPTY_STRING},
-            {"0", FALSE_STR, PNF1, pn12, PF1, p12, EMPTY_STRING},
-            {"0", FALSE_STR, PNF1, pn11, PF1, p12, EMPTY_STRING},
-            {"1", FALSE_STR, PNF1, pn11, PF1, p11, EMPTY_STRING},
-            {"1", FALSE_STR, PNF1, pn12, PF1, p12, EMPTY_STRING},
-            {"1", FALSE_STR, PNF1, pn11, PF1, p12, EMPTY_STRING},
-            {"2", TRUE_STR, PNF1, pn12, PF1, p11, EMPTY_STRING},
-            {"2", TRUE_STR, PNF1, pn12, PF1, p12, EMPTY_STRING},
-            {"2", TRUE_STR, PNF1, pn11, PF1, p12, EMPTY_STRING},
-            {"3", FALSE_STR, PNF1, pn11, PF1, p11, EMPTY_STRING},
-            {"3", FALSE_STR, PNF1, pn12, PF1, p12, EMPTY_STRING},
-            {"3", FALSE_STR, PNF1, pn12, PF1, p12, EMPTY_STRING}}};
+        const std::array<std::array<std::string, 7>, 12> fields = {
+            {{"0", FALSE_STR, PNF1, pn11, PF1, p11, EMPTY_STRING},
+             {"0", FALSE_STR, PNF1, pn12, PF1, p12, EMPTY_STRING},
+             {"0", FALSE_STR, PNF1, pn11, PF1, p12, EMPTY_STRING},
+             {"1", FALSE_STR, PNF1, pn11, PF1, p11, EMPTY_STRING},
+             {"1", FALSE_STR, PNF1, pn12, PF1, p12, EMPTY_STRING},
+             {"1", FALSE_STR, PNF1, pn11, PF1, p12, EMPTY_STRING},
+             {"2", TRUE_STR, PNF1, pn12, PF1, p11, EMPTY_STRING},
+             {"2", TRUE_STR, PNF1, pn12, PF1, p12, EMPTY_STRING},
+             {"2", TRUE_STR, PNF1, pn11, PF1, p12, EMPTY_STRING},
+             {"3", FALSE_STR, PNF1, pn11, PF1, p11, EMPTY_STRING},
+             {"3", FALSE_STR, PNF1, pn12, PF1, p12, EMPTY_STRING},
+             {"3", FALSE_STR, PNF1, pn12, PF1, p12, EMPTY_STRING}}};
         constexpr std::array scales = {1.9, 2.5, 1.7, 2.9};
 
         for (std::size_t i = 0; i < 300; ++i) {
@@ -1854,10 +1861,9 @@ BOOST_AUTO_TEST_CASE(testDetectorEqualizing) {
         static constexpr ml::model::function_t::EFunction function(
             ml::model::function_t::E_IndividualMetricMax);
 
-        const std::array<std::array<std::string, 7>, 2> fields = {{
-            {"0", FALSE_STR, PNF1, pn11, PF1, p11, EMPTY_STRING},
-            {"1", FALSE_STR, PNF1, pn11, PF1, p11, EMPTY_STRING}
-        }};
+        const std::array<std::array<std::string, 7>, 2> fields = {
+            {{"0", FALSE_STR, PNF1, pn11, PF1, p11, EMPTY_STRING},
+             {"1", FALSE_STR, PNF1, pn11, PF1, p11, EMPTY_STRING}}};
         constexpr std::array scales = {1.0, 3.5};
 
         for (std::size_t i = 0; i < 500; ++i) {

--- a/lib/model/unittest/CHierarchicalResultsTest.cc
+++ b/lib/model/unittest/CHierarchicalResultsTest.cc
@@ -39,6 +39,8 @@
 #include <test/BoostTestCloseAbsolute.h>
 #include <test/CRandomNumbers.h>
 
+#include "ModelTestHelpers.h"
+
 #include <boost/algorithm/cxx11/is_sorted.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
@@ -1464,12 +1466,17 @@ BOOST_AUTO_TEST_CASE(testWriter) {
         auto interimBucketCorrector =
             std::make_shared<model::CInterimBucketCorrector>(modelConfig.bucketLength());
         model::CSearchKey key;
-        model::CAnomalyDetectorModel::TDataGathererPtr dataGatherer(
-            std::make_shared<model::CDataGatherer>(
-                model_t::E_EventRate, model_t::E_None, params, EMPTY_STRING,
-                EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, TStrVec{}, key,
-                model_t::TFeatureVec{model_t::E_IndividualCountByBucketAndPerson},
-                modelConfig.bucketLength(), 0));
+        // model::CAnomalyDetectorModel::TDataGathererPtr dataGatherer(
+        //     std::make_shared<model::CDataGatherer>(
+        //         model_t::E_EventRate, model_t::E_None, params, EMPTY_STRING,
+        //         EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, TStrVec{}, key,
+        //         model_t::TFeatureVec{model_t::E_IndividualCountByBucketAndPerson},
+        //         modelConfig.bucketLength(), 0));
+        auto dataGatherer =
+            model::CDataGathererBuilder(model_t::E_EventRate,
+                                        {model_t::E_IndividualCountByBucketAndPerson},
+                                        params, key, modelConfig.bucketLength())
+                .buildSharedPtr();
         model::CEventData dummy;
         dataGatherer->addArrival(TStrCPtrVec(1, &EMPTY_STRING), dummy, resourceMonitor);
         dummy.clear();

--- a/lib/model/unittest/CHierarchicalResultsTest.cc
+++ b/lib/model/unittest/CHierarchicalResultsTest.cc
@@ -1448,12 +1448,6 @@ BOOST_AUTO_TEST_CASE(testWriter) {
         auto interimBucketCorrector =
             std::make_shared<model::CInterimBucketCorrector>(modelConfig.bucketLength());
         model::CSearchKey const key;
-        // model::CAnomalyDetectorModel::TDataGathererPtr dataGatherer(
-        //     std::make_shared<model::CDataGatherer>(
-        //         model_t::E_EventRate, model_t::E_None, params, EMPTY_STRING,
-        //         EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, TStrVec{}, key,
-        //         model_t::TFeatureVec{model_t::E_IndividualCountByBucketAndPerson},
-        //         modelConfig.bucketLength(), 0));
         auto dataGatherer =
             model::CDataGathererBuilder(model_t::E_EventRate,
                                         {model_t::E_IndividualCountByBucketAndPerson},

--- a/lib/model/unittest/CHierarchicalResultsTest.cc
+++ b/lib/model/unittest/CHierarchicalResultsTest.cc
@@ -1854,11 +1854,11 @@ BOOST_AUTO_TEST_CASE(testDetectorEqualizing) {
         static constexpr ml::model::function_t::EFunction function(
             ml::model::function_t::E_IndividualMetricMax);
 
-        constexpr std::array<std::array<std::string, 7>, 2> fields = {{
+        const std::array<std::array<std::string, 7>, 2> fields = {{
             {"0", FALSE_STR, PNF1, pn11, PF1, p11, EMPTY_STRING},
             {"1", FALSE_STR, PNF1, pn11, PF1, p11, EMPTY_STRING}
         }};
-        constexpr std::array<double, 2> scales = {1.0, 3.5};
+        constexpr std::array scales = {1.0, 3.5};
 
         for (std::size_t i = 0; i < 500; ++i) {
             model::CHierarchicalResults results;

--- a/lib/model/unittest/CHierarchicalResultsTest.cc
+++ b/lib/model/unittest/CHierarchicalResultsTest.cc
@@ -328,12 +328,11 @@ public:
     double test(double minimumSignificance) const {
         maths::common::CBasicStatistics::SSampleMean<double>::TAccumulator meanSignificance;
 
-        for (const auto& nodeProbabilities : this->leafSet() | std::views::values) {
-            const SNodeProbabilities& probabilities = nodeProbabilities;
+        for (const auto & [ _, probabilities ] : this->leafSet()) {
             LOG_DEBUG(<< "leaf = " << probabilities.s_Name);
 
             std::vector<int> detectors;
-            for (const auto& detector : probabilities.s_Probabilities | std::views::keys) {
+            for (const auto & [ detector, _ ] : probabilities.s_Probabilities) {
                 detectors.push_back(detector);
             }
 
@@ -1542,7 +1541,7 @@ BOOST_AUTO_TEST_CASE(testNormalizer) {
         model::CHierarchicalResults results;
         TDoubleVec p;
         rng.generateUniformSamples(0.0, 1.0, std::size(fields), p);
-        constexpr TAttributeProbabilityVec empty;
+        const TAttributeProbabilityVec empty;
         for (std::size_t j = 0; j < std::size(fields); ++j) {
             addResult(boost::lexical_cast<int>(fields[j][0]), fields[j][1] == TRUE_STR,
                       FUNC, function, fields[j][2], fields[j][3], fields[j][4],
@@ -1788,7 +1787,7 @@ BOOST_AUTO_TEST_CASE(testDetectorEqualizing) {
 
         for (std::size_t i = 0; i < 300; ++i) {
             model::CHierarchicalResults results;
-            constexpr TAttributeProbabilityVec empty;
+            const TAttributeProbabilityVec empty;
             for (const auto& field : fields) {
                 int const detector = boost::lexical_cast<int>(field[0]);
                 TDoubleVec p;
@@ -1803,7 +1802,7 @@ BOOST_AUTO_TEST_CASE(testDetectorEqualizing) {
 
         for (std::size_t i = 0; i < 300; ++i) {
             model::CHierarchicalResults results;
-            constexpr TAttributeProbabilityVec empty;
+            const TAttributeProbabilityVec empty;
             for (const auto& field : fields) {
                 int const detector = boost::lexical_cast<int>(field[0]);
                 TDoubleVec p;
@@ -1862,7 +1861,7 @@ BOOST_AUTO_TEST_CASE(testDetectorEqualizing) {
 
         for (std::size_t i = 0; i < 500; ++i) {
             model::CHierarchicalResults results;
-            constexpr TAttributeProbabilityVec empty;
+            const TAttributeProbabilityVec empty;
             for (const auto& field : fields) {
                 int const detector = boost::lexical_cast<int>(field[0]);
                 TDoubleVec p;
@@ -1880,7 +1879,7 @@ BOOST_AUTO_TEST_CASE(testDetectorEqualizing) {
 
         for (std::size_t i = 0; i < 100; ++i) {
             model::CHierarchicalResults results;
-            constexpr TAttributeProbabilityVec empty;
+            const TAttributeProbabilityVec empty;
             for (const auto& field : fields) {
                 int const detector = boost::lexical_cast<int>(field[0]);
                 TDoubleVec p;

--- a/lib/model/unittest/CHierarchicalResultsTest.cc
+++ b/lib/model/unittest/CHierarchicalResultsTest.cc
@@ -68,13 +68,13 @@ const std::string EMPTY_STRING;
 const TOptionalStr EMPTY_OPTIONAL_STR;
 
 //! \brief Checks that we visit the nodes in decreasing depth order.
-class CBreadthFirstCheck : public model::CHierarchicalResultsVisitor {
+class CBreadthFirstCheck final : public model::CHierarchicalResultsVisitor {
 public:
     using TNodeCPtrSet = std::set<const TNode*>;
     using TNodeCPtrSetVec = std::vector<TNodeCPtrSet>;
 
 public:
-    CBreadthFirstCheck() : m_Layers(1, TNodeCPtrSet()) {}
+    CBreadthFirstCheck() = default;
 
     void visit(const model::CHierarchicalResults& /*results*/, const TNode& node, bool /*pivot*/) override {
         LOG_DEBUG(<< "Visiting " << node.print());
@@ -140,7 +140,7 @@ private:
 
 private:
     std::size_t m_Layer = 0;
-    TNodeCPtrSetVec m_Layers;
+    TNodeCPtrSetVec m_Layers{1, TNodeCPtrSet()};
 };
 
 //! \brief Checks that we visit all a nodes children immediately
@@ -244,7 +244,7 @@ public:
 //! \brief Checks that if we write a result for a node, we also write one
 //! for its parent (if there is one) and one for at least one child (if
 //! there are any children).
-class CWriteConsistencyChecker : public model::CHierarchicalResultsVisitor {
+class CWriteConsistencyChecker final : public model::CHierarchicalResultsVisitor {
 public:
     explicit CWriteConsistencyChecker(const model::CLimits& limits)
         : m_Limits(limits) {}

--- a/lib/model/unittest/CMetricDataGathererTest.cc
+++ b/lib/model/unittest/CMetricDataGathererTest.cc
@@ -702,10 +702,12 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         peopleToRemove.push_back(1);
         gatherer.recyclePeople(peopleToRemove);
 
-        CDataGatherer expectedGatherer(model_t::E_Metric, model_t::E_None,
-                                       params, EMPTY_STRING, EMPTY_STRING,
-                                       EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                                       {}, KEY, features, startTime, 0);
+        // CDataGatherer expectedGatherer(model_t::E_Metric, model_t::E_None,
+        //                                params, EMPTY_STRING, EMPTY_STRING,
+        //                                EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+        //                                {}, KEY, features, startTime, 0);
+
+        CDataGatherer expectedGatherer = CDataGathererBuilder(model_t::E_Metric, features, params, KEY, startTime).build();
         BOOST_REQUIRE_EQUAL(0, addPerson("p3", expectedGatherer, m_ResourceMonitor));
         BOOST_REQUIRE_EQUAL(1, addPerson("p4", expectedGatherer, m_ResourceMonitor));
         BOOST_REQUIRE_EQUAL(2, addPerson("p5", expectedGatherer, m_ResourceMonitor));
@@ -735,10 +737,12 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         peopleToRemove.push_back(7);
         gatherer.recyclePeople(peopleToRemove);
 
-        CDataGatherer expectedGatherer(model_t::E_Metric, model_t::E_None,
-                                       params, EMPTY_STRING, EMPTY_STRING,
-                                       EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                                       {}, KEY, features, startTime, 0);
+        // CDataGatherer expectedGatherer(model_t::E_Metric, model_t::E_None,
+        //                                params, EMPTY_STRING, EMPTY_STRING,
+        //                                EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+        //                                {}, KEY, features, startTime, 0);
+        CDataGatherer expectedGatherer = CDataGathererBuilder(model_t::E_Metric, features, params, KEY, startTime).build();
+
         BOOST_REQUIRE_EQUAL(0, addPerson("p3", expectedGatherer, m_ResourceMonitor));
         BOOST_REQUIRE_EQUAL(1, addPerson("p6", expectedGatherer, m_ResourceMonitor));
         BOOST_REQUIRE_EQUAL(2, addPerson("p7", expectedGatherer, m_ResourceMonitor));
@@ -765,10 +769,11 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         peopleToRemove.push_back(6);
         gatherer.recyclePeople(peopleToRemove);
 
-        CDataGatherer expectedGatherer(model_t::E_Metric, model_t::E_None,
-                                       params, EMPTY_STRING, EMPTY_STRING,
-                                       EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                                       {}, KEY, features, startTime, 0);
+        // CDataGatherer expectedGatherer(model_t::E_Metric, model_t::E_None,
+        //                                params, EMPTY_STRING, EMPTY_STRING,
+        //                                EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+        //                                {}, KEY, features, startTime, 0);
+        CDataGatherer expectedGatherer = CDataGathererBuilder(model_t::E_Metric, features, params, KEY, startTime).build();
 
         LOG_DEBUG(<< "checksum          = " << gatherer.checksum());
         LOG_DEBUG(<< "expected checksum = " << expectedGatherer.checksum());
@@ -797,17 +802,19 @@ BOOST_FIXTURE_TEST_CASE(testSum, CTestFixture) {
     TFeatureVec sumFeatures;
     sumFeatures.push_back(model_t::E_IndividualSumByBucketAndPerson);
     SModelParams params(bucketLength);
-    CDataGatherer sum(model_t::E_Metric, model_t::E_None, params, EMPTY_STRING,
-                      EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                      {}, KEY, sumFeatures, startTime, 0);
+    // CDataGatherer sum(model_t::E_Metric, model_t::E_None, params, EMPTY_STRING,
+    //                   EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+    //                   {}, KEY, sumFeatures, startTime, 0);
+    CDataGatherer sum = CDataGathererBuilder(model_t::E_Metric,sumFeatures, params, KEY, startTime).build();
     BOOST_REQUIRE_EQUAL(0, addPerson("p1", sum, m_ResourceMonitor));
 
     TFeatureVec nonZeroSumFeatures;
     nonZeroSumFeatures.push_back(model_t::E_IndividualNonNullSumByBucketAndPerson);
 
-    CDataGatherer nonZeroSum(model_t::E_Metric, model_t::E_None, params, EMPTY_STRING,
-                             EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                             {}, KEY, nonZeroSumFeatures, startTime, 0);
+    // CDataGatherer nonZeroSum(model_t::E_Metric, model_t::E_None, params, EMPTY_STRING,
+    //                          EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+    //                          {}, KEY, nonZeroSumFeatures, startTime, 0);
+    CDataGatherer nonZeroSum = CDataGathererBuilder(model_t::E_Metric,nonZeroSumFeatures, params, KEY, startTime).build();
     BOOST_REQUIRE_EQUAL(0, addPerson("p1", nonZeroSum, m_ResourceMonitor));
 
     core_t::TTime bucketStart = startTime;

--- a/lib/model/unittest/CMetricDataGathererTest.cc
+++ b/lib/model/unittest/CMetricDataGathererTest.cc
@@ -247,8 +247,7 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeries, CTestFixture) {
         {
             TFeatureSizeFeatureDataPrVecPrVec featureData;
             gatherer.sampleNow(startTime);
-            gatherer.featureData((startTime + bucketLength - 1),
-                                 bucketLength, featureData);
+            gatherer.featureData((startTime + bucketLength - 1), bucketLength, featureData);
             LOG_DEBUG(<< "featureData = " << featureData);
             BOOST_TEST_REQUIRE(!featureData.empty());
             BOOST_REQUIRE_CLOSE_ABSOLUTE(
@@ -707,7 +706,9 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         //                                EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
         //                                {}, KEY, features, startTime, 0);
 
-        CDataGatherer expectedGatherer = CDataGathererBuilder(model_t::E_Metric, features, params, KEY, startTime).build();
+        CDataGatherer expectedGatherer =
+            CDataGathererBuilder(model_t::E_Metric, features, params, KEY, startTime)
+                .build();
         BOOST_REQUIRE_EQUAL(0, addPerson("p3", expectedGatherer, m_ResourceMonitor));
         BOOST_REQUIRE_EQUAL(1, addPerson("p4", expectedGatherer, m_ResourceMonitor));
         BOOST_REQUIRE_EQUAL(2, addPerson("p5", expectedGatherer, m_ResourceMonitor));
@@ -741,7 +742,9 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         //                                params, EMPTY_STRING, EMPTY_STRING,
         //                                EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
         //                                {}, KEY, features, startTime, 0);
-        CDataGatherer expectedGatherer = CDataGathererBuilder(model_t::E_Metric, features, params, KEY, startTime).build();
+        CDataGatherer expectedGatherer =
+            CDataGathererBuilder(model_t::E_Metric, features, params, KEY, startTime)
+                .build();
 
         BOOST_REQUIRE_EQUAL(0, addPerson("p3", expectedGatherer, m_ResourceMonitor));
         BOOST_REQUIRE_EQUAL(1, addPerson("p6", expectedGatherer, m_ResourceMonitor));
@@ -773,7 +776,9 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
         //                                params, EMPTY_STRING, EMPTY_STRING,
         //                                EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
         //                                {}, KEY, features, startTime, 0);
-        CDataGatherer expectedGatherer = CDataGathererBuilder(model_t::E_Metric, features, params, KEY, startTime).build();
+        CDataGatherer expectedGatherer =
+            CDataGathererBuilder(model_t::E_Metric, features, params, KEY, startTime)
+                .build();
 
         LOG_DEBUG(<< "checksum          = " << gatherer.checksum());
         LOG_DEBUG(<< "expected checksum = " << expectedGatherer.checksum());
@@ -805,7 +810,9 @@ BOOST_FIXTURE_TEST_CASE(testSum, CTestFixture) {
     // CDataGatherer sum(model_t::E_Metric, model_t::E_None, params, EMPTY_STRING,
     //                   EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
     //                   {}, KEY, sumFeatures, startTime, 0);
-    CDataGatherer sum = CDataGathererBuilder(model_t::E_Metric,sumFeatures, params, KEY, startTime).build();
+    CDataGatherer sum = CDataGathererBuilder(model_t::E_Metric, sumFeatures,
+                                             params, KEY, startTime)
+                            .build();
     BOOST_REQUIRE_EQUAL(0, addPerson("p1", sum, m_ResourceMonitor));
 
     TFeatureVec nonZeroSumFeatures;
@@ -814,7 +821,9 @@ BOOST_FIXTURE_TEST_CASE(testSum, CTestFixture) {
     // CDataGatherer nonZeroSum(model_t::E_Metric, model_t::E_None, params, EMPTY_STRING,
     //                          EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
     //                          {}, KEY, nonZeroSumFeatures, startTime, 0);
-    CDataGatherer nonZeroSum = CDataGathererBuilder(model_t::E_Metric,nonZeroSumFeatures, params, KEY, startTime).build();
+    CDataGatherer nonZeroSum = CDataGathererBuilder(model_t::E_Metric, nonZeroSumFeatures,
+                                                    params, KEY, startTime)
+                                   .build();
     BOOST_REQUIRE_EQUAL(0, addPerson("p1", nonZeroSum, m_ResourceMonitor));
 
     core_t::TTime bucketStart = startTime;
@@ -1152,7 +1161,10 @@ BOOST_FIXTURE_TEST_CASE(testResetBucketGivenMultipleSeries, CTestFixture) {
     features.push_back(model_t::E_IndividualMinByPerson);
     features.push_back(model_t::E_IndividualMaxByPerson);
     features.push_back(model_t::E_IndividualSumByBucketAndPerson);
-    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_Metric,features, params, KEY, startTime).sampleCountOverride(2U).build();
+    CDataGatherer gatherer =
+        CDataGathererBuilder(model_t::E_Metric, features, params, KEY, startTime)
+            .sampleCountOverride(2U)
+            .build();
     addPerson("p1", gatherer, m_ResourceMonitor);
     addPerson("p2", gatherer, m_ResourceMonitor);
     addPerson("p3", gatherer, m_ResourceMonitor);
@@ -1448,9 +1460,11 @@ BOOST_FIXTURE_TEST_CASE(testInfluenceStatistics, CTestFixture) {
     features.push_back(model_t::E_IndividualMaxByPerson);
     features.push_back(model_t::E_IndividualSumByBucketAndPerson);
     TStrVec influencerNames(std::begin(influencerNames_), std::end(influencerNames_));
-    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_Metric,features, params, KEY, startTime)
-    .influenceFieldNames(influencerNames)
-    .sampleCountOverride(2U).build();
+    CDataGatherer gatherer =
+        CDataGathererBuilder(model_t::E_Metric, features, params, KEY, startTime)
+            .influenceFieldNames(influencerNames)
+            .sampleCountOverride(2U)
+            .build();
     addPerson("p1", gatherer, m_ResourceMonitor, influencerNames.size());
     addPerson("p2", gatherer, m_ResourceMonitor, influencerNames.size());
 

--- a/lib/model/unittest/CMetricDataGathererTest.cc
+++ b/lib/model/unittest/CMetricDataGathererTest.cc
@@ -389,17 +389,15 @@ BOOST_FIXTURE_TEST_CASE(testMultipleSeries, CTestFixture) {
     BOOST_REQUIRE_EQUAL(0, addPerson("p1", gatherer, m_ResourceMonitor));
     BOOST_REQUIRE_EQUAL(1, addPerson("p2", gatherer, m_ResourceMonitor));
 
-    std::array bucket11 = {
-        TTimeDoublePr{1, 1.0},   TTimeDoublePr{15, 2.1},
-        TTimeDoublePr{180, 0.9}, TTimeDoublePr{190, 1.5},
-        TTimeDoublePr{400, 1.5}, TTimeDoublePr{550, 2.0}};
-    std::array bucket12 = {
-        TTimeDoublePr{600, 2.0}, TTimeDoublePr{799, 2.2}, TTimeDoublePr{1199, 1.8}};
-    std::array bucket13 = {TTimeDoublePr{1200, 2.1},
-                                             TTimeDoublePr{1250, 2.5}};
+    std::array bucket11 = {TTimeDoublePr{1, 1.0},   TTimeDoublePr{15, 2.1},
+                           TTimeDoublePr{180, 0.9}, TTimeDoublePr{190, 1.5},
+                           TTimeDoublePr{400, 1.5}, TTimeDoublePr{550, 2.0}};
+    std::array bucket12 = {TTimeDoublePr{600, 2.0}, TTimeDoublePr{799, 2.2},
+                           TTimeDoublePr{1199, 1.8}};
+    std::array bucket13 = {TTimeDoublePr{1200, 2.1}, TTimeDoublePr{1250, 2.5}};
     std::array bucket14 = {TTimeDoublePr{1900, 3.5}};
-    std::array bucket15 = {
-        TTimeDoublePr{2420, 3.5}, TTimeDoublePr{2480, 3.2}, TTimeDoublePr{2490, 3.8}};
+    std::array bucket15 = {TTimeDoublePr{2420, 3.5}, TTimeDoublePr{2480, 3.2},
+                           TTimeDoublePr{2490, 3.8}};
     TTimeDoublePrVecVec buckets1;
     buckets1.emplace_back(std::begin(bucket11), std::end(bucket11));
     buckets1.emplace_back(std::begin(bucket12), std::end(bucket12));
@@ -878,8 +876,9 @@ BOOST_FIXTURE_TEST_CASE(testSingleSeriesOutOfOrder, CTestFixture) {
             TTimeDoublePr(1, 1.0), TTimeDoublePr(15, 2.1), TTimeDoublePr(180, 0.9),
             TTimeDoublePr(400, 1.5), TTimeDoublePr(550, 2.0)};
         constexpr core_t::TTime startTime = 0;
-        constexpr std::array bucket2 = {TTimeDoublePr(600, 2.0), TTimeDoublePr(190, 1.5),
-                                    TTimeDoublePr(799, 2.2), TTimeDoublePr(1199, 1.8)};
+        constexpr std::array bucket2 = {TTimeDoublePr(600, 2.0),
+                                        TTimeDoublePr(190, 1.5), TTimeDoublePr(799, 2.2),
+                                        TTimeDoublePr(1199, 1.8)};
         TFeatureVec features;
         features.push_back(model_t::E_IndividualMeanByPerson);
         features.push_back(model_t::E_IndividualMinByPerson);
@@ -1373,7 +1372,8 @@ BOOST_FIXTURE_TEST_CASE(testInfluenceStatistics, CTestFixture) {
     params.s_SampleQueueGrowthFactor = 0.1;
 
     constexpr std::array influencerNames_ = {"i1", "i2"};
-    std::array<std::array<std::string, 3>, 2> influencerValues = {{{"i11", "i12", "i13"}, {"i21", "i22", "i23"}}};
+    std::array<std::array<std::string, 3>, 2> influencerValues = {
+        {{"i11", "i12", "i13"}, {"i21", "i22", "i23"}}};
 
     std::array data = {
         TTimeDoubleStrStrTuple(1, 1.0, influencerValues[0][0], influencerValues[1][0]), // Bucket 1
@@ -1452,11 +1452,9 @@ BOOST_FIXTURE_TEST_CASE(testInfluenceStatistics, CTestFixture) {
                 for (const auto& val : data_ | std::views::values) {
                     TStrDoubleDoublePrPrVec statistics;
                     for (const auto& influenceValue : val.s_InfluenceValues) {
-                        for (const auto & [fst, snd] : influenceValue) {
+                        for (const auto & [ fst, snd ] : influenceValue) {
                             statistics.emplace_back(
-                                fst,
-                                TDoubleDoublePr(snd.first[0],
-                                                snd.second));
+                                fst, TDoubleDoublePr(snd.first[0], snd.second));
                         }
                     }
                     std::ranges::sort(statistics, maths::common::COrderings::SFirstLess());
@@ -1491,20 +1489,20 @@ BOOST_FIXTURE_TEST_CASE(testMultivariate, CTestFixture) {
     params.s_MultivariateComponentDelimiter = DELIMITER;
 
     std::array bucket1 = {TTimeDoubleDoubleTuple(1, 1.0, 1.0),
-                                        TTimeDoubleDoubleTuple(15, 2.1, 2.0),
-                                        TTimeDoubleDoubleTuple(180, 0.9, 0.8),
-                                        TTimeDoubleDoubleTuple(190, 1.5, 1.4),
-                                        TTimeDoubleDoubleTuple(400, 1.5, 1.4),
-                                        TTimeDoubleDoubleTuple(550, 2.0, 1.8)};
+                          TTimeDoubleDoubleTuple(15, 2.1, 2.0),
+                          TTimeDoubleDoubleTuple(180, 0.9, 0.8),
+                          TTimeDoubleDoubleTuple(190, 1.5, 1.4),
+                          TTimeDoubleDoubleTuple(400, 1.5, 1.4),
+                          TTimeDoubleDoubleTuple(550, 2.0, 1.8)};
     std::array bucket2 = {TTimeDoubleDoubleTuple(600, 2.0, 1.8),
-                                        TTimeDoubleDoubleTuple(799, 2.2, 2.0),
-                                        TTimeDoubleDoubleTuple(1199, 1.8, 1.6)};
+                          TTimeDoubleDoubleTuple(799, 2.2, 2.0),
+                          TTimeDoubleDoubleTuple(1199, 1.8, 1.6)};
     std::array bucket3 = {TTimeDoubleDoubleTuple(1200, 2.1, 2.0),
-                                        TTimeDoubleDoubleTuple(1250, 2.5, 2.4)};
+                          TTimeDoubleDoubleTuple(1250, 2.5, 2.4)};
     std::array bucket4 = {TTimeDoubleDoubleTuple(1900, 3.5, 3.2)};
     std::array bucket5 = {TTimeDoubleDoubleTuple(2420, 3.5, 3.2),
-                                        TTimeDoubleDoubleTuple(2480, 3.2, 3.0),
-                                        TTimeDoubleDoubleTuple(2490, 3.8, 3.8)};
+                          TTimeDoubleDoubleTuple(2480, 3.2, 3.0),
+                          TTimeDoubleDoubleTuple(2490, 3.8, 3.8)};
 
     {
         TFeatureVec features;

--- a/lib/model/unittest/CMetricDataGathererTest.cc
+++ b/lib/model/unittest/CMetricDataGathererTest.cc
@@ -96,7 +96,7 @@ void addArrival(CDataGatherer& gatherer,
                 const std::string& person,
                 double lat,
                 double lng,
-                const std::string& delimiter) {
+                std::string_view delimiter) {
     CDataGatherer::TStrCPtrVec fieldValues;
     fieldValues.push_back(&person);
     std::string latlngAsString;
@@ -167,7 +167,6 @@ double variance(const TDoubleVec& values, double& mean) {
 }
 
 const CSearchKey KEY;
-const std::string EMPTY_STRING;
 }
 
 class CTestFixture {
@@ -799,7 +798,7 @@ BOOST_FIXTURE_TEST_CASE(testSum, CTestFixture) {
     core_t::TTime bucketStart = startTime;
     for (const auto count : bucketCounts) {
         TDoubleVec times;
-        rng.generateUniformSamples(0.0, static_cast<double>(bucketLength - 0.1), count, times);
+        rng.generateUniformSamples(0.0, bucketLength - 0.1, count, times);
         std::ranges::sort(times);
 
         TDoubleVec values;
@@ -1444,7 +1443,7 @@ BOOST_FIXTURE_TEST_CASE(testInfluenceStatistics, CTestFixture) {
             LOG_DEBUG(<< "*** processing bucket ***");
             TFeatureSizeFeatureDataPrVecPrVec featureData;
             gatherer.featureData(bucketStart, bucketLength, featureData);
-            for (auto& j : featureData) {
+            for (auto const& j : featureData) {
                 model_t::EFeature const feature = j.first;
                 LOG_DEBUG(<< "feature = " << model_t::print(feature));
 

--- a/lib/model/unittest/CMetricPopulationDataGathererTest.cc
+++ b/lib/model/unittest/CMetricPopulationDataGathererTest.cc
@@ -34,6 +34,8 @@
 #include <string>
 #include <vector>
 
+#include "ModelTestHelpers.h"
+
 BOOST_AUTO_TEST_SUITE(CMetricPopulationDataGathererTest)
 
 using namespace ml;
@@ -669,10 +671,12 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
     features.push_back(model_t::E_PopulationMinByPersonAndAttribute);
     features.push_back(model_t::E_PopulationMaxByPersonAndAttribute);
     features.push_back(model_t::E_PopulationSumByBucketPersonAndAttribute);
-    CDataGatherer gatherer(model_t::E_PopulationMetric, model_t::E_None, params,
-                           EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                           EMPTY_STRING, {}, searchKey, features, startTime, 0);
-
+    // CDataGatherer gatherer(model_t::E_PopulationMetric, model_t::E_None, params,
+    //                        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+    //                        EMPTY_STRING, {}, searchKey, features, startTime, 0);
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_PopulationMetric, features,
+                                                      params, searchKey, startTime)
+                                     .build();
     TMessageVec messages;
     generateTestMessages(startTime, messages);
 
@@ -804,9 +808,12 @@ BOOST_FIXTURE_TEST_CASE(testRemoveAttributes, CTestFixture) {
     features.push_back(model_t::E_PopulationMinByPersonAndAttribute);
     features.push_back(model_t::E_PopulationMaxByPersonAndAttribute);
     features.push_back(model_t::E_PopulationSumByBucketPersonAndAttribute);
-    CDataGatherer gatherer(model_t::E_PopulationMetric, model_t::E_None, params,
-                           EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                           EMPTY_STRING, {}, searchKey, features, startTime, 0);
+    // CDataGatherer gatherer(model_t::E_PopulationMetric, model_t::E_None, params,
+    //                        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+    //                        EMPTY_STRING, {}, searchKey, features, startTime, 0);
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_PopulationMetric, features,
+                                                  params, searchKey, startTime)
+                                 .build();
 
     TMessageVec messages;
     generateTestMessages(startTime, messages);
@@ -972,9 +979,14 @@ BOOST_FIXTURE_TEST_CASE(testInfluenceStatistics, CTestFixture) {
     features.push_back(model_t::E_PopulationMaxByPersonAndAttribute);
     features.push_back(model_t::E_PopulationHighSumByBucketPersonAndAttribute);
     TStrVec influencerNames(std::begin(influencerNames_), std::end(influencerNames_));
-    CDataGatherer gatherer(model_t::E_PopulationMetric, model_t::E_None, params, EMPTY_STRING,
-                           EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-                           influencerNames, searchKey, features, startTime, 2);
+    // CDataGatherer gatherer(model_t::E_PopulationMetric, model_t::E_None, params, EMPTY_STRING,
+    //                        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+    //                        influencerNames, searchKey, features, startTime, 2);
+    CDataGatherer gatherer = CDataGathererBuilder(model_t::E_PopulationMetric, features,
+                                                  params, searchKey, startTime)
+                                 .influenceFieldNames(influencerNames)
+                                 .build();
+
 
     core_t::TTime bucketStart = startTime;
     for (std::size_t i = 0; i < std::size(data); ++i) {
@@ -1031,10 +1043,13 @@ BOOST_FIXTURE_TEST_CASE(testPersistence, CTestFixture) {
     features.push_back(model_t::E_PopulationMinByPersonAndAttribute);
     features.push_back(model_t::E_PopulationMaxByPersonAndAttribute);
     features.push_back(model_t::E_PopulationHighSumByBucketPersonAndAttribute);
-    CDataGatherer origDataGatherer(model_t::E_PopulationMetric, model_t::E_None,
-                                   params, EMPTY_STRING, EMPTY_STRING,
-                                   EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, {},
-                                   searchKey, features, startTime, 0);
+    // CDataGatherer origDataGatherer(model_t::E_PopulationMetric, model_t::E_None,
+    //                                params, EMPTY_STRING, EMPTY_STRING,
+    //                                EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, {},
+    //                                searchKey, features, startTime, 0);
+    CDataGatherer origDataGatherer = CDataGathererBuilder(model_t::E_PopulationMetric, features,
+                                                  params, searchKey, startTime)
+                                 .build();
 
     TMessageVec messages;
     generateTestMessages(startTime, messages);

--- a/lib/model/unittest/CMetricPopulationDataGathererTest.cc
+++ b/lib/model/unittest/CMetricPopulationDataGathererTest.cc
@@ -652,9 +652,6 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
     features.push_back(model_t::E_PopulationMinByPersonAndAttribute);
     features.push_back(model_t::E_PopulationMaxByPersonAndAttribute);
     features.push_back(model_t::E_PopulationSumByBucketPersonAndAttribute);
-    // CDataGatherer gatherer(model_t::E_PopulationMetric, model_t::E_None, params,
-    //                        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-    //                        EMPTY_STRING, {}, searchKey, features, startTime, 0);
     CDataGatherer gatherer = CDataGathererBuilder(model_t::E_PopulationMetric, features,
                                                   params, searchKey, startTime)
                                  .build();
@@ -787,9 +784,6 @@ BOOST_FIXTURE_TEST_CASE(testRemoveAttributes, CTestFixture) {
     features.push_back(model_t::E_PopulationMinByPersonAndAttribute);
     features.push_back(model_t::E_PopulationMaxByPersonAndAttribute);
     features.push_back(model_t::E_PopulationSumByBucketPersonAndAttribute);
-    // CDataGatherer gatherer(model_t::E_PopulationMetric, model_t::E_None, params,
-    //                        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-    //                        EMPTY_STRING, {}, searchKey, features, startTime, 0);
     CDataGatherer gatherer = CDataGathererBuilder(model_t::E_PopulationMetric, features,
                                                   params, searchKey, startTime)
                                  .build();
@@ -958,9 +952,6 @@ BOOST_FIXTURE_TEST_CASE(testInfluenceStatistics, CTestFixture) {
     features.push_back(model_t::E_PopulationMaxByPersonAndAttribute);
     features.push_back(model_t::E_PopulationHighSumByBucketPersonAndAttribute);
     TStrVec const influencerNames(std::begin(influencerNames_), std::end(influencerNames_));
-    // CDataGatherer gatherer(model_t::E_PopulationMetric, model_t::E_None, params, EMPTY_STRING,
-    //                        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-    //                        influencerNames, searchKey, features, startTime, 2);
     CDataGatherer gatherer = CDataGathererBuilder(model_t::E_PopulationMetric, features,
                                                   params, searchKey, startTime)
                                  .influenceFieldNames(influencerNames)
@@ -1012,10 +1003,6 @@ BOOST_FIXTURE_TEST_CASE(testPersistence, CTestFixture) {
     features.push_back(model_t::E_PopulationMinByPersonAndAttribute);
     features.push_back(model_t::E_PopulationMaxByPersonAndAttribute);
     features.push_back(model_t::E_PopulationHighSumByBucketPersonAndAttribute);
-    // CDataGatherer origDataGatherer(model_t::E_PopulationMetric, model_t::E_None,
-    //                                params, EMPTY_STRING, EMPTY_STRING,
-    //                                EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, {},
-    //                                searchKey, features, startTime, 0);
     CDataGatherer origDataGatherer =
         CDataGathererBuilder(model_t::E_PopulationMetric, features, params, searchKey, startTime)
             .build();

--- a/lib/model/unittest/CMetricPopulationDataGathererTest.cc
+++ b/lib/model/unittest/CMetricPopulationDataGathererTest.cc
@@ -437,11 +437,10 @@ BOOST_FIXTURE_TEST_CASE(testSampleCount, CTestFixture) {
     CDataGatherer& gatherer(*gathererPtr);
 
     std::size_t bucket = 0;
-    for (auto& message : messages) {
-        core_t::TTime const bucketStart =
-            startTime + (static_cast<core_t::TTime>(bucket) * bucketLength);
-
-        if (message.s_Time >= bucketStart + bucketLength) {
+    for (const auto& message : messages) {
+        if (core_t::TTime const bucketStart =
+                startTime + (static_cast<core_t::TTime>(bucket) * bucketLength);
+            message.s_Time >= bucketStart + bucketLength) {
             gatherer.sampleNow(bucketStart);
             LOG_DEBUG(<< gatherer.effectiveSampleCount(0));
             BOOST_REQUIRE_CLOSE_ABSOLUTE(expectedSampleCounts[bucket],

--- a/lib/model/unittest/CMetricPopulationDataGathererTest.cc
+++ b/lib/model/unittest/CMetricPopulationDataGathererTest.cc
@@ -675,8 +675,8 @@ BOOST_FIXTURE_TEST_CASE(testRemovePeople, CTestFixture) {
     //                        EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
     //                        EMPTY_STRING, {}, searchKey, features, startTime, 0);
     CDataGatherer gatherer = CDataGathererBuilder(model_t::E_PopulationMetric, features,
-                                                      params, searchKey, startTime)
-                                     .build();
+                                                  params, searchKey, startTime)
+                                 .build();
     TMessageVec messages;
     generateTestMessages(startTime, messages);
 
@@ -987,7 +987,6 @@ BOOST_FIXTURE_TEST_CASE(testInfluenceStatistics, CTestFixture) {
                                  .influenceFieldNames(influencerNames)
                                  .build();
 
-
     core_t::TTime bucketStart = startTime;
     for (std::size_t i = 0; i < std::size(data); ++i) {
         if (data[i].s_Time >= bucketStart + bucketLength) {
@@ -1047,9 +1046,9 @@ BOOST_FIXTURE_TEST_CASE(testPersistence, CTestFixture) {
     //                                params, EMPTY_STRING, EMPTY_STRING,
     //                                EMPTY_STRING, EMPTY_STRING, EMPTY_STRING, {},
     //                                searchKey, features, startTime, 0);
-    CDataGatherer origDataGatherer = CDataGathererBuilder(model_t::E_PopulationMetric, features,
-                                                  params, searchKey, startTime)
-                                 .build();
+    CDataGatherer origDataGatherer =
+        CDataGathererBuilder(model_t::E_PopulationMetric, features, params, searchKey, startTime)
+            .build();
 
     TMessageVec messages;
     generateTestMessages(startTime, messages);

--- a/lib/model/unittest/CMetricPopulationDataGathererTest.cc
+++ b/lib/model/unittest/CMetricPopulationDataGathererTest.cc
@@ -30,8 +30,8 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
-#include <ranges>
 #include <map>
+#include <ranges>
 #include <string>
 #include <utility>
 #include <vector>
@@ -86,7 +86,8 @@ void generateTestMessages(const core_t::TTime& startTime, TMessageVec& result) {
     constexpr std::size_t numberCategories = 10;
     constexpr std::array locations = {1.0, 2.0,  5.0,  15.0, 3.0,
                                       0.5, 10.0, 17.0, 8.5,  1.5};
-    constexpr std::array scales = {1.0, 1.0, 3.0, 2.0, 0.5, 0.5, 2.0, 3.0, 4.0, 1.0};
+    constexpr std::array scales = {1.0, 1.0, 3.0, 2.0, 0.5,
+                                   0.5, 2.0, 3.0, 4.0, 1.0};
 
     result.clear();
     result.reserve(numberMessages);
@@ -903,7 +904,8 @@ BOOST_FIXTURE_TEST_CASE(testInfluenceStatistics, CTestFixture) {
     params.s_DecayRate = 0.001;
 
     constexpr std::array influencerNames_ = {"i1", "i2"};
-    std::array<std::array<std::string, 3>, 2> const influencerValues = {{{"i11", "i12", "i13"}, {"i21", "i22", "i23"}}};
+    std::array<std::array<std::string, 3>, 2> const influencerValues = {
+        {{"i11", "i12", "i13"}, {"i21", "i22", "i23"}}};
 
     const std::array data = {
         SMessage(1, "p1", "", 1.0, vec(influencerValues[0][0], influencerValues[1][0])), // Bucket 1

--- a/lib/model/unittest/CModelDetailsViewTest.cc
+++ b/lib/model/unittest/CModelDetailsViewTest.cc
@@ -28,8 +28,8 @@
 #include <boost/test/unit_test.hpp>
 
 #include <memory>
-#include <vector>
 #include <ranges>
+#include <vector>
 
 BOOST_TEST_DONT_PRINT_LOG_VALUE(ml::model::CModelPlotData::TFeatureStrByFieldDataUMapUMapCItr);
 
@@ -103,11 +103,10 @@ BOOST_FIXTURE_TEST_CASE(testModelPlot, CTestFixture) {
         BOOST_TEST_REQUIRE(plotData.begin() != plotData.end());
         for (const auto& plotDataValues : plotData | std::views::values) {
             BOOST_REQUIRE_EQUAL(values.size(), plotDataValues.size());
-            for (const auto& [fst, snd] : plotDataValues) {
+            for (const auto & [ fst, snd ] : plotDataValues) {
                 BOOST_TEST_REQUIRE(gatherer->personId(fst, pid));
                 BOOST_REQUIRE_EQUAL(1, snd.s_ValuesPerOverField.size());
-                for (const auto& val : snd.s_ValuesPerOverField |
-                                           std::views::values) {
+                for (const auto& val : snd.s_ValuesPerOverField | std::views::values) {
                     BOOST_REQUIRE_EQUAL(values[pid], val);
                 }
             }
@@ -131,11 +130,10 @@ BOOST_FIXTURE_TEST_CASE(testModelPlot, CTestFixture) {
         BOOST_TEST_REQUIRE(plotData.begin() != plotData.end());
         for (const auto& plotDataValues : plotData | std::views::values) {
             BOOST_REQUIRE_EQUAL(values.size(), plotDataValues.size());
-            for (const auto& [fst, snd] : plotDataValues) {
+            for (const auto & [ fst, snd ] : plotDataValues) {
                 BOOST_TEST_REQUIRE(gatherer->personId(fst, pid));
                 BOOST_REQUIRE_EQUAL(1, snd.s_ValuesPerOverField.size());
-                for (const auto& val : snd.s_ValuesPerOverField |
-                                           std::views::values) {
+                for (const auto& val : snd.s_ValuesPerOverField | std::views::values) {
                     BOOST_REQUIRE_EQUAL(values[pid], val);
                 }
             }

--- a/lib/model/unittest/CModelDetailsViewTest.cc
+++ b/lib/model/unittest/CModelDetailsViewTest.cc
@@ -59,8 +59,8 @@ BOOST_FIXTURE_TEST_CASE(testModelPlot, CTestFixture) {
                                                features, params, key, 0)
                        .personFieldName("p")
                        .buildSharedPtr();
-        const std::vector<std::string> persons{"p11", "p12", "p21", "p22"};
-        for (const auto& person : persons) {
+        for (const std::vector<std::string> persons{"p11", "p12", "p21", "p22"};
+             const auto& person : persons) {
             bool addedPerson{false};
             gatherer->addPerson(person, m_ResourceMonitor, addedPerson);
         }

--- a/lib/model/unittest/CModelDetailsViewTest.cc
+++ b/lib/model/unittest/CModelDetailsViewTest.cc
@@ -23,6 +23,7 @@
 #include <model/CSearchKey.h>
 
 #include "Mocks.h"
+#include "ModelTestHelpers.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -60,10 +61,10 @@ BOOST_FIXTURE_TEST_CASE(testModelPlot, CTestFixture) {
     TMockModelPtr model;
 
     auto setupTest = [&]() {
-        gatherer = std::make_shared<model::CDataGatherer>(
-            model_t::analysisCategory(features[0]), model_t::E_None, params,
-            EMPTY_STRING, EMPTY_STRING, "p", EMPTY_STRING, EMPTY_STRING,
-            TStrVec{}, key, features, 0, 0);
+        gatherer = model::CDataGathererBuilder(model_t::analysisCategory(features[0]),
+                                               features, params, key, 0)
+                       .personFieldName("p")
+                       .buildSharedPtr();
         std::string person11{"p11"};
         std::string person12{"p12"};
         std::string person21{"p21"};

--- a/lib/model/unittest/CModelDetailsViewTest.cc
+++ b/lib/model/unittest/CModelDetailsViewTest.cc
@@ -101,12 +101,12 @@ BOOST_FIXTURE_TEST_CASE(testModelPlot, CTestFixture) {
         model::CModelPlotData plotData;
         model->details()->modelPlot(0, 90.0, {}, plotData);
         BOOST_TEST_REQUIRE(plotData.begin() != plotData.end());
-        for (const auto& plotDataValues : plotData | std::views::values) {
+        for (const auto & [ _, plotDataValues ] : plotData) {
             BOOST_REQUIRE_EQUAL(values.size(), plotDataValues.size());
             for (const auto & [ fst, snd ] : plotDataValues) {
                 BOOST_TEST_REQUIRE(gatherer->personId(fst, pid));
                 BOOST_REQUIRE_EQUAL(1, snd.s_ValuesPerOverField.size());
-                for (const auto& val : snd.s_ValuesPerOverField | std::views::values) {
+                for (const auto & [ _, val ] : snd.s_ValuesPerOverField) {
                     BOOST_REQUIRE_EQUAL(values[pid], val);
                 }
             }
@@ -128,12 +128,12 @@ BOOST_FIXTURE_TEST_CASE(testModelPlot, CTestFixture) {
         model::CModelPlotData plotData;
         model->details()->modelPlot(0, 90.0, {}, plotData);
         BOOST_TEST_REQUIRE(plotData.begin() != plotData.end());
-        for (const auto& plotDataValues : plotData | std::views::values) {
+        for (const auto & [ _, plotDataValues ] : plotData) {
             BOOST_REQUIRE_EQUAL(values.size(), plotDataValues.size());
             for (const auto & [ fst, snd ] : plotDataValues) {
                 BOOST_TEST_REQUIRE(gatherer->personId(fst, pid));
                 BOOST_REQUIRE_EQUAL(1, snd.s_ValuesPerOverField.size());
-                for (const auto& val : snd.s_ValuesPerOverField | std::views::values) {
+                for (const auto & [ _, val ] : snd.s_ValuesPerOverField) {
                     BOOST_REQUIRE_EQUAL(values[pid], val);
                 }
             }

--- a/lib/model/unittest/CModelDetailsViewTest.cc
+++ b/lib/model/unittest/CModelDetailsViewTest.cc
@@ -106,7 +106,7 @@ BOOST_FIXTURE_TEST_CASE(testModelPlot, CTestFixture) {
             for (const auto & [ fst, snd ] : plotDataValues) {
                 BOOST_TEST_REQUIRE(gatherer->personId(fst, pid));
                 BOOST_REQUIRE_EQUAL(1, snd.s_ValuesPerOverField.size());
-                for (const auto & [ _, val ] : snd.s_ValuesPerOverField) {
+                for (const auto & [ field_name, val ] : snd.s_ValuesPerOverField) {
                     BOOST_REQUIRE_EQUAL(values[pid], val);
                 }
             }
@@ -133,7 +133,7 @@ BOOST_FIXTURE_TEST_CASE(testModelPlot, CTestFixture) {
             for (const auto & [ fst, snd ] : plotDataValues) {
                 BOOST_TEST_REQUIRE(gatherer->personId(fst, pid));
                 BOOST_REQUIRE_EQUAL(1, snd.s_ValuesPerOverField.size());
-                for (const auto & [ _, val ] : snd.s_ValuesPerOverField) {
+                for (const auto & [ field_name, val ] : snd.s_ValuesPerOverField) {
                     BOOST_REQUIRE_EQUAL(values[pid], val);
                 }
             }

--- a/lib/model/unittest/CRuleConditionTest.cc
+++ b/lib/model/unittest/CRuleConditionTest.cc
@@ -13,7 +13,6 @@
 
 #include <model/CAnomalyDetectorModel.h>
 #include <model/CDataGatherer.h>
-#include <model/CDetectionRule.h>
 #include <model/CRuleCondition.h>
 #include <model/CSearchKey.h>
 #include <model/ModelTypes.h>
@@ -32,29 +31,19 @@ BOOST_AUTO_TEST_SUITE(CRuleConditionTest)
 using namespace ml;
 using namespace model;
 
-namespace {
-
-using TStrVec = std::vector<std::string>;
-
-const std::string EMPTY_STRING;
-}
-
 BOOST_AUTO_TEST_CASE(testTimeContition) {
-    core_t::TTime bucketLength = 100;
-    core_t::TTime startTime = 100;
-    CSearchKey key;
-    SModelParams params(bucketLength);
-    CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
+    constexpr core_t::TTime bucketLength = 100;
+    constexpr core_t::TTime startTime = 100;
+    CSearchKey const key;
+    SModelParams const params(bucketLength);
+    constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
 
     model_t::TFeatureVec features;
     features.push_back(model_t::E_IndividualMeanByPerson);
-    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-    //     model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-    //     EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
     auto gathererPtr = CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime)
                            .buildSharedPtr();
 
-    CMockModel model(params, gathererPtr, influenceCalculators);
+    CMockModel const model(params, gathererPtr, influenceCalculators);
 
     {
         CRuleCondition condition;
@@ -62,13 +51,11 @@ BOOST_AUTO_TEST_CASE(testTimeContition) {
         condition.op(CRuleCondition::E_GTE);
         condition.value(500);
 
-        model_t::CResultType resultType(model_t::CResultType::E_Final);
+        model_t::CResultType const resultType(model_t::CResultType::E_Final);
         BOOST_TEST_REQUIRE(condition.test(model, model_t::E_IndividualCountByBucketAndPerson,
-                                          resultType, std::size_t(0), std::size_t(1),
-                                          core_t::TTime(450)) == false);
+                                          resultType, 0, 1, 450) == false);
         BOOST_TEST_REQUIRE(condition.test(model, model_t::E_IndividualCountByBucketAndPerson,
-                                          resultType, std::size_t(0),
-                                          std::size_t(1), core_t::TTime(550)));
+                                          resultType, 0, 1, 550));
     }
 
     {
@@ -77,13 +64,11 @@ BOOST_AUTO_TEST_CASE(testTimeContition) {
         condition.op(CRuleCondition::E_LT);
         condition.value(600);
 
-        model_t::CResultType resultType(model_t::CResultType::E_Final);
+        model_t::CResultType const resultType(model_t::CResultType::E_Final);
         BOOST_TEST_REQUIRE(condition.test(model, model_t::E_IndividualCountByBucketAndPerson,
-                                          resultType, std::size_t(0), std::size_t(1),
-                                          core_t::TTime(600)) == false);
+                                          resultType, 0, 1, 600) == false);
         BOOST_TEST_REQUIRE(condition.test(model, model_t::E_IndividualCountByBucketAndPerson,
-                                          resultType, std::size_t(0),
-                                          std::size_t(1), core_t::TTime(599)));
+                                          resultType, 0, 1, 599));
     }
 }
 

--- a/lib/model/unittest/CRuleConditionTest.cc
+++ b/lib/model/unittest/CRuleConditionTest.cc
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(testTimeContition) {
     constexpr core_t::TTime startTime = 100;
     CSearchKey const key;
     SModelParams const params(bucketLength);
-    constexpr CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
+    const CAnomalyDetectorModel::TFeatureInfluenceCalculatorCPtrPrVecVec influenceCalculators;
 
     model_t::TFeatureVec features;
     features.push_back(model_t::E_IndividualMeanByPerson);

--- a/lib/model/unittest/CRuleConditionTest.cc
+++ b/lib/model/unittest/CRuleConditionTest.cc
@@ -20,6 +20,7 @@
 #include <model/SModelParams.h>
 
 #include "Mocks.h"
+#include "ModelTestHelpers.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -47,9 +48,11 @@ BOOST_AUTO_TEST_CASE(testTimeContition) {
 
     model_t::TFeatureVec features;
     features.push_back(model_t::E_IndividualMeanByPerson);
-    CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
-        model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
-        EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
+    // CAnomalyDetectorModel::TDataGathererPtr gathererPtr(std::make_shared<CDataGatherer>(
+    //     model_t::E_Metric, model_t::E_None, params, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING,
+    //     EMPTY_STRING, EMPTY_STRING, TStrVec{}, key, features, startTime, 0));
+    auto gathererPtr = CDataGathererBuilder(model_t::E_Metric, features, params, key, startTime)
+                           .buildSharedPtr();
 
     CMockModel model(params, gathererPtr, influenceCalculators);
 

--- a/lib/model/unittest/ModelTestHelpers.h
+++ b/lib/model/unittest/ModelTestHelpers.h
@@ -88,22 +88,36 @@ public:
     using TStrVec = CDataGatherer::TStrVec;
 
 public:
-    CDataGathererBuilder(model_t::EAnalysisCategory gathererType, const TFeatureVec& features, const SModelParams& params, const CSearchKey& searchKey,
-                         const core_t::TTime startTime
-    ): m_Features(features), m_Params(params),  m_StartTime(startTime), m_SearchKey(searchKey), m_GathererType(gathererType) {}
+    CDataGathererBuilder(model_t::EAnalysisCategory gathererType,
+                         const TFeatureVec& features,
+                         const SModelParams& params,
+                         const CSearchKey& searchKey,
+                         const core_t::TTime startTime)
+        : m_Features(features), m_Params(params), m_StartTime(startTime),
+          m_SearchKey(searchKey), m_GathererType(gathererType) {}
 
     CDataGatherer build() const {
-        return {m_GathererType, m_SummaryMode, m_Params, m_SummaryCountFieldName,
-                             m_PartitionFieldValue, m_PersonFieldName, m_AttributeFieldName,
-                             m_ValueFieldName, m_InfluenceFieldNames, m_SearchKey, m_Features,
-                             m_StartTime, m_SampleCountOverride};
+        return {m_GathererType,
+                m_SummaryMode,
+                m_Params,
+                m_SummaryCountFieldName,
+                m_PartitionFieldValue,
+                m_PersonFieldName,
+                m_AttributeFieldName,
+                m_ValueFieldName,
+                m_InfluenceFieldNames,
+                m_SearchKey,
+                m_Features,
+                m_StartTime,
+                m_SampleCountOverride};
     }
 
     std::shared_ptr<CDataGatherer> buildSharedPtr() const {
-        return std::make_shared<CDataGatherer>(m_GathererType, m_SummaryMode, m_Params, m_SummaryCountFieldName,
-                             m_PartitionFieldValue, m_PersonFieldName, m_AttributeFieldName,
-                             m_ValueFieldName, m_InfluenceFieldNames, m_SearchKey, m_Features,
-                             m_StartTime, m_SampleCountOverride);
+        return std::make_shared<CDataGatherer>(
+            m_GathererType, m_SummaryMode, m_Params, m_SummaryCountFieldName,
+            m_PartitionFieldValue, m_PersonFieldName, m_AttributeFieldName,
+            m_ValueFieldName, m_InfluenceFieldNames, m_SearchKey, m_Features,
+            m_StartTime, m_SampleCountOverride);
     }
 
     CDataGathererBuilder& partitionFieldValue(const std::string& partitionFieldValue) {
@@ -155,9 +169,7 @@ private:
     std::string m_ValueFieldName{EMPTY_STRING};
     TStrVec m_InfluenceFieldNames;
     int m_SampleCountOverride{0};
-
 };
-
 }
 }
 

--- a/lib/model/unittest/ModelTestHelpers.h
+++ b/lib/model/unittest/ModelTestHelpers.h
@@ -81,6 +81,71 @@ static void testGathererAttributes(const CDataGatherer& gatherer,
     BOOST_REQUIRE_EQUAL(startTime, gatherer.currentBucketStartTime());
     BOOST_REQUIRE_EQUAL(bucketLength, gatherer.bucketLength());
 }
+
+class CDataGathererBuilder {
+public:
+    using TFeatureVec = CDataGatherer::TFeatureVec;
+    using TStrVec = CDataGatherer::TStrVec;
+
+public:
+    CDataGathererBuilder(model_t::EAnalysisCategory gathererType, const TFeatureVec& features, const SModelParams& params, const CSearchKey& searchKey,
+                         const core_t::TTime startTime
+    ): m_Features(features), m_Params(params),  m_StartTime(startTime), m_SearchKey(searchKey), m_GathererType(gathererType) {}
+
+    CDataGatherer build() const {
+        return {m_GathererType, m_SummaryMode, m_Params, m_SummaryCountFieldName,
+                             m_PartitionFieldValue, m_PersonFieldName, m_AttributeFieldName,
+                             m_ValueFieldName, m_InfluenceFieldNames, m_SearchKey, m_Features,
+                             m_StartTime, m_SampleCountOverride};
+    }
+
+    CDataGathererBuilder& personFieldName(const std::string& personFieldName) {
+        m_PersonFieldName = personFieldName;
+        return *this;
+    }
+
+    CDataGathererBuilder& valueFieldName(const std::string& valueFieldName) {
+        m_ValueFieldName = valueFieldName;
+        return *this;
+    }
+
+    CDataGathererBuilder& influenceFieldNames(const TStrVec& influenceFieldName) {
+        m_InfluenceFieldNames = influenceFieldName;
+        return *this;
+    }
+
+    CDataGathererBuilder& attributeFieldName(const std::string& attributeFieldName) {
+        m_AttributeFieldName = attributeFieldName;
+        return *this;
+    }
+
+    CDataGathererBuilder& gathererType(model_t::EAnalysisCategory gathererType) {
+        m_GathererType = gathererType;
+        return *this;
+    }
+
+    CDataGathererBuilder& sampleCountOverride(std::size_t sampleCount) {
+        m_SampleCountOverride = sampleCount;
+        return *this;
+    }
+
+private:
+    const TFeatureVec& m_Features;
+    const SModelParams& m_Params;
+    core_t::TTime m_StartTime;
+    const CSearchKey& m_SearchKey;
+    model_t::EAnalysisCategory m_GathererType;
+    model_t::ESummaryMode m_SummaryMode{model_t::E_None};
+    std::string m_SummaryCountFieldName{EMPTY_STRING};
+    std::string m_PartitionFieldValue{EMPTY_STRING};
+    std::string m_PersonFieldName{EMPTY_STRING};
+    std::string m_AttributeFieldName{EMPTY_STRING};
+    std::string m_ValueFieldName{EMPTY_STRING};
+    TStrVec m_InfluenceFieldNames;
+    int m_SampleCountOverride{0};
+
+};
+
 }
 }
 

--- a/lib/model/unittest/ModelTestHelpers.h
+++ b/lib/model/unittest/ModelTestHelpers.h
@@ -99,6 +99,18 @@ public:
                              m_StartTime, m_SampleCountOverride};
     }
 
+    std::shared_ptr<CDataGatherer> buildSharedPtr() const {
+        return std::make_shared<CDataGatherer>(m_GathererType, m_SummaryMode, m_Params, m_SummaryCountFieldName,
+                             m_PartitionFieldValue, m_PersonFieldName, m_AttributeFieldName,
+                             m_ValueFieldName, m_InfluenceFieldNames, m_SearchKey, m_Features,
+                             m_StartTime, m_SampleCountOverride);
+    }
+
+    CDataGathererBuilder& partitionFieldValue(const std::string& partitionFieldValue) {
+        m_PartitionFieldValue = partitionFieldValue;
+        return *this;
+    }
+
     CDataGathererBuilder& personFieldName(const std::string& personFieldName) {
         m_PersonFieldName = personFieldName;
         return *this;

--- a/lib/model/unittest/ModelTestHelpers.h
+++ b/lib/model/unittest/ModelTestHelpers.h
@@ -119,17 +119,17 @@ public:
             m_StartTime, m_SampleCountOverride);
     }
 
-    CDataGathererBuilder& partitionFieldValue(const std::string& partitionFieldValue) {
+    CDataGathererBuilder& partitionFieldValue(std::string_view partitionFieldValue) {
         m_PartitionFieldValue = partitionFieldValue;
         return *this;
     }
 
-    CDataGathererBuilder& personFieldName(const std::string& personFieldName) {
+    CDataGathererBuilder& personFieldName(std::string_view personFieldName) {
         m_PersonFieldName = personFieldName;
         return *this;
     }
 
-    CDataGathererBuilder& valueFieldName(const std::string& valueFieldName) {
+    CDataGathererBuilder& valueFieldName(std::string_view valueFieldName) {
         m_ValueFieldName = valueFieldName;
         return *this;
     }
@@ -139,7 +139,7 @@ public:
         return *this;
     }
 
-    CDataGathererBuilder& attributeFieldName(const std::string& attributeFieldName) {
+    CDataGathererBuilder& attributeFieldName(std::string_view attributeFieldName) {
         m_AttributeFieldName = attributeFieldName;
         return *this;
     }

--- a/lib/model/unittest/ModelTestHelpers.h
+++ b/lib/model/unittest/ModelTestHelpers.h
@@ -18,7 +18,6 @@
 #include <model/CDataGatherer.h>
 #include <model/CSearchKey.h>
 #include <model/ModelTypes.h>
-#include <model/SModelParams.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/lib/model/unittest/ModelTestHelpers.h
+++ b/lib/model/unittest/ModelTestHelpers.h
@@ -150,7 +150,7 @@ public:
     }
 
     CDataGathererBuilder& sampleCountOverride(std::size_t sampleCount) {
-        m_SampleCountOverride = sampleCount;
+        m_SampleCountOverride = static_cast<int>(sampleCount);
         return *this;
     }
 


### PR DESCRIPTION
This is a refactoring PR. It cleans up and refactors some unit tests. No functional changes have been made. 

It also fixes the linting issues from clang-tidy and SonarQube.