### PR TITLE
Treat source-branch-only backport resolution as a clean pass

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -52,7 +52,9 @@ jobs:
         run: cat ~/.backport/backport.info.log
 
       # When version labels were detected we always run the Backport Action. If it fails with
-      # no-branches-exception, backport PRs were not created — fail CI so this is not silent.
+      # no-branches-exception, backport PRs were not created — fail CI so this is not silent,
+      # UNLESS the label resolved only to the source branch (current-version label, e.g.
+      # v9.6.0 -> main), which legitimately has nothing to backport (see step logic).
       - name: Check for real failures
         if: steps.backport.outcome == 'failure'
         env:
@@ -67,6 +69,18 @@ jobs:
 
           if grep -q '"code":"no-branches-exception"' ~/.backport/backport.debug.log 2>/dev/null; then
             if [ "${HAS_VERSION_LABEL}" = "true" ]; then
+              # A version label for the current main version (e.g. v9.6.0 -> main via
+              # branchLabelMapping) resolves only to the source branch, so there is
+              # legitimately nothing to backport. The CLI still raises
+              # no-branches-exception in that case; treat it as success, but ONLY when
+              # every resolved target is the source branch (isSourceBranch:true and no
+              # isSourceBranch:false). A genuine misconfiguration (label mapped to a
+              # real, different, or missing branch) still fails loudly below.
+              if grep -Ehq '"isSourceBranch":[[:space:]]*true' ~/.backport/backport.info.log ~/.backport/backport.debug.log 2>/dev/null \
+                 && ! grep -Ehq '"isSourceBranch":[[:space:]]*false' ~/.backport/backport.info.log ~/.backport/backport.debug.log 2>/dev/null; then
+                echo "Version label resolved only to the source branch — nothing to backport (expected for current-version labels)."
+                exit 0
+              fi
               echo "::error::Backport CLI reported no-branches-exception while this PR had version labels. No backport PRs were opened — check branchLabelMapping / targetBranchChoices in .backportrc.json, review logs above, or open backports manually."
               exit 1
             fi

--- a/dev-tools/unittest/test_backport_workflow.py
+++ b/dev-tools/unittest/test_backport_workflow.py
@@ -75,3 +75,11 @@ def test_backport_workflow_treats_source_branch_only_as_success() -> None:
     assert error_idx != -1 and exempt_idx < error_idx, (
         "source-branch exemption must be evaluated before the hard-failure error"
     )
+    # The exemption block itself must exit successfully — otherwise the message
+    # could remain while the step still fails. Scope the check to the text between
+    # the exemption message and the hard-failure error.
+    exemption_block = text[exempt_idx:error_idx]
+    assert re.search(r"\bexit\s+0\b", exemption_block), exemption_block
+    assert not re.search(r"\bexit\s+1\b", exemption_block), (
+        "exemption block must not fail the step"
+    )

--- a/dev-tools/unittest/test_backport_workflow.py
+++ b/dev-tools/unittest/test_backport_workflow.py
@@ -52,3 +52,26 @@ def test_bump_main_minor_freeze_applies_no_backport_label() -> None:
     # Tolerate quote style and surrounding whitespace on the --label argument.
     pattern = re.compile(r"--label\s+['\"]no-backport['\"]")
     assert pattern.search(text), text
+
+
+def test_backport_workflow_treats_source_branch_only_as_success() -> None:
+    """A current-version label (e.g. v9.6.0 -> main) resolves only to the source
+    branch, so the no-branches-exception it produces must be treated as success
+    rather than a failing Backport check.
+    """
+    text = _BACKPORT_WORKFLOW.read_text(encoding="utf-8")
+    # The exemption keys off isSourceBranch being exclusively true: it must inspect
+    # both the true and false variants (the latter negated) so a real, different
+    # target branch is not silently exempted.
+    assert re.search(r'"isSourceBranch":\[\[:space:\]\]\*true', text), text
+    assert re.search(r'"isSourceBranch":\[\[:space:\]\]\*false', text), text
+    # A negated grep (! grep ...) guards the false variant.
+    assert re.search(r'!\s*grep[^\n]*isSourceBranch[^\n]*false', text), text
+    # The exemption must appear before the version-label hard-failure error, and
+    # exit 0 rather than exit 1.
+    exempt_idx = text.find("resolved only to the source branch")
+    error_idx = text.find("no-branches-exception while this PR had version labels")
+    assert exempt_idx != -1, text
+    assert error_idx != -1 and exempt_idx < error_idx, (
+        "source-branch exemption must be evaluated before the hard-failure error"
+    )


### PR DESCRIPTION
## Summary

Follow-up to #3072. That PR fixed `branchLabelMapping` precedence so a `v9.6.0` label resolves to `main` instead of a non-existent `9.6`. Verified working on #3075 (labeled `v9.6.0`, no `no-backport`): the label correctly mapped to `main` via `^v9.6.0$`, and **no** `9.6` backport was attempted.

However, because the resolved target (`main`) **is** the source branch, the backport CLI aborts with `no-branches-exception`, and the `Check for real failures` step escalates that (version label present) into a **failing Backport check**. So every ordinary `v9.6.0` PR on `main` that lacks `no-backport` now shows a red post-merge Backport check even though nothing needed backporting (see the run for #3075: https://github.com/elastic/ml-cpp/actions/runs/29386549942).

## Changes

- **`.github/workflows/backport.yml`**: in `Check for real failures`, treat `no-branches-exception` as **success** when every resolved target is the source branch (`isSourceBranch:true` present, `isSourceBranch:false` absent) — i.e. a current-version label with legitimately nothing to backport. Genuine misconfigurations (label mapped to a real/different/missing branch) still fail loudly.
- **`dev-tools/unittest/test_backport_workflow.py`**: add a guard-rail test asserting the exemption exists, inspects both `isSourceBranch` variants, and is evaluated before the hard-failure error.

## Test plan

- [x] `python3 -m pytest dev-tools/unittest/test_backport_workflow.py -v` (4 passed)
- [x] `backport.yml` parses as valid YAML
- [ ] After merge: a `v9.6.0` PR without `no-backport` (like #3075) shows the Backport check **green** ("resolved only to the source branch — nothing to backport")
- [ ] A PR whose version label maps to a real target branch still backports (or fails loudly if misconfigured)

## Related

- Follows #3072 (mapping precedence) and #3070 (`no-backport` guard).

Made with [Cursor](https://cursor.com)