### PR TITLE
[8.17] [ML] Restrict file system access for pytorch models (#2851)

### DIFF
--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -43,14 +43,15 @@
 
 namespace {
 // Add more forbidden ops here if needed
-const std::unordered_set<std::string_view> FORBIDDEN_OPERATIONS = {"aten::from_file", "aten::save"};
+const std::unordered_set<std::string> FORBIDDEN_OPERATIONS = {"aten::from_file", "aten::save"};
 
 void verifySafeModel(const torch::jit::script::Module& module_) {
     try {
         const auto method = module_.get_method("forward");
-        for (const auto graph = method.graph(); const auto& node : graph->nodes()) {
-            if (const std::string opName = node->kind().toQualString();
-                FORBIDDEN_OPERATIONS.contains(opName)) {
+        const auto graph = method.graph();
+        for (const auto& node : graph->nodes()) {
+            const std::string opName = node->kind().toQualString();
+            if (FORBIDDEN_OPERATIONS.find(opName) != FORBIDDEN_OPERATIONS.end()) {
                 HANDLE_FATAL(<< "Loading the inference process failed because it contains forbidden operation: "
                              << opName);
             }

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -41,6 +41,28 @@
 #include <optional>
 #include <string>
 
+namespace {
+// Add more forbidden ops here if needed
+const std::unordered_set<std::string_view> FORBIDDEN_OPERATIONS = {"aten::from_file", "aten::save"};
+
+void verifySafeModel(const torch::jit::script::Module& module_) {
+    try {
+        const auto method = module_.get_method("forward");
+        for (const auto graph = method.graph(); const auto& node : graph->nodes()) {
+            if (const std::string opName = node->kind().toQualString();
+                FORBIDDEN_OPERATIONS.contains(opName)) {
+                HANDLE_FATAL(<< "Loading the inference process failed because it contains forbidden operation: "
+                             << opName);
+            }
+        }
+    } catch (const c10::Error& e) {
+        LOG_FATAL(<< "Failed to get forward method: " << e.what());
+    }
+
+    LOG_DEBUG(<< "Model verified: no forbidden operations detected.");
+}
+}
+
 torch::Tensor infer(torch::jit::script::Module& module_,
                     ml::torch::CCommandParser::SRequest& request) {
 
@@ -280,6 +302,7 @@ int main(int argc, char** argv) {
             return EXIT_FAILURE;
         }
         module_ = torch::jit::load(std::move(readAdapter));
+        verifySafeModel(module_);
         module_.eval();
 
         LOG_DEBUG(<< "model loaded");

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,33 +28,6 @@
 
 //=== Regressions
 
-== {es} version 9.1.0
-
-=== Enhancements
-
-* Track memory used in the hierarchical results normalizer. (See {ml-pull}2831[#2831].)
-
-=== Bug Fixes
-
-== {es} version 9.0.0
-
-=== Enhancements
-
-* Update Linux build images to Rocky Linux 8 with gcc 13.3. (See {ml-pull}2773[#2773].)
-
-== {es} version 8.19.0
-
-=== Enhancements
-
-* Better messaging regarding OOM process termination. (See {ml-pull}2841[#2841].)
-
-== {es} version 8.18.0
-
-=== Enhancements
-
-* Update the PyTorch library to version 2.5.1. (See {ml-pull}2783[#2798], {ml-pull}2799[#2799].)
-* Upgrade Boost libraries to version 1.86. (See {ml-pull}2780[#2780], {ml-pull}2779[#2779].)
-
 == {es} version 8.17.7
 
 === Enhancements

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,38 @@
 
 //=== Regressions
 
+== {es} version 9.1.0
+
+=== Enhancements
+
+* Track memory used in the hierarchical results normalizer. (See {ml-pull}2831[#2831].)
+
+=== Bug Fixes
+
+== {es} version 9.0.0
+
+=== Enhancements
+
+* Update Linux build images to Rocky Linux 8 with gcc 13.3. (See {ml-pull}2773[#2773].)
+
+== {es} version 8.19.0
+
+=== Enhancements
+
+* Better messaging regarding OOM process termination. (See {ml-pull}2841[#2841].)
+
+== {es} version 8.18.0
+
+=== Enhancements
+
+* Update the PyTorch library to version 2.5.1. (See {ml-pull}2783[#2798], {ml-pull}2799[#2799].)
+* Upgrade Boost libraries to version 1.86. (See {ml-pull}2780[#2780], {ml-pull}2779[#2779].)
+
+== {es} version 8.17.7
+
+=== Enhancements
+* Restrict file system access for PyTorch models (See {ml-pull}2851[#2851].)
+
 == {es} version 8.16.6
 
 === Bug Fixes


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[ML] Restrict file system access for pytorch models (#2851)](https://github.com/elastic/ml-cpp/pull/2851)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)