### PR TITLE
[DO NOT MERGE] CI verify: version-bump topic branch skips ES IT (8.19)

### DIFF
--- a/.buildkite/ml_pipeline/config.py
+++ b/.buildkite/ml_pipeline/config.py
@@ -11,6 +11,37 @@
 import os
 import re
 
+# Trim PR CI for automated version-bump PRs (metadata-only changes): skip the Java ES
+# integration test pipelines. Applied via the ci:skip-es-tests label and/or version-bump
+# topic branch names.
+SKIP_VERSION_BUMP_PR_CI_LABEL = "ci:skip-es-tests"
+
+_VERSION_BUMP_TOPIC_BRANCH_PATTERNS = (
+    re.compile(r"^ci/ml-cpp-version-bump-"),
+    re.compile(r"^ci/ml-cpp-minor-freeze-main-"),
+)
+
+
+def normalize_buildkite_branch(branch: str) -> str:
+    """Return the PR source branch name from BUILDKITE_BRANCH (fork or same-repo)."""
+
+    if ":" in branch:
+        branch = branch.split(":", 1)[1]
+    if "+" in branch:
+        if "/" in branch:
+            # Fork PR: author+branch/with/slashes (only the author separator is "+").
+            branch = branch.split("+", 1)[1]
+        else:
+            # Branch name with "/" encoded as "+" throughout (no fork author prefix).
+            branch = branch.replace("+", "/")
+    return branch
+
+
+def is_version_bump_topic_branch(branch: str) -> bool:
+    normalized = normalize_buildkite_branch(branch)
+    return any(pattern.search(normalized) for pattern in _VERSION_BUMP_TOPIC_BRANCH_PATTERNS)
+
+
 class Config:
     build_windows: bool = False
     build_macos: bool = False
@@ -19,6 +50,7 @@ class Config:
     build_x86_64: str = ""
     run_qa_tests: bool = False
     run_pytorch_tests: bool = False
+    skip_version_bump_pr_ci: bool = False
     action: str = "build"
 
     def parse_comment(self):
@@ -140,4 +172,35 @@ class Config:
             self.build_aarch64 = "--build-aarch64"
             self.build_x86_64 = "--build-x86_64"
             self.run_qa_tests = False
+
+        self._apply_skip_version_bump_pr_ci()
+
+    def _apply_skip_version_bump_pr_ci(self):
+        """Skip extra PR CI (Java ES ITs) for automated version-bump PRs."""
+
+        if self.skip_version_bump_pr_ci:
+            return
+
+        for env_key in ("GITHUB_PR_LABELS", "BUILDKITE_PULL_REQUEST_LABELS"):
+            raw = os.environ.get(env_key, "")
+            if not raw:
+                continue
+            labels = [label.strip().lower() for label in raw.split(",")]
+            if SKIP_VERSION_BUMP_PR_CI_LABEL in labels:
+                self.skip_version_bump_pr_ci = True
+                return
+
+        for env_key in ("GITHUB_PR_BRANCH", "BUILDKITE_BRANCH"):
+            branch = os.environ.get(env_key, "")
+            if branch and is_version_bump_topic_branch(branch):
+                self.skip_version_bump_pr_ci = True
+                return
+
+
+def should_skip_version_bump_pr_ci() -> bool:
+    """Return True when PR CI should omit the Java ES integration test steps."""
+
+    config = Config()
+    config.parse()
+    return config.skip_version_bump_pr_ci
 

--- a/.buildkite/pipeline.json.py
+++ b/.buildkite/pipeline.json.py
@@ -50,8 +50,9 @@ def main():
         pipeline_steps.append(build_linux)
 
         if config.build_x86_64:
-            pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests x86_64 runner pipeline",
-                                                               ".buildkite/pipelines/run_es_tests_x86_64.yml.sh"))
+            if not config.skip_version_bump_pr_ci:
+                pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests x86_64 runner pipeline",
+                                                                   ".buildkite/pipelines/run_es_tests_x86_64.yml.sh"))
             # We only use linux x86_64 builds for QA tests.
             if config.run_qa_tests:
                 pipeline_steps.append(pipeline_steps.generate_step("Upload QA tests runner pipeline",
@@ -59,7 +60,7 @@ def main():
             if config.run_pytorch_tests:
                 pipeline_steps.append(pipeline_steps.generate_step("Upload QA PyTorch tests runner pipeline",
                                                                    ".buildkite/pipelines/run_pytorch_tests.yml.sh"))
-        if config.build_aarch64:
+        if config.build_aarch64 and not config.skip_version_bump_pr_ci:
             pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests aarch64 runner pipeline",
                                                                ".buildkite/pipelines/run_es_tests_aarch64.yml.sh"))
 


### PR DESCRIPTION
**Throwaway CI-verification PR — will be closed, do not review/merge.**

Non-destructively confirms test-plan item 2 of #3089 — a PR whose branch matches `ci/ml-cpp-version-bump-*` generates a pipeline with **no** Java ES Integration Test steps on `8.19`.

- Contains **only** the CI-only commits from #3089 (no version-file changes).
- The branch name is the sole trigger under test.
- Build cancelled right after the dynamic-pipeline upload step; branch/PR then deleted.

Made with [Cursor](https://cursor.com)