### PR TITLE
[ML] Automate version bump in CI pipeline

### DIFF
--- a/.buildkite/job-version-bump.json.py
+++ b/.buildkite/job-version-bump.json.py
@@ -65,6 +65,14 @@ def main():
 
     pipeline_steps = [
         {
+            "label": "Queue a :slack: notification for the pipeline",
+            "depends_on": None,
+            "command": ".buildkite/pipelines/send_slack_notification.sh | buildkite-agent pipeline upload",
+            "agents": {
+                "image": "python",
+            },
+        },
+        {
             "label": "Bump version to ${NEW_VERSION}",
             "key": "bump-version",
             "agents": {
@@ -151,16 +159,6 @@ def main():
 
     pipeline = {
         "steps": pipeline_steps,
-        "notify": [
-            {
-                "slack": {"channels": ["#machine-learn-build"]},
-                "if": (
-                    "(build.branch == 'main' || "
-                    "build.branch =~ /^[0-9]+\\.[0-9x]+$/) && "
-                    "(build.state == 'passed' || build.state == 'failed')"
-                ),
-            },
-        ],
     }
 
     print(json.dumps(pipeline, indent=2))

--- a/.buildkite/job-version-bump.json.py
+++ b/.buildkite/job-version-bump.json.py
@@ -20,24 +20,23 @@ import json
 
 def main():
     pipeline = {}
-    # TODO: replace the block step with version bump logic
     pipeline_steps = [
         {
-            "block": "Ready to fetch for DRA artifacts?",
-            "prompt": (
-                "Unblock when your team is ready to proceed.\n\n"
-                "Trigger parameters:\n"
-                "- NEW_VERSION: ${NEW_VERSION}\n"
-                "- BRANCH: ${BRANCH}\n"
-                "- WORKFLOW: ${WORKFLOW}\n"
-            ),
-            "key": "block-get-dra-artifacts",
-            "blocked_state": "running",
+            "label": "Bump version to ${NEW_VERSION}",
+            "key": "bump-version",
+            "agents": {
+                "image": "docker.elastic.co/release-eng/wolfi-build-essential-release-eng:latest",
+                "cpu": "250m",
+                "memory": "512Mi",
+            },
+            "command": [
+                "dev-tools/bump_version.sh",
+            ],
         },
         {
             "label": "Fetch DRA Artifacts",
             "key": "fetch-dra-artifacts",
-            "depends_on": "block-get-dra-artifacts",
+            "depends_on": "bump-version",
             "agents": {
                 "image": "docker.elastic.co/release-eng/wolfi-build-essential-release-eng:latest",
                 "cpu": "250m",
@@ -87,21 +86,6 @@ def main():
                 "build.branch =~ /^[0-9]+\\.[0-9x]+$/) && "
                 "(build.state == 'passed' || build.state == 'failed')"
             ),
-        },
-        {
-            "slack": {
-                "channels": ["#machine-learn-build"],
-                "message": (
-                    "Pipeline waiting for approval\n"
-                    "Repo: `${REPO}`\n\n"
-                    "Ready to fetch DRA artifacts - please unblock when ready.\n"
-                    "New version: `${NEW_VERSION}`\n"
-                    "Branch: `${BRANCH}`\n"
-                    "Workflow: `${WORKFLOW}`\n"
-                    "${BUILDKITE_BUILD_URL}\n"
-                ),
-            },
-            "if": 'build.state == "blocked"',
         },
     ]
 

--- a/.buildkite/job-version-bump.json.py
+++ b/.buildkite/job-version-bump.json.py
@@ -10,22 +10,65 @@
 #
 # This script generates JSON for the ml-cpp version bump pipeline.
 # It is intended to be triggered by the centralized release-eng pipeline.
-# It can be integrated into existing or new workflows and includes a plugin
-# that polls artifact URLs until the expected version is available.
+#
+# Supports two workflows via the WORKFLOW env var:
+#   patch (default) — bump version on BRANCH, wait for 2 artifact sets
+#   minor           — create minor branch + bump BRANCH, wait for 3 artifact sets
 
 
 import contextlib
 import json
+import os
+
+
+WOLFI_IMAGE = "docker.elastic.co/release-eng/wolfi-build-essential-release-eng:latest"
+STAGING_URL = "https://artifacts-staging.elastic.co/ml-cpp/latest"
+SNAPSHOT_URL = "https://storage.googleapis.com/elastic-artifacts-snapshot/ml-cpp/latest"
+
+
+def json_watcher_plugin(url, expected_value):
+    return {
+        "elastic/json-watcher#v1.0.0": {
+            "url": url,
+            "field": ".version",
+            "expected_value": expected_value,
+            "polling_interval": "30",
+        }
+    }
+
+
+def dra_step(label, key, depends_on, plugins):
+    return {
+        "label": label,
+        "key": key,
+        "depends_on": depends_on,
+        "agents": {
+            "image": WOLFI_IMAGE,
+            "cpu": "250m",
+            "memory": "512Mi",
+            "ephemeralStorage": "1Gi",
+        },
+        "command": [
+            'echo "Waiting for DRA artifacts..."',
+        ],
+        "timeout_in_minutes": 240,
+        "retry": {
+            "automatic": [{"exit_status": "*", "limit": 2}],
+            "manual": {"permit_on_passed": True},
+        },
+        "plugins": plugins,
+    }
 
 
 def main():
-    pipeline = {}
+    workflow = os.environ.get("WORKFLOW", "patch")
+
     pipeline_steps = [
         {
             "label": "Bump version to ${NEW_VERSION}",
             "key": "bump-version",
             "agents": {
-                "image": "docker.elastic.co/release-eng/wolfi-build-essential-release-eng:latest",
+                "image": WOLFI_IMAGE,
                 "cpu": "250m",
                 "memory": "512Mi",
             },
@@ -33,61 +76,92 @@ def main():
                 "dev-tools/bump_version.sh",
             ],
         },
-        {
-            "label": "Fetch DRA Artifacts",
-            "key": "fetch-dra-artifacts",
-            "depends_on": "bump-version",
-            "agents": {
-                "image": "docker.elastic.co/release-eng/wolfi-build-essential-release-eng:latest",
-                "cpu": "250m",
-                "memory": "512Mi",
-                "ephemeralStorage": "1Gi",
-            },
-            "command": [
-                'echo "Starting DRA artifacts retrieval..."',
-            ],
-            "timeout_in_minutes": 240,
-            "retry": {
-                "automatic": [
-                    {
-                        "exit_status": "*",
-                        "limit": 2,
-                    }
-                ],
-                "manual": {"permit_on_passed": True},
-            },
-            "plugins": [
-                {
-                    "elastic/json-watcher#v1.0.0": {
-                        "url": "https://artifacts-staging.elastic.co/ml-cpp/latest/${BRANCH}.json",
-                        "field": ".version",
-                        "expected_value": "${NEW_VERSION}",
-                        "polling_interval": "30",
-                    }
-                },
-                {
-                    "elastic/json-watcher#v1.0.0": {
-                        "url": "https://storage.googleapis.com/elastic-artifacts-snapshot/ml-cpp/latest/${BRANCH}.json",
-                        "field": ".version",
-                        "expected_value": "${NEW_VERSION}-SNAPSHOT",
-                        "polling_interval": "30",
-                    }
-                },
-            ],
-        },
     ]
 
-    pipeline["steps"] = pipeline_steps
-    pipeline["notify"] = [
-        {
-            "slack": {"channels": ["#machine-learn-build"]},
-            "if": (
-                "(build.branch == 'main' || "
-                "build.branch =~ /^[0-9]+\\.[0-9x]+$/) && "
-                "(build.state == 'passed' || build.state == 'failed')"
-            ),
-        },
-    ]
+    if workflow == "minor":
+        # Minor workflow: artifact checks for both the upstream branch and the
+        # new minor branch, running in parallel after the bump step.
+        #
+        # Derive the minor branch from NEW_VERSION: if NEW_VERSION=9.5.0
+        # then the previous minor (the new branch) is 9.4 with version 9.4.0.
+        new_version = os.environ.get("NEW_VERSION", "0.0.0")
+        parts = new_version.split(".")
+        if len(parts) >= 2:
+            major, minor_num = parts[0], int(parts[1])
+            minor_branch = f"{major}.{minor_num - 1}"
+            minor_version = f"{major}.{minor_num - 1}.0"
+        else:
+            minor_branch = "unknown"
+            minor_version = "unknown"
+
+        pipeline_steps.append(
+            dra_step(
+                label=f"Fetch DRA Artifacts (${{BRANCH}})",
+                key="fetch-dra-upstream",
+                depends_on="bump-version",
+                plugins=[
+                    json_watcher_plugin(
+                        f"{STAGING_URL}/${{BRANCH}}.json",
+                        "${NEW_VERSION}",
+                    ),
+                    json_watcher_plugin(
+                        f"{SNAPSHOT_URL}/${{BRANCH}}.json",
+                        "${NEW_VERSION}-SNAPSHOT",
+                    ),
+                ],
+            )
+        )
+
+        pipeline_steps.append(
+            dra_step(
+                label=f"Fetch DRA Artifacts ({minor_branch})",
+                key="fetch-dra-minor",
+                depends_on="bump-version",
+                plugins=[
+                    json_watcher_plugin(
+                        f"{STAGING_URL}/{minor_branch}.json",
+                        minor_version,
+                    ),
+                    json_watcher_plugin(
+                        f"{SNAPSHOT_URL}/{minor_branch}.json",
+                        f"{minor_version}-SNAPSHOT",
+                    ),
+                ],
+            )
+        )
+    else:
+        # Patch workflow: staging + snapshot for BRANCH
+        pipeline_steps.append(
+            dra_step(
+                label="Fetch DRA Artifacts",
+                key="fetch-dra-artifacts",
+                depends_on="bump-version",
+                plugins=[
+                    json_watcher_plugin(
+                        f"{STAGING_URL}/${{BRANCH}}.json",
+                        "${NEW_VERSION}",
+                    ),
+                    json_watcher_plugin(
+                        f"{SNAPSHOT_URL}/${{BRANCH}}.json",
+                        "${NEW_VERSION}-SNAPSHOT",
+                    ),
+                ],
+            )
+        )
+
+    pipeline = {
+        "steps": pipeline_steps,
+        "notify": [
+            {
+                "slack": {"channels": ["#machine-learn-build"]},
+                "if": (
+                    "(build.branch == 'main' || "
+                    "build.branch =~ /^[0-9]+\\.[0-9x]+$/) && "
+                    "(build.state == 'passed' || build.state == 'failed')"
+                ),
+            },
+        ],
+    }
 
     print(json.dumps(pipeline, indent=2))
 

--- a/dev-tools/bump_version.sh
+++ b/dev-tools/bump_version.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+#
+# Automated version bump script for the release-eng pipeline.
+#
+# Updates elasticsearchVersion in gradle.properties to $NEW_VERSION,
+# commits, and pushes directly to the target branch.  Designed to be
+# called from a Buildkite step with NEW_VERSION and BRANCH set.
+#
+# Follows the same pattern as the Elasticsearch repo's automated
+# Lucene snapshot updates (.buildkite/scripts/lucene-snapshot/).
+
+set -euo pipefail
+
+: "${NEW_VERSION:?NEW_VERSION must be set}"
+: "${BRANCH:?BRANCH must be set}"
+
+GRADLE_PROPS="gradle.properties"
+
+# Ensure we're on the correct branch and up to date
+git checkout "$BRANCH"
+git pull --ff-only origin "$BRANCH"
+
+CURRENT_VERSION=$(grep '^elasticsearchVersion=' "$GRADLE_PROPS" | cut -d= -f2)
+if [ "$CURRENT_VERSION" = "$NEW_VERSION" ]; then
+    echo "Version is already $NEW_VERSION — nothing to do"
+    exit 0
+fi
+
+echo "Bumping version: $CURRENT_VERSION → $NEW_VERSION"
+sed -i "s/^elasticsearchVersion=.*/elasticsearchVersion=${NEW_VERSION}/" "$GRADLE_PROPS"
+
+# Verify the substitution worked
+if ! grep -q "^elasticsearchVersion=${NEW_VERSION}$" "$GRADLE_PROPS"; then
+    echo "ERROR: version update verification failed"
+    cat "$GRADLE_PROPS"
+    exit 1
+fi
+
+# Check there's actually a diff (guards against no-op)
+if git diff-index --quiet HEAD --; then
+    echo "No changes to commit (file unchanged after sed)"
+    exit 0
+fi
+
+git config --global user.name elasticsearchmachine
+git config --global user.email 'infra-root+elasticsearchmachine@elastic.co'
+
+git add "$GRADLE_PROPS"
+git commit -m "[ML] Bump version to ${NEW_VERSION}"
+git push origin "$BRANCH"
+
+echo "Version bumped to ${NEW_VERSION} on branch ${BRANCH}"

--- a/dev-tools/bump_version.sh
+++ b/dev-tools/bump_version.sh
@@ -15,6 +15,8 @@
 # commits, and pushes directly to the target branch.  Designed to be
 # called from a Buildkite step with NEW_VERSION and BRANCH set.
 #
+# Set DRY_RUN=true to perform all steps except the final git push.
+#
 # Follows the same pattern as the Elasticsearch repo's automated
 # Lucene snapshot updates (.buildkite/scripts/lucene-snapshot/).
 
@@ -22,8 +24,13 @@ set -euo pipefail
 
 : "${NEW_VERSION:?NEW_VERSION must be set}"
 : "${BRANCH:?BRANCH must be set}"
+DRY_RUN="${DRY_RUN:-false}"
 
 GRADLE_PROPS="gradle.properties"
+
+if [ "$DRY_RUN" = "true" ]; then
+    echo "=== DRY RUN MODE — will not push ==="
+fi
 
 # Ensure we're on the correct branch and up to date
 git checkout "$BRANCH"
@@ -36,12 +43,17 @@ if [ "$CURRENT_VERSION" = "$NEW_VERSION" ]; then
 fi
 
 echo "Bumping version: $CURRENT_VERSION → $NEW_VERSION"
-sed -i "s/^elasticsearchVersion=.*/elasticsearchVersion=${NEW_VERSION}/" "$GRADLE_PROPS"
+# macOS sed requires -i '' while GNU sed requires -i without an argument
+if sed --version >/dev/null 2>&1; then
+    sed -i "s/^elasticsearchVersion=.*/elasticsearchVersion=${NEW_VERSION}/" "$GRADLE_PROPS"
+else
+    sed -i '' "s/^elasticsearchVersion=.*/elasticsearchVersion=${NEW_VERSION}/" "$GRADLE_PROPS"
+fi
 
 # Verify the substitution worked
 if ! grep -q "^elasticsearchVersion=${NEW_VERSION}$" "$GRADLE_PROPS"; then
     echo "ERROR: version update verification failed"
-    cat "$GRADLE_PROPS"
+    grep 'elasticsearchVersion' "$GRADLE_PROPS"
     exit 1
 fi
 
@@ -51,11 +63,23 @@ if git diff-index --quiet HEAD --; then
     exit 0
 fi
 
-git config --global user.name elasticsearchmachine
-git config --global user.email 'infra-root+elasticsearchmachine@elastic.co'
+git config user.name elasticsearchmachine
+git config user.email 'infra-root+elasticsearchmachine@elastic.co'
 
 git add "$GRADLE_PROPS"
 git commit -m "[ML] Bump version to ${NEW_VERSION}"
-git push origin "$BRANCH"
 
-echo "Version bumped to ${NEW_VERSION} on branch ${BRANCH}"
+if [ "$DRY_RUN" = "true" ]; then
+    echo ""
+    echo "=== DRY RUN: commit created but NOT pushed ==="
+    echo "Branch:  $BRANCH"
+    echo "Version: $CURRENT_VERSION → $NEW_VERSION"
+    echo "Commit:  $(git log -1 --format='%h %s')"
+    echo "Author:  $(git log -1 --format='%an <%ae>')"
+    echo ""
+    echo "To inspect: git log -1 -p"
+    echo "To undo:    git reset --soft HEAD~1 && git restore --staged $GRADLE_PROPS && git checkout -- $GRADLE_PROPS"
+else
+    git push origin "$BRANCH"
+    echo "Version bumped to ${NEW_VERSION} on branch ${BRANCH}"
+fi

--- a/dev-tools/bump_version.sh
+++ b/dev-tools/bump_version.sh
@@ -11,11 +11,18 @@
 #
 # Automated version bump script for the release-eng pipeline.
 #
-# Updates elasticsearchVersion in gradle.properties to $NEW_VERSION,
-# commits, and pushes directly to the target branch.  Designed to be
-# called from a Buildkite step with NEW_VERSION and BRANCH set.
+# Supports two workflows:
+#   WORKFLOW=patch (default)
+#     Updates elasticsearchVersion in gradle.properties to $NEW_VERSION
+#     on $BRANCH, commits, and pushes.
 #
-# Set DRY_RUN=true to perform all steps except the final git push.
+#   WORKFLOW=minor
+#     1. Creates a new minor branch from $BRANCH (e.g., 9.4 from main)
+#        inheriting the current version.
+#     2. Bumps $BRANCH to $NEW_VERSION (the next minor).
+#     Both branches are pushed.
+#
+# Set DRY_RUN=true to perform all steps except git push.
 #
 # Follows the same pattern as the Elasticsearch repo's automated
 # Lucene snapshot updates (.buildkite/scripts/lucene-snapshot/).
@@ -24,6 +31,7 @@ set -euo pipefail
 
 : "${NEW_VERSION:?NEW_VERSION must be set}"
 : "${BRANCH:?BRANCH must be set}"
+WORKFLOW="${WORKFLOW:-patch}"
 DRY_RUN="${DRY_RUN:-false}"
 
 GRADLE_PROPS="gradle.properties"
@@ -32,54 +40,138 @@ if [ "$DRY_RUN" = "true" ]; then
     echo "=== DRY RUN MODE — will not push ==="
 fi
 
-# Ensure we're on the correct branch and up to date
-git checkout "$BRANCH"
-git pull --ff-only origin "$BRANCH"
+git_push() {
+    local target_branch="$1"
+    if [ "$DRY_RUN" = "true" ]; then
+        echo "  [DRY RUN] Would push $target_branch"
+    else
+        git push origin "$target_branch"
+        echo "  Pushed $target_branch"
+    fi
+}
 
-CURRENT_VERSION=$(grep '^elasticsearchVersion=' "$GRADLE_PROPS" | cut -d= -f2)
-if [ "$CURRENT_VERSION" = "$NEW_VERSION" ]; then
-    echo "Version is already $NEW_VERSION — nothing to do"
-    exit 0
-fi
+sed_inplace() {
+    if sed --version >/dev/null 2>&1; then
+        sed -i "$@"
+    else
+        sed -i '' "$@"
+    fi
+}
 
-echo "Bumping version: $CURRENT_VERSION → $NEW_VERSION"
-# macOS sed requires -i '' while GNU sed requires -i without an argument
-if sed --version >/dev/null 2>&1; then
-    sed -i "s/^elasticsearchVersion=.*/elasticsearchVersion=${NEW_VERSION}/" "$GRADLE_PROPS"
-else
-    sed -i '' "s/^elasticsearchVersion=.*/elasticsearchVersion=${NEW_VERSION}/" "$GRADLE_PROPS"
-fi
+configure_git() {
+    git config user.name elasticsearchmachine
+    git config user.email 'infra-root+elasticsearchmachine@elastic.co'
+}
 
-# Verify the substitution worked
-if ! grep -q "^elasticsearchVersion=${NEW_VERSION}$" "$GRADLE_PROPS"; then
-    echo "ERROR: version update verification failed"
-    grep 'elasticsearchVersion' "$GRADLE_PROPS"
-    exit 1
-fi
+bump_version_on_branch() {
+    local target_branch="$1"
+    local target_version="$2"
 
-# Check there's actually a diff (guards against no-op)
-if git diff-index --quiet HEAD --; then
-    echo "No changes to commit (file unchanged after sed)"
-    exit 0
-fi
+    git checkout "$target_branch"
+    git pull --ff-only origin "$target_branch"
 
-git config user.name elasticsearchmachine
-git config user.email 'infra-root+elasticsearchmachine@elastic.co'
+    local current_version
+    current_version=$(grep '^elasticsearchVersion=' "$GRADLE_PROPS" | cut -d= -f2)
+    if [ "$current_version" = "$target_version" ]; then
+        echo "Version on $target_branch is already $target_version — nothing to do"
+        return 0
+    fi
 
-git add "$GRADLE_PROPS"
-git commit -m "[ML] Bump version to ${NEW_VERSION}"
+    echo "Bumping version on $target_branch: $current_version → $target_version"
+    sed_inplace "s/^elasticsearchVersion=.*/elasticsearchVersion=${target_version}/" "$GRADLE_PROPS"
+
+    if ! grep -q "^elasticsearchVersion=${target_version}$" "$GRADLE_PROPS"; then
+        echo "ERROR: version update verification failed on $target_branch"
+        grep 'elasticsearchVersion' "$GRADLE_PROPS"
+        exit 1
+    fi
+
+    if git diff-index --quiet HEAD --; then
+        echo "No changes to commit on $target_branch (file unchanged after sed)"
+        return 0
+    fi
+
+    configure_git
+    git add "$GRADLE_PROPS"
+    git commit -m "[ML] Bump version to ${target_version}"
+    git_push "$target_branch"
+}
+
+# ---------------------------------------------------------------------------
+# Patch workflow: bump version on the target branch
+# ---------------------------------------------------------------------------
+do_patch() {
+    echo "=== Patch workflow: bump $BRANCH to $NEW_VERSION ==="
+    bump_version_on_branch "$BRANCH" "$NEW_VERSION"
+}
+
+# ---------------------------------------------------------------------------
+# Minor workflow: create minor branch, then bump upstream to next minor
+# ---------------------------------------------------------------------------
+do_minor() {
+    echo "=== Minor workflow: create minor branch from $BRANCH, then bump to $NEW_VERSION ==="
+
+    git checkout "$BRANCH"
+    git pull --ff-only origin "$BRANCH"
+
+    local current_version
+    current_version=$(grep '^elasticsearchVersion=' "$GRADLE_PROPS" | cut -d= -f2)
+
+    # Derive the minor branch name from current version (e.g., 9.4.0 → 9.4)
+    local major minor
+    major=$(echo "$current_version" | cut -d. -f1)
+    minor=$(echo "$current_version" | cut -d. -f2)
+    local minor_branch="${major}.${minor}"
+
+    echo "Current version on $BRANCH: $current_version"
+    echo "Minor branch to create: $minor_branch"
+    echo "New version for $BRANCH: $NEW_VERSION"
+
+    # Export minor branch info for downstream Buildkite steps
+    if [ "${BUILDKITE:-false}" = "true" ]; then
+        buildkite-agent meta-data set "MINOR_BRANCH" "$minor_branch"
+        buildkite-agent meta-data set "MINOR_VERSION" "$current_version"
+    fi
+    export MINOR_BRANCH="$minor_branch"
+    export MINOR_VERSION="$current_version"
+
+    # Check if the minor branch already exists on the remote
+    if git ls-remote --exit-code --heads origin "$minor_branch" >/dev/null 2>&1; then
+        echo "Branch $minor_branch already exists on origin — skipping creation"
+    else
+        echo "Creating branch $minor_branch from $BRANCH..."
+        git checkout -b "$minor_branch"
+        configure_git
+        git_push "$minor_branch"
+        echo "Branch $minor_branch created with version $current_version"
+    fi
+
+    # Now bump the upstream branch to the new version
+    bump_version_on_branch "$BRANCH" "$NEW_VERSION"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+case "$WORKFLOW" in
+    patch)
+        do_patch
+        ;;
+    minor)
+        do_minor
+        ;;
+    *)
+        echo "ERROR: unknown WORKFLOW '$WORKFLOW' (expected 'patch' or 'minor')"
+        exit 1
+        ;;
+esac
 
 if [ "$DRY_RUN" = "true" ]; then
     echo ""
-    echo "=== DRY RUN: commit created but NOT pushed ==="
-    echo "Branch:  $BRANCH"
-    echo "Version: $CURRENT_VERSION → $NEW_VERSION"
-    echo "Commit:  $(git log -1 --format='%h %s')"
-    echo "Author:  $(git log -1 --format='%an <%ae>')"
-    echo ""
-    echo "To inspect: git log -1 -p"
-    echo "To undo:    git reset --soft HEAD~1 && git restore --staged $GRADLE_PROPS && git checkout -- $GRADLE_PROPS"
-else
-    git push origin "$BRANCH"
-    echo "Version bumped to ${NEW_VERSION} on branch ${BRANCH}"
+    echo "=== DRY RUN SUMMARY ==="
+    echo "Workflow: $WORKFLOW"
+    echo "Branch:   $BRANCH"
+    echo "Version:  $NEW_VERSION"
+    echo "Recent commits:"
+    git log --oneline -3
 fi

--- a/dev-tools/bump_version.sh
+++ b/dev-tools/bump_version.sh
@@ -35,6 +35,7 @@ WORKFLOW="${WORKFLOW:-patch}"
 DRY_RUN="${DRY_RUN:-false}"
 
 GRADLE_PROPS="gradle.properties"
+BACKPORT_CONFIG=".backportrc.json"
 
 if [ "$DRY_RUN" = "true" ]; then
     echo "=== DRY RUN MODE — will not push ==="
@@ -86,13 +87,37 @@ bump_version_on_branch() {
         exit 1
     fi
 
+    # Update .backportrc.json so the new version maps to main
+    if [[ "$target_branch" == "main" && -f "$BACKPORT_CONFIG" ]]; then
+        local escaped_version
+        escaped_version=$(echo "$target_version" | sed 's/\./\\./g')
+        echo "Updating backport config: v${target_version} → main"
+        # Use python for a reliable cross-platform JSON-safe replacement
+        python3 -c "
+import json, re, sys
+with open('$BACKPORT_CONFIG') as f:
+    data = json.load(f)
+mapping = data.get('branchLabelMapping', {})
+new_mapping = {}
+for k, v in mapping.items():
+    if v == 'main' and re.match(r'\^v\d+\.\d+\.\d+\\\$', k):
+        new_mapping['^v${target_version}\$'] = 'main'
+    else:
+        new_mapping[k] = v
+data['branchLabelMapping'] = new_mapping
+with open('$BACKPORT_CONFIG', 'w') as f:
+    json.dump(data, f, indent=2)
+    f.write('\n')
+" || echo "WARNING: could not update backport config — please check $BACKPORT_CONFIG manually"
+    fi
+
     if git diff-index --quiet HEAD --; then
         echo "No changes to commit on $target_branch (file unchanged after sed)"
         return 0
     fi
 
     configure_git
-    git add "$GRADLE_PROPS"
+    git add "$GRADLE_PROPS" "$BACKPORT_CONFIG"
     git commit -m "[ML] Bump version to ${target_version}"
     git_push "$target_branch"
 }


### PR DESCRIPTION
## Summary
Replaces the manual block step in the version-bump pipeline with automated version bump logic, supporting both patch and minor release workflows.

### Patch workflow (`WORKFLOW=patch`, default)
1. **Bump version** — checks out `$BRANCH`, updates `elasticsearchVersion` in `gradle.properties` to `$NEW_VERSION`, commits as `elasticsearchmachine`, pushes
2. **Fetch DRA Artifacts** — polls staging + snapshot artifact URLs until the new version is available

### Minor workflow (`WORKFLOW=minor`, feature freeze day)
1. **Create minor branch** — derives the branch name from the current version on `$BRANCH` (e.g., `main` at `9.4.0` → branch `9.4`), pushes it (inherits the current version)
2. **Bump upstream** — bumps `$BRANCH` (e.g., `main`) to `$NEW_VERSION` (e.g., `9.5.0`), commits, pushes
3. **Fetch DRA Artifacts** — two parallel steps:
   - Upstream branch: polls for `$NEW_VERSION` staging + snapshot
   - Minor branch: polls for the inherited version staging + snapshot

### Pattern
Follows the established Elasticsearch repo pattern for automated commits from CI:
- `elasticsearchmachine` / `infra-root+elasticsearchmachine@elastic.co` as committer
- Local `git config` (not `--global`)
- `git diff-index --quiet HEAD` for idempotency
- `git pull --ff-only` before push to handle concurrent commits

### Script features
- `DRY_RUN=true` — performs all steps except `git push`
- Portable `sed -i` (macOS/Linux)
- Idempotent: skips if version already matches, skips branch creation if it already exists
- Reusable helpers: `git_push`, `sed_inplace`, `configure_git`, `bump_version_on_branch`
- Unknown `WORKFLOW` values rejected with clear error
- Exports `MINOR_BRANCH`/`MINOR_VERSION` via Buildkite meta-data for downstream steps

### Pipeline features
- `WORKFLOW` env var selects pipeline shape at generation time
- Minor branch name/version derived from `NEW_VERSION` (e.g., `9.5.0` → `9.4` branch, `9.4.0` version)
- DRA step generation refactored into helper functions

### Files
- `dev-tools/bump_version.sh` — standalone script with patch + minor support
- `.buildkite/job-version-bump.json.py` — pipeline generator with workflow-aware step generation

## Test plan
- [x] CI passes
- [x] Dry-run patch: `NEW_VERSION=99.99.99 BRANCH=test/... DRY_RUN=true` — commit created with correct author/message, no push
- [x] Real push patch: commit pushed to throwaway branch successfully
- [x] Idempotency patch: re-running with same version produces "nothing to do"
- [x] Dry-run minor: `NEW_VERSION=99.99.0 BRANCH=test/... WORKFLOW=minor DRY_RUN=true` — creates `9.4` branch, bumps upstream to `99.99.0`, no push
- [x] Unknown workflow: rejected with clear error
- [x] Edge cases: missing `NEW_VERSION`/`BRANCH` fail with clear errors; non-existent branch fails at checkout
- [x] Pipeline JSON: patch generates 2 steps, minor generates 3 steps with correct artifact URLs
- [x] Repo-level branch protection: `elasticsearchmachine` added to bypass list on `main`, `9.3`, `9.2`, `9.1`, `8.18`
- [ ] **Blocker**: Elastic org-level ruleset `[org] Require a PR` has no bypass actors. Coordinate with Release Engineering.
- [ ] End-to-end Buildkite pipeline test (requires PR merged to `main` and org-level bypass resolved)