### PR TITLE
Harden extract_model_ops: default trust_remote_code=False (CVE-2026-5241)

### DIFF
--- a/dev-tools/extract_model_ops/README.md
+++ b/dev-tools/extract_model_ops/README.md
@@ -116,6 +116,25 @@ Each file maps a short architecture name to a HuggingFace model identifier:
 }
 ```
 
+An entry may instead be an object with `model_id` plus optional fields:
+`quantized`, `auto_class`, `config_overrides`, and `trust_remote_code`.
+
+```json
+{
+    "jina-embeddings-v5-text-nano": {
+        "model_id": "jinaai/jina-embeddings-v5-text-nano",
+        "trust_remote_code": true
+    }
+}
+```
+
+`trust_remote_code` defaults to `false` so an untrusted or compromised model
+repo cannot execute arbitrary Python on the build machine during load (see
+CVE-2026-5241, where a nested config could override the caller's setting).
+Enable it only for a vetted model that genuinely ships custom modeling code
+(e.g. the Jina v5 embeddings model above). The bundled reference/validation
+models are otherwise native architectures that load without remote code.
+
 To add a new architecture, append an entry to `reference_models.json`,
 re-run `extract_model_ops.py --cpp`, and update `CSupportedOperations.cc`.
 Then add the same entry (plus any task-specific variants) to

--- a/dev-tools/extract_model_ops/extract_model_ops.py
+++ b/dev-tools/extract_model_ops/extract_model_ops.py
@@ -49,7 +49,8 @@ DEFAULT_CONFIG = SCRIPT_DIR / "reference_models.json"
 def extract_ops_for_model(model_name: str,
                           quantize: bool = False,
                           auto_class: str | None = None,
-                          config_overrides: dict | None = None) -> Optional[set[str]]:
+                          config_overrides: dict | None = None,
+                          trust_remote_code: bool = False) -> Optional[set[str]]:
     """Trace a HuggingFace model and return its TorchScript op set.
 
     Returns None if the model could not be loaded or traced.
@@ -58,7 +59,8 @@ def extract_ops_for_model(model_name: str,
     print(f"  Loading {label}...", file=sys.stderr)
     traced = load_and_trace_hf_model(model_name, quantize=quantize,
                                      auto_class=auto_class,
-                                     config_overrides=config_overrides)
+                                     config_overrides=config_overrides,
+                                     trust_remote_code=trust_remote_code)
     if traced is None:
         return None
     return collect_inlined_ops(traced)
@@ -99,7 +101,8 @@ def main():
         ops = extract_ops_for_model(spec["model_id"],
                                     quantize=spec["quantized"],
                                     auto_class=spec["auto_class"],
-                                    config_overrides=spec["config_overrides"])
+                                    config_overrides=spec["config_overrides"],
+                                    trust_remote_code=spec["trust_remote_code"])
         if ops is None:
             failed.append(arch)
             print(f"  {arch}: FAILED", file=sys.stderr)

--- a/dev-tools/extract_model_ops/reference_models.json
+++ b/dev-tools/extract_model_ops/reference_models.json
@@ -30,7 +30,8 @@
     "elastic-eis-elser-v2-quantized": {"model_id": "elastic/eis-elser-v2", "quantized": true},
     "elastic-test-elser-v2-quantized": {"model_id": "elastic/test-elser-v2", "quantized": true},
 
-    "jina-embeddings-v5-text-nano": "jinaai/jina-embeddings-v5-text-nano",
+    "_comment:trust-remote-code": "trust_remote_code defaults to false for safety (see CVE-2026-5241). Enable it only for vetted models that ship custom modeling code; jina-embeddings-v5 is one such model.",
+    "jina-embeddings-v5-text-nano": {"model_id": "jinaai/jina-embeddings-v5-text-nano", "trust_remote_code": true},
 
     "_comment:qa-models": "Models from the Appex QA pytorch_tests suite. BART models require auto_class and config_overrides to trace correctly.",
     "qa-tinyroberta-squad2": {"model_id": "deepset/tinyroberta-squad2", "auto_class": "AutoModelForQuestionAnswering"},

--- a/dev-tools/extract_model_ops/requirements.txt
+++ b/dev-tools/extract_model_ops/requirements.txt
@@ -1,4 +1,10 @@
 torch==2.7.1
+# Pinned to the 4.x line on purpose: transformers 5.0 removed TorchScript
+# support (the torchscript=True config + torch.jit tracing this tool relies on).
+# CVE-2026-5241 (RCE via the LightGlue loading path) is not reachable here -- the
+# configured models are curated NLP encoders, never LightGlue, and this is a
+# dev/CI-only tool. We additionally default trust_remote_code=False (see
+# torchscript_utils.load_and_trace_hf_model) to neutralise that class of issue.
 transformers>=4.40.0,<5.0.0
 sentencepiece>=0.2.0
 protobuf>=5.0.0

--- a/dev-tools/extract_model_ops/torchscript_utils.py
+++ b/dev-tools/extract_model_ops/torchscript_utils.py
@@ -57,12 +57,21 @@ def load_model_config(config_path: Path) -> dict[str, dict]:
                 raise ValueError(
                     f"Config entry {key!r} is a dict but missing required "
                     f"'model_id' key: {value!r}")
+            trust_remote_code = value.get("trust_remote_code", False)
+            # Validate strictly: this flag gates remote code execution, so a
+            # non-bool (e.g. the string "false", which is truthy) must never be
+            # silently coerced into enabling it.
+            if not isinstance(trust_remote_code, bool):
+                raise ValueError(
+                    f"Config entry {key!r} has non-boolean 'trust_remote_code' "
+                    f"{trust_remote_code!r} ({type(trust_remote_code).__name__}); "
+                    f"expected true or false.")
             models[key] = {
                 "model_id": value["model_id"],
                 "quantized": value.get("quantized", False),
                 "auto_class": value.get("auto_class"),
                 "config_overrides": value.get("config_overrides", {}),
-                "trust_remote_code": value.get("trust_remote_code", False),
+                "trust_remote_code": trust_remote_code,
             }
         else:
             raise ValueError(

--- a/dev-tools/extract_model_ops/torchscript_utils.py
+++ b/dev-tools/extract_model_ops/torchscript_utils.py
@@ -31,6 +31,10 @@ def load_model_config(config_path: Path) -> dict[str, dict]:
       of ``AutoModel`` (e.g. ``"AutoModelForSequenceClassification"``).
     - ``config_overrides`` (dict) — extra kwargs passed to
       ``AutoConfig.from_pretrained`` (e.g. ``{"use_cache": false}``).
+    - ``trust_remote_code`` (bool, default False) — allow the model repo to
+      execute custom Python during load. Off by default so an untrusted repo
+      cannot run arbitrary code (see CVE-2026-5241); enable it only for a
+      vetted model that genuinely ships a custom architecture.
 
     Keys starting with ``_comment`` are silently skipped.
 
@@ -46,7 +50,8 @@ def load_model_config(config_path: Path) -> dict[str, dict]:
             continue
         if isinstance(value, str):
             models[key] = {"model_id": value, "quantized": False,
-                           "auto_class": None, "config_overrides": {}}
+                           "auto_class": None, "config_overrides": {},
+                           "trust_remote_code": False}
         elif isinstance(value, dict):
             if "model_id" not in value:
                 raise ValueError(
@@ -57,6 +62,7 @@ def load_model_config(config_path: Path) -> dict[str, dict]:
                 "quantized": value.get("quantized", False),
                 "auto_class": value.get("auto_class"),
                 "config_overrides": value.get("config_overrides", {}),
+                "trust_remote_code": value.get("trust_remote_code", False),
             }
         else:
             raise ValueError(
@@ -96,7 +102,8 @@ def _resolve_auto_class(class_name: str | None):
 
 def load_and_trace_hf_model(model_name: str, quantize: bool = False,
                             auto_class: str | None = None,
-                            config_overrides: dict | None = None):
+                            config_overrides: dict | None = None,
+                            trust_remote_code: bool = False):
     """Load a HuggingFace model, tokenize sample input, and trace to TorchScript.
 
     When *quantize* is True the model is dynamically quantized (nn.Linear
@@ -109,6 +116,12 @@ def load_and_trace_hf_model(model_name: str, quantize: bool = False,
     *config_overrides* supplies extra kwargs to ``AutoConfig.from_pretrained``
     (e.g. ``{"use_cache": False}`` for encoder-decoder models like BART).
 
+    *trust_remote_code* allows the model repo to execute custom Python during
+    load. It defaults to False so that an untrusted/compromised repo cannot run
+    arbitrary code on the build machine (see CVE-2026-5241, where a nested
+    config could override the caller's setting). Enable it per-model only for a
+    vetted architecture that genuinely ships custom modeling code.
+
     Returns the traced module, or None if the model could not be loaded or traced.
     """
     token = os.environ.get("HF_TOKEN") or None
@@ -117,13 +130,13 @@ def load_and_trace_hf_model(model_name: str, quantize: bool = False,
 
     try:
         tokenizer = AutoTokenizer.from_pretrained(
-            model_name, token=token, trust_remote_code=True)
+            model_name, token=token, trust_remote_code=trust_remote_code)
         config = AutoConfig.from_pretrained(
             model_name, torchscript=True, token=token,
-            trust_remote_code=True, **overrides)
+            trust_remote_code=trust_remote_code, **overrides)
         model = model_cls.from_pretrained(
             model_name, config=config, token=token,
-            trust_remote_code=True)
+            trust_remote_code=trust_remote_code)
         model.eval()
     except Exception as exc:
         print(f"    LOAD ERROR: {exc}", file=sys.stderr)

--- a/dev-tools/extract_model_ops/validate_allowlist.py
+++ b/dev-tools/extract_model_ops/validate_allowlist.py
@@ -123,6 +123,7 @@ def validate_model(model_name: str,
                    quantize: bool = False,
                    auto_class: str | None = None,
                    config_overrides: dict | None = None,
+                   trust_remote_code: bool = False,
                    timeout: int = MODEL_TIMEOUT_SECONDS) -> str:
     """Validate one HuggingFace model.
 
@@ -139,7 +140,8 @@ def validate_model(model_name: str,
     try:
         traced = load_and_trace_hf_model(model_name, quantize=quantize,
                                          auto_class=auto_class,
-                                         config_overrides=config_overrides)
+                                         config_overrides=config_overrides,
+                                         trust_remote_code=trust_remote_code)
     except ModelTimeoutError:
         print(f"    SKIPPED (timed out after {timeout}s)", file=sys.stderr)
         return "skip"
@@ -212,6 +214,7 @@ def main():
             quantize=spec["quantized"],
             auto_class=spec.get("auto_class"),
             config_overrides=spec.get("config_overrides"),
+            trust_remote_code=spec.get("trust_remote_code", False),
             timeout=args.model_timeout)
 
     if args.pt_dir and args.pt_dir.is_dir():

--- a/dev-tools/extract_model_ops/validation_models.json
+++ b/dev-tools/extract_model_ops/validation_models.json
@@ -31,7 +31,8 @@
     "es-cross-encoder-ms-marco": "cross-encoder/ms-marco-MiniLM-L-6-v2",
     "es-dpr-question-encoder": "facebook/dpr-question_encoder-single-nq-base",
 
-    "jina-embeddings-v5-text-nano": "jinaai/jina-embeddings-v5-text-nano",
+    "_comment:trust-remote-code": "trust_remote_code defaults to false for safety (see CVE-2026-5241). Enable it only for vetted models that ship custom modeling code; jina-embeddings-v5 is one such model.",
+    "jina-embeddings-v5-text-nano": {"model_id": "jinaai/jina-embeddings-v5-text-nano", "trust_remote_code": true},
 
     "_comment:qa-models": "Models from the Appex QA pytorch_tests suite. BART models require auto_class and config_overrides to trace correctly.",
     "qa-tinyroberta-squad2": {"model_id": "deepset/tinyroberta-squad2", "auto_class": "AutoModelForQuestionAnswering"},

--- a/dev-tools/unittest/test_extract_model_ops_config.py
+++ b/dev-tools/unittest/test_extract_model_ops_config.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the following additional limitation. Functionality enabled by the
+# files subject to the Elastic License 2.0 may only be used in production when
+# invoked by an Elasticsearch process with a license key installed that permits
+# use of machine learning features. You may not use this file except in
+# compliance with the Elastic License 2.0 and the foregoing additional
+# limitation.
+
+"""Tests for dev-tools/extract_model_ops config parsing (trust_remote_code).
+
+The extract_model_ops tool defaults ``trust_remote_code`` to False so an
+untrusted model repo cannot run arbitrary code during load (CVE-2026-5241);
+it must be opt-in per model. ``torchscript_utils`` imports torch/transformers
+at module load, so these tests are skipped where those deps are absent (e.g.
+the lean dev-tools CI unittest env); they run in the extract_model_ops venv.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch", reason="extract_model_ops requires torch")
+pytest.importorskip("transformers", reason="extract_model_ops requires transformers")
+
+_EXTRACT_DIR = Path(__file__).resolve().parents[1] / "extract_model_ops"
+if str(_EXTRACT_DIR) not in sys.path:
+    sys.path.insert(0, str(_EXTRACT_DIR))
+
+import torchscript_utils as tsu  # noqa: E402
+
+
+def _write(tmp_path: Path, data: dict) -> Path:
+    p = tmp_path / "models.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    return p
+
+
+def test_string_entry_defaults_trust_remote_code_false(tmp_path: Path) -> None:
+    cfg = _write(tmp_path, {"bert": "bert-base-uncased"})
+    models = tsu.load_model_config(cfg)
+    assert models["bert"]["trust_remote_code"] is False
+
+
+def test_dict_entry_defaults_trust_remote_code_false(tmp_path: Path) -> None:
+    cfg = _write(tmp_path, {"m": {"model_id": "foo/bar", "quantized": True}})
+    models = tsu.load_model_config(cfg)
+    assert models["m"]["trust_remote_code"] is False
+
+
+def test_dict_entry_opt_in_trust_remote_code(tmp_path: Path) -> None:
+    cfg = _write(tmp_path, {"jina": {"model_id": "jinaai/x", "trust_remote_code": True}})
+    models = tsu.load_model_config(cfg)
+    assert models["jina"]["trust_remote_code"] is True
+
+
+def test_bundled_configs_only_trust_vetted_models() -> None:
+    # The real configs must not silently trust arbitrary repos: only models
+    # explicitly known to ship custom code may opt in.
+    allowed_trusted = {"jina-embeddings-v5-text-nano"}
+    for name in ("reference_models.json", "validation_models.json"):
+        models = tsu.load_model_config(_EXTRACT_DIR / name)
+        trusted = {k for k, v in models.items() if v["trust_remote_code"]}
+        assert trusted <= allowed_trusted, f"{name} trusts unexpected models: {trusted - allowed_trusted}"

--- a/dev-tools/unittest/test_extract_model_ops_config.py
+++ b/dev-tools/unittest/test_extract_model_ops_config.py
@@ -59,6 +59,15 @@ def test_dict_entry_opt_in_trust_remote_code(tmp_path: Path) -> None:
     assert models["jina"]["trust_remote_code"] is True
 
 
+@pytest.mark.parametrize("bad_value", ["false", "true", 1, 0, None, ["true"]])
+def test_non_bool_trust_remote_code_is_rejected(tmp_path: Path, bad_value) -> None:
+    # A non-bool must never be silently coerced into enabling remote code:
+    # e.g. the string "false" is truthy and would otherwise turn it on.
+    cfg = _write(tmp_path, {"m": {"model_id": "foo/bar", "trust_remote_code": bad_value}})
+    with pytest.raises(ValueError, match="trust_remote_code"):
+        tsu.load_model_config(cfg)
+
+
 def test_bundled_configs_only_trust_vetted_models() -> None:
     # The real configs must not silently trust arbitrary repos: only models
     # explicitly known to ship custom code may opt in.


### PR DESCRIPTION
## Summary

Addresses Dependabot alert [#12](https://github.com/elastic/ml-cpp/security/dependabot/12) — **CVE-2026-5241 / GHSA-fgcw-684q-jj6r** (High): RCE via the transformers **LightGlue** loading path, where a model repo's nested `config.json` can override the caller's `trust_remote_code` and execute arbitrary code. Patched upstream in `transformers` **5.5.0**.

We **cannot** simply bump `transformers` to `>=5.5.0`: transformers **5.0 removed TorchScript support** (the `torchscript=True` config + `torch.jit` tracing) that `extract_model_ops`/`validate_allowlist` depend on to build the TorchScript op allowlist for `bin/pytorch_inference`. A version bump would break the tool and its CMake/CI validation target.

Instead we **harden the actual attack vector**, which is a better fit here:

- The vulnerable code path is **not reachable**: this is a dev/CI-only tool that only loads a curated set of NLP encoder models (BERT, RoBERTa, ELSER, e5, BART-MNLI, …) — never LightGlue — and it is not part of any shipped ml-cpp artifact.
- The loader nonetheless passed `trust_remote_code=True` **unconditionally**, which is exactly the mechanism CVE-2026-5241 abuses and is unnecessary for these native architectures.

## Changes

- **`torchscript_utils.py`**: add a per-model `trust_remote_code` option (**default `False`**) and thread it through `load_and_trace_hf_model`; all three `from_pretrained` calls now honour it. Loads are safe-by-default.
- **`extract_model_ops.py` / `validate_allowlist.py`**: pass the per-model flag through.
- **`reference_models.json` / `validation_models.json`**: opt `trust_remote_code: true` **only** for `jina-embeddings-v5-text-nano`, which genuinely ships custom modeling code (verified: it requires `trust_remote_code=True`). Every other model loads natively with it off.
- **`requirements.txt`**: document why we stay on `transformers` 4.x and why the CVE is not reachable here.
- **`README.md`**: document the new field + the safe-by-default rationale.
- **`dev-tools/unittest/test_extract_model_ops_config.py`**: new tests for the default/opt-in behaviour, incl. a guard that the bundled configs only ever trust vetted models. Skipped where `torch`/`transformers` are absent (lean CI unittest env); run in the tool's venv.

## Test plan

- [x] `python3 -m pytest dev-tools/unittest/ -q` → 68 passed, 2 skipped (git-integration); new config tests pass locally with torch 2.7.1 / transformers 4.48.0
- [x] `load_model_config` on both real configs: `trust_remote_code` is `False` everywhere except `jina-embeddings-v5-text-nano`
- [x] `py_compile` of all three modified scripts
- [x] Full `validate_pytorch_inference_models` run in the venv (loads models over the network) to confirm native models still trace with the flag off — **30 passed, 0 failed, 5 skipped**; every loadable model traces with `trust_remote_code=False`. Skips are environment-only: 4 private/gated models need `HF_TOKEN`, and `jina-embeddings-v5-text-nano` (the sole `trust_remote_code: true` model) needs the optional `peft` package to finish tracing (its remote-code path did activate).

## Recommendation on the alert

Suggest **dismissing Dependabot #12** as *not exploitable / risk tolerated* once this merges: the fix version drops TorchScript support the tool needs, the CVE path is unreachable (curated NLP models, dev-only tool), and this PR removes the underlying `trust_remote_code` exposure. Upgrading to transformers 5.x (re-engineering op extraction off TorchScript, min Python 3.10) can be tracked separately if we later want to stay current.

Made with [Cursor](https://cursor.com)
