### PR TITLE
ci: add team Slack mention to version bump pipeline notifications

### DIFF
--- a/.buildkite/pipelines/send_slack_version_bump_notification.sh
+++ b/.buildkite/pipelines/send_slack_version_bump_notification.sh
@@ -75,6 +75,7 @@ steps:
           channels:
             - "${CHANNEL}"
           message: |
+            <!subteam^S76JPTCBE|ml-team>
             ${slack_title}
             ${branch_line}
             ${pr_line}
@@ -115,6 +116,7 @@ steps:
           channels:
             - "${CHANNEL}"
           message: |
+            <!subteam^S76JPTCBE|ml-team>
             ${slack_title}
             ${slack_body}
             WORKFLOW: \${WORKFLOW:-"(unset)"}


### PR DESCRIPTION
## Summary

 Add an @ml-team Slack subteam mention to the version-bump approval notification posted to #machine-learn-build.

The mention is added in `.buildkite/pipelines/send_slack_version_bump_notification.sh`, which runs after the bump steps and notifies the channel when action may be required (e.g. a GitHub PR needs review/approval).

This covers both workflows:

 * Patch (WORKFLOW=patch) — when a version-bump PR is opened
 * Minor feature freeze (WORKFLOW=minor) — when the release branch is created and/or a main-bump PR is opened

## Context

Version bump pipelines are triggered centrally by release-eng (unified-release-centralized-version-bump). Previously, notifications in #machine-learn-build did not ping @ml-team, so the team could miss when a bump PR was waiting for approval (e.g. ml-cpp-version-bump #58 (https://buildkite.com/elastic/ml-cpp-version-bump/builds/58) / #3068).

This change targets the active notification script used since #3064 (https://github.com/elastic/ml-cpp/pull/3064). It does not modify build blocked/finished notifications — the legacy send_version_bump_notification.sh script was removed in that PR.

Feel free to suggest a different Slack handle or a dedicated person to ping if this isn't the right one for your team.

## Test plan

- [ ] Verify Slack notification in the team channel includes the team mention on next version bump run
- [ ] Confirm the mention appears for both patch and minor-freeze notifications when a PR is opened or approval is needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)