### PR TITLE
[ML] Downgrade redundant CStateDecompressor empty-state log to INFO

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -38,7 +38,6 @@
 
 * Harden pytorch_inference with TorchScript model graph validation. (See {ml-pull}3008[#3008].)
 * Better handling of invalid JSON state documents (See {ml-pull}[]#2895].)
-* Downgrade redundant "Failed to find valid JSON" log in `CStateDecompressor` from ERROR to INFO for empty or missing state documents (See {ml-issue}2875[#2875].)
 * Better error handling regarding quantiles state documents (See {ml-pull}[#2894])
 
 == {es} version 9.3.0

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -38,6 +38,7 @@
 
 * Harden pytorch_inference with TorchScript model graph validation. (See {ml-pull}3008[#3008].)
 * Better handling of invalid JSON state documents (See {ml-pull}[]#2895].)
+* Downgrade redundant "Failed to find valid JSON" log in `CStateDecompressor` from ERROR to INFO for empty or missing state documents (See {ml-issue}2875[#2875].)
 * Better error handling regarding quantiles state documents (See {ml-pull}[#2894])
 
 == {es} version 9.3.0

--- a/lib/core/CStateDecompressor.cc
+++ b/lib/core/CStateDecompressor.cc
@@ -149,7 +149,7 @@ bool CStateDecompressor::CDechunkFilter::parseNext() {
 
 bool CStateDecompressor::CDechunkFilter::readHeader() {
     if (this->parseNext() == false) {
-        LOG_ERROR(<< "Failed to find valid JSON");
+        LOG_INFO(<< "No valid JSON found in compressed state stream (empty or missing state document)");
         m_Initialised = false;
         m_IStream.reset();
         ++m_CurrentDocNum;


### PR DESCRIPTION
## Summary

Downgrade the redundant `LOG_ERROR("Failed to find valid JSON")` in `CStateDecompressor::readHeader()` to `LOG_INFO` with a clearer message for empty or missing compressed state documents. PR #2895 fixed the fatal categorizer-restore cascade but left this line at ERROR; it fires routinely when no categorizer state exists yet and was tripping the serverless log error-rate promotion gate. Genuine corruption remains ERROR-logged in `parseNext()`.

Relates #2875