### PR TITLE
[ML] Fix Slack notification in version bump pipeline

### DIFF
--- a/.buildkite/job-version-bump.json.py
+++ b/.buildkite/job-version-bump.json.py
@@ -23,6 +23,14 @@ def main():
     # TODO: replace the block step with version bump logic
     pipeline_steps = [
         {
+            "label": "Queue a :slack: notification for the pipeline",
+            "depends_on": None,
+            "command": ".buildkite/pipelines/send_version_bump_notification.sh | buildkite-agent pipeline upload",
+            "agents": {
+                "image": "python",
+            },
+        },
+        {
             "block": "Ready to fetch for DRA artifacts?",
             "prompt": (
                 "Unblock when your team is ready to proceed.\n\n"
@@ -79,31 +87,6 @@ def main():
     ]
 
     pipeline["steps"] = pipeline_steps
-    pipeline["notify"] = [
-        {
-            "slack": {"channels": ["#machine-learn-build"]},
-            "if": (
-                "(build.branch == 'main' || "
-                "build.branch =~ /^[0-9]+\\.[0-9x]+$/) && "
-                "(build.state == 'passed' || build.state == 'failed')"
-            ),
-        },
-        {
-            "slack": {
-                "channels": ["#machine-learn-build"],
-                "message": (
-                    "Pipeline waiting for approval\n"
-                    "Repo: `${REPO}`\n\n"
-                    "Ready to fetch DRA artifacts - please unblock when ready.\n"
-                    "New version: `${NEW_VERSION}`\n"
-                    "Branch: `${BRANCH}`\n"
-                    "Workflow: `${WORKFLOW}`\n"
-                    "${BUILDKITE_BUILD_URL}\n"
-                ),
-            },
-            "if": 'build.state == "blocked"',
-        },
-    ]
 
     print(json.dumps(pipeline, indent=2))
 

--- a/.buildkite/pipelines/send_version_bump_notification.sh
+++ b/.buildkite/pipelines/send_version_bump_notification.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+#
+# Slack notifications for the version bump pipeline.
+# Sends notifications on build completion and when the build is blocked.
+cat <<EOL
+steps:
+  - label: "Schedule :slack: notification"
+    command: "echo schedule :slack: notification"
+notify:
+  - slack:
+      channels:
+        - "#machine-learn-build"
+      message: |
+        :large_green_circle: Version bump pipeline waiting for approval
+        Branch: \${BUILDKITE_BRANCH}
+        New version: \${NEW_VERSION}
+        Workflow: \${WORKFLOW}
+        Pipeline: \${BUILDKITE_BUILD_URL}
+    if: build.state == "blocked"
+  - slack:
+      channels:
+        - "#machine-learn-build"
+      message: |
+        Version bump pipeline finished (${BUILDKITE_BUILD_URL})
+        Branch: \${BUILDKITE_BRANCH}
+        New version: \${NEW_VERSION}
+        Workflow: \${WORKFLOW}
+    if: build.state != "blocked"
+EOL

--- a/.buildkite/pipelines/send_version_bump_notification.sh
+++ b/.buildkite/pipelines/send_version_bump_notification.sh
@@ -18,6 +18,7 @@ notify:
   - slack:
       channels:
         - "#machine-learn-build"
+        - "#ml-core"
       message: |
         :large_green_circle: Version bump pipeline waiting for approval
         Branch: \${BUILDKITE_BRANCH}


### PR DESCRIPTION
## Summary

The `ml-cpp-version-bump` pipeline never sent Slack notifications despite having a `notify` block configured.

## Root cause

The version bump pipeline generator (`job-version-bump.json.py`) outputs a top-level `notify` block in its JSON. However, when this JSON is dynamically uploaded via `buildkite-agent pipeline upload`, the `notify` block doesn't fire reliably for build-level state changes.

All other ml-cpp pipelines use a different pattern that works: they add a step that uploads a notification shell script as a sub-pipeline, which has its own `notify` block.

## Fix

Replace the top-level `notify` block with a step that uploads a dedicated `send_version_bump_notification.sh` as a sub-pipeline. This script includes two `notify` blocks:

- `build.state == "blocked"` — notifies `#machine-learn-build` that the pipeline is waiting for approval (with version, branch, workflow details)
- `build.state != "blocked"` — notifies on any terminal state (pass, fail, cancel)

## Test results

Verified on builds [#4](https://buildkite.com/elastic/ml-cpp-version-bump/builds/4) and [#5](https://buildkite.com/elastic/ml-cpp-version-bump/builds/5):

- [x] "Waiting for approval" notification sent to `#machine-learn-build` when build reaches blocked state
- [x] "Finished" notification sent to `#machine-learn-build` when build is cancelled
- [x] Notification includes branch, version, workflow, and build URL