### PR TITLE
[ML] Disable auto-merge of backport PRs; merge only after CI is green

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -119,15 +119,20 @@ jobs:
           echo "::error::Backport failed — see logs above."
           exit 1
 
-      # Approve the backport PRs with GITHUB_TOKEN (github-actions[bot]) and arm
+      # Approve the backport PRs with GITHUB_TOKEN (github-actions[bot]) but do NOT arm
       # auto-merge. Because the PRs were authored by the ephemeral-token identity above,
       # github-actions[bot] is a *different* identity and its approval counts (a token
       # cannot approve its own PR). One approval satisfies the org-wide "[org] Require a
       # PR" ruleset on the release branches (one review, no code-owner requirement); the
-      # repo has "Allow GitHub Actions to create and approve pull requests" enabled. This
-      # is the same author-with-app / approve-with-GITHUB_TOKEN pattern the ECP GitOps
-      # repos (e.g. elastic/catalog-sync-config) use under the identical ruleset.
-      - name: Approve and enable auto-merge on backport PRs
+      # repo has "Allow GitHub Actions to create and approve pull requests" enabled.
+      #
+      # Auto-merge is intentionally disabled: the release branches do not require the
+      # ml-cpp build/test checks, so `gh pr merge --auto` would merge a backport as soon
+      # as the lightweight required checks (CLA, labels, snyk) pass — before the C++
+      # build/test matrix finishes. Approving-but-not-merging leaves each backport as a
+      # one-click merge for a human once its CI build is green. Re-enable auto-merge only
+      # after a required status check gating the full build/test matrix is in place.
+      - name: Approve backport PRs (auto-merge disabled pending required CI check)
         if: >-
           steps.backport.outcome == 'success' &&
           contains(github.event.pull_request.labels.*.name, 'auto-backport')
@@ -143,7 +148,7 @@ jobs:
           PR_NUMBERS=$(grep -oE '"pullRequestNumber":[0-9]+' ~/.backport/backport.info.log \
             | grep -oE '[0-9]+' || true)
           if [ -z "$PR_NUMBERS" ]; then
-            echo "No backport PRs found in log. Skipping approval / auto-merge."
+            echo "No backport PRs found in log. Skipping approval."
             exit 0
           fi
           for pr in $PR_NUMBERS; do
@@ -152,15 +157,13 @@ jobs:
               # approval is from a distinct identity and satisfies the required review.
               echo "Approving backport PR #$pr as github-actions[bot]"
               gh pr review "$pr" --repo "$REPO" --approve \
-                --body "Automated approval: clean backport of an already-reviewed change." || \
+                --body "Automated approval: clean backport of an already-reviewed change. Auto-merge is disabled — a maintainer should merge once this PR's CI build is green." || \
                 echo "::warning::Could not approve #$pr"
             else
               echo "::warning::Ephemeral token was unavailable (is the backport Token Policy registered in elastic/catalog-info?); #$pr was authored by github-actions[bot], so it cannot be auto-approved and will need a manual approval to merge."
             fi
 
-            echo "Enabling auto-merge (squash) on PR #$pr"
-            gh pr merge "$pr" --repo "$REPO" --auto --squash || \
-              echo "::warning::Could not enable auto-merge on #$pr (is auto-merge enabled in repo settings?)"
+            echo "Auto-merge is disabled; leaving PR #$pr for a maintainer to merge once CI is green."
           done
 
   remove-backport-pending:


### PR DESCRIPTION
## Summary

Prioritise safety: **backport PRs should only merge after a successful CI build** (automatically or by a human). Until a required status check gates the full build/test matrix, this disables the auto-merge arming in the backport workflow.

### Problem
The release branches' protection rules do **not** require the ml-cpp build/test checks. So `gh pr merge --auto --squash` merges a backport as soon as the lightweight required checks (`CLA`, `Check labels`, snyk) pass — *before* the C++ build/test matrix finishes. That's exactly how the #3080/#3081 backports (#3106–#3111) auto-merged mid-build, one with a failing build step.

We also confirmed that flipping `set_commit_status: true` (#3112) does **not** by itself produce a resolvable `ml-cpp-ci` rollup status in this pipeline (only per-step contexts are published), so there is currently nothing safe to mark as a required check.

### Change
The final workflow step still:
- authors backports with the ephemeral token (so **CI runs** on them, #3103/#3094), and
- **approves** them with `github-actions[bot]` (so the org "require 1 review" ruleset is satisfied),

but it **no longer arms auto-merge**. Each backport is left as a one-click merge for a maintainer once its CI build is green.

No behaviour change to backport *creation* or CI triggering — only the automatic merge is removed.

### Re-enabling auto-merge later
Re-add `gh pr merge --auto --squash` once a required status check gating the full build/test matrix exists on `main`/release branches (e.g. a Buildkite pipeline "one combined status per build" named `ml-cpp-ci`, made a required check). Tracked in #3099.

Fixes the premature-merge half of #3099.

## Test plan

> **Superseded by #3122 (merged 2026-07-27), which re-enabled auto-merge once the required `buildkite/ml-cpp-pr-builds` rollup gate was in place.** The items below verify the *temporary disabled* state introduced here and are intentionally left unchecked — that behaviour no longer exists. See #3122 for the current design and its test plan.
- [ ] Merge a `>bug` PR carrying version + `auto-backport` labels.
- [ ] Confirm backport PRs are opened, CI is triggered, and they receive a `github-actions[bot]` approval.
- [ ] Confirm **no** auto-merge is armed (PRs stay open until a maintainer merges).

Made with [Cursor](https://cursor.com)