### PR TITLE
[ML] Bump version to 9.3.9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.daemon=false
 
-elasticsearchVersion=9.3.8
+elasticsearchVersion=9.3.9
 
 artifactName=ml-cpp
 


### PR DESCRIPTION
Automated patch version bump for branch `9.3`.

| | |
| --- | --- |
| **elasticsearchVersion** | `9.3.8` → `9.3.9` |

Unblocks Buildkite `ml-cpp-version-bump` after PR create failed with `ERROR: unknown argument: --label` (helpers from older release-branch tip). Topic branch was already pushed by CI; this opens the missing PR. Root-cause fix: #3083.


Made with [Cursor](https://cursor.com)