### PR TITLE
[ML] TEMP: widen ml-cpp-version-bump branch filter for smoke test

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -254,7 +254,9 @@ spec:
       description: Buildkite Pipeline for ml-cpp version bump
     spec:
       allow_rebuilds: true
-      branch_configuration: main
+      # TEMPORARY: allow Buildkite API/UI test runs for the ml-cpp-version-bump
+      # pipeline from this branch. Revert to `main` only after the smoke test.
+      branch_configuration: main feature/version-bump-patch-only
       cancel_intermediate_builds: false
       clone_method: https
       pipeline_file: .buildkite/job-version-bump.json.py


### PR DESCRIPTION
Allow branch feature/version-bump-patch-only alongside main so the version bump pipeline can be triggered from that branch for validation. Revert to main-only after the smoke test completes.

Made-with: Cursor