### PR TITLE
[ML] Fix PyTorch Docker builds: copy libtorch from installed package

### DIFF
--- a/dev-tools/docker/linux_aarch64_native_image/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_image/Dockerfile
@@ -187,10 +187,15 @@ RUN \
   export PYTORCH_BUILD_NUMBER=1 && \
   export MAX_JOBS=10 && \
   /usr/local/bin/python3.12 setup.py install && \
+  # Recent PyTorch redirects `setup.py install` to `pip install .`, which installs the
+  # torch package (headers + libs) into site-packages rather than leaving them in the
+  # source tree (see pytorch/pytorch#152276). Resolve the installed package location so
+  # this works whether the build is in-tree (older tags) or a wheel install (newer).
+  TORCH_DIR=$(/usr/local/bin/python3.12 -c "import sysconfig, os; print(os.path.join(sysconfig.get_paths()['platlib'], 'torch'))") && \
   mkdir /usr/local/gcc133/include/pytorch && \
-  cp -r torch/include/* /usr/local/gcc133/include/pytorch/ && \
-  cp torch/lib/libtorch_cpu.so /usr/local/gcc133/lib && \
-  cp torch/lib/libc10.so /usr/local/gcc133/lib && \
+  cp -r "${TORCH_DIR}"/include/* /usr/local/gcc133/include/pytorch/ && \
+  cp "${TORCH_DIR}"/lib/libtorch_cpu.so /usr/local/gcc133/lib && \
+  cp "${TORCH_DIR}"/lib/libc10.so /usr/local/gcc133/lib && \
   cd .. && \
   rm -rf pytorch /tmp/*
 

--- a/dev-tools/docker/linux_aarch64_native_image/Dockerfile
+++ b/dev-tools/docker/linux_aarch64_native_image/Dockerfile
@@ -192,7 +192,7 @@ RUN \
   # source tree (see pytorch/pytorch#152276). Resolve the installed package location so
   # this works whether the build is in-tree (older tags) or a wheel install (newer).
   TORCH_DIR=$(/usr/local/bin/python3.12 -c "import sysconfig, os; print(os.path.join(sysconfig.get_paths()['platlib'], 'torch'))") && \
-  mkdir /usr/local/gcc133/include/pytorch && \
+  mkdir -p /usr/local/gcc133/include/pytorch && \
   cp -r "${TORCH_DIR}"/include/* /usr/local/gcc133/include/pytorch/ && \
   cp "${TORCH_DIR}"/lib/libtorch_cpu.so /usr/local/gcc133/lib && \
   cp "${TORCH_DIR}"/lib/libc10.so /usr/local/gcc133/lib && \

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -202,10 +202,15 @@ RUN \
   export PYTORCH_BUILD_NUMBER=1 && \
   export MAX_JOBS=10 && \
   /usr/local/bin/python3.12 setup.py install && \
+  # Recent PyTorch redirects `setup.py install` to `pip install .`, which installs the
+  # torch package (headers + libs) into site-packages rather than leaving them in the
+  # source tree (see pytorch/pytorch#152276). Resolve the installed package location so
+  # this works whether the build is in-tree (older tags) or a wheel install (newer).
+  TORCH_DIR=$(/usr/local/bin/python3.12 -c "import sysconfig, os; print(os.path.join(sysconfig.get_paths()['platlib'], 'torch'))") && \
   mkdir /usr/local/gcc133/include/pytorch && \
-  cp -r torch/include/* /usr/local/gcc133/include/pytorch/ && \
-  cp torch/lib/libtorch_cpu.so /usr/local/gcc133/lib && \
-  cp torch/lib/libc10.so /usr/local/gcc133/lib && \
+  cp -r "${TORCH_DIR}"/include/* /usr/local/gcc133/include/pytorch/ && \
+  cp "${TORCH_DIR}"/lib/libtorch_cpu.so /usr/local/gcc133/lib && \
+  cp "${TORCH_DIR}"/lib/libc10.so /usr/local/gcc133/lib && \
   cd .. && \
   rm -rf pytorch /tmp/*
 

--- a/dev-tools/docker/linux_image/Dockerfile
+++ b/dev-tools/docker/linux_image/Dockerfile
@@ -207,7 +207,7 @@ RUN \
   # source tree (see pytorch/pytorch#152276). Resolve the installed package location so
   # this works whether the build is in-tree (older tags) or a wheel install (newer).
   TORCH_DIR=$(/usr/local/bin/python3.12 -c "import sysconfig, os; print(os.path.join(sysconfig.get_paths()['platlib'], 'torch'))") && \
-  mkdir /usr/local/gcc133/include/pytorch && \
+  mkdir -p /usr/local/gcc133/include/pytorch && \
   cp -r "${TORCH_DIR}"/include/* /usr/local/gcc133/include/pytorch/ && \
   cp "${TORCH_DIR}"/lib/libtorch_cpu.so /usr/local/gcc133/lib && \
   cp "${TORCH_DIR}"/lib/libc10.so /usr/local/gcc133/lib && \

--- a/dev-tools/docker/pytorch_linux_image/Dockerfile
+++ b/dev-tools/docker/pytorch_linux_image/Dockerfile
@@ -108,10 +108,15 @@ RUN --mount=type=secret,id=gcs_key \
   /usr/local/bin/python3.12 -m pip install --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --trusted-host pypi.org -r requirements.txt && \
   /usr/local/bin/python3.12 setup.py install && \
   if command -v sccache &>/dev/null && sccache --show-stats &>/dev/null; then sccache --show-stats; sccache --stop-server; fi && \
+  # Recent PyTorch redirects `setup.py install` to `pip install .`, which installs the
+  # torch package (headers + libs) into site-packages rather than leaving them in the
+  # source tree (see pytorch/pytorch#152276). Resolve the installed package location so
+  # this works whether the build is in-tree (older tags) or a wheel install (newer).
+  TORCH_DIR=$(/usr/local/bin/python3.12 -c "import sysconfig, os; print(os.path.join(sysconfig.get_paths()['platlib'], 'torch'))") && \
   mkdir -p /usr/local/gcc133/include/pytorch && \
-  /bin/cp -rf torch/include/* /usr/local/gcc133/include/pytorch/ && \
-  /bin/cp -f torch/lib/libtorch_cpu.so /usr/local/gcc133/lib && \
-  /bin/cp -f torch/lib/libc10.so /usr/local/gcc133/lib && \
+  /bin/cp -rf "${TORCH_DIR}"/include/* /usr/local/gcc133/include/pytorch/ && \
+  /bin/cp -f "${TORCH_DIR}"/lib/libtorch_cpu.so /usr/local/gcc133/lib && \
+  /bin/cp -f "${TORCH_DIR}"/lib/libc10.so /usr/local/gcc133/lib && \
   cd .. && \
   rm -rf pytorch
 


### PR DESCRIPTION
## Summary

The nightly `ml-cpp-pytorch-builds` image build fails at the post-install header copy:

```
cp: cannot stat 'torch/include/*': No such file or directory
```
([build 765](https://buildkite.com/elastic/ml-cpp-pytorch-builds/builds/765))

### Root cause

The build itself succeeds — the failure is the artifact copy afterwards. Recent PyTorch turns `python setup.py install` into a redirect to `pip install . --no-build-isolation` (see [pytorch/pytorch#152276](https://github.com/pytorch/pytorch/issues/152276)):

```
WARNING: Redirecting 'python setup.py install' to 'pip install . -v --no-build-isolation'
```

A wheel install places the built `torch` package (headers + libs) under Python **site-packages** and no longer leaves `torch/include` populated in the source checkout. The Dockerfiles then copy from the stale source-tree path `torch/include` / `torch/lib` and fail.

This bit the nightly first because it tracks `viable/strict`. The pinned `v2.7.1` images (`linux_image`, `linux_aarch64_native_image`) still build in-tree today, so they pass — but they will break the same way when PyTorch is next bumped.

### Fix

Resolve the installed `torch` package directory via `sysconfig` and copy the headers/libraries from there. This works whether the build is in-tree (older tags) or a wheel install (newer):

```dockerfile
TORCH_DIR=$(python3.12 -c "import sysconfig, os; print(os.path.join(sysconfig.get_paths()['platlib'], 'torch'))")
cp -r "${TORCH_DIR}"/include/* ...
cp    "${TORCH_DIR}"/lib/libtorch_cpu.so ...
cp    "${TORCH_DIR}"/lib/libc10.so ...
```

Applied to all three Linux images (nightly + both pinned-release builds) for consistency and future-proofing.

## Test plan

- [x] Verified the failure in build 765 is the source-tree `torch/include` copy after the `setup.py install` -> `pip install .` redirect
- [x] Confirmed BuildKit strips the inline `#` comment lines from the continued `RUN` (chained `&&` stays intact) via a local `docker build`
- [x] Nightly `ml-cpp-pytorch-builds` produces a working image (headers + libtorch present under `/usr/local/gcc133`) — validated non-destructively against a real installed torch (see comment below)
- [x] Pinned `v2.7.1` linux / aarch64 images still build and are unchanged in content — validated non-destructively on both arches (see comment below)

Made with [Cursor](https://cursor.com)