### PR TITLE
[ML] Skip backport for minor-freeze version bump PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,12 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     # Only run for merged PRs that are not themselves backports (avoid loops).
     # Skip automation PRs (minor-freeze main bumps carry a release version label from
-    # elasticsearchmachine but must not backport to the new release branch).
+    # elasticsearchmachine but must not backport to the new release branch). The
+    # head.ref fallback keys off the minor-freeze topic branch created by
+    # dev-tools/bump_main_minor_freeze.sh (ci/ml-cpp-minor-freeze-main-*) so it cannot
+    # accidentally skip an unrelated PR whose title merely mentions a minor freeze.
     if: |
       github.event.pull_request.merged == true &&
       !(contains(github.event.pull_request.labels.*.name, 'backport')) &&
       !(contains(github.event.pull_request.labels.*.name, 'no-backport')) &&
-      !contains(github.event.pull_request.title, '(minor freeze)')
+      !startsWith(github.event.pull_request.head.ref, 'ci/ml-cpp-minor-freeze-main-')
     steps:
       - name: Check for version labels
         id: check-labels

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,9 +13,13 @@ jobs:
     name: Backport PR
     runs-on: ubuntu-latest
     # Only run for merged PRs that are not themselves backports (avoid loops).
+    # Skip automation PRs (minor-freeze main bumps carry a release version label from
+    # elasticsearchmachine but must not backport to the new release branch).
     if: |
       github.event.pull_request.merged == true &&
-      !(contains(github.event.pull_request.labels.*.name, 'backport'))
+      !(contains(github.event.pull_request.labels.*.name, 'backport')) &&
+      !(contains(github.event.pull_request.labels.*.name, 'no-backport')) &&
+      !contains(github.event.pull_request.title, '(minor freeze)')
     steps:
       - name: Check for version labels
         id: check-labels

--- a/dev-tools/bump_main_minor_freeze.sh
+++ b/dev-tools/bump_main_minor_freeze.sh
@@ -158,6 +158,7 @@ pr_cmd=(
     --title "[ML] Bump version to ${MAIN_NEW_VERSION} (minor freeze)"
     --body "$pr_body"
     --label "ci:skip-es-tests"
+    --label "no-backport"
 )
 if [[ "${VERSION_BUMP_NO_MERGE:-}" != "true" ]]; then
     if [[ "${VERSION_BUMP_MERGE_AUTO:-}" == "true" ]]; then

--- a/dev-tools/unittest/test_backport_workflow.py
+++ b/dev-tools/unittest/test_backport_workflow.py
@@ -8,10 +8,16 @@
 # compliance with the Elastic License 2.0 and the foregoing additional
 # limitation.
 
-"""Guard rails for automatic backport of version-bump automation PRs."""
+"""Guard rails for automatic backport of version-bump automation PRs.
+
+Assertions use whitespace/quote-tolerant regexes so cosmetic edits to backport.yml
+(e.g. !(contains(...)) vs !contains(...), or single vs double quotes) do not cause
+noisy failures without an actual behavioral regression.
+"""
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -21,15 +27,28 @@ _BUMP_MAIN_MINOR_FREEZE = _REPO_ROOT / "dev-tools" / "bump_main_minor_freeze.sh"
 
 def test_backport_workflow_skips_no_backport_label() -> None:
     text = _BACKPORT_WORKFLOW.read_text(encoding="utf-8")
-    assert "no-backport" in text
-    assert "!(contains(github.event.pull_request.labels.*.name, 'no-backport'))" in text
+    # Negated contains() over the PR labels for the no-backport label, tolerating
+    # optional wrapping parentheses and either quote style.
+    pattern = re.compile(
+        r"!\s*\(?\s*contains\(\s*github\.event\.pull_request\.labels\.\*\.name\s*,"
+        r"\s*['\"]no-backport['\"]\s*\)",
+    )
+    assert pattern.search(text), text
 
 
-def test_backport_workflow_skips_minor_freeze_title() -> None:
+def test_backport_workflow_skips_minor_freeze_branch() -> None:
     text = _BACKPORT_WORKFLOW.read_text(encoding="utf-8")
-    assert "!contains(github.event.pull_request.title, '(minor freeze)')" in text
+    # Negated startsWith() over the PR head ref for the minor-freeze topic branch,
+    # tolerating optional wrapping parentheses and either quote style.
+    pattern = re.compile(
+        r"!\s*\(?\s*startsWith\(\s*github\.event\.pull_request\.head\.ref\s*,"
+        r"\s*['\"]ci/ml-cpp-minor-freeze-main-['\"]\s*\)",
+    )
+    assert pattern.search(text), text
 
 
 def test_bump_main_minor_freeze_applies_no_backport_label() -> None:
     text = _BUMP_MAIN_MINOR_FREEZE.read_text(encoding="utf-8")
-    assert '--label "no-backport"' in text
+    # Tolerate quote style and surrounding whitespace on the --label argument.
+    pattern = re.compile(r"--label\s+['\"]no-backport['\"]")
+    assert pattern.search(text), text

--- a/dev-tools/unittest/test_backport_workflow.py
+++ b/dev-tools/unittest/test_backport_workflow.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
+"""Guard rails for automatic backport of version-bump automation PRs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BACKPORT_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "backport.yml"
+_BUMP_MAIN_MINOR_FREEZE = _REPO_ROOT / "dev-tools" / "bump_main_minor_freeze.sh"
+
+
+def test_backport_workflow_skips_no_backport_label() -> None:
+    text = _BACKPORT_WORKFLOW.read_text(encoding="utf-8")
+    assert "no-backport" in text
+    assert "!(contains(github.event.pull_request.labels.*.name, 'no-backport'))" in text
+
+
+def test_backport_workflow_skips_minor_freeze_title() -> None:
+    text = _BACKPORT_WORKFLOW.read_text(encoding="utf-8")
+    assert "!contains(github.event.pull_request.title, '(minor freeze)')" in text
+
+
+def test_bump_main_minor_freeze_applies_no_backport_label() -> None:
+    text = _BUMP_MAIN_MINOR_FREEZE.read_text(encoding="utf-8")
+    assert '--label "no-backport"' in text


### PR DESCRIPTION
## Summary

After the 9.5 minor freeze, merging #3068 (Leg B main bump to 9.6.0) triggered the automatic backport workflow and opened spurious #3069 onto branch `9.5`. That PR would have incorrectly bumped the release branch to 9.6.0; it has been closed without merging.

This happens because:
- `elasticsearchmachine` labels minor-freeze PRs with the **release** version (e.g. `v9.5.0`)
- The same merge adds the new release branch to `targetBranchChoices` in `.backportrc.json`
- The generic `branchLabelMapping` rule then backports the **main-only** freeze commit onto the new release branch

This will recur on every minor freeze unless we skip backport for these automation PRs.

## Changes

- Add a `no-backport` label to minor-freeze PRs opened by `bump_main_minor_freeze.sh`
- Skip the Backport workflow when that label is present, and as a fallback when the PR head branch is a minor-freeze topic branch (`ci/ml-cpp-minor-freeze-main-*`)
- Add unit tests guarding both the workflow and the bump script

The `no-backport` label already exists on the repo.

## Test plan

- [x] `python3 -m pytest dev-tools/unittest/test_backport_workflow.py -v`
- [x] CI `dev-tools pytest` step passes
- [ ] After merge: dummy PR backport-skip smoke test (see **Manual verification** below)
- [ ] Next production minor freeze: Leg B PR has `no-backport` and does not spawn a spurious backport PR

## Manual verification

### After this PR merges to `main` — backport skip smoke test

No need to wait for the next minor freeze. Once #3070 is on `main`:

1. Open a harmless test PR to `main` (e.g. a trivial dev-tools comment) with:
   - Labels: `no-backport`, a version label (e.g. `v9.6.0`), `:ml`, `>test`
2. Merge that PR.
3. Confirm:
   - **Actions → Backport** for that merge: the **Backport PR** job is **Skipped** (workflow `if` is false).
   - **No new PR** with the `backport` label referencing the test PR.

This reproduces the #3068 → #3069 failure mode (version label on a main-only change) without running the version-bump pipeline. Revert or close the test PR afterward.

### On the next production minor freeze

When release-eng triggers `ml-cpp-version-bump` with `WORKFLOW=minor` again:

- Leg B PR opened by `bump_main_minor_freeze.sh` should include the `no-backport` label and be created from a `ci/ml-cpp-minor-freeze-main-*` branch.
- Merging that PR should **not** open a spurious backport onto the new release branch.

Note: sandbox refs (`testing-*`) skip Leg B in CI, so they cannot be used for a full Leg B label E2E test.

## Review notes

Addressed Copilot feedback:
- Replaced the broad `(minor freeze)` title-substring fallback with a head-ref check on the automation topic branch (`ci/ml-cpp-minor-freeze-main-*`) so unrelated PRs mentioning a minor freeze in their title are not skipped.
- Made the guard-rail tests tolerant of whitespace/quote-style changes in `backport.yml` via regex.