### PR TITLE
[ML] Make changelog validation robust to shallow-clone merge base

### DIFF
--- a/.buildkite/scripts/steps/validate-changelogs.sh
+++ b/.buildkite/scripts/steps/validate-changelogs.sh
@@ -57,11 +57,35 @@ if ! git rev-parse --verify "origin/${TARGET_BRANCH}" >/dev/null 2>&1; then
   exit 0
 fi
 
-CHANGED_CHANGELOGS=$(git diff --name-only --diff-filter=ACM "origin/${TARGET_BRANCH}"...HEAD -- 'docs/changelog/*.yaml')
-DIFF_EXIT=$?
-if [[ $DIFF_EXIT -ne 0 ]]; then
-  echo "Warning: git diff failed (exit $DIFF_EXIT), skipping changelog validation"
-  exit 0
+# List changelog files this PR adds/modifies relative to its merge base with
+# the target branch. When the PR branched from an older commit, the shallow
+# (--depth=1) history fetched above shares no common ancestor with HEAD and the
+# three-dot diff fails with "fatal: origin/${TARGET_BRANCH}...HEAD: no merge
+# base" (exit 128). Because it runs in a command substitution under `set -e`,
+# that aborts the whole script before any $? inspection, so it must be guarded
+# with `if` (which suppresses `set -e`). On failure we progressively deepen both
+# histories to recover a merge base and retry; only if that still fails do we
+# soft-skip. This step is a required status check, so a CI clone-depth
+# limitation must never hard-fail an otherwise valid PR.
+changed_changelogs() {
+  git diff --name-only --diff-filter=ACM \
+    "origin/${TARGET_BRANCH}"...HEAD -- 'docs/changelog/*.yaml' 2>/dev/null
+}
+
+if ! CHANGED_CHANGELOGS=$(changed_changelogs); then
+  merge_base_found=false
+  for depth in 50 250 1000; do
+    git fetch origin "${TARGET_BRANCH}" --deepen="${depth}" 2>/dev/null || true
+    git fetch origin --deepen="${depth}" 2>/dev/null || true
+    if CHANGED_CHANGELOGS=$(changed_changelogs); then
+      merge_base_found=true
+      break
+    fi
+  done
+  if [[ "${merge_base_found}" != "true" ]]; then
+    echo "Warning: could not establish a merge base with origin/${TARGET_BRANCH} (shallow clone); skipping changelog validation."
+    exit 0
+  fi
 fi
 
 if [[ -z "${CHANGED_CHANGELOGS}" ]]; then


### PR DESCRIPTION
## Summary

The `Validate changelog entries` step (`.buildkite/scripts/steps/validate-changelogs.sh`) fetches the PR base with `--depth=1` and then runs a three-dot diff:

```
git diff --name-only --diff-filter=ACM origin/<base>...HEAD -- 'docs/changelog/*.yaml'
```

When a PR branched from an older point of the base branch, the shallow (`--depth=1`) histories share **no common ancestor**, so git aborts with:

```
fatal: origin/main...HEAD: no merge base
```

(exit 128). The diff runs inside a command substitution under `set -euo pipefail`, so the script dies at that line — **before** its own `DIFF_EXIT`/"skipping" soft-handler could run. The handler was effectively dead code, and the step hard-failed.

This is latent for any sufficiently-diverged branch; it surfaced on #3078 (see build [2895](https://buildkite.com/elastic/ml-cpp-pr-builds/builds/2895#019fa120-19e4-42de-bc08-a9f72788e9b5)).

### Fix
- Guard the diff with `if ! VAR=$(...)`, which suppresses `set -e` for that command (the previous `$?` inspection could never be reached).
- On failure, progressively deepen both histories (`--deepen 50/250/1000`) to recover a merge base and retry.
- Only if that still fails, soft-skip with a warning.

This matters now that the overall build status (`buildkite/ml-cpp-pr-builds`) is a **required** check on `main`: a CI clone-depth limitation must never hard-fail an otherwise valid PR. Valid changelogs are still fully validated whenever a merge base is available (the common case, and now the deepened case).

## Test plan
- [x] CI green on this PR (its own changelog check is skipped via the `>build` label, exercising the early-exit path).
- [x] Re-run the failing #3078 build after it picks up this change and confirm `Validate changelog entries` passes (merge base recovered, `docs/changelog/3078.yaml` validated).