### PR TITLE
[ML] Enhance error logging in CJsonStateRestoreTraverser for improved debugging.

### DIFF
--- a/lib/core/CJsonStateRestoreTraverser.cc
+++ b/lib/core/CJsonStateRestoreTraverser.cc
@@ -317,59 +317,57 @@ bool CJsonStateRestoreTraverser::start() {
         // Enhanced error logging with comprehensive debugging information
         std::string tokenTypeName;
         switch (m_Handler.s_Type) {
-            case SBoostJsonHandler::E_TokenNull:
-                tokenTypeName = "null";
-                break;
-            case SBoostJsonHandler::E_TokenKey:
-                tokenTypeName = "key";
-                break;
-            case SBoostJsonHandler::E_TokenBool:
-                tokenTypeName = "boolean";
-                break;
-            case SBoostJsonHandler::E_TokenInt64:
-                tokenTypeName = "int64";
-                break;
-            case SBoostJsonHandler::E_TokenUInt64:
-                tokenTypeName = "uint64";
-                break;
-            case SBoostJsonHandler::E_TokenDouble:
-                tokenTypeName = "double";
-                break;
-            case SBoostJsonHandler::E_TokenString:
-                tokenTypeName = "string";
-                break;
-            case SBoostJsonHandler::E_TokenObjectStart:
-                tokenTypeName = "object_start";
-                break;
-            case SBoostJsonHandler::E_TokenObjectEnd:
-                tokenTypeName = "object_end";
-                break;
-            case SBoostJsonHandler::E_TokenArrayStart:
-                tokenTypeName = "array_start";
-                break;
-            case SBoostJsonHandler::E_TokenArrayEnd:
-                tokenTypeName = "array_end";
-                break;
-            case SBoostJsonHandler::E_TokenKeyPart:
-                tokenTypeName = "key_part";
-                break;
-            case SBoostJsonHandler::E_TokenStringPart:
-                tokenTypeName = "string_part";
-                break;
-            default:
-                tokenTypeName = "unknown";
-                break;
+        case SBoostJsonHandler::E_TokenNull:
+            tokenTypeName = "null";
+            break;
+        case SBoostJsonHandler::E_TokenKey:
+            tokenTypeName = "key";
+            break;
+        case SBoostJsonHandler::E_TokenBool:
+            tokenTypeName = "boolean";
+            break;
+        case SBoostJsonHandler::E_TokenInt64:
+            tokenTypeName = "int64";
+            break;
+        case SBoostJsonHandler::E_TokenUInt64:
+            tokenTypeName = "uint64";
+            break;
+        case SBoostJsonHandler::E_TokenDouble:
+            tokenTypeName = "double";
+            break;
+        case SBoostJsonHandler::E_TokenString:
+            tokenTypeName = "string";
+            break;
+        case SBoostJsonHandler::E_TokenObjectStart:
+            tokenTypeName = "object_start";
+            break;
+        case SBoostJsonHandler::E_TokenObjectEnd:
+            tokenTypeName = "object_end";
+            break;
+        case SBoostJsonHandler::E_TokenArrayStart:
+            tokenTypeName = "array_start";
+            break;
+        case SBoostJsonHandler::E_TokenArrayEnd:
+            tokenTypeName = "array_end";
+            break;
+        case SBoostJsonHandler::E_TokenKeyPart:
+            tokenTypeName = "key_part";
+            break;
+        case SBoostJsonHandler::E_TokenStringPart:
+            tokenTypeName = "string_part";
+            break;
+        default:
+            tokenTypeName = "unknown";
+            break;
         }
 
-        LOG_ERROR(<< "JSON state must be object at root. Found token type: " 
-                  << tokenTypeName << " (value: " << m_Handler.s_Type 
-                  << "), isArrayOfObjects: " << m_IsArrayOfObjects 
-                  << ", isEof: " << this->isEof()
-                  << ", stream state - bad: " << m_ReadStream.bad() 
-                  << ", fail: " << m_ReadStream.fail()
+        LOG_ERROR(<< "JSON state must be object at root. Found token type: " << tokenTypeName
+                  << " (value: " << m_Handler.s_Type << "), isArrayOfObjects: " << m_IsArrayOfObjects
+                  << ", isEof: " << this->isEof() << ", stream state - bad: "
+                  << m_ReadStream.bad() << ", fail: " << m_ReadStream.fail()
                   << ", eof: " << m_ReadStream.eof()
-                  << ", bytes remaining: " << m_BytesRemaining
-                  << ", buffer position: " << (m_BufferPtr ? (m_BufferPtr - m_Buffer) : -1));
+                  << ", bytes remaining: " << m_BytesRemaining << ", buffer position: "
+                  << (m_BufferPtr ? (m_BufferPtr - m_Buffer) : -1));
         return false;
     }
 
@@ -404,15 +402,12 @@ bool CJsonStateRestoreTraverser::advance() {
 }
 
 void CJsonStateRestoreTraverser::logError() {
-    LOG_ERROR(<< "Error parsing JSON: " << m_Reader.last_error()
-              << ", stream state - bad: " << m_ReadStream.bad() 
-              << ", fail: " << m_ReadStream.fail()
-              << ", eof: " << m_ReadStream.eof()
-              << ", bytes remaining: " << m_BytesRemaining
+    LOG_ERROR(<< "Error parsing JSON: " << m_Reader.last_error() << ", stream state - bad: "
+              << m_ReadStream.bad() << ", fail: " << m_ReadStream.fail()
+              << ", eof: " << m_ReadStream.eof() << ", bytes remaining: " << m_BytesRemaining
               << ", buffer position: " << (m_BufferPtr ? (m_BufferPtr - m_Buffer) : -1)
               << ", current token type: " << m_Handler.s_Type
-              << ", isArrayOfObjects: " << m_IsArrayOfObjects
-              << ", started: " << m_Started
+              << ", isArrayOfObjects: " << m_IsArrayOfObjects << ", started: " << m_Started
               << ", desired level: " << m_DesiredLevel);
     this->setBadState();
 }


### PR DESCRIPTION
Added detailed information about token types and stream state during JSON parsing errors.

When you encounter the error now, you'll get detailed information like:
```
JSON state must be object at root. Found token type: string (value: 6), isArrayOfObjects: false, isEof: false, stream state - bad: false, fail: false, eof: false, bytes remaining: 15, buffer position: 0
````

This will help you understand:
- What type of JSON content was actually found (string, number, boolean, etc.)
- Stream health - whether the input stream is corrupted
- Buffer state - how much data was read and where the parser was positioned
- Parsing context - whether it was expecting an array of objects or a single object