### PR TITLE
Make minor-freeze version bump idempotent for already-completed bumps

### DIFF
--- a/dev-tools/unittest/test_version_bump_validation.py
+++ b/dev-tools/unittest/test_version_bump_validation.py
@@ -231,6 +231,56 @@ def test_minor_freeze_rejects_main_not_at_new_version() -> None:
         )
 
 
+def test_minor_freeze_idempotent_when_already_completed() -> None:
+    # Freeze already done: branch cut at NEW_VERSION and main advanced to MAIN_NEW_VERSION.
+    # Re-running the centralized bump must succeed (no-op), not fail.
+    main_new = vbu.validate_minor_freeze_params(
+        main_version="9.6.0",
+        new_version="9.5.0",
+        branch="9.5",
+        release_branch_exists=True,
+        release_branch_version="9.5.0",
+    )
+    assert main_new == "9.6.0"
+
+
+def test_minor_freeze_branch_exists_main_not_yet_bumped() -> None:
+    # Intermediate state: branch cut but main not yet bumped — still valid.
+    main_new = vbu.validate_minor_freeze_params(
+        main_version="9.5.0",
+        new_version="9.5.0",
+        branch="9.5",
+        release_branch_exists=True,
+        release_branch_version="9.5.0",
+    )
+    assert main_new == "9.6.0"
+
+
+def test_minor_freeze_rejects_main_bumped_without_branch() -> None:
+    # main advanced to MAIN_NEW_VERSION but the release branch was never cut:
+    # a genuinely inconsistent state that must still be rejected.
+    with pytest.raises(ValueError, match="main elasticsearchVersion"):
+        vbu.validate_minor_freeze_params(
+            main_version="9.6.0",
+            new_version="9.5.0",
+            branch="9.5",
+            release_branch_exists=False,
+            release_branch_version=None,
+        )
+
+
+def test_minor_freeze_rejects_unrelated_main_version_with_branch() -> None:
+    # Branch exists at NEW_VERSION but main is at neither NEW_VERSION nor MAIN_NEW_VERSION.
+    with pytest.raises(ValueError, match="main elasticsearchVersion"):
+        vbu.validate_minor_freeze_params(
+            main_version="9.7.0",
+            new_version="9.5.0",
+            branch="9.5",
+            release_branch_exists=True,
+            release_branch_version="9.5.0",
+        )
+
+
 def test_main_minor_bump_ok() -> None:
     vbu.validate_main_minor_bump(
         current_version="9.5.0",

--- a/dev-tools/version_bump_validation.py
+++ b/dev-tools/version_bump_validation.py
@@ -227,8 +227,10 @@ def validate_minor_freeze_params(
         pass
     else:
         raise ValueError(
-            "minor freeze requires main elasticsearchVersion to equal NEW_VERSION "
-            f"before branching (main={main_version!r}, NEW_VERSION={new_version!r})"
+            "minor freeze requires main elasticsearchVersion to be NEW_VERSION before branching, "
+            "or MAIN_NEW_VERSION only if the release branch already exists "
+            f"(main={main_version!r}, NEW_VERSION={new_version!r}, MAIN_NEW_VERSION={main_new_version!r}, "
+            f"release_branch_exists={release_branch_exists})"
         )
 
     return main_new_version

--- a/dev-tools/version_bump_validation.py
+++ b/dev-tools/version_bump_validation.py
@@ -201,11 +201,6 @@ def validate_minor_freeze_params(
             "elasticsearchVersion on main must be MAJOR.MINOR.PATCH, "
             f"got {main_version!r}"
         )
-    if main_version != new_version:
-        raise ValueError(
-            "minor freeze requires main elasticsearchVersion to equal NEW_VERSION "
-            f"before branching (main={main_version!r}, NEW_VERSION={new_version!r})"
-        )
 
     main_new_version = derive_main_new_version(new_version)
 
@@ -219,6 +214,22 @@ def validate_minor_freeze_params(
                 f"release branch {branch!r} exists with version {release_branch_version!r}, "
                 f"expected {new_version!r}"
             )
+
+    # main may be at NEW_VERSION (freeze not yet applied) or, when the release branch
+    # has already been cut, at MAIN_NEW_VERSION (freeze already completed). Accepting
+    # the latter keeps re-runs of the centralized version bump idempotent instead of
+    # failing after the freeze has already succeeded (see the centralized version-bump
+    # pipeline re-triggering completed bumps). If main has advanced without the branch
+    # being cut, that is a genuinely inconsistent state and is still rejected.
+    if main_version == new_version:
+        pass
+    elif main_version == main_new_version and release_branch_exists:
+        pass
+    else:
+        raise ValueError(
+            "minor freeze requires main elasticsearchVersion to equal NEW_VERSION "
+            f"before branching (main={main_version!r}, NEW_VERSION={new_version!r})"
+        )
 
     return main_new_version
 
@@ -333,6 +344,11 @@ def main() -> int:
             print(f"ERROR: {e}", file=sys.stderr)
             return 1
         print(f"OK: minor freeze NEW_VERSION={args_ns.new} on branch {args_ns.branch}")
+        if args_ns.main_version == main_new:
+            print(
+                f"OK: main already bumped to {main_new} and branch {args_ns.branch} "
+                "exists — minor freeze already completed (idempotent no-op)."
+            )
         if is_sandbox_release_branch(args_ns.branch):
             identity = release_branch_identity(args_ns.branch)
             print(


### PR DESCRIPTION
## Summary

When the Centralized Version Bump pipeline re-triggered the `9.5.0` minor bump (to unblock another service) ml-cpp's `ml-cpp-version-bump` [build #59](https://buildkite.com/elastic/ml-cpp-version-bump/builds/59/canvas) failed because the bump had **already completed**. Release engineering asked that the version-bump logic be idempotent: it should not fail if the minor branch has already been cut and `main` has already been bumped to the next expected version.

**Root cause (Leg A):** `validate_minor_freeze_params` (used by `create_minor_branch.sh`) hard-required `main == NEW_VERSION`. After a completed freeze, `main` is at `MAIN_NEW_VERSION` (e.g. `9.6.0`) while `NEW_VERSION` is still `9.5.0`, so validation raised and the step failed. Leg B (`validate_main_minor_bump`) was already idempotent (no-ops when `current == MAIN_NEW_VERSION`).

## Changes

- **`dev-tools/version_bump_validation.py`**: `validate_minor_freeze_params` now accepts `main` being at either:
  - `NEW_VERSION` — freeze not yet applied (normal pre-freeze), or
  - the derived `MAIN_NEW_VERSION` — freeze already completed, **only when the release branch already exists** (idempotent re-run).

  `main` advancing to `MAIN_NEW_VERSION` *without* the release branch being cut is still rejected as a genuinely inconsistent state. The validator also logs a clear "minor freeze already completed (idempotent no-op)" line for the Buildkite log.
- **`dev-tools/unittest/test_version_bump_validation.py`**: added regression tests for the completed-freeze re-run, the branch-cut-but-main-not-yet-bumped intermediate state, and the two states that must still be rejected.

## Effect on the pipeline

With this fix, a re-run after a completed freeze no-ops cleanly:

- Leg A: `create_minor_branch.sh` validates OK, sees the branch already exists, sets `ml_cpp_minor_branch_needed=false`, and exits 0.
- Leg B: `bump_main_minor_freeze.sh` validates OK (no-op), finds no `gradle.properties`/`.backportrc.json` diff, prints "nothing to do", sets `ml_cpp_main_bump_needed=false`, and exits 0.

## Test plan

- [x] `python3 -m pytest dev-tools/unittest/test_version_bump_validation.py -q` passes (26 passed, 2 git-integration skipped)
- [x] CLI check: `validate-minor-freeze --main-version 9.6.0 --new 9.5.0 --branch 9.5 --release-branch-exists --release-branch-version 9.5.0` returns 0
- [x] CLI check: `validate-main-minor-bump --current 9.6.0 --main-new-version 9.6.0 --release-branch-version 9.5.0` returns 0
- [ ] Optional: dry-run re-trigger of `ml-cpp-version-bump` against the completed `9.5.0` freeze confirms both legs no-op

## Related

- Follows the same minor-freeze automation touched by #3064, #3070, #3072.

Made with [Cursor](https://cursor.com)