### PR TITLE
Fix main-snapshot DRA alias lookup in minor-freeze wait

### DIFF
--- a/dev-tools/unittest/test_wait_version_bump_dra.py
+++ b/dev-tools/unittest/test_wait_version_bump_dra.py
@@ -74,12 +74,10 @@ def test_poll_logs_progress_when_versions_unavailable(capsys) -> None:
     assert "still waiting: staging=None, snapshot=None" in out
 
 
-def test_wait_minor_polls_version_keyed_alias_for_main_snapshot() -> None:
-    """release-manager's project-configs dir for main is "master", not "main", so it only
-    ever publishes the branch-keyed "latest" snapshot alias as .../latest/master.json —
-    .../latest/main.json is never created. _wait_minor must poll the version-keyed alias
-    (.../latest/{version}.json) for the main snapshot check instead, sidestepping the
-    branch/master naming mismatch entirely."""
+def test_wait_minor_polls_master_alias_for_main_snapshot() -> None:
+    """release-manager's project-configs dir for main is "master", not "main"; the DRA
+    "latest" snapshot alias it publishes is .../latest/master.json. _wait_minor must poll
+    that alias, not a .../latest/main.json that release-manager never creates."""
     mod = _load_wait_module()
     captured: list[tuple[str, str, str]] = []
 
@@ -92,9 +90,8 @@ def test_wait_minor_polls_version_keyed_alias_for_main_snapshot() -> None:
 
     main_snapshot = next(c for c in captured if c[0] == "main snapshot")
     _, url, expected = main_snapshot
-    assert url == "https://storage.googleapis.com/elastic-artifacts-snapshot/ml-cpp/latest/9.6.0-SNAPSHOT.json"
+    assert url == "https://storage.googleapis.com/elastic-artifacts-snapshot/ml-cpp/latest/master.json"
     assert "latest/main.json" not in url
-    assert "latest/master.json" not in url
     assert expected == "9.6.0-SNAPSHOT"
 
 

--- a/dev-tools/unittest/test_wait_version_bump_dra.py
+++ b/dev-tools/unittest/test_wait_version_bump_dra.py
@@ -74,6 +74,30 @@ def test_poll_logs_progress_when_versions_unavailable(capsys) -> None:
     assert "still waiting: staging=None, snapshot=None" in out
 
 
+def test_wait_minor_polls_version_keyed_alias_for_main_snapshot() -> None:
+    """release-manager's project-configs dir for main is "master", not "main", so it only
+    ever publishes the branch-keyed "latest" snapshot alias as .../latest/master.json —
+    .../latest/main.json is never created. _wait_minor must poll the version-keyed alias
+    (.../latest/{version}.json) for the main snapshot check instead, sidestepping the
+    branch/master naming mismatch entirely."""
+    mod = _load_wait_module()
+    captured: list[tuple[str, str, str]] = []
+
+    def fake_wait_for_checks(checks: list[tuple[str, str, str]]) -> int:
+        captured.extend(checks)
+        return 0
+
+    with patch.object(mod, "_wait_for_checks", side_effect=fake_wait_for_checks):
+        assert mod._wait_minor("9.5", "9.5.0", "9.6.0") == 0
+
+    main_snapshot = next(c for c in captured if c[0] == "main snapshot")
+    _, url, expected = main_snapshot
+    assert url == "https://storage.googleapis.com/elastic-artifacts-snapshot/ml-cpp/latest/9.6.0-SNAPSHOT.json"
+    assert "latest/main.json" not in url
+    assert "latest/master.json" not in url
+    assert expected == "9.6.0-SNAPSHOT"
+
+
 def test_main_skips_dra_wait_for_sandbox_branch(capsys) -> None:
     mod = _load_wait_module()
     with patch.dict(

--- a/dev-tools/wait_version_bump_dra.py
+++ b/dev-tools/wait_version_bump_dra.py
@@ -45,11 +45,9 @@ PROGRESS_LOG_EVERY = 1
 STAGING_TMPL = "https://artifacts-staging.elastic.co/ml-cpp/latest/{branch}.json"
 SNAPSHOT_TMPL = "https://storage.googleapis.com/elastic-artifacts-snapshot/ml-cpp/latest/{branch}.json"
 
-# release-manager also publishes a version-keyed "latest" alias alongside the branch-keyed
-# one (e.g. latest/9.6.0-SNAPSHOT.json). Main's branch-keyed alias is unreliable — release-
-# manager's project-configs dir for main is named "master", not "main", so it never
-# publishes latest/main.json — so the main-snapshot check below polls by version instead.
-VERSION_SNAPSHOT_TMPL = "https://storage.googleapis.com/elastic-artifacts-snapshot/ml-cpp/latest/{version}.json"
+# release-manager's project-configs dir for main is named "master", not "main", so the
+# DRA "latest" snapshot alias it publishes is .../latest/master.json, never .../latest/main.json.
+MAIN_BRANCH_DRA_ALIAS = "master"
 
 
 def _meta_get(key: str) -> str | None:
@@ -151,7 +149,7 @@ def _wait_patch(branch: str, new_version: str) -> int:
 
 
 def _wait_minor(branch: str, new_version: str, main_new_version: str) -> int:
-    main_snapshot_url = VERSION_SNAPSHOT_TMPL.format(version=f"{main_new_version}-SNAPSHOT")
+    main_snapshot_url = SNAPSHOT_TMPL.format(branch=MAIN_BRANCH_DRA_ALIAS)
     branch_staging_url = STAGING_TMPL.format(branch=branch)
     branch_snapshot_url = SNAPSHOT_TMPL.format(branch=branch)
     checks = [

--- a/dev-tools/wait_version_bump_dra.py
+++ b/dev-tools/wait_version_bump_dra.py
@@ -45,6 +45,12 @@ PROGRESS_LOG_EVERY = 1
 STAGING_TMPL = "https://artifacts-staging.elastic.co/ml-cpp/latest/{branch}.json"
 SNAPSHOT_TMPL = "https://storage.googleapis.com/elastic-artifacts-snapshot/ml-cpp/latest/{branch}.json"
 
+# release-manager also publishes a version-keyed "latest" alias alongside the branch-keyed
+# one (e.g. latest/9.6.0-SNAPSHOT.json). Main's branch-keyed alias is unreliable — release-
+# manager's project-configs dir for main is named "master", not "main", so it never
+# publishes latest/main.json — so the main-snapshot check below polls by version instead.
+VERSION_SNAPSHOT_TMPL = "https://storage.googleapis.com/elastic-artifacts-snapshot/ml-cpp/latest/{version}.json"
+
 
 def _meta_get(key: str) -> str | None:
     """Read Buildkite meta-data. Returns None when not on Buildkite or key is unset."""
@@ -145,7 +151,7 @@ def _wait_patch(branch: str, new_version: str) -> int:
 
 
 def _wait_minor(branch: str, new_version: str, main_new_version: str) -> int:
-    main_snapshot_url = SNAPSHOT_TMPL.format(branch="main")
+    main_snapshot_url = VERSION_SNAPSHOT_TMPL.format(version=f"{main_new_version}-SNAPSHOT")
     branch_staging_url = STAGING_TMPL.format(branch=branch)
     branch_snapshot_url = SNAPSHOT_TMPL.format(branch=branch)
     checks = [


### PR DESCRIPTION
## Describe your changes

`dev-tools/wait_version_bump_dra.py`'s minor-freeze DRA wait polls `.../latest/main.json` for the main branch's post-bump snapshot version. That alias never gets created: release-manager's `project-configs` directory for main is named `master`, not `main`, so it only ever publishes the "latest" snapshot alias as `.../latest/master.json`. The wait would run until its 4h timeout and fail instead of resolving once the artifact is actually published.

Fix: poll `.../latest/master.json` directly for the main-snapshot check instead of the non-existent `.../latest/main.json`.

Observed on the 9.5.0 minor freeze: [ml-cpp-version-bump #58](https://buildkite.com/elastic/ml-cpp-version-bump/builds/58) sat waiting on "main snapshot" even though the underlying main snapshot build ([main-snapshot-builds #6665](https://buildkite.com/elastic/ml-cpp-snapshot-builds/builds/6665)) had already passed and published `latest/master.json` with version `9.6.0-SNAPSHOT`.

Added a regression test (`test_wait_minor_polls_master_alias_for_main_snapshot`) asserting the main-snapshot check polls `latest/master.json` and never references `latest/main.json`.

## Test plan

- [x] `./dev-tools/run_dev_tools_tests.sh` — 60 passed, 2 skipped (unrelated, pre-existing skips)
- [x] Manually verified against live artifacts: `latest/main.json` → 404, `latest/master.json` → 200 with `version: "9.6.0-SNAPSHOT"`