### PR TITLE
[ML] Bump version to 8.19.20

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.daemon=false
 
-elasticsearchVersion=8.19.19
+elasticsearchVersion=8.19.20
 
 artifactName=ml-cpp
 


### PR DESCRIPTION
Automated patch version bump for branch `8.19`.

| | |
| --- | --- |
| **elasticsearchVersion** | `8.19.19` → `8.19.20` |

Unblocks Buildkite `ml-cpp-version-bump` after PR create failed with `ERROR: unknown argument: --label` (helpers from older release-branch tip). Topic branch was already pushed by CI; this opens the missing PR. Root-cause fix: #3083.


Made with [Cursor](https://cursor.com)