### PR TITLE
Mark ML controller non-dumpable before accepting commands

### DIFF
--- a/bin/controller/Main.cc
+++ b/bin/controller/Main.cc
@@ -81,8 +81,14 @@ bool makeProcessNonDumpable() {
         return false;
     }
     // Confirm the attribute stuck — a silent no-op would leave the process exposed.
-    if (::prctl(PR_GET_DUMPABLE) != 0) {
-        LOG_ERROR(<< "process remains dumpable after PR_SET_DUMPABLE(0)");
+    const int dumpable{::prctl(PR_GET_DUMPABLE)};
+    if (dumpable == -1) {
+        LOG_ERROR(<< "prctl PR_GET_DUMPABLE failed: " << std::strerror(errno));
+        return false;
+    }
+    if (dumpable != 0) {
+        LOG_ERROR(<< "process remains dumpable (" << dumpable
+                  << ") after PR_SET_DUMPABLE(0)");
         return false;
     }
     return true;

--- a/bin/controller/Main.cc
+++ b/bin/controller/Main.cc
@@ -87,8 +87,7 @@ bool makeProcessNonDumpable() {
         return false;
     }
     if (dumpable != 0) {
-        LOG_ERROR(<< "process remains dumpable (" << dumpable
-                  << ") after PR_SET_DUMPABLE(0)");
+        LOG_ERROR(<< "process remains dumpable (" << dumpable << ") after PR_SET_DUMPABLE(0)");
         return false;
     }
     return true;

--- a/bin/controller/Main.cc
+++ b/bin/controller/Main.cc
@@ -63,6 +63,36 @@
 #include <iostream>
 #include <string>
 
+#ifdef Linux
+#include <sys/prctl.h>
+#endif
+
+namespace {
+
+//! Prevent same-UID peers (e.g. a compromised pytorch_inference / JVM Attach
+//! agent in the shared pod) from writing this process's memory via
+//! /proc/<pid>/mem.  That path was used to overwrite access@GOT and turn a
+//! controller spawn into dlopen (elastic/security#12621).  Fail closed: if we
+//! cannot establish the boundary, refuse to accept commands.
+bool makeProcessNonDumpable() {
+#ifdef Linux
+    if (::prctl(PR_SET_DUMPABLE, 0) != 0) {
+        LOG_ERROR(<< "prctl PR_SET_DUMPABLE(0) failed: " << std::strerror(errno));
+        return false;
+    }
+    // Confirm the attribute stuck — a silent no-op would leave the process exposed.
+    if (::prctl(PR_GET_DUMPABLE) != 0) {
+        LOG_ERROR(<< "process remains dumpable after PR_SET_DUMPABLE(0)");
+        return false;
+    }
+    return true;
+#else
+    // /proc/<pid>/mem same-UID writes are a Linux concern; no equivalent gate here.
+    return true;
+#endif
+}
+}
+
 int main(int argc, char** argv) {
     const std::string& defaultNamedPipePath{ml::core::CNamedPipeFactory::defaultPath()};
     const std::string& progName{ml::core::CProgName::progName()};
@@ -121,6 +151,13 @@ int main(int argc, char** argv) {
     // must be done from the program, and NOT a shared library, as each program
     // statically links its own version library.
     LOG_INFO(<< ml::ver::CBuildInfo::fullInfo());
+
+    // Harden against same-UID /proc/<pid>/mem writes before accepting commands.
+    if (makeProcessNonDumpable() == false) {
+        LOG_FATAL(<< "Could not mark ML controller non-dumpable");
+        cancellerThread.stop();
+        return EXIT_FAILURE;
+    }
 
     // Unlike other programs we DON'T reduce the process priority here, because
     // the controller is critical to the overall system.  Also its resource

--- a/bin/controller/Main.cc
+++ b/bin/controller/Main.cc
@@ -71,9 +71,9 @@ namespace {
 
 //! Prevent same-UID peers (e.g. a compromised pytorch_inference / JVM Attach
 //! agent in the shared pod) from writing this process's memory via
-//! /proc/<pid>/mem.  That path was used to overwrite access@GOT and turn a
-//! controller spawn into dlopen (elastic/security#12621).  Fail closed: if we
-//! cannot establish the boundary, refuse to accept commands.
+//! /proc/<pid>/mem.  That path could be used to overwrite access@GOT and turn a
+//! controller spawn into dlopen (privately reported security finding).  Fail
+//! closed: if we cannot establish the boundary, refuse to accept commands.
 bool makeProcessNonDumpable() {
 #ifdef Linux
     if (::prctl(PR_SET_DUMPABLE, 0) != 0) {

--- a/docs/changelog/3081.yaml
+++ b/docs/changelog/3081.yaml
@@ -1,0 +1,5 @@
+area: Machine Learning
+issues: []
+pr: 3081
+summary: Mark ML controller non-dumpable before accepting commands
+type: bug


### PR DESCRIPTION
## Summary

Follow-up to a privately reported security finding (details tracked internally): the ML controller shared UID `1000` with the JVM / `pytorch_inference` and remained dumpable, so a compromised peer could write `/proc/<controller-pid>/mem`, overwrite `access@GOT`, and turn `access(path, X_OK)` into `dlopen(path, RTLD_LAZY)` (`X_OK == RTLD_LAZY == 1`) when handling a spawn command — loading attacker code under the controller's laxer RuntimeDefault-only seccomp.

## Fix

After logging is reconfigured and **before** opening command/output pipes (i.e. before accepting commands):

1. `prctl(PR_SET_DUMPABLE, 0)`
2. Confirm with `prctl(PR_GET_DUMPABLE) == 0`
3. **Fail closed** (`LOG_FATAL` + `EXIT_FAILURE`) if either step fails

No-op on non-Linux platforms (`/proc/<pid>/mem` same-UID writes are the Linux concern).

## Test plan

- [x] Linux CI: controller still starts and processes commands normally.
- [x] On Linux: after start, `/proc/<controller-pid>/status` shows `Dumpable: 0` (or equivalent).
- [x] Confirm fail-closed path if `PR_SET_DUMPABLE` cannot be applied (manual / mocked).

Related: #3078 (`__setstate__` pre-load), #3080 (seccomp arch/ABI check).