### PR TITLE
[ML] Test HOMER changelog area override (Machine Learning)

### DIFF
--- a/docs/changelog/3058.yaml
+++ b/docs/changelog/3058.yaml
@@ -1,0 +1,5 @@
+area: Machine Learning
+issues: []
+pr: 3058
+summary: Test HOMER changelog area override (Machine Learning)
+type: enhancement


### PR DESCRIPTION
Minimal PR (empty commit) to verify HOMER changelog generation writes **`area: Machine Learning`** (via **`areaOverrides`**) rather than **`ml`**.

Intended labels: **`:ml`**, **`>enhancement`**, **`v9.5.0`**. Safe to close after verification.