### PR TITLE
[9.3] [ML] Automate patch version bump in CI pipeline (#3030)

### DIFF
--- a/.buildkite/job-version-bump-phase2.json.py
+++ b/.buildkite/job-version-bump-phase2.json.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+#
+# Phase 2 of the ml-cpp version-bump pipeline (uploaded by
+# dev-tools/version_bump_upload_phase2.sh after validate). Step-level `if` cannot
+# use Buildkite meta-data; gating is done in that shell script instead.
+
+import contextlib
+import json
+import os
+
+
+WOLFI_IMAGE = "docker.elastic.co/release-eng/wolfi-build-essential-release-eng:latest"
+
+
+def main():
+    pipeline_steps = [
+        {
+            "label": "Bump version to ${NEW_VERSION}",
+            "key": "bump-version",
+            "depends_on": "schedule-version-bump-follow-up",
+            "agents": {
+                "image": WOLFI_IMAGE,
+                "cpu": "250m",
+                "memory": "512Mi",
+            },
+            "env": {
+                "VERSION_BUMP_MERGE_AUTO": os.environ.get("VERSION_BUMP_MERGE_AUTO", "true"),
+            },
+            "command": [
+                "dev-tools/bump_version.sh",
+            ],
+        },
+        {
+            "label": "Notify :slack: — version bump PR needs approval",
+            "key": "queue-slack-notify",
+            "depends_on": "bump-version",
+            "command": [
+                ".buildkite/pipelines/send_slack_version_bump_notification.sh",
+            ],
+            "agents": {
+                # Same image as bump-version: the minimal python image does not ship
+                # buildkite-agent, so meta-data get / pipeline upload silently skipped Slack.
+                "image": WOLFI_IMAGE,
+                "cpu": "250m",
+                "memory": "512Mi",
+            },
+        },
+        {
+            "label": "Fetch DRA Artifacts",
+            "key": "fetch-dra-artifacts",
+            "depends_on": "queue-slack-notify",
+            "agents": {
+                "image": WOLFI_IMAGE,
+                "cpu": "250m",
+                "memory": "512Mi",
+                "ephemeralStorage": "1Gi",
+            },
+            "command": [
+                "python3",
+                "dev-tools/wait_version_bump_dra.py",
+            ],
+            "timeout_in_minutes": 240,
+            "retry": {
+                "automatic": [{"exit_status": "*", "limit": 2}],
+                "manual": {"permit_on_passed": True},
+            },
+        },
+    ]
+
+    print(json.dumps({"steps": pipeline_steps}, indent=2))
+
+
+if __name__ == "__main__":
+    with contextlib.suppress(KeyboardInterrupt):
+        main()

--- a/.buildkite/job-version-bump.json.py
+++ b/.buildkite/job-version-bump.json.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+#
+# Phase 1 of the ml-cpp version bump pipeline (dynamic upload from release-eng).
+#
+# Buildkite step `if` expressions cannot use build meta-data (see
+# https://buildkite.com/docs/pipelines/conditionals ). validate_version_bump_params.sh
+# sets ml_cpp_version_bump_noop when origin already matches NEW_VERSION; phase 2
+# (Slack, bump, DRA wait) is uploaded only when needed by
+# dev-tools/version_bump_upload_phase2.sh.
+
+import contextlib
+import json
+
+
+WOLFI_IMAGE = "docker.elastic.co/release-eng/wolfi-build-essential-release-eng:latest"
+
+
+def main():
+    pipeline_steps = [
+        {
+            "label": "Validate version bump parameters",
+            "key": "validate-version-bump",
+            "depends_on": None,
+            "agents": {
+                "image": WOLFI_IMAGE,
+                "cpu": "250m",
+                "memory": "512Mi",
+            },
+            "command": [
+                "dev-tools/validate_version_bump_params.sh",
+            ],
+        },
+        {
+            "label": "Schedule version bump follow-up steps",
+            "key": "schedule-version-bump-follow-up",
+            "depends_on": "validate-version-bump",
+            "agents": {
+                # Wolfi ships buildkite-agent; python image does not (needed for
+                # meta-data get + phase-2 pipeline upload in version_bump_upload_phase2.sh).
+                "image": WOLFI_IMAGE,
+                "cpu": "250m",
+                "memory": "512Mi",
+            },
+            "command": [
+                "dev-tools/version_bump_upload_phase2.sh",
+            ],
+        },
+    ]
+
+    print(json.dumps({"steps": pipeline_steps}, indent=2))
+
+
+if __name__ == "__main__":
+    with contextlib.suppress(KeyboardInterrupt):
+        main()

--- a/.buildkite/pipelines/send_slack_version_bump_notification.sh
+++ b/.buildkite/pipelines/send_slack_version_bump_notification.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+#
+# Single Slack notification for the ml-cpp-version-bump pipeline: runs after the
+# bump step opens the PR. Reads ml_cpp_version_bump_pr_url from Buildkite meta-data
+# (set by dev-tools/bump_version.sh) and posts the PR link so reviewers can approve.
+#
+# Slack notify must live on the step (see Buildkite docs): build-level notify fires only
+# on build.finished — after every downstream step including long DRA waits — so the
+# message would appear hours late or never if someone checks earlier.
+#
+# Optional env:
+#   ML_CPP_VERSION_BUMP_SLACK_CHANNEL — override channel (default #machine-learn-build)
+
+set -euo pipefail
+
+CHANNEL="${ML_CPP_VERSION_BUMP_SLACK_CHANNEL:-#machine-learn-build}"
+
+if [[ "${BUILDKITE:-}" != "true" ]]; then
+    echo "BUILDKITE is not true — skipping Slack notification (local run)."
+    exit 0
+fi
+
+if ! command -v buildkite-agent >/dev/null 2>&1; then
+    echo "ERROR: buildkite-agent not in PATH; cannot read meta-data or upload Slack notify pipeline." >&2
+    echo "Use the same agent image as bump-version (Wolfi), not a minimal python image." >&2
+    exit 1
+fi
+
+pr_url=""
+changed="false"
+pr_url=$(buildkite-agent meta-data get "ml_cpp_version_bump_pr_url" 2>/dev/null || true)
+changed=$(buildkite-agent meta-data get "ml_cpp_version_bump_changed" 2>/dev/null || echo "false")
+# Meta-data values must not contain stray whitespace (Breaks truthiness.)
+pr_url=$(echo -n "${pr_url}" | tr -d '\r')
+changed=$(echo -n "${changed}" | tr -d '\r')
+
+if [[ -z "${pr_url}" && "${changed}" != "true" ]]; then
+    echo "No version-bump PR opened (pr_url empty, ml_cpp_version_bump_changed=${changed}); skipping Slack notification."
+    exit 0
+fi
+
+if [[ -z "${pr_url}" && "${changed}" == "true" ]]; then
+    body_line="DRY RUN — no pull request URL (simulated bump)."
+else
+    body_line="Pull request (approval required): ${pr_url}"
+fi
+
+(
+    cat <<EOF
+steps:
+  - label: "Schedule :slack: notification (version bump)"
+    command: "echo schedule :slack: notification"
+    notify:
+      - slack:
+          channels:
+            - "${CHANNEL}"
+          message: |
+            **Version bump PR — approval required**
+            ${body_line}
+            Branch: \${BUILDKITE_BRANCH}
+            NEW_VERSION: \${NEW_VERSION:-"(unset)"}
+            BRANCH (param): \${BRANCH:-"(unset)"}
+            VERSION_BUMP_MERGE_AUTO: \${VERSION_BUMP_MERGE_AUTO:-"(unset)"}
+            DRY_RUN: \${DRY_RUN:-"(unset)"}
+            Pipeline: \${BUILDKITE_BUILD_URL}
+            Build: \${BUILDKITE_BUILD_NUMBER}
+            Please review and approve this pull request so it can merge (subject to branch protection).
+EOF
+) | buildkite-agent pipeline upload

--- a/.buildkite/pipelines/send_version_bump_notification.sh
+++ b/.buildkite/pipelines/send_version_bump_notification.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+#
+# Slack notifications for the version bump pipeline.
+# Sends notifications on build completion and when the build is blocked.
+cat <<EOL
+steps:
+  - label: "Schedule :slack: notification"
+    command: "echo schedule :slack: notification"
+notify:
+  - slack:
+      channels:
+        - "#machine-learn-build"
+        - "#ml-core"
+      message: |
+        :large_green_circle: Version bump pipeline waiting for approval
+        Branch: \${BUILDKITE_BRANCH}
+        New version: \${NEW_VERSION}
+        Pipeline: \${BUILDKITE_BUILD_URL}
+    if: build.state == "blocked"
+  - slack:
+      channels:
+        - "#machine-learn-build"
+      message: |
+        Version bump pipeline finished (${BUILDKITE_BUILD_URL})
+        Branch: \${BUILDKITE_BRANCH}
+        New version: \${NEW_VERSION}
+    if: build.state != "blocked"
+EOL

--- a/dev-tools/bump_version.sh
+++ b/dev-tools/bump_version.sh
@@ -1,0 +1,263 @@
+#!/bin/bash
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+#
+# Automated patch version bump for the release-eng pipeline.
+#
+# Parameter checks run in dev-tools/validate_version_bump_params.sh before this
+# step. After git fetch, we re-run the same patch rules against the branch tip so a
+# race (another bump / manual edits) cannot downgrade elasticsearchVersion.
+#
+# Creates a topic branch from origin/${BRANCH}, commits elasticsearchVersion in
+# gradle.properties, pushes the topic branch to origin, and opens a GitHub pull
+# request into ${BRANCH} via gh pr create (rulesets often disallow direct pushes).
+# Optionally merges after PR creation unless VERSION_BUMP_NO_MERGE=true:
+#   VERSION_BUMP_MERGE_AUTO=true — gh pr merge --auto --squash (merge when checks pass; default for CI pipeline)
+#   else — immediate gh pr merge --squash (legacy / escape hatch)
+# Does not modify .backportrc.json (reserved for future release automation).
+#
+# Environment:
+#   NEW_VERSION, BRANCH — required
+#   DRY_RUN — true to skip push and PR creation
+#   BUILDKITE_BUILD_NUMBER — appended to topic branch name for uniqueness
+#   VERSION_BUMP_TOPIC_BRANCH — optional override for topic branch name
+#   GITHUB_TOKEN / VAULT_GITHUB_TOKEN / GH_TOKEN — auth for gh (CI sets Vault token)
+#   VERSION_BUMP_NO_MERGE — set to true to open PR only (no merge / auto-merge step)
+#   VERSION_BUMP_MERGE_AUTO — true: enable GitHub auto-merge (--auto --squash); false/unset with merge: immediate squash
+#   VERSION_BUMP_MERGE_METHOD — merge | squash | rebase (default: squash)
+#   VERSION_BUMP_MERGE_ADMIN — true to pass gh pr merge --admin (needs repo bypass rights)
+#   gh install (apk/tarball): dev-tools/ensure_github_cli.sh via create_github_pull_request.sh
+#
+# Buildkite (BUILDKITE=true): sets meta-data:
+#   ml_cpp_version_bump_changed — true|false so the DRA wait step can skip when no PR was opened
+#   ml_cpp_version_bump_pr_url — HTTPS URL of the opened PR (only set when non-empty;
+#     Buildkite forbids empty meta-data values)
+#
+# Follows the same pattern as the Elasticsearch repo's automated
+# Lucene snapshot updates (.buildkite/scripts/lucene-snapshot/).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON="${PYTHON:-python3}"
+VALIDATION_PY="${SCRIPT_DIR}/version_bump_validation.py"
+CREATE_PR_SH="${SCRIPT_DIR}/create_github_pull_request.sh"
+
+: "${NEW_VERSION:?NEW_VERSION must be set}"
+: "${BRANCH:?BRANCH must be set}"
+
+# Normalise env (Buildkite / Windows agents may inject trailing CR or spaces).
+version_bump_trim_value() {
+    local s=$1
+    s="${s//$'\r'/}"
+    s="${s#"${s%%[![:space:]]*}"}"
+    s="${s%"${s##*[![:space:]]}"}"
+    printf '%s' "$s"
+}
+NEW_VERSION="$(version_bump_trim_value "${NEW_VERSION}")"
+BRANCH="$(version_bump_trim_value "${BRANCH}")"
+
+DRY_RUN="${DRY_RUN:-false}"
+
+GRADLE_PROPS="gradle.properties"
+
+if [ "$DRY_RUN" = "true" ]; then
+    echo "=== DRY RUN MODE — will not push or create PR ==="
+fi
+
+# Parse elastic/ml-cpp from origin (https://github.com/elastic/ml-cpp.git or git@...)
+github_repo_slug() {
+    local url
+    url=$(git remote get-url origin 2>/dev/null || true)
+    if [[ "$url" =~ github\.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]]; then
+        echo "${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+        return 0
+    fi
+    echo "ERROR: could not parse owner/repo from git remote url: ${url:-empty}" >&2
+    return 1
+}
+
+topic_branch_name() {
+    local tb
+    if [[ -n "${VERSION_BUMP_TOPIC_BRANCH:-}" ]]; then
+        echo "${VERSION_BUMP_TOPIC_BRANCH}"
+        return 0
+    fi
+    tb="ci/ml-cpp-version-bump-${BRANCH}-${NEW_VERSION}"
+    if [[ -n "${BUILDKITE_BUILD_NUMBER:-}" ]]; then
+        tb="${tb}-bk${BUILDKITE_BUILD_NUMBER}"
+    fi
+    echo "$tb"
+}
+
+# In-place edit without GNU/BSD/BusyBox `sed -i` differences: write to a temp file then replace.
+sed_inplace() {
+    local script=$1
+    local target=$2
+    local tmp
+    tmp=$(mktemp "${target}.sedtmp.XXXXXX")
+    if ! sed "${script}" "$target" >"$tmp"; then
+        rm -f "$tmp"
+        return 1
+    fi
+    mv "$tmp" "$target"
+}
+
+configure_git() {
+    git config user.name elasticsearchmachine
+    git config user.email 'infra-root+elasticsearchmachine@elastic.co'
+}
+
+# Record whether this run actually opened a version-bump PR (for Buildkite DRA wait gating).
+version_bump_set_buildkite_meta_changed() {
+    local changed="$1"
+    if [[ "${BUILDKITE:-}" != "true" ]]; then
+        return 0
+    fi
+    if ! command -v buildkite-agent >/dev/null 2>&1; then
+        echo "WARNING: BUILDKITE=true but buildkite-agent not in PATH; skipping meta-data ml_cpp_version_bump_changed=${changed}" >&2
+        return 0
+    fi
+    buildkite-agent meta-data set "ml_cpp_version_bump_changed" "$changed"
+}
+
+# PR URL for the Slack step (after bump). Omit calling when there is no URL — Buildkite
+# rejects meta-data set with an empty value ("value cannot be empty…").
+version_bump_set_pr_url_meta() {
+    local url="${1:-}"
+    if [[ -z "${url}" ]]; then
+        return 0
+    fi
+    if [[ "${BUILDKITE:-}" != "true" ]]; then
+        return 0
+    fi
+    if ! command -v buildkite-agent >/dev/null 2>&1; then
+        echo "WARNING: BUILDKITE=true but buildkite-agent not in PATH; skipping meta-data ml_cpp_version_bump_pr_url" >&2
+        return 0
+    fi
+    buildkite-agent meta-data set "ml_cpp_version_bump_pr_url" "$url"
+}
+
+bump_version_via_pr() {
+    local target_branch="$1"
+    local target_version="$2"
+    local topic_branch current_version repo_slug pr_url
+
+    # Default: no DRA wait unless we open a PR (or DRY_RUN simulates one).
+    version_bump_set_buildkite_meta_changed false
+
+    topic_branch=$(topic_branch_name)
+
+    git fetch origin "$target_branch"
+
+    # Topic branch starts at release-branch tip (same tree validation uses).
+    git checkout -B "$topic_branch" "origin/${target_branch}"
+
+    current_version=$(
+        grep '^elasticsearchVersion=' "$GRADLE_PROPS" | head -1 | cut -d= -f2 | tr -d '[:space:]' || true
+    )
+    if [[ -z "$current_version" ]]; then
+        echo "ERROR: could not read elasticsearchVersion from ${GRADLE_PROPS} on origin/${target_branch}" >&2
+        exit 1
+    fi
+
+    if ! "$PYTHON" "$VALIDATION_PY" validate \
+        --current "$current_version" \
+        --new "$target_version" \
+        --branch "$target_branch"
+    then
+        echo "ERROR: version bump does not match branch tip after fetch (current=${current_version}, target=${target_version})." >&2
+        echo "Refusing to rewrite elasticsearchVersion — resolve manually if another automation advanced the branch." >&2
+        exit 1
+    fi
+
+    if [ "$current_version" = "$target_version" ]; then
+        echo "Version on origin/${target_branch} is already ${target_version} — nothing to do"
+        return 0
+    fi
+
+    echo "Bumping version via PR branch ${topic_branch}: ${current_version} → ${target_version} (base ${target_branch})"
+    sed_inplace "s/^elasticsearchVersion=.*/elasticsearchVersion=${target_version}/" "$GRADLE_PROPS"
+
+    if ! grep -q "^elasticsearchVersion=${target_version}$" "$GRADLE_PROPS"; then
+        echo "ERROR: version update verification failed on ${topic_branch}"
+        grep 'elasticsearchVersion' "$GRADLE_PROPS"
+        exit 1
+    fi
+
+    if git diff-index --quiet HEAD --; then
+        echo "No changes to commit (file unchanged after sed)"
+        return 0
+    fi
+
+    configure_git
+    git add "$GRADLE_PROPS"
+    git commit -m "[ML] Bump version to ${target_version}"
+
+    if [ "$DRY_RUN" = "true" ]; then
+        echo "  [DRY RUN] Would push origin ${topic_branch} and open PR into ${target_branch}"
+        version_bump_set_buildkite_meta_changed true
+        return 0
+    fi
+
+    git push -u origin "$topic_branch"
+    echo "  Pushed topic branch ${topic_branch}"
+
+    repo_slug=$(github_repo_slug) || exit 1
+
+    local pr_body
+    pr_body="$(cat <<EOF
+Automated patch version bump for branch \`${target_branch}\`.
+
+| | |
+| --- | --- |
+| **elasticsearchVersion** | \`${current_version}\` → \`${target_version}\` |
+
+When merging is enabled (\`VERSION_BUMP_NO_MERGE\` not true): **auto-merge** (\`gh pr merge --auto --squash\`) if \`VERSION_BUMP_MERGE_AUTO=true\`, otherwise **immediate squash** (\`gh pr merge --squash\`). Override merge style with \`VERSION_BUMP_MERGE_METHOD\`.
+EOF
+)"
+
+    local -a pr_cmd=(
+        "$CREATE_PR_SH"
+        --repo "$repo_slug"
+        --base "$target_branch"
+        --head "$topic_branch"
+        --title "[ML] Bump version to ${target_version}"
+        --body "$pr_body"
+    )
+    if [[ "${VERSION_BUMP_NO_MERGE:-}" != "true" ]]; then
+        if [[ "${VERSION_BUMP_MERGE_AUTO:-}" == "true" ]]; then
+            pr_cmd+=(--merge-auto)
+        else
+            pr_cmd+=(--merge)
+        fi
+    fi
+    if [[ -n "${VERSION_BUMP_MERGE_METHOD:-}" ]]; then
+        pr_cmd+=(--merge-method "${VERSION_BUMP_MERGE_METHOD}")
+    fi
+
+    pr_url=$("${pr_cmd[@]}")
+    echo "  Pull request: ${pr_url}"
+    version_bump_set_buildkite_meta_changed true
+    version_bump_set_pr_url_meta "$pr_url"
+}
+
+echo "=== Patch version bump (PR workflow): ${BRANCH} → ${NEW_VERSION} ==="
+bump_version_via_pr "$BRANCH" "$NEW_VERSION"
+
+if [ "$DRY_RUN" = "true" ]; then
+    echo ""
+    echo "=== DRY RUN SUMMARY ==="
+    echo "Branch:         $BRANCH"
+    echo "Version:        $NEW_VERSION"
+    echo "Topic branch:   $(topic_branch_name)"
+    echo "Recent commits:"
+    git log --oneline -3
+fi

--- a/dev-tools/create_github_pull_request.sh
+++ b/dev-tools/create_github_pull_request.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+#
+# Create a pull request (and optionally merge) using the GitHub CLI.
+#
+# Requires: gh (https://cli.github.com/) in PATH, authenticated via:
+#   GITHUB_TOKEN, VAULT_GITHUB_TOKEN, or GH_TOKEN
+# If gh is missing, dev-tools/ensure_github_cli.sh runs (Wolfi apk, else Linux
+# tarball) unless SKIP_GH_AUTO_INSTALL=true.
+#
+# Usage:
+#   create_github_pull_request.sh --repo ORG/REPO --base BASE --head HEAD \
+#       --title T --body B [--merge | --merge-auto] [--merge-method merge|squash|rebase]
+#
+# On success, prints the PR URL to stdout (single line). Merge progress to stderr.
+#
+#   --merge       Squash/merge/rebase immediately after create (subject to branch rules).
+#   --merge-auto  Enable GitHub auto-merge with the chosen merge method (same pattern as
+#                 backport workflow: gh pr merge --auto --squash). Merge occurs when
+#                 required checks pass; no human click needed if policies allow the bot.
+#
+# Environment:
+#   VERSION_BUMP_MERGE_METHOD — merge style for --merge / --merge-auto (merge|squash|rebase).
+#     Default squash — elastic/ml-cpp forbids merge commits on protected branches.
+#   VERSION_BUMP_MERGE_ADMIN — set to true to add gh pr merge --admin (bypasses some rule
+#     violations only if the token identity has appropriate admin/bypass rights on the repo).
+#   SKIP_GH_AUTO_INSTALL, GH_CLI_VERSION, GH_CLI_INSTALL_PREFIX — see ensure_github_cli.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v gh >/dev/null 2>&1; then
+    "${SCRIPT_DIR}/ensure_github_cli.sh"
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "ERROR: GitHub CLI (gh) is not available; see dev-tools/ensure_github_cli.sh" >&2
+    exit 1
+fi
+
+REPO=""
+BASE=""
+HEAD_REF=""
+TITLE=""
+BODY=""
+DO_MERGE="false"
+DO_MERGE_AUTO="false"
+MERGE_METHOD="${VERSION_BUMP_MERGE_METHOD:-squash}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)
+            REPO="$2"
+            shift 2
+            ;;
+        --base)
+            BASE="$2"
+            shift 2
+            ;;
+        --head)
+            HEAD_REF="$2"
+            shift 2
+            ;;
+        --title)
+            TITLE="$2"
+            shift 2
+            ;;
+        --body)
+            BODY="$2"
+            shift 2
+            ;;
+        --merge)
+            DO_MERGE="true"
+            shift 1
+            ;;
+        --merge-auto)
+            DO_MERGE_AUTO="true"
+            shift 1
+            ;;
+        --merge-method)
+            MERGE_METHOD="$2"
+            shift 2
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ "$DO_MERGE" == "true" && "$DO_MERGE_AUTO" == "true" ]]; then
+    echo "ERROR: use only one of --merge or --merge-auto." >&2
+    exit 1
+fi
+
+if [[ -z "$REPO" || -z "$BASE" || -z "$HEAD_REF" || -z "$TITLE" || -z "$BODY" ]]; then
+    echo "ERROR: --repo, --base, --head, --title, and --body are required." >&2
+    exit 1
+fi
+
+case "$MERGE_METHOD" in
+    merge) MERGE_TYPE=(--merge) ;;
+    squash) MERGE_TYPE=(--squash) ;;
+    rebase) MERGE_TYPE=(--rebase) ;;
+    *)
+        echo "ERROR: invalid merge method: ${MERGE_METHOD}" >&2
+        exit 1
+        ;;
+esac
+
+# gh honors GH_TOKEN; validate after CLI args so invalid flag combinations fail without secrets.
+if [[ -z "${GH_TOKEN:-}" ]]; then
+    if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        export GH_TOKEN="${GITHUB_TOKEN}"
+    elif [[ -n "${VAULT_GITHUB_TOKEN:-}" ]]; then
+        export GH_TOKEN="${VAULT_GITHUB_TOKEN}"
+    fi
+fi
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+    echo "ERROR: Set GITHUB_TOKEN, VAULT_GITHUB_TOKEN, or GH_TOKEN for gh auth." >&2
+    exit 1
+fi
+
+PR_URL=$(gh pr create \
+    --repo "$REPO" \
+    --base "$BASE" \
+    --head "$HEAD_REF" \
+    --title "$TITLE" \
+    --body "$BODY")
+
+echo "$PR_URL"
+
+if [[ "$DO_MERGE" == "true" || "$DO_MERGE_AUTO" == "true" ]]; then
+    # Older packaged gh (e.g. Wolfi apk) does not support --yes on pr merge; rely on
+    # non-TTY / GH_PROMPT_DISABLED for unattended merges.
+    declare -a merge_admin=()
+    if [[ "${VERSION_BUMP_MERGE_ADMIN:-}" == "true" ]]; then
+        merge_admin+=(--admin)
+    fi
+    if [[ "$DO_MERGE_AUTO" == "true" ]]; then
+        GH_PROMPT_DISABLED=1 gh pr merge "$PR_URL" --auto "${MERGE_TYPE[@]}" "${merge_admin[@]}"
+        echo "Enabled auto-merge: ${PR_URL}" >&2
+    else
+        GH_PROMPT_DISABLED=1 gh pr merge "$PR_URL" "${MERGE_TYPE[@]}" "${merge_admin[@]}"
+        echo "Merged: ${PR_URL}" >&2
+    fi
+fi

--- a/dev-tools/ensure_github_cli.sh
+++ b/dev-tools/ensure_github_cli.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+#
+# Ensure the GitHub CLI (gh) is available on PATH. Used by automated PR flows
+# (e.g. dev-tools/create_github_pull_request.sh) when the image does not
+# pre-install gh (Wolfi: try apk; Linux: fall back to GitHub release tarball).
+#
+# Environment:
+#   SKIP_GH_AUTO_INSTALL — set to true to skip and exit non-zero if gh is missing
+#   GH_CLI_VERSION — pinned release for tarball fallback (default below)
+
+set -euo pipefail
+
+if command -v gh >/dev/null 2>&1; then
+    exit 0
+fi
+
+if [[ "${SKIP_GH_AUTO_INSTALL:-}" == "true" ]]; then
+    echo "ERROR: gh not found and SKIP_GH_AUTO_INSTALL=true" >&2
+    exit 1
+fi
+
+echo "Installing GitHub CLI (gh)..." >&2
+
+# Wolfi / Alpine-style images (ml-cpp version-bump uses release-eng Wolfi)
+if command -v apk >/dev/null 2>&1; then
+    if apk add --no-cache gh 2>/dev/null || apk add --no-cache github-cli 2>/dev/null; then
+        command -v gh >/dev/null 2>&1 && exit 0
+    fi
+fi
+
+OS=$(uname -s)
+ARCH=$(uname -m)
+if [[ "$OS" != Linux ]]; then
+    echo "ERROR: gh not installed; on ${OS} install from https://cli.github.com/ (e.g. brew install gh)." >&2
+    exit 1
+fi
+
+case "$ARCH" in
+    x86_64) GH_ARCH=amd64 ;;
+    aarch64 | arm64) GH_ARCH=arm64 ;;
+    *)
+        echo "ERROR: unsupported Linux machine type for gh tarball: ${ARCH}" >&2
+        exit 1
+        ;;
+esac
+
+GH_CLI_VERSION="${GH_CLI_VERSION:-2.63.2}"
+PREFIX="${GH_CLI_INSTALL_PREFIX:-/usr/local}"
+BIN_DIR="${PREFIX}/bin"
+if ! mkdir -p "$BIN_DIR" 2>/dev/null || [[ ! -w "$BIN_DIR" ]]; then
+    echo "ERROR: cannot write gh to ${BIN_DIR}; install gh manually or run as a user that can write there." >&2
+    exit 1
+fi
+
+TMP=$(mktemp -d)
+trap 'rm -rf "${TMP}"' EXIT
+
+ARCHIVE_BASENAME="gh_${GH_CLI_VERSION}_linux_${GH_ARCH}.tar.gz"
+URL="https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/${ARCHIVE_BASENAME}"
+if ! curl -fsSL "$URL" -o "${TMP}/gh.tgz"; then
+    echo "ERROR: failed to download gh ${GH_CLI_VERSION} from GitHub releases (set GH_CLI_VERSION?)." >&2
+    exit 1
+fi
+
+CHECKSUMS_URL="https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_checksums.txt"
+if ! curl -fsSL "$CHECKSUMS_URL" -o "${TMP}/checksums.txt"; then
+    echo "ERROR: failed to download gh ${GH_CLI_VERSION} checksums (set GH_CLI_VERSION?)." >&2
+    exit 1
+fi
+EXPECTED_SHA=""
+EXPECTED_SHA=$(awk -v fn="$ARCHIVE_BASENAME" '$2 == fn { print $1; exit }' "${TMP}/checksums.txt")
+if [[ -z "${EXPECTED_SHA}" ]]; then
+    echo "ERROR: no SHA256 line for ${ARCHIVE_BASENAME} in gh release checksums." >&2
+    exit 1
+fi
+if ! command -v sha256sum >/dev/null 2>&1; then
+    echo "ERROR: sha256sum not found; cannot verify gh tarball integrity." >&2
+    exit 1
+fi
+ACTUAL_SHA=$(sha256sum "${TMP}/gh.tgz" | awk '{ print $1 }')
+if [[ "${ACTUAL_SHA}" != "${EXPECTED_SHA}" ]]; then
+    echo "ERROR: gh tarball SHA256 mismatch (possible corrupt download or supply-chain issue)." >&2
+    echo "  expected: ${EXPECTED_SHA}" >&2
+    echo "  actual:   ${ACTUAL_SHA}" >&2
+    exit 1
+fi
+
+tar -xzf "${TMP}/gh.tgz" -C "${TMP}"
+GH_BIN=$(find "${TMP}" -path '*/bin/gh' -type f | head -1)
+if [[ -z "${GH_BIN}" ]]; then
+    echo "ERROR: gh binary not found in release archive." >&2
+    exit 1
+fi
+
+install -m 0755 "${GH_BIN}" "${BIN_DIR}/gh"
+hash -r 2>/dev/null || true
+echo "Installed gh to ${BIN_DIR}/gh" >&2
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "ERROR: gh still not on PATH after install (ensure ${BIN_DIR} is on PATH)." >&2
+    exit 1
+fi

--- a/dev-tools/unittest/test_job_version_bump_pipeline.py
+++ b/dev-tools/unittest/test_job_version_bump_pipeline.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
+"""Tests for .buildkite/job-version-bump*.json.py pipeline generators."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PIPELINE_PHASE1 = _REPO_ROOT / ".buildkite" / "job-version-bump.json.py"
+_PIPELINE_PHASE2 = _REPO_ROOT / ".buildkite" / "job-version-bump-phase2.json.py"
+
+
+def _run_phase1(extra_env: dict[str, str] | None = None) -> dict:
+    env = os.environ.copy()
+    env.pop("VERSION_BUMP_MERGE_AUTO", None)
+    if extra_env:
+        env.update(extra_env)
+    out = subprocess.check_output(
+        [sys.executable, str(_PIPELINE_PHASE1)],
+        cwd=str(_REPO_ROOT),
+        env=env,
+        text=True,
+    )
+    return json.loads(out)
+
+
+def _run_phase2(extra_env: dict[str, str] | None = None) -> dict:
+    env = os.environ.copy()
+    env.pop("VERSION_BUMP_MERGE_AUTO", None)
+    if extra_env:
+        env.update(extra_env)
+    out = subprocess.check_output(
+        [sys.executable, str(_PIPELINE_PHASE2)],
+        cwd=str(_REPO_ROOT),
+        env=env,
+        text=True,
+    )
+    return json.loads(out)
+
+
+def _step_by_key(pipeline: dict, key: str) -> dict:
+    return next(s for s in pipeline["steps"] if s.get("key") == key)
+
+
+def test_phase1_has_validate_and_schedule_only() -> None:
+    pipeline = _run_phase1()
+    keys = [s.get("key") for s in pipeline["steps"]]
+    assert keys == ["validate-version-bump", "schedule-version-bump-follow-up"]
+
+
+def test_phase1_has_no_step_if_using_meta_data() -> None:
+    """Buildkite rejects build.meta_data in step if expressions at pipeline upload."""
+    pipeline = _run_phase1()
+    for step in pipeline["steps"]:
+        cond = step.get("if")
+        if cond is None:
+            continue
+        assert "build.meta_data" not in cond
+
+
+def test_phase1_schedule_depends_on_validate() -> None:
+    pipeline = _run_phase1()
+    sched = _step_by_key(pipeline, "schedule-version-bump-follow-up")
+    assert sched["depends_on"] == "validate-version-bump"
+    assert sched["command"] == ["dev-tools/version_bump_upload_phase2.sh"]
+
+
+def test_phase1_schedule_uses_wolfi_image_like_validate() -> None:
+    """Schedule step needs buildkite-agent for meta-data and pipeline upload."""
+    pipeline = _run_phase1()
+    validate_img = _step_by_key(pipeline, "validate-version-bump")["agents"]["image"]
+    sched_img = _step_by_key(pipeline, "schedule-version-bump-follow-up")["agents"]["image"]
+    assert sched_img == validate_img
+    assert "wolfi" in sched_img
+
+
+def test_phase2_bump_defaults_merge_auto_true() -> None:
+    pipeline = _run_phase2()
+    bump = _step_by_key(pipeline, "bump-version")
+    assert bump["env"]["VERSION_BUMP_MERGE_AUTO"] == "true"
+
+
+def test_phase2_bump_respects_merge_auto_override_false() -> None:
+    pipeline = _run_phase2({"VERSION_BUMP_MERGE_AUTO": "false"})
+    bump = _step_by_key(pipeline, "bump-version")
+    assert bump["env"]["VERSION_BUMP_MERGE_AUTO"] == "false"
+
+
+def test_phase2_dra_uses_wait_script_not_meta_in_if() -> None:
+    pipeline = _run_phase2()
+    dra = _step_by_key(pipeline, "fetch-dra-artifacts")
+    assert "if" not in dra
+    assert "plugins" not in dra
+    assert dra["command"] == ["python3", "dev-tools/wait_version_bump_dra.py"]
+
+
+def test_phase2_order_bump_then_slack_then_dra() -> None:
+    pipeline = _run_phase2()
+    assert (
+        _step_by_key(pipeline, "bump-version")["depends_on"]
+        == "schedule-version-bump-follow-up"
+    )
+    assert _step_by_key(pipeline, "queue-slack-notify")["depends_on"] == "bump-version"
+    slack_cmd = _step_by_key(pipeline, "queue-slack-notify")["command"]
+    assert slack_cmd == [".buildkite/pipelines/send_slack_version_bump_notification.sh"]
+    assert (
+        _step_by_key(pipeline, "fetch-dra-artifacts")["depends_on"]
+        == "queue-slack-notify"
+    )
+
+
+def test_phase2_slack_step_uses_same_agent_image_as_bump() -> None:
+    """Slack step must run where buildkite-agent is available (see send_slack script)."""
+    pipeline = _run_phase2()
+    bump_img = _step_by_key(pipeline, "bump-version")["agents"]["image"]
+    slack_img = _step_by_key(pipeline, "queue-slack-notify")["agents"]["image"]
+    assert slack_img == bump_img
+
+
+def test_mutually_exclusive_merge_flags_script() -> None:
+    """create_github_pull_request.sh rejects --merge and --merge-auto together."""
+    script = _REPO_ROOT / "dev-tools" / "create_github_pull_request.sh"
+    proc = subprocess.run(
+        [
+            "bash",
+            str(script),
+            "--repo",
+            "r/r",
+            "--base",
+            "b",
+            "--head",
+            "h",
+            "--title",
+            "t",
+            "--body",
+            "body",
+            "--merge",
+            "--merge-auto",
+        ],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+    assert "only one of --merge or --merge-auto" in proc.stderr
+
+
+def test_create_pr_script_requires_body() -> None:
+    """create_github_pull_request.sh requires --body alongside other PR fields."""
+    script = _REPO_ROOT / "dev-tools" / "create_github_pull_request.sh"
+    proc = subprocess.run(
+        [
+            "bash",
+            str(script),
+            "--repo",
+            "r/r",
+            "--base",
+            "b",
+            "--head",
+            "h",
+            "--title",
+            "t",
+        ],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+    assert "--body" in proc.stderr

--- a/dev-tools/unittest/test_version_bump_validation.py
+++ b/dev-tools/unittest/test_version_bump_validation.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
+"""Pytest tests for dev-tools/version_bump_validation.py (Buildkite bump rules).
+
+Integration tests (real ``git fetch`` + ``validate_version_bump_params.sh``) are
+opt-in so CI stays deterministic:
+
+    export VERSION_BUMP_GIT_INTEGRATION=1
+    export VERSION_BUMP_TEST_BRANCH=9.5   # MAJOR.MINOR branch that exists on origin
+    python3 -m pip install -r dev-tools/test-requirements.txt
+    ./dev-tools/run_dev_tools_tests.sh
+
+Optional: ``VERSION_BUMP_SKIP_NEGATIVE_INTEGRATION=1`` to skip the negative
+``patch+2`` check only.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_DEV_TOOLS = Path(__file__).resolve().parents[1]
+if str(_DEV_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_DEV_TOOLS))
+
+import version_bump_validation as vbu  # noqa: E402
+
+_REPO_ROOT = _DEV_TOOLS.parent
+_VALIDATOR_SCRIPT = _DEV_TOOLS / "validate_version_bump_params.sh"
+_MODULE = _DEV_TOOLS / "version_bump_validation.py"
+
+
+def test_parse_semver_ok() -> None:
+    assert vbu.parse_semver("9.5.1") == (9, 5, 1)
+
+
+def test_parse_semver_rejects() -> None:
+    assert vbu.parse_semver("9.5") is None
+    assert vbu.parse_semver("v9.5.0") is None
+    assert vbu.parse_semver("9.5.0.1") is None
+    assert vbu.parse_semver(" 9.5.1") is None
+    assert vbu.parse_semver("9.5.1 ") is None
+
+
+def test_validate_rejects_outer_whitespace_new_version() -> None:
+    with pytest.raises(ValueError, match="whitespace"):
+        vbu.validate_version_bump_params(
+            current_version="9.5.0",
+            new_version=" 9.5.1",
+            branch="9.5",
+        )
+
+
+def test_validate_rejects_outer_whitespace_branch() -> None:
+    with pytest.raises(ValueError, match="whitespace"):
+        vbu.validate_version_bump_params(
+            current_version="9.5.0",
+            new_version="9.5.1",
+            branch="9.5 ",
+        )
+
+
+def test_patch_ok_consecutive() -> None:
+    vbu.validate_version_bump_params(
+        current_version="9.5.0",
+        new_version="9.5.1",
+        branch="9.5",
+    )
+
+
+def test_patch_ok_noop_same_version() -> None:
+    vbu.validate_version_bump_params(
+        current_version="9.5.1",
+        new_version="9.5.1",
+        branch="9.5",
+    )
+
+
+def test_patch_rejects_skip() -> None:
+    with pytest.raises(ValueError):
+        vbu.validate_version_bump_params(
+            current_version="9.5.0",
+            new_version="9.5.2",
+            branch="9.5",
+        )
+
+
+def test_patch_rejects_wrong_release_branch() -> None:
+    with pytest.raises(ValueError):
+        vbu.validate_version_bump_params(
+            current_version="9.5.0",
+            new_version="9.5.1",
+            branch="9.4",
+        )
+
+
+def test_patch_rejects_major_minor_mismatch() -> None:
+    with pytest.raises(ValueError):
+        vbu.validate_version_bump_params(
+            current_version="9.4.9",
+            new_version="9.5.1",
+            branch="9.5",
+        )
+
+
+def test_cli_validate_patch_ok() -> None:
+    rc = subprocess.call(
+        [
+            sys.executable,
+            str(_MODULE),
+            "validate",
+            "--current",
+            "9.5.0",
+            "--new",
+            "9.5.1",
+            "--branch",
+            "9.5",
+        ],
+        cwd=str(_REPO_ROOT),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    assert rc == 0
+
+
+def test_cli_validate_patch_negative() -> None:
+    rc = subprocess.call(
+        [
+            sys.executable,
+            str(_MODULE),
+            "validate",
+            "--current",
+            "9.5.0",
+            "--new",
+            "9.5.2",
+            "--branch",
+            "9.5",
+        ],
+        cwd=str(_REPO_ROOT),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    assert rc != 0
+
+
+@pytest.mark.skipif(
+    not _VALIDATOR_SCRIPT.is_file(),
+    reason="validate_version_bump_params.sh missing",
+)
+def test_shell_skip_validation_env() -> None:
+    env = os.environ.copy()
+    env["SKIP_VERSION_VALIDATION"] = "true"
+    env.pop("NEW_VERSION", None)
+    env.pop("BRANCH", None)
+    out = subprocess.run(
+        ["/bin/bash", str(_VALIDATOR_SCRIPT)],
+        cwd=str(_REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert out.returncode == 0, out.stderr + out.stdout
+
+
+@pytest.mark.skipif(
+    not _VALIDATOR_SCRIPT.is_file(),
+    reason="validate_version_bump_params.sh missing",
+)
+def test_shell_rejects_non_patch_workflow() -> None:
+    """Upstream may send WORKFLOW=minor; fail before git fetch."""
+    env = os.environ.copy()
+    env["WORKFLOW"] = "minor"
+    env["NEW_VERSION"] = "9.5.1"
+    env["BRANCH"] = "9.5"
+    env.pop("SKIP_VERSION_VALIDATION", None)
+    out = subprocess.run(
+        ["/bin/bash", str(_VALIDATOR_SCRIPT)],
+        cwd=str(_REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert out.returncode != 0, out.stderr + out.stdout
+    assert "WORKFLOW" in out.stderr or "WORKFLOW" in out.stdout
+
+
+def _integration_requested() -> bool:
+    return os.environ.get("VERSION_BUMP_GIT_INTEGRATION") == "1"
+
+
+def _integration_branch() -> str | None:
+    b = os.environ.get("VERSION_BUMP_TEST_BRANCH", "").strip()
+    return b or None
+
+
+def _read_version_from_fetch_head(repo: Path) -> str:
+    proc = subprocess.run(
+        ["git", "show", "FETCH_HEAD:gradle.properties"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"git show FETCH_HEAD:gradle.properties failed: {proc.stderr}"
+        )
+    for line in proc.stdout.splitlines():
+        if line.startswith("elasticsearchVersion="):
+            return line.split("=", 1)[1].strip()
+    raise AssertionError("elasticsearchVersion not found in FETCH_HEAD gradle.properties")
+
+
+@pytest.fixture
+def git_patch_integration_branch() -> str:
+    """Release branch MAJOR.MINOR; requires network + origin ref."""
+    if not _integration_requested():
+        pytest.skip(
+            "Set VERSION_BUMP_GIT_INTEGRATION=1 and VERSION_BUMP_TEST_BRANCH "
+            "(e.g. 9.5) to run git integration tests."
+        )
+    br = _integration_branch()
+    if not br:
+        pytest.skip("VERSION_BUMP_TEST_BRANCH is not set.")
+    return br
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not _VALIDATOR_SCRIPT.is_file(),
+    reason="validate_version_bump_params.sh missing",
+)
+def test_integration_patch_validate_script_with_git_fetch(git_patch_integration_branch: str) -> None:
+    """Run validate_version_bump_params.sh after fetch; NEW_VERSION = patch+1 from origin."""
+    branch = git_patch_integration_branch
+    fetch = subprocess.run(
+        ["git", "fetch", "origin", branch],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert fetch.returncode == 0, fetch.stderr + fetch.stdout
+
+    cur = _read_version_from_fetch_head(_REPO_ROOT)
+    triple = vbu.parse_semver(cur)
+    assert triple is not None, f"unexpected elasticsearchVersion on branch: {cur!r}"
+    maj, mino, pat = triple
+    new_version = f"{maj}.{mino}.{pat + 1}"
+
+    env = os.environ.copy()
+    env["NEW_VERSION"] = new_version
+    env["BRANCH"] = branch
+    env["WORKFLOW"] = "patch"
+    env.pop("SKIP_VERSION_VALIDATION", None)
+
+    out = subprocess.run(
+        ["/bin/bash", str(_VALIDATOR_SCRIPT)],
+        cwd=str(_REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert out.returncode == 0, out.stderr + out.stdout
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not _VALIDATOR_SCRIPT.is_file(),
+    reason="validate_version_bump_params.sh missing",
+)
+@pytest.mark.skipif(
+    os.environ.get("VERSION_BUMP_SKIP_NEGATIVE_INTEGRATION") == "1",
+    reason="VERSION_BUMP_SKIP_NEGATIVE_INTEGRATION=1",
+)
+def test_integration_patch_validate_script_rejects_bad_jump(git_patch_integration_branch: str) -> None:
+    """Same fetch as production path; NEW_VERSION = patch+2 must fail validation."""
+    branch = git_patch_integration_branch
+    fetch = subprocess.run(
+        ["git", "fetch", "origin", branch],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert fetch.returncode == 0, fetch.stderr + fetch.stdout
+
+    cur = _read_version_from_fetch_head(_REPO_ROOT)
+    triple = vbu.parse_semver(cur)
+    assert triple is not None
+    maj, mino, pat = triple
+    bad_version = f"{maj}.{mino}.{pat + 2}"
+
+    env = os.environ.copy()
+    env["NEW_VERSION"] = bad_version
+    env["BRANCH"] = branch
+    env["WORKFLOW"] = "patch"
+    env.pop("SKIP_VERSION_VALIDATION", None)
+
+    out = subprocess.run(
+        ["/bin/bash", str(_VALIDATOR_SCRIPT)],
+        cwd=str(_REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert out.returncode != 0, "validator should reject non-consecutive patch bump"

--- a/dev-tools/unittest/test_wait_version_bump_dra.py
+++ b/dev-tools/unittest/test_wait_version_bump_dra.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
+"""Tests for dev-tools/wait_version_bump_dra.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WAIT_SCRIPT = _REPO_ROOT / "dev-tools" / "wait_version_bump_dra.py"
+
+
+def _load_wait_module():
+    spec = importlib.util.spec_from_file_location("wait_version_bump_dra", _WAIT_SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["wait_version_bump_dra"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_poll_logs_progress_when_versions_unavailable(capsys) -> None:
+    """Log each poll even when staging/snapshot fetches return None (not stalled)."""
+    mod = _load_wait_module()
+    t = 0.0
+
+    def fake_monotonic() -> float:
+        return t
+
+    def advance_sleep(_seconds: float) -> None:
+        nonlocal t
+        t += float(_seconds) + 1.0
+
+    with (
+        patch.dict(
+            "os.environ",
+            {
+                "BRANCH": "9.5",
+                "NEW_VERSION": "9.5.1",
+                "BUILDKITE": "false",
+            },
+            clear=False,
+        ),
+        patch.object(mod, "_meta_get", return_value="true"),
+        patch.object(mod, "_fetch_version", return_value=None),
+        patch.object(mod.time, "monotonic", side_effect=fake_monotonic),
+        patch.object(mod.time, "sleep", side_effect=advance_sleep),
+        patch.object(mod, "TIMEOUT_SECONDS", 120),
+        patch.object(mod, "POLL_SECONDS", 1),
+        patch.object(mod, "PROGRESS_LOG_EVERY", 1),
+    ):
+        assert mod.main() == 1
+
+    out = capsys.readouterr().out
+    assert "staging=None snapshot=None (still waiting)" in out

--- a/dev-tools/validate_version_bump_params.sh
+++ b/dev-tools/validate_version_bump_params.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+#
+# Validates NEW_VERSION / BRANCH against elasticsearchVersion on the
+# remote release branch before ml-cpp-version-bump runs bump_version.sh.
+# Semantic rules live in version_bump_validation.py (unit-tested).
+#
+# Environment:
+#   NEW_VERSION — required target stack version (MAJOR.MINOR.PATCH), unless skipped
+#   BRANCH — required release branch (e.g. 9.5), unless skipped
+#   WORKFLOW — optional; defaults to patch. If set by upstream automation, must be
+#              exactly "patch" (this pipeline does not support minor bumps).
+#   SKIP_VERSION_VALIDATION — set to "true" to skip (emergency override only)
+#   PYTHON — interpreter (default: python3)
+#
+# Buildkite (BUILDKITE=true): sets meta-data ml_cpp_version_bump_noop to true when
+# origin/BRANCH already has NEW_VERSION, so downstream Slack/bump steps are skipped.
+
+set -euo pipefail
+
+version_bump_set_noop_meta() {
+    local noop="$1"
+    if [[ "${BUILDKITE:-}" != "true" ]]; then
+        return 0
+    fi
+    if ! command -v buildkite-agent >/dev/null 2>&1; then
+        echo "WARNING: BUILDKITE=true but buildkite-agent not in PATH; skipping meta-data ml_cpp_version_bump_noop=${noop}" >&2
+        return 0
+    fi
+    buildkite-agent meta-data set "ml_cpp_version_bump_noop" "$noop"
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON="${PYTHON:-python3}"
+VALIDATION_PY="${SCRIPT_DIR}/version_bump_validation.py"
+
+SKIP_VERSION_VALIDATION="${SKIP_VERSION_VALIDATION:-false}"
+
+if [[ "$SKIP_VERSION_VALIDATION" == "true" ]]; then
+    echo "WARNING: SKIP_VERSION_VALIDATION=true — version increment checks skipped." >&2
+    version_bump_set_noop_meta false
+    exit 0
+fi
+
+: "${NEW_VERSION:?NEW_VERSION must be set}"
+: "${BRANCH:?BRANCH must be set}"
+
+version_bump_trim_value() {
+    local s=$1
+    s="${s//$'\r'/}"
+    s="${s#"${s%%[![:space:]]*}"}"
+    s="${s%"${s##*[![:space:]]}"}"
+    printf '%s' "$s"
+}
+NEW_VERSION="$(version_bump_trim_value "${NEW_VERSION}")"
+BRANCH="$(version_bump_trim_value "${BRANCH}")"
+
+WORKFLOW="${WORKFLOW:-patch}"
+if [[ "$WORKFLOW" != "patch" ]]; then
+    echo "ERROR: WORKFLOW must be \"patch\" for this pipeline, got \"${WORKFLOW}\"" >&2
+    exit 1
+fi
+
+echo "=== Version bump validation (patch) ==="
+echo "WORKFLOW:     ${WORKFLOW}"
+echo "NEW_VERSION:  ${NEW_VERSION}"
+echo "BRANCH:       ${BRANCH}"
+
+# Patch-only pipeline (no WORKFLOW=minor): consecutive patch on this release
+# branch. Current version is read from origin/${BRANCH} by design — there is no
+# minor-line bump mode in dev-tools/version_bump_validation.py or this pipeline.
+
+echo "Fetching origin/${BRANCH}..."
+git fetch origin "$BRANCH"
+
+if ! git cat-file -e FETCH_HEAD:gradle.properties 2>/dev/null; then
+    echo "ERROR: gradle.properties missing at FETCH_HEAD (origin/${BRANCH})" >&2
+    exit 1
+fi
+
+# Allow empty result: with pipefail, grep exits 1 when there is no match, which
+# would abort the substitution before the explicit empty check below.
+CURRENT_VERSION=$(
+    git show FETCH_HEAD:gradle.properties | grep '^elasticsearchVersion=' | head -1 | cut -d= -f2 | tr -d '[:space:]' || true
+)
+
+if [[ -z "$CURRENT_VERSION" ]]; then
+    echo "ERROR: could not read elasticsearchVersion from origin/${BRANCH} gradle.properties" >&2
+    exit 1
+fi
+
+echo "Current version on origin/${BRANCH}: ${CURRENT_VERSION}"
+
+if ! "$PYTHON" "$VALIDATION_PY" validate-and-report \
+    --current "$CURRENT_VERSION" \
+    --new "$NEW_VERSION" \
+    --branch "$BRANCH"
+then
+    exit 1
+fi
+
+# Compare trimmed forms for no-op meta-data (gradle value is already space-stripped).
+cur_trim=$(echo "$CURRENT_VERSION" | tr -d '[:space:]')
+new_trim=$(echo "$NEW_VERSION" | tr -d '[:space:]')
+if [[ "$cur_trim" == "$new_trim" ]]; then
+    version_bump_set_noop_meta true
+else
+    version_bump_set_noop_meta false
+fi

--- a/dev-tools/version_bump_upload_phase2.sh
+++ b/dev-tools/version_bump_upload_phase2.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+#
+# Second phase of the ml-cpp version-bump pipeline (after validate). Buildkite step
+# `if` cannot read build meta-data, so we gate follow-up steps by reading
+# ml_cpp_version_bump_noop here and uploading phase-2 YAML only when a bump is needed.
+
+set -euo pipefail
+
+if [[ -n "${BUILDKITE_BUILD_CHECKOUT_PATH:-}" ]]; then
+    cd "${BUILDKITE_BUILD_CHECKOUT_PATH}"
+else
+    ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+    if [[ -z "${ROOT}" ]]; then
+        echo "ERROR: set BUILDKITE_BUILD_CHECKOUT_PATH or run from a git checkout" >&2
+        exit 1
+    fi
+    cd "${ROOT}"
+fi
+
+if [[ "${DRY_RUN:-}" == "true" ]]; then
+    echo "DRY_RUN=true — not scheduling version-bump follow-up steps."
+    exit 0
+fi
+
+if ! command -v buildkite-agent >/dev/null 2>&1; then
+    echo "ERROR: buildkite-agent not found; cannot upload phase-2 pipeline." >&2
+    exit 1
+fi
+
+noop=$(buildkite-agent meta-data get "ml_cpp_version_bump_noop" 2>/dev/null || echo "false")
+if [[ "${noop}" == "true" ]]; then
+    echo "ml_cpp_version_bump_noop=true — branch already at NEW_VERSION; skipping follow-up steps."
+    exit 0
+fi
+
+exec python3 .buildkite/job-version-bump-phase2.json.py | buildkite-agent pipeline upload

--- a/dev-tools/version_bump_validation.py
+++ b/dev-tools/version_bump_validation.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+#
+"""Rules for ml-cpp patch release version bump parameters (Buildkite / release-eng).
+
+Used by dev-tools/validate_version_bump_params.sh and unit-tested under
+dev-tools/unittest/.
+
+Run tests from repo root (install dev-tools test deps first, see
+``dev-tools/run_dev_tools_tests.sh``):
+
+    python3 -m pip install -r dev-tools/test-requirements.txt
+    ./dev-tools/run_dev_tools_tests.sh
+
+Optional git integration (real ``git fetch`` + shell validator): set
+``VERSION_BUMP_GIT_INTEGRATION=1`` and ``VERSION_BUMP_TEST_BRANCH=MAJOR.MINOR``.
+See ``unittest/test_version_bump_validation.py`` module docstring.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from typing import Optional, Tuple
+
+SEMVER_RE = re.compile(r"^([0-9]+)\.([0-9]+)\.([0-9]+)$")
+BRANCH_RE = re.compile(r"^([0-9]+)\.([0-9]+)$")
+
+
+def _reject_outer_whitespace(label: str, value: str) -> None:
+    """Disallow leading/trailing ASCII whitespace or CR so values match shell expectations."""
+    if value != value.strip(" \t\n\r\v\f"):
+        raise ValueError(
+            f"{label} must not have leading or trailing whitespace, got {value!r}"
+        )
+
+
+def parse_semver(version: str) -> Optional[Tuple[int, int, int]]:
+    m = SEMVER_RE.match(version)
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+
+def parse_release_branch(branch: str) -> Optional[Tuple[int, int]]:
+    m = BRANCH_RE.match(branch)
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)))
+
+
+def validate_version_bump_params(
+    *,
+    current_version: str,
+    new_version: str,
+    branch: str,
+) -> None:
+    """Validate patch bump parameters. Raises ValueError on failure.
+
+    When current_version == new_version, the bump is a no-op and always valid.
+    """
+    _reject_outer_whitespace("NEW_VERSION", new_version)
+    _reject_outer_whitespace("BRANCH", branch)
+    _reject_outer_whitespace("current_version", current_version)
+
+    new_t = parse_semver(new_version)
+    if new_t is None:
+        raise ValueError(
+            f"NEW_VERSION must be MAJOR.MINOR.PATCH (digits only), got {new_version!r}"
+        )
+    new_major, new_minor, new_patch = new_t
+
+    br = parse_release_branch(branch)
+    if br is None:
+        raise ValueError(
+            f"BRANCH must be MAJOR.MINOR (e.g. 9.5), got {branch!r}"
+        )
+    br_major, br_minor = br
+    if br_major != new_major or br_minor != new_minor:
+        raise ValueError(
+            f"BRANCH {branch!r} must match MAJOR.MINOR of NEW_VERSION "
+            f"({new_major}.{new_minor}), got NEW_VERSION {new_version!r}"
+        )
+
+    cur_t = parse_semver(current_version)
+    if cur_t is None:
+        raise ValueError(
+            "elasticsearchVersion on branch must be MAJOR.MINOR.PATCH, "
+            f"got {current_version!r}"
+        )
+    cur_major, cur_minor, cur_patch = cur_t
+
+    if current_version == new_version:
+        return
+
+    if cur_major != new_major or cur_minor != new_minor:
+        raise ValueError(
+            "patch bump requires same MAJOR.MINOR as current "
+            f"({cur_major}.{cur_minor} vs {new_major}.{new_minor})"
+        )
+    expected_patch = cur_patch + 1
+    if new_patch != expected_patch:
+        raise ValueError(
+            "patch bump expects NEW_VERSION patch = current patch + 1 "
+            f"({current_version} → {new_major}.{new_minor}.{expected_patch}), "
+            f"got {new_version}"
+        )
+
+
+def _cmd_validate(args: argparse.Namespace) -> int:
+    try:
+        validate_version_bump_params(
+            current_version=args.current,
+            new_version=args.new,
+            branch=args.branch,
+        )
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def _cmd_validate_and_report(args: argparse.Namespace) -> int:
+    rc = _cmd_validate(args)
+    if rc != 0:
+        return rc
+    cur = args.current
+    new = args.new
+    if cur == new:
+        print(f"OK: branch already at {new} — bump step will no-op.")
+    else:
+        print(f"OK: patch increment {cur} → {new}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="ml-cpp patch version bump parameter validation"
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_val = sub.add_parser(
+        "validate",
+        help="check current/new/branch (same rules as Buildkite)",
+    )
+    p_val.add_argument("--current", required=True, help="elasticsearchVersion on branch")
+    p_val.add_argument("--new", required=True, dest="new", help="NEW_VERSION")
+    p_val.add_argument("--branch", required=True, help="BRANCH (MAJOR.MINOR)")
+    p_val.set_defaults(func=_cmd_validate)
+
+    p_rep = sub.add_parser(
+        "validate-and-report",
+        help="validate and print the same OK lines as validate_version_bump_params.sh",
+    )
+    p_rep.add_argument("--current", required=True)
+    p_rep.add_argument("--new", required=True, dest="new")
+    p_rep.add_argument("--branch", required=True)
+    p_rep.set_defaults(func=_cmd_validate_and_report)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev-tools/wait_version_bump_dra.py
+++ b/dev-tools/wait_version_bump_dra.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
+"""Poll DRA staging/snapshot JSON until versions match (replaces json-watcher plugin).
+
+Buildkite step conditionals cannot use build meta-data; this script reads
+ml_cpp_version_bump_changed via ``buildkite-agent meta-data get`` and exits
+immediately when no PR was opened.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+POLL_SECONDS = 30
+TIMEOUT_SECONDS = 240 * 60
+# Heartbeat in Buildkite logs every N poll iterations (even when fetches return None).
+PROGRESS_LOG_EVERY = 1
+
+STAGING_TMPL = "https://artifacts-staging.elastic.co/ml-cpp/latest/{branch}.json"
+SNAPSHOT_TMPL = "https://storage.googleapis.com/elastic-artifacts-snapshot/ml-cpp/latest/{branch}.json"
+
+
+def _meta_get(key: str) -> str | None:
+    """Read Buildkite meta-data. Returns None when not on Buildkite or key is unset.
+
+    On BUILDKITE=true, missing ``buildkite-agent`` or unexpected failures exit
+    non-zero so we do not silently skip the DRA wait.
+    """
+    if os.environ.get("BUILDKITE") != "true":
+        return None
+    try:
+        proc = subprocess.run(
+            ["buildkite-agent", "meta-data", "get", key],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+    except FileNotFoundError:
+        print(
+            "ERROR: BUILDKITE=true but buildkite-agent is not available; "
+            "cannot read meta-data for DRA wait gating.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2) from None
+    except subprocess.TimeoutExpired:
+        print(
+            f"ERROR: buildkite-agent meta-data get {key!r} timed out.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2) from None
+
+    err = (proc.stderr or "").strip()
+    out = (proc.stdout or "").strip()
+
+    if proc.returncode == 0:
+        return out if out else None
+
+    err_lower = err.lower()
+    if proc.returncode == 1 and (
+        "not found" in err_lower
+        or "does not exist" in err_lower
+        or "couldn't find" in err_lower
+        or "could not find" in err_lower
+    ):
+        return None
+
+    print(
+        f"ERROR: buildkite-agent meta-data get {key!r} failed "
+        f"(exit {proc.returncode}): {err or '(no stderr)'}",
+        file=sys.stderr,
+    )
+    raise SystemExit(2) from None
+
+
+def _fetch_version(url: str) -> str | None:
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "ml-cpp-version-bump-dra-wait"})
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        ver = data.get("version")
+        if ver is None:
+            return None
+        return str(ver).strip()
+    except (urllib.error.URLError, json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        return None
+
+
+def main() -> int:
+    if os.environ.get("DRY_RUN") == "true":
+        print("DRY_RUN=true — skipping DRA wait.")
+        return 0
+
+    if _meta_get("ml_cpp_version_bump_changed") != "true":
+        print(
+            "ml_cpp_version_bump_changed is not true — no PR opened; skipping DRA wait.",
+            file=sys.stderr,
+        )
+        return 0
+
+    branch = os.environ.get("BRANCH", "").strip()
+    new_version = os.environ.get("NEW_VERSION", "").strip()
+    if not branch or not new_version:
+        print("ERROR: BRANCH and NEW_VERSION must be set.", file=sys.stderr)
+        return 1
+
+    staging_url = STAGING_TMPL.format(branch=branch)
+    snapshot_url = SNAPSHOT_TMPL.format(branch=branch)
+    want_staging = new_version
+    want_snapshot = f"{new_version}-SNAPSHOT"
+
+    print(f"Waiting for DRA artifacts (timeout {TIMEOUT_SECONDS}s, poll {POLL_SECONDS}s)...")
+    print(f"  staging:  {want_staging!r}  <= {staging_url}")
+    print(f"  snapshot: {want_snapshot!r} <= {snapshot_url}")
+
+    deadline = time.monotonic() + TIMEOUT_SECONDS
+    iteration = 0
+    while time.monotonic() < deadline:
+        iteration += 1
+        st = _fetch_version(staging_url)
+        sn = _fetch_version(snapshot_url)
+        if st == want_staging and sn == want_snapshot:
+            print("OK: staging and snapshot versions matched.")
+            return 0
+        if iteration % PROGRESS_LOG_EVERY == 0:
+            print(f"  staging={st!r} snapshot={sn!r} (still waiting)")
+        time.sleep(POLL_SECONDS)
+
+    print("ERROR: timed out waiting for DRA artifact versions.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Backport of #3030 to the 9.3 branch.

Automates patch `elasticsearchVersion` bumps for ml-cpp via the **ml-cpp-version-bump** Buildkite pipeline: validate parameters, optionally run the bump (topic branch + GitHub PR + merge), notify Slack, then wait for DRA artifacts.

## Test plan

- [x] CI passes on 9.3 branch
- [x] dev-tools pytest checks pass


Made with [Cursor](https://cursor.com)