### PR TITLE
[ML] Allow github-actions[bot] to trigger ml-cpp-pr-builds CI

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -5,6 +5,7 @@
       "pipeline_slug": "ml-cpp-pr-builds",
       "allow_org_users": true,
       "allowed_repo_permissions": ["admin", "write"],
+      "allowed_list": ["github-actions[bot]"],
       "set_commit_status": false,
       "commit_status_context": "ml-cpp-ci",
       "build_on_commit": true,


### PR DESCRIPTION
## Summary

Backport PRs opened by our auto-backport workflow are authored by `github-actions[bot]`. `buildkite-pr-bot` decides whether to trigger `ml-cpp-pr-builds` from the push/PR **sender** identity, via three allow paths (see `elastic/buildkite-pr-bot`):

1. `allowed_list` membership
2. `admin`/`write` permission on the base repo
3. `allow_org_users: true` + Elastic org membership

Bot accounts (logins ending `[bot]`) **cannot be org members**, so path 3 never matches them, and we don't list them anywhere — so bot-authored backports get **no** Buildkite build. Only `CLA`, `Check labels`, and Snyk run; the build/test matrix never starts, and auto-merge (once approval is sorted) can't rely on CI.

This adds `github-actions[bot]` to `allowed_list` (path 1), so its PRs — i.e. the automated backports — trigger the full matrix like any human-authored PR.

This is exactly the fix `elastic/elasticsearch` applied in [elasticsearch#147815](https://github.com/elastic/elasticsearch/pull/147815) ("Update allowed list in pull-requests.json"), whose `allowed_list` already contains `github-actions[bot]` and `elastic-vault-github-plugin-prod[bot]`.

### Notes
- `buildkite-pr-bot` reads `.buildkite/pull-requests.json` from the repo's **default branch** (`main`), not the PR base branch (`src/config.ts`: `configBranch || 'main'`). So this single change on `main` covers backports targeting every release branch — no per-branch edit needed.
- The triggered build is still created by `buildkite-pr-bot` as `elasticmachine`, so it satisfies the pipeline's `filter_condition` (`build.creator.name == 'elasticmachine'`).
- If we later move to authoring backports with the ephemeral-token identity, add `elastic-vault-github-plugin-prod[bot]` here too (as ES does).

Addresses the CI-trigger half of the stall; the approval half is tracked separately (#3094).

Fixes #3099

## Test plan
- [x] Merge to `main`.
- [x] Merge a `>bug` PR carrying version labels so the auto-backport workflow opens backport PRs authored by `github-actions[bot]`.
- [x] Confirm each backport PR now auto-triggers an `ml-cpp-pr-builds` build within ~seconds of opening (creator `elasticmachine`), without a manual `buildkite build` comment.
- [x] Confirm no change to human-authored PR triggering (already worked).

> Note: CI on *this* PR is intentionally skipped — `skip_ci_on_only_changed` lists `^\.buildkite/pull-requests\.json$`, and this PR only edits that file.