### PR TITLE
add release-eng write access

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -266,4 +266,6 @@ spec:
         everyone:
           access_level: READ_ONLY
         ml-core: {}
+        release-eng:
+          access_level: BUILD_AND_READ
         


### PR DESCRIPTION
This PR is a followup pr to: https://github.com/elastic/ml-cpp/pull/2918


It grants write access to release-eng. When triggering the orchestration pipeline, the pipeline doesn't have sufficient access to trigger ml-cpp-version-bump pipeline.