### PR TITLE
[ML] Fail Backport workflow when CLI reports no-branches with version labels

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -44,15 +44,30 @@ jobs:
         if: steps.backport.outcome == 'success'
         run: cat ~/.backport/backport.info.log
 
+      # When version labels were detected we always run the Backport Action. If it fails with
+      # no-branches-exception, backport PRs were not created — fail CI so this is not silent.
       - name: Check for real failures
         if: steps.backport.outcome == 'failure'
+        env:
+          HAS_VERSION_LABEL: ${{ steps.check-labels.outputs.has_version_label }}
         run: |
-          cat ~/.backport/backport.debug.log
+          echo "::group::backport.debug.log"
+          cat ~/.backport/backport.debug.log 2>/dev/null || echo "(missing ~/.backport/backport.debug.log)"
+          echo "::endgroup::"
+          echo "::group::backport.info.log"
+          cat ~/.backport/backport.info.log 2>/dev/null || echo "(missing ~/.backport/backport.info.log)"
+          echo "::endgroup::"
+
           if grep -q '"code":"no-branches-exception"' ~/.backport/backport.debug.log 2>/dev/null; then
-            echo "No target branches matched the version labels — nothing to backport. This is OK."
+            if [ "${HAS_VERSION_LABEL}" = "true" ]; then
+              echo "::error::Backport CLI reported no-branches-exception while this PR had version labels. No backport PRs were opened — check branchLabelMapping / targetBranchChoices in .backportrc.json, review logs above, or open backports manually."
+              exit 1
+            fi
+            echo "No target branches matched (no version labels from workflow check) — nothing to backport."
             exit 0
           fi
-          echo "::error::Backport failed with a real error"
+
+          echo "::error::Backport failed — see logs above."
           exit 1
 
       - name: Enable auto-merge on backport PRs


### PR DESCRIPTION
## Summary

After https://github.com/elastic/ml-cpp/pull/3052 merged with `v9.x.x` labels, the Backport workflow completed green even though the sorenlouv/backport CLI raised `no-branches-exception` and **no backport PRs** were created (see https://github.com/elastic/ml-cpp/actions/runs/25476521769).

## Changes

- When `no-branches-exception` appears in `backport.debug.log` **and** the PR matched our `vN.N.N` label check, the workflow **fails** with a clear `::error::` annotation instead of exiting 0.
- On backport failure, print **both** `backport.debug.log` and `backport.info.log` in collapsible GitHub Actions groups so investigation does not require downloading raw logs.

The defensive branch (`HAS_VERSION_LABEL` not true) keeps the previous skip behaviour if the workflow layout changes later.

## Labels

Please apply `:ml`, `>enhancement` or `>build`, and version labels as appropriate.

Made with [Cursor](https://cursor.com)