### PR TITLE
[ML] Publish ml-cpp-ci rollup commit status for PR builds

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -6,7 +6,7 @@
       "allow_org_users": true,
       "allowed_repo_permissions": ["admin", "write"],
       "allowed_list": ["github-actions[bot]", "elastic-vault-github-plugin-prod[bot]"],
-      "set_commit_status": false,
+      "set_commit_status": true,
       "commit_status_context": "ml-cpp-ci",
       "build_on_commit": true,
       "build_on_comment": true,


### PR DESCRIPTION
## Summary

Part 1 of making auto-backport-and-merge (#3099) safe: publish a single, stable rollup CI status so merges can be gated on it.

Today `ml-cpp-pr-builds` runs with `set_commit_status: false`, so the only per-commit signals are the individual Buildkite step statuses ("Build and test on … RelWithDebInfo", etc.). None are marked *required*, so `gh pr merge --auto` (armed by the backport workflow) merges as soon as `CLA`/snyk/clang-format/review are green — **before the build/test matrix finishes**. That's how the #3080/#3081 backports (#3106–#3111) auto-merged mid-build.

This flips `set_commit_status: true` (the context `ml-cpp-ci` is already defined) so `buildkite-pr-bot` publishes one overall `ml-cpp-ci` status per PR head commit.

### Why a rollup rather than requiring the per-step contexts
- One stable context across `main` and every release branch (the per-step names differ between pipelines).
- Survives pipeline step renames.
- Robust to partial/label-scoped builds (`ci:skip-es-tests`, single-platform `buildkite build on linux`, …) that don't post every per-step context — a required per-step check that never arrives would block the PR forever.

### Follow-up (not in this PR)
Once merged and `main` serves the new config, the next PR build will carry an `ml-cpp-ci` status. After confirming it transitions `pending → success/failure`, add `ml-cpp-ci` to the required status checks on `main`/`9.5`/`9.4`/`8.19` so auto-merge waits for CI.

## Notes
- No production code touched. This PR only edits `.buildkite/pull-requests.json`, which is in `skip_ci_on_only_changed`, so the C++ matrix is intentionally skipped here.

Made with [Cursor](https://cursor.com)
