### PR TITLE
[ML] Fix dependencies for nightly pytorch build

### DIFF
--- a/dev-tools/docker/pytorch_linux_image/Dockerfile
+++ b/dev-tools/docker/pytorch_linux_image/Dockerfile
@@ -61,6 +61,7 @@ RUN \
   export PYTORCH_BUILD_VERSION && \
   export PYTORCH_BUILD_NUMBER=1 && \
   export MAX_JOBS=10 && \
+  /usr/local/bin/python3.12 -m pip install --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --trusted-host pypi.org -r requirements.txt && \
   /usr/local/bin/python3.12 setup.py install && \
   mkdir -p /usr/local/gcc133/include/pytorch && \
   /bin/cp -rf torch/include/* /usr/local/gcc133/include/pytorch/ && \


### PR DESCRIPTION
Recent runs of the nightly PyTorch builds have been failing. Investigation shows that it is due to an issue with the installation of some python packages

```
Installed /usr/local/lib/python3.12/site-packages/torch-2.9.0a0+git2022588-py3.12-linux-x86_64.egg
Processing dependencies for torch==2.9.0a0+git2022588
Searching for fsspec
Reading https://pypi.org/simple/fsspec/
Download error on https://pypi.org/simple/fsspec/: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1000) -- Some packages may not be found!
Couldn't find index page for 'fsspec' (maybe misspelled?)
Scanning index of all packages (this may take a while)
Reading https://pypi.org/simple/
Download error on https://pypi.org/simple/: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1000) -- Some packages may not be found!
No local packages or working download links found for fsspec
error: Could not find suitable distribution for Requirement.parse('fsspec')
```

As a workaround, explicitly install the required packages ahead of the build.