### PR TITLE
[ML] Update backport config for 9.5.0 development

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -3,7 +3,7 @@
   "targetBranchChoices" : [ "main", "9.3", "9.2", "9.1", "9.0", "8.19", "8.18", "8.17", "7.17" ],
   "targetPRLabels" : [ "backport" ],
   "branchLabelMapping" : {
-    "^v9.4.0$" : "main",
+    "^v9.5.0$" : "main",
     "^v(\\d+).(\\d+).\\d+(?:-(?:alpha|beta|rc)\\d+)?$" : "$1.$2"
   },
   "copySourcePRLabels" : "^(?!backport$)(?!v\\d).*$",

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,6 +1,6 @@
 {
   "upstream" : "elastic/ml-cpp",
-  "targetBranchChoices" : [ "main", "9.3", "9.2", "9.1", "9.0", "8.19", "8.18", "8.17", "7.17" ],
+  "targetBranchChoices" : [ "main", "9.4", "9.3",  "8.19",  "7.17" ],
   "targetPRLabels" : [ "backport" ],
   "branchLabelMapping" : {
     "^v9.5.0$" : "main",


### PR DESCRIPTION
## Summary

Fixes backport failures on all PRs labelled `v9.5.0`.

The `branchLabelMapping` in `.backportrc.json` still mapped `v9.4.0` to `main` from the previous release cycle. Since `main` is now at `9.5.0`, the `v9.5.0` label was matching the generic pattern (`v(\d+).(\d+).\d+` → `$1.$2`) and attempting to backport to a `9.5` branch that doesn't exist.

One-line fix: `^v9.4.0$` → `^v9.5.0$` for the `main` mapping.

This should be updated as part of each version bump — it's a candidate for inclusion in `dev-tools/bump_version.sh`.

Made with [Cursor](https://cursor.com)