### PR TITLE
[TEST] verify ml-cpp-ci rollup status (do not merge)

### DIFF
--- a/lib/ver/CBuildInfo.cc
+++ b/lib/ver/CBuildInfo.cc
@@ -18,6 +18,7 @@ namespace ver {
 
 // Initialise static strings
 // Variables are supplied by command line macro definitions
+// (throwaway probe for ml-cpp-ci rollup status verification -- do not merge)
 #ifdef DEV_BUILD
 const std::string CBuildInfo::VERSION_NUMBER("based on " STRINGIFY_MACRO(PRODUCT_VERSION));
 const std::string CBuildInfo::BUILD_NUMBER("DEVELOPMENT BUILD by " STRINGIFY_MACRO(ML_USER));


### PR DESCRIPTION
Throwaway PR to confirm buildkite-pr-bot now publishes a single **ml-cpp-ci** commit status (set_commit_status:true, #3112) that resolves pending→success/failure. Will be closed once observed. Do not merge.

Made with [Cursor](https://cursor.com)