### PR TITLE
[ML] Fix PyTorch Docker CI: sccache layout and MKL for torch imports

### DIFF
--- a/.buildkite/pipelines/validate_pytorch_allowlist.yml.sh
+++ b/.buildkite/pipelines/validate_pytorch_allowlist.yml.sh
@@ -20,6 +20,9 @@ steps:
     timeout_in_minutes: 60
     env:
         HF_HUB_DISABLE_XET: "1"
+        # torch is linked against MKL under /usr/local/gcc133; importing torch fails without this
+        # (e.g. libmkl_intel_lp64.so.2: cannot open shared object file).
+        LD_LIBRARY_PATH: "/usr/local/gcc133/lib64:/usr/local/gcc133/lib:/usr/lib:/lib"
     command:
         - "if [ ! -f dev-tools/extract_model_ops/validate_allowlist.py ]; then echo 'validate_allowlist.py not found, skipping'; exit 0; fi"
         - "python3 -c \"import torch; print(f'PyTorch version: {torch.__version__}')\""

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -211,6 +211,10 @@ RUN \
 
 FROM rockylinux:8
 COPY --from=builder /usr/local/gcc133 /usr/local/gcc133
+# Match the builder so dynamically loaded deps (MKL, libtorch_cpu, etc.) resolve when
+# running tools under plain python3 without the full compile-time shell.
+ENV LD_LIBRARY_PATH=/usr/local/gcc133/lib64:/usr/local/gcc133/lib:/usr/lib:/lib
+ENV PATH=/usr/local/gcc133/bin:/usr/bin:/bin:/usr/sbin:/sbin
 RUN \
   dnf -y update && \
   dnf install -y bzip2 gcc git make unzip which zip zlib-devel findutils && \

--- a/dev-tools/docker/pytorch_linux_image/Dockerfile
+++ b/dev-tools/docker/pytorch_linux_image/Dockerfile
@@ -20,11 +20,13 @@ RUN dnf -y update && \
     dnf config-manager --set-enabled powertools && \
     dnf install -y bzip2 curl gcc gcc-c++ git libffi-devel make texinfo unzip wget which xz zip zlib-devel findutils
 
-# Install sccache for GCS-backed compilation caching across builds (same dir as the pinned GCC toolchain)
+# Install sccache for GCS-backed compilation caching. Keep it under /usr/local/bin (not under
+# /usr/local/gcc133) so it is not copied into the final image with the toolchain tree.
 ARG SCCACHE_VERSION=v0.14.0
-RUN curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
-    | tar xz -C /usr/local/gcc133/bin --strip-components=1 "sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache" && \
-    chmod +x /usr/local/gcc133/bin/sccache
+RUN mkdir -p /usr/local/bin && \
+    curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+    | tar xz -C /usr/local/bin --strip-components=1 "sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache" && \
+    chmod +x /usr/local/bin/sccache
 
 # For compiling with hardening and optimisation
 ENV CFLAGS="-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2 -msse4.2 -mfpmath=sse"
@@ -34,9 +36,10 @@ ENV LDFLAGS_FOR_TARGET="-Wl,-z,relro -Wl,-z,now"
 
 ARG build_dir=/usr/src
 
-# Update paths to use the compiler in C++17 mode
+# Update paths to use the compiler in C++17 mode. /usr/local/bin is on PATH in this stage only
+# so the PyTorch compile step can invoke sccache without shipping it inside /usr/local/gcc133.
 ENV LD_LIBRARY_PATH=/usr/local/gcc133/lib64:/usr/local/gcc133/lib:/usr/lib:/lib
-ENV PATH=/usr/local/gcc133/bin:/usr/bin:/bin:/usr/sbin:/sbin
+ENV PATH=/usr/local/gcc133/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 ENV CXX="g++ -std=gnu++17"
 
 # Clone PyTorch and build LibTorch
@@ -97,7 +100,6 @@ RUN --mount=type=secret,id=gcs_key \
 
 FROM rockylinux:8
 COPY --from=builder /usr/local/gcc133 /usr/local/gcc133
-RUN rm -f /usr/local/gcc133/bin/sccache
 # Python 3.12 + torch site-packages for allowlist validation
 COPY --from=builder /usr/local/bin/python3.12 /usr/local/bin/python3.12
 COPY --from=builder /usr/local/bin/pip3.12 /usr/local/bin/pip3.12

--- a/dev-tools/docker/pytorch_linux_image/Dockerfile
+++ b/dev-tools/docker/pytorch_linux_image/Dockerfile
@@ -20,11 +20,11 @@ RUN dnf -y update && \
     dnf config-manager --set-enabled powertools && \
     dnf install -y bzip2 curl gcc gcc-c++ git libffi-devel make texinfo unzip wget which xz zip zlib-devel findutils
 
-# Install sccache for GCS-backed compilation caching across builds
+# Install sccache for GCS-backed compilation caching across builds (same dir as the pinned GCC toolchain)
 ARG SCCACHE_VERSION=v0.14.0
 RUN curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
-    | tar xz -C /usr/local/bin --strip-components=1 "sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache" && \
-    chmod +x /usr/local/bin/sccache
+    | tar xz -C /usr/local/gcc133/bin --strip-components=1 "sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache" && \
+    chmod +x /usr/local/gcc133/bin/sccache
 
 # For compiling with hardening and optimisation
 ENV CFLAGS="-g -O3 -fstack-protector -D_FORTIFY_SOURCE=2 -msse4.2 -mfpmath=sse"
@@ -97,6 +97,7 @@ RUN --mount=type=secret,id=gcs_key \
 
 FROM rockylinux:8
 COPY --from=builder /usr/local/gcc133 /usr/local/gcc133
+RUN rm -f /usr/local/gcc133/bin/sccache
 # Python 3.12 + torch site-packages for allowlist validation
 COPY --from=builder /usr/local/bin/python3.12 /usr/local/bin/python3.12
 COPY --from=builder /usr/local/bin/pip3.12 /usr/local/bin/pip3.12


### PR DESCRIPTION
## Summary

- **PyTorch nightly Docker image (`dev-tools/docker/pytorch_linux_image`)**  
  Install the `sccache` release binary into `/usr/local/gcc133/bin` so it is on the existing builder `PATH` (avoids `sccache: command not found` / exit **127** when BuildKit mounts the GCS key). Strip `sccache` from the **final** image after copying `gcc133` so the runtime image does not ship the build-only tool.

- **`ml-linux-build` image (`dev-tools/docker/linux_image`)**  
  Export `LD_LIBRARY_PATH` and `PATH` in the final `rockylinux` stage (aligned with the builder) so dynamically loaded libraries (Intel MKL, `libtorch_cpu`, etc.) resolve when running tools such as `python3 -c "import torch"` outside the compile `RUN`.

- **Buildkite**  
  Set `LD_LIBRARY_PATH` on the **Validate PyTorch allowlist** step so **currently published** `ml-linux-build:34` agents pick up MKL until a new Linux image is published that includes the Dockerfile change.

## Root causes

1. **PyTorch image build:** `sccache` was unpacked to `/usr/local/bin` while `PATH` listed `/usr/local/gcc133/bin` and `/usr/bin` only, so the GCS-enabled compile step could not execute `sccache`.

2. **PR pipeline:** Allowlist validation uses the same Docker image as Linux builds; `import torch` failed with `libmkl_intel_lp64.so.2: cannot open shared object file` because MKL lives under `/usr/local/gcc133/lib` but the runtime environment did not include that on the dynamic linker search path.
