### PR TITLE
[ML] Auto-approve backport PRs so auto-merge can complete

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -5,7 +5,7 @@
       "pipeline_slug": "ml-cpp-pr-builds",
       "allow_org_users": true,
       "allowed_repo_permissions": ["admin", "write"],
-      "allowed_list": ["github-actions[bot]"],
+      "allowed_list": ["github-actions[bot]", "elastic-vault-github-plugin-prod[bot]"],
       "set_commit_status": false,
       "commit_status_context": "ml-cpp-ci",
       "build_on_commit": true,

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -91,22 +91,53 @@ jobs:
           echo "::error::Backport failed — see logs above."
           exit 1
 
-      - name: Enable auto-merge on backport PRs
+      # Mint a short-lived token for the backport-approver GitHub App so its review
+      # counts as an approval from an identity distinct from the PR author
+      # (github-actions[bot]). The release branches require one approving review via an
+      # org-wide ruleset with no bypass actors, so auto-merge cannot complete without a
+      # real approval. This mirrors the Elasticsearch auto-backport-and-merge model.
+      # The step is skipped (leaving backports for manual approval) until the App
+      # credentials are configured, so the workflow is safe to run before provisioning.
+      - name: Generate backport-approver app token
+        id: approver_token
+        if: >-
+          steps.backport.outcome == 'success' &&
+          contains(github.event.pull_request.labels.*.name, 'auto-backport') &&
+          vars.ML_BACKPORT_APPROVER_APP_ID != ''
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.ML_BACKPORT_APPROVER_APP_ID }}
+          private-key: ${{ secrets.ML_BACKPORT_APPROVER_PRIVATE_KEY }}
+
+      - name: Approve and enable auto-merge on backport PRs
         if: >-
           steps.backport.outcome == 'success' &&
           contains(github.event.pull_request.labels.*.name, 'auto-backport')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPROVE_TOKEN: ${{ steps.approver_token.outputs.token }}
           REPO: ${{ github.repository }}
         run: |
           # Extract created PR numbers from the backport info log.
           PR_NUMBERS=$(grep -oE '"pullRequestNumber":[0-9]+' ~/.backport/backport.info.log \
             | grep -oE '[0-9]+' || true)
           if [ -z "$PR_NUMBERS" ]; then
-            echo "No backport PRs found in log. Skipping auto-merge."
+            echo "No backport PRs found in log. Skipping approval / auto-merge."
             exit 0
           fi
           for pr in $PR_NUMBERS; do
+            # Auto-approve with the backport-approver App (a distinct, non-author identity)
+            # so the required review is satisfied. The backport is a clean cherry-pick of a
+            # change already reviewed on the source branch.
+            if [ -n "$APPROVE_TOKEN" ]; then
+              echo "Approving backport PR #$pr as the backport-approver App"
+              GH_TOKEN="$APPROVE_TOKEN" gh pr review "$pr" --repo "$REPO" --approve \
+                --body "Automated approval: clean backport of an already-reviewed change." || \
+                echo "::warning::Could not approve #$pr with the backport-approver App"
+            else
+              echo "::warning::No backport-approver App token configured (set the ML_BACKPORT_APPROVER_APP_ID variable and ML_BACKPORT_APPROVER_PRIVATE_KEY secret); #$pr will need a manual approval to merge."
+            fi
+
             echo "Enabling auto-merge (squash) on PR #$pr"
             gh pr merge "$pr" --repo "$REPO" --auto --squash || \
               echo "::warning::Could not enable auto-merge on #$pr (is auto-merge enabled in repo settings?)"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,6 +12,12 @@ jobs:
   backport:
     name: Backport PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      # Required by elastic/ci-gh-actions/fetch-github-token to authenticate to Vault
+      # via OIDC and mint the ephemeral approval token.
+      id-token: write
     # Only run for merged PRs that are not themselves backports (avoid loops).
     # Skip automation PRs (minor-freeze main bumps carry a release version label from
     # elasticsearchmachine but must not backport to the new release branch). The
@@ -91,23 +97,27 @@ jobs:
           echo "::error::Backport failed — see logs above."
           exit 1
 
-      # Mint a short-lived token for the backport-approver GitHub App so its review
-      # counts as an approval from an identity distinct from the PR author
-      # (github-actions[bot]). The release branches require one approving review via an
-      # org-wide ruleset with no bypass actors, so auto-merge cannot complete without a
-      # real approval. This mirrors the Elasticsearch auto-backport-and-merge model.
-      # The step is skipped (leaving backports for manual approval) until the App
-      # credentials are configured, so the workflow is safe to run before provisioning.
-      - name: Generate backport-approver app token
+      # Mint a short-lived token from Elastic's central ephemeral-token GitHub App
+      # (via OIDC -> Vault) so the backport PR can be approved by an identity distinct
+      # from the author (github-actions[bot]). The release branches require one
+      # approving review via the org-wide "[org] Require a PR" ruleset, which has no
+      # bypass actors, so auto-merge cannot complete without a real approval. This
+      # mirrors the Elasticsearch auto-backport-and-merge model but reuses the shared
+      # ephemeral-token service rather than a bespoke App or machine account.
+      #
+      # continue-on-error keeps the workflow safe before the Token Policy is registered
+      # (resources/github-token-policies in elastic/catalog-info): the fetch fails
+      # softly, the approval below is skipped with a warning, and the backport still
+      # opens and arms auto-merge to await a manual approval.
+      - name: Fetch ephemeral GitHub token for approval
         id: approver_token
         if: >-
           steps.backport.outcome == 'success' &&
-          contains(github.event.pull_request.labels.*.name, 'auto-backport') &&
-          vars.ML_BACKPORT_APPROVER_APP_ID != ''
-        uses: actions/create-github-app-token@v1
+          contains(github.event.pull_request.labels.*.name, 'auto-backport')
+        continue-on-error: true
+        uses: elastic/ci-gh-actions/fetch-github-token@v1
         with:
-          app-id: ${{ vars.ML_BACKPORT_APPROVER_APP_ID }}
-          private-key: ${{ secrets.ML_BACKPORT_APPROVER_PRIVATE_KEY }}
+          vault-instance: "ci-prod"
 
       - name: Approve and enable auto-merge on backport PRs
         if: >-
@@ -126,16 +136,16 @@ jobs:
             exit 0
           fi
           for pr in $PR_NUMBERS; do
-            # Auto-approve with the backport-approver App (a distinct, non-author identity)
-            # so the required review is satisfied. The backport is a clean cherry-pick of a
-            # change already reviewed on the source branch.
+            # Auto-approve with the ephemeral-token identity (a distinct, non-author
+            # identity) so the required review is satisfied. The backport is a clean
+            # cherry-pick of a change already reviewed on the source branch.
             if [ -n "$APPROVE_TOKEN" ]; then
-              echo "Approving backport PR #$pr as the backport-approver App"
+              echo "Approving backport PR #$pr with the ephemeral-token identity"
               GH_TOKEN="$APPROVE_TOKEN" gh pr review "$pr" --repo "$REPO" --approve \
                 --body "Automated approval: clean backport of an already-reviewed change." || \
-                echo "::warning::Could not approve #$pr with the backport-approver App"
+                echo "::warning::Could not approve #$pr with the ephemeral token"
             else
-              echo "::warning::No backport-approver App token configured (set the ML_BACKPORT_APPROVER_APP_ID variable and ML_BACKPORT_APPROVER_PRIVATE_KEY secret); #$pr will need a manual approval to merge."
+              echo "::warning::No ephemeral approval token available (is the backport Token Policy registered in elastic/catalog-info?); #$pr will need a manual approval to merge."
             fi
 
             echo "Enabling auto-merge (squash) on PR #$pr"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -45,13 +45,35 @@ jobs:
           echo "No version label matching vN.N.N found — nothing to backport."
           echo "has_version_label=false" >> "$GITHUB_OUTPUT"
 
+      # Mint a short-lived token from Elastic's central ephemeral-token GitHub App
+      # (via OIDC -> Vault) and use it to AUTHOR the backport PRs. This mirrors the
+      # pattern used by elastic/cloud, elastic/elasticsearch-ruby and the ECP GitOps
+      # repos. Authoring with a real token (not the built-in GITHUB_TOKEN) means:
+      #   * the backport PR is opened by a distinct, non-github-actions identity, so
+      #     github-actions[bot] can later approve it (a token cannot approve its own
+      #     PR); and
+      #   * CI actually runs on the backport PR (PRs opened with GITHUB_TOKEN do not
+      #     trigger further workflow runs).
+      #
+      # continue-on-error keeps the workflow safe before the Token Policy is registered
+      # (resources/github-token-policies in elastic/catalog-info): the fetch fails
+      # softly and we fall back to GITHUB_TOKEN below, so backports still open — but CI
+      # is not triggered on them and they will need a manual approval to merge.
+      - name: Fetch ephemeral GitHub token
+        id: ephemeral_token
+        if: steps.check-labels.outputs.has_version_label == 'true'
+        continue-on-error: true
+        uses: elastic/ci-gh-actions/fetch-github-token@v1
+        with:
+          vault-instance: "ci-prod"
+
       - name: Backport Action
         id: backport
         if: steps.check-labels.outputs.has_version_label == 'true'
         uses: sorenlouv/backport-github-action@v10.2.0
         continue-on-error: true
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.ephemeral_token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Info log
         if: steps.backport.outcome == 'success'
@@ -97,35 +119,24 @@ jobs:
           echo "::error::Backport failed — see logs above."
           exit 1
 
-      # Mint a short-lived token from Elastic's central ephemeral-token GitHub App
-      # (via OIDC -> Vault) so the backport PR can be approved by an identity distinct
-      # from the author (github-actions[bot]). The release branches require one
-      # approving review via the org-wide "[org] Require a PR" ruleset, which has no
-      # bypass actors, so auto-merge cannot complete without a real approval. This
-      # mirrors the Elasticsearch auto-backport-and-merge model but reuses the shared
-      # ephemeral-token service rather than a bespoke App or machine account.
-      #
-      # continue-on-error keeps the workflow safe before the Token Policy is registered
-      # (resources/github-token-policies in elastic/catalog-info): the fetch fails
-      # softly, the approval below is skipped with a warning, and the backport still
-      # opens and arms auto-merge to await a manual approval.
-      - name: Fetch ephemeral GitHub token for approval
-        id: approver_token
-        if: >-
-          steps.backport.outcome == 'success' &&
-          contains(github.event.pull_request.labels.*.name, 'auto-backport')
-        continue-on-error: true
-        uses: elastic/ci-gh-actions/fetch-github-token@v1
-        with:
-          vault-instance: "ci-prod"
-
+      # Approve the backport PRs with GITHUB_TOKEN (github-actions[bot]) and arm
+      # auto-merge. Because the PRs were authored by the ephemeral-token identity above,
+      # github-actions[bot] is a *different* identity and its approval counts (a token
+      # cannot approve its own PR). One approval satisfies the org-wide "[org] Require a
+      # PR" ruleset on the release branches (one review, no code-owner requirement); the
+      # repo has "Allow GitHub Actions to create and approve pull requests" enabled. This
+      # is the same author-with-app / approve-with-GITHUB_TOKEN pattern the ECP GitOps
+      # repos (e.g. elastic/catalog-sync-config) use under the identical ruleset.
       - name: Approve and enable auto-merge on backport PRs
         if: >-
           steps.backport.outcome == 'success' &&
           contains(github.event.pull_request.labels.*.name, 'auto-backport')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPROVE_TOKEN: ${{ steps.approver_token.outputs.token }}
+          # 'true' only when the ephemeral token was minted (Token Policy registered),
+          # i.e. the backport PRs were authored by the ephemeral-token app identity and
+          # can therefore be approved by github-actions[bot].
+          EPHEMERAL_AUTHORED: ${{ steps.ephemeral_token.outputs.token != '' }}
           REPO: ${{ github.repository }}
         run: |
           # Extract created PR numbers from the backport info log.
@@ -136,16 +147,15 @@ jobs:
             exit 0
           fi
           for pr in $PR_NUMBERS; do
-            # Auto-approve with the ephemeral-token identity (a distinct, non-author
-            # identity) so the required review is satisfied. The backport is a clean
-            # cherry-pick of a change already reviewed on the source branch.
-            if [ -n "$APPROVE_TOKEN" ]; then
-              echo "Approving backport PR #$pr with the ephemeral-token identity"
-              GH_TOKEN="$APPROVE_TOKEN" gh pr review "$pr" --repo "$REPO" --approve \
+            if [ "$EPHEMERAL_AUTHORED" = "true" ]; then
+              # Authored by the ephemeral-token identity, so this github-actions[bot]
+              # approval is from a distinct identity and satisfies the required review.
+              echo "Approving backport PR #$pr as github-actions[bot]"
+              gh pr review "$pr" --repo "$REPO" --approve \
                 --body "Automated approval: clean backport of an already-reviewed change." || \
-                echo "::warning::Could not approve #$pr with the ephemeral token"
+                echo "::warning::Could not approve #$pr"
             else
-              echo "::warning::No ephemeral approval token available (is the backport Token Policy registered in elastic/catalog-info?); #$pr will need a manual approval to merge."
+              echo "::warning::Ephemeral token was unavailable (is the backport Token Policy registered in elastic/catalog-info?); #$pr was authored by github-actions[bot], so it cannot be auto-approved and will need a manual approval to merge."
             fi
 
             echo "Enabling auto-merge (squash) on PR #$pr"


### PR DESCRIPTION
## Summary

Backport PRs opened by the `auto-backport` workflow have auto-merge enabled but never merge (e.g. #3092). Two independent things blocked them:

1. **No CI.** `buildkite-pr-bot` only triggers `ml-cpp-pr-builds` for a PR whose sender is org-allowed: it matches an `allowed_list` entry, has `admin`/`write` on the repo, or is an org member (`allow_org_users`). Bot accounts are never org members and apps don't match the write-permission path, so a bot-authored backport got **no build**.
2. **No approval.** The release branches require **one approving review** via the org-wide ruleset **`[org] Require a PR`** (id `221255`, `source: elastic`), which has **no bypass actors**. A PR authored by `github-actions[bot]` cannot be approved by `github-actions[bot]` (GitHub blocks self-approval), so the required review was never satisfied and auto-merge stayed `BLOCKED`.

The CI-trigger half (1) for `github-actions[bot]` is already fixed and validated by #3103 (`allowed_list: ["github-actions[bot]"]`, #3099). This PR fixes the **approval** half (2) and completes the CI-trigger config for the ephemeral-token author.

### What this PR changes
Adopts the production-proven **author-with-ephemeral-token / approve-with-`GITHUB_TOKEN`** pattern (used by `elastic/cloud`, `elastic/elasticsearch-ruby` and the ECP GitOps repos such as `elastic/catalog-sync-config`):

- **`backport.yml`:** mints a short-lived token from Elastic's central ephemeral-token service (`elastic/ci-gh-actions/fetch-github-token@v1`, `ci-prod`, via OIDC->Vault) **before** the backport action and passes it as the action's `github_token`, so the backport PRs are **authored by the ephemeral-token identity** (`elastic-vault-github-plugin-prod[bot]`) — a distinct identity from `github-actions[bot]`. It then approves each backport PR with `GITHUB_TOKEN` (`github-actions[bot]`) — a *different* identity from the author, so the approval counts — and enables auto-merge (squash). Adds `id-token: write` for OIDC.
- **`.buildkite/pull-requests.json`:** adds `elastic-vault-github-plugin-prod[bot]` to `allowed_list`, so `buildkite-pr-bot` triggers CI on the ephemeral-authored backport PRs. Combined with #3103's `github-actions[bot]` entry, this matches `elastic/elasticsearch`'s allow-list exactly (both bots).
- **Safe no-op before the Token Policy is registered:** the token fetch uses `continue-on-error` and the workflow falls back to authoring with `GITHUB_TOKEN` (`github-actions[bot]`, which #3103 already allow-lists for CI); auto-approval is skipped with a warning and the backport awaits a manual approval.

### Why this counts (verified, not assumed)
`elastic/catalog-sync-config` merges renovate PRs under the **identical** org-only ruleset (221255 + 1225254; `count: 1`, `require_code_owner_review: false`, `require_last_push_approval: false` — same as ml-cpp): a PR authored by one bot and approved by `github-actions[bot]` (a non-author identity) shows `reviewDecision: APPROVED` and auto-merges (e.g. `elastic/catalog-sync-config#83`, `elastic/catalog-info#4264`). ml-cpp already has *Allow GitHub Actions to create and approve pull requests* enabled (`can_approve_pull_request_reviews: true`). GitHub's only relevant restriction is self-approval, which the author != approver split avoids.

The CI-trigger half was validated empirically: with #3103 live on `main`, a throwaway PR authored by `github-actions[bot]` auto-started `ml-cpp-pr-builds` (creator `elasticmachine`) within ~20s.

## Required to activate (not in this repo)
Register the GitHub Token Policy in `elastic/catalog-info` (elastic/catalog-info#4281), scoped as:
- `bound_claims.workflow_ref: elastic/ml-cpp/.github/workflows/backport.yml@*`
- `permissionset.additional_permissions: { contents: write, pull_requests: write }` (contents to push the backport branch, pull_requests to open the PR), selector `repository: elastic/ml-cpp`
- `owner: group:ml-core`

## Notes
- The earlier approach (approve *with* the ephemeral token) relied on an app holding only `pull_requests: write` being an eligible approver, which has no production precedent in the org. This pattern instead approves with `GITHUB_TOKEN`, which is proven to count.
- `elastic/ci-gh-actions/fetch-github-token@v1` is used by tag; happy to pin to a SHA if org policy requires it.

## Test plan
- [x] Merge with the Token Policy **unregistered** -> a subsequent backport still opens the PR (authored by `github-actions[bot]`), gets CI (via #3103), and arms auto-merge; logs the "ephemeral token unavailable" warning; does not fail.
- [x] Register the Token Policy (#4281), trigger a backport, and confirm the PR is authored by `elastic-vault-github-plugin-prod[bot]`, CI runs on it (via the new `allowed_list` entry), `github-actions[bot]` approves it, and it merges once checks pass.

Made with [Cursor](https://cursor.com)