### PR TITLE
Fix branchLabelMapping precedence for main override in .backportrc.json

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -12,8 +12,8 @@
     "backport"
   ],
   "branchLabelMapping": {
-    "^v(\\d+).(\\d+).\\d+(?:-(?:alpha|beta|rc)\\d+)?$": "$1.$2",
-    "^v9.6.0$": "main"
+    "^v9.6.0$": "main",
+    "^v(\\d+).(\\d+).\\d+(?:-(?:alpha|beta|rc)\\d+)?$": "$1.$2"
   },
   "copySourcePRLabels": "^(?!backport$)(?!v\\d).*$",
   "sourcePRLabels": [

--- a/dev-tools/unittest/test_update_backportrc.py
+++ b/dev-tools/unittest/test_update_backportrc.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
+"""Pytest tests for dev-tools/update_backportrc.py (minor-freeze backportrc update).
+
+The backport tool applies the FIRST matching ``branchLabelMapping`` entry, so the
+specific main-only override (``^v<main>$`` -> ``main``) must be emitted before the
+generic ``^vX.Y.Z$`` -> ``X.Y`` rule. Otherwise the new main version label resolves
+to a non-existent MAJOR.MINOR release branch and the backport fails.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_DEV_TOOLS = Path(__file__).resolve().parents[1]
+if str(_DEV_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_DEV_TOOLS))
+
+import update_backportrc as ubrc  # noqa: E402
+
+_GENERIC_KEY = r"^v(\d+).(\d+).\d+(?:-(?:alpha|beta|rc)\d+)?$"
+
+
+def _base_data() -> dict:
+    return {
+        "targetBranchChoices": ["main", "9.4", "9.3"],
+        "branchLabelMapping": {
+            _GENERIC_KEY: "$1.$2",
+            "^v9.5.0$": "main",
+        },
+    }
+
+
+def test_main_override_emitted_first() -> None:
+    data = _base_data()
+    changed = ubrc.update_backportrc_for_minor_freeze(
+        data, new_release_branch="9.5", main_new_version="9.6.0"
+    )
+    assert changed is True
+
+    keys = list(data["branchLabelMapping"].keys())
+    assert keys[0] == "^v9.6.0$", f"main override must be first, got {keys}"
+    assert data["branchLabelMapping"]["^v9.6.0$"] == "main"
+    # The generic rule is preserved, just after the override.
+    assert data["branchLabelMapping"][_GENERIC_KEY] == "$1.$2"
+
+
+def test_stale_main_override_removed() -> None:
+    data = _base_data()
+    ubrc.update_backportrc_for_minor_freeze(
+        data, new_release_branch="9.5", main_new_version="9.6.0"
+    )
+    # The previous main override (^v9.5.0$) must not linger.
+    assert "^v9.5.0$" not in data["branchLabelMapping"]
+    main_keys = [k for k, v in data["branchLabelMapping"].items() if v == "main"]
+    assert main_keys == ["^v9.6.0$"]
+
+
+def test_reorder_only_is_detected_as_change() -> None:
+    # Mapping already has the right content but the generic rule is first.
+    data = {
+        "targetBranchChoices": ["main", "9.5"],
+        "branchLabelMapping": {
+            _GENERIC_KEY: "$1.$2",
+            "^v9.6.0$": "main",
+        },
+    }
+    changed = ubrc.update_backportrc_for_minor_freeze(
+        data, new_release_branch="9.5", main_new_version="9.6.0"
+    )
+    assert changed is True
+    assert list(data["branchLabelMapping"].keys())[0] == "^v9.6.0$"
+
+
+def test_idempotent_when_already_ordered() -> None:
+    data = {
+        "targetBranchChoices": ["main", "9.5"],
+        "branchLabelMapping": {
+            "^v9.6.0$": "main",
+            _GENERIC_KEY: "$1.$2",
+        },
+    }
+    changed = ubrc.update_backportrc_for_minor_freeze(
+        data, new_release_branch="9.5", main_new_version="9.6.0"
+    )
+    assert changed is False
+    assert list(data["branchLabelMapping"].keys())[0] == "^v9.6.0$"
+
+
+def test_generic_rule_preserved_exactly() -> None:
+    data = _base_data()
+    ubrc.update_backportrc_for_minor_freeze(
+        data, new_release_branch="9.5", main_new_version="9.6.0"
+    )
+    assert _GENERIC_KEY in data["branchLabelMapping"]

--- a/dev-tools/unittest/test_update_backportrc.py
+++ b/dev-tools/unittest/test_update_backportrc.py
@@ -102,3 +102,22 @@ def test_generic_rule_preserved_exactly() -> None:
         data, new_release_branch="9.5", main_new_version="9.6.0"
     )
     assert _GENERIC_KEY in data["branchLabelMapping"]
+
+
+def test_misconfigured_main_key_is_corrected() -> None:
+    # Existing mapping already has the new main key but pointing at a (wrong)
+    # release branch instead of "main". The override must still win.
+    data = {
+        "targetBranchChoices": ["main", "9.5"],
+        "branchLabelMapping": {
+            _GENERIC_KEY: "$1.$2",
+            "^v9.6.0$": "9.6",
+        },
+    }
+    changed = ubrc.update_backportrc_for_minor_freeze(
+        data, new_release_branch="9.5", main_new_version="9.6.0"
+    )
+    assert changed is True
+    keys = list(data["branchLabelMapping"].keys())
+    assert keys[0] == "^v9.6.0$", f"main override must be first, got {keys}"
+    assert data["branchLabelMapping"]["^v9.6.0$"] == "main"

--- a/dev-tools/unittest/test_update_backportrc.py
+++ b/dev-tools/unittest/test_update_backportrc.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 _DEV_TOOLS = Path(__file__).resolve().parents[1]
 if str(_DEV_TOOLS) not in sys.path:
     sys.path.insert(0, str(_DEV_TOOLS))
@@ -121,3 +123,13 @@ def test_misconfigured_main_key_is_corrected() -> None:
     keys = list(data["branchLabelMapping"].keys())
     assert keys[0] == "^v9.6.0$", f"main override must be first, got {keys}"
     assert data["branchLabelMapping"]["^v9.6.0$"] == "main"
+
+
+@pytest.mark.parametrize("bad_version", ["9.6", "v9.6.0", "9", "9.6.0.1", "9.6.x", ""])
+def test_rejects_non_semver_main_new_version(bad_version: str) -> None:
+    # A value like "9.6" would produce key ^v9.6$ and silently never match a
+    # v9.6.0 label, so the main override must be rejected up front.
+    with pytest.raises(ValueError, match="MAJOR.MINOR.PATCH"):
+        ubrc.update_backportrc_for_minor_freeze(
+            _base_data(), new_release_branch="9.5", main_new_version=bad_version
+        )

--- a/dev-tools/update_backportrc.py
+++ b/dev-tools/update_backportrc.py
@@ -38,16 +38,20 @@ def update_backportrc_for_minor_freeze(
         data["targetBranchChoices"] = choices
         changed = True
 
-    mapping: dict[str, str] = dict(data.get("branchLabelMapping", {}))
+    old_mapping: dict[str, str] = dict(data.get("branchLabelMapping", {}))
     new_main_key = f"^v{main_new_version}$"
-    old_main_keys = [k for k, v in mapping.items() if v == "main" and k != new_main_key]
-    for key in old_main_keys:
-        del mapping[key]
+    # Rebuild the mapping with the main-only override FIRST. The backport tool applies
+    # the first matching branchLabelMapping key, so the specific main override (e.g.
+    # ^v9.6.0$ -> main) must precede the generic ^vX.Y.Z$ -> X.Y rule. Otherwise the
+    # main version label resolves to a non-existent MAJOR.MINOR release branch and the
+    # backport fails (see PR #3071 attempting a non-existent "9.6" branch).
+    non_main = {k: v for k, v in old_mapping.items() if v != "main"}
+    new_mapping: dict[str, str] = {new_main_key: "main"}
+    new_mapping.update(non_main)
+    # dict equality ignores order, so compare item order explicitly to catch reorders.
+    if list(new_mapping.items()) != list(old_mapping.items()):
         changed = True
-    if mapping.get(new_main_key) != "main":
-        mapping[new_main_key] = "main"
-        changed = True
-    data["branchLabelMapping"] = mapping
+    data["branchLabelMapping"] = new_mapping
 
     return changed
 

--- a/dev-tools/update_backportrc.py
+++ b/dev-tools/update_backportrc.py
@@ -45,7 +45,9 @@ def update_backportrc_for_minor_freeze(
     # ^v9.6.0$ -> main) must precede the generic ^vX.Y.Z$ -> X.Y rule. Otherwise the
     # main version label resolves to a non-existent MAJOR.MINOR release branch and the
     # backport fails (see PR #3071 attempting a non-existent "9.6" branch).
-    non_main = {k: v for k, v in old_mapping.items() if v != "main"}
+    # Exclude new_main_key so a misconfigured existing entry (e.g. ^v9.6.0$ -> "9.6")
+    # cannot overwrite the correct override below via the update() call.
+    non_main = {k: v for k, v in old_mapping.items() if v != "main" and k != new_main_key}
     new_mapping: dict[str, str] = {new_main_key: "main"}
     new_mapping.update(non_main)
     # dict equality ignores order, so compare item order explicitly to catch reorders.

--- a/dev-tools/update_backportrc.py
+++ b/dev-tools/update_backportrc.py
@@ -14,9 +14,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
+
+_MAIN_NEW_VERSION_RE = re.compile(r"\d+\.\d+\.\d+")
 
 
 def update_backportrc_for_minor_freeze(
@@ -25,7 +28,18 @@ def update_backportrc_for_minor_freeze(
     new_release_branch: str,
     main_new_version: str,
 ) -> bool:
-    """Apply minor-freeze updates in place. Returns True if anything changed."""
+    """Apply minor-freeze updates in place. Returns True if anything changed.
+
+    Raises ValueError if main_new_version is not MAJOR.MINOR.PATCH: a value like
+    "9.6" would produce the key ^v9.6$, which never matches a v9.6.0 label, so the
+    main override would silently never fire.
+    """
+    if not _MAIN_NEW_VERSION_RE.fullmatch(main_new_version):
+        raise ValueError(
+            "main_new_version must be MAJOR.MINOR.PATCH (e.g. 9.6.0), "
+            f"got {main_new_version!r}"
+        )
+
     changed = False
 
     choices: list[str] = list(data.get("targetBranchChoices", []))
@@ -67,11 +81,15 @@ def _cmd_update(args: argparse.Namespace) -> int:
     with path.open(encoding="utf-8") as handle:
         data = json.load(handle)
 
-    changed = update_backportrc_for_minor_freeze(
-        data,
-        new_release_branch=args.new_release_branch,
-        main_new_version=args.main_new_version,
-    )
+    try:
+        changed = update_backportrc_for_minor_freeze(
+            data,
+            new_release_branch=args.new_release_branch,
+            main_new_version=args.main_new_version,
+        )
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
     if not changed:
         print(f"OK: {path} already configured for branch {args.new_release_branch} and main {args.main_new_version}")
         return 0


### PR DESCRIPTION
## Summary

The backport tool (`sorenlouv/backport-github-action`) applies the **first** matching `branchLabelMapping` entry. The minor-freeze automation appended the specific main override after the generic rule, so on `main` we ended up with:

```json
"branchLabelMapping": {
  "^v(\\d+).(\\d+).\\d+(?:-(?:alpha|beta|rc)\\d+)?$": "$1.$2",
  "^v9.6.0$": "main"
}
```

The generic `^vX.Y.Z$` rule matched `v9.6.0` first and resolved it to `9.6`, a branch that does not exist. This is why merging #3071 (labeled `v9.6.0`) triggered a **failing** backport attempt to a non-existent `9.6` branch.

## Changes

- **`.backportrc.json`**: reorder so `^v9.6.0$` -> `main` precedes the generic `^vX.Y.Z$` -> `X.Y` rule.
- **`dev-tools/update_backportrc.py`**: rebuild `branchLabelMapping` with the main-only override emitted **first**, and treat a pure reorder as a change so future minor freezes produce the correct order. Stale main overrides (e.g. `^v9.5.0$`) are still removed.
- **`dev-tools/unittest/test_update_backportrc.py`**: new tests asserting the main override is emitted first, stale overrides are dropped, reorders are detected as changes, and the operation is idempotent when already correct.

## Test plan

- [x] `python3 -m pytest dev-tools/unittest/test_update_backportrc.py -q` passes
- [x] Running `update_backportrc.py` against the fixed `.backportrc.json` is idempotent (reports "already configured", no diff)
- [x] Next PR labeled `v9.6.0` should map to `main` (or be skipped where appropriate) and not attempt a `9.6` backport

### Verification (post-merge)

Confirmed on **#3075** (merged 2026-07-15, labeled `v9.6.0`, no `no-backport`, so the backport workflow actually ran). The backport action loaded the fixed `.backportrc.json` and resolved the label via `"branchLabelMappingKey": "^v9.6.0$"` to `main` — **not** `9.6`. No spurious `9.6` backport was attempted. :white_check_mark:

Residual note: because `main` is the source branch, the CLI aborts with `no-branches-exception`, which the `Check for real failures` guard escalated into a failing (but harmless) Backport check on such PRs. Fixed as a follow-up in **#3077**, which treats source-branch-only resolution as a clean pass.

## Related

- Follows up on the spurious/failing backports observed on #3068 (#3069) and #3071.
- Complements the `no-backport` guard added in #3070; this PR fixes the mapping so version-labeled PRs resolve to the correct branch.
- Follow-up: #3077 (silence the residual red check).

Made with [Cursor](https://cursor.com)
