### PR TITLE
[ML] Pass explicit vault-role for the Backstage-registered backport token policy

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -66,6 +66,12 @@ jobs:
         uses: elastic/ci-gh-actions/fetch-github-token@v1
         with:
           vault-instance: "ci-prod"
+          # The Token Policy was registered via the Backstage self-service template,
+          # which names the Vault role after the AppRole name (token-policy-ml-cpp-backport)
+          # rather than the SHA-256 hash of the workflow ref that fetch-github-token
+          # derives by default. Pass the role explicitly so the lookup matches the
+          # registered policy (github/token/token-policy-ml-cpp-backport).
+          vault-role: "token-policy-ml-cpp-backport"
 
       - name: Backport Action
         id: backport


### PR DESCRIPTION
## Summary

Follow-up to #3094. The backport workflow's ephemeral-token step needs an explicit `vault-role` to match the Token Policy registered via the Backstage self-service template.

`elastic/ci-gh-actions/fetch-github-token@v1`, when no `vault-role` is given, derives the Vault role from a **SHA-256 hash of the workflow ref**:

```
VAULT_ROLE="token-policy-$WORKFLOW_HASH"   # sha256("elastic/ml-cpp/.github/workflows/backport.yml")[:12]
                                           # => token-policy-e51e59ad2806
```

The Token Policy was registered through the blessed **Backstage template** (`github-token-policy-registration`), which names the Vault role after the **AppRole name** (`ml-cpp-backport`) → `token-policy-ml-cpp-backport`, **not** the hash. So the default lookup (`github/token/token-policy-e51e59ad2806`) would miss, the fetch would fail, and the workflow would silently fall back to `github-actions[bot]` authoring (no auto-approval).

This passes the role explicitly, which is exactly the action's documented escape hatch:

```yaml
with:
  vault-instance: "ci-prod"
  vault-role: "token-policy-ml-cpp-backport"
```

## Notes
- Safe to merge before/after the Token Policy lands: until the role exists the fetch just fails softly (same fallback as today), and once it exists the lookup matches.
- No production code affected — CI on this PR is only config/workflow.

## Test plan
- [ ] After the Token Policy (`token-policy-ml-cpp-backport`) is merged in `elastic/catalog-info`, merge a `>bug` PR carrying version + `auto-backport` labels.
- [ ] Confirm the backport PRs are authored by `elastic-vault-github-plugin-prod[bot]` (ephemeral fetch succeeded), get CI (via the `allowed_list`), are approved by `github-actions[bot]`, and auto-merge.

Made with [Cursor](https://cursor.com)
