### PR TITLE
[ML] Re-enable auto-merge for backport PRs (gated on required CI rollup)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -119,20 +119,22 @@ jobs:
           echo "::error::Backport failed — see logs above."
           exit 1
 
-      # Approve the backport PRs with GITHUB_TOKEN (github-actions[bot]) but do NOT arm
+      # Approve the backport PRs with GITHUB_TOKEN (github-actions[bot]) and arm
       # auto-merge. Because the PRs were authored by the ephemeral-token identity above,
       # github-actions[bot] is a *different* identity and its approval counts (a token
       # cannot approve its own PR). One approval satisfies the org-wide "[org] Require a
       # PR" ruleset on the release branches (one review, no code-owner requirement); the
       # repo has "Allow GitHub Actions to create and approve pull requests" enabled.
       #
-      # Auto-merge is intentionally disabled: the release branches do not require the
-      # ml-cpp build/test checks, so `gh pr merge --auto` would merge a backport as soon
-      # as the lightweight required checks (CLA, labels, snyk) pass — before the C++
-      # build/test matrix finishes. Approving-but-not-merging leaves each backport as a
-      # one-click merge for a human once its CI build is green. Re-enable auto-merge only
-      # after a required status check gating the full build/test matrix is in place.
-      - name: Approve backport PRs (auto-merge disabled pending required CI check)
+      # Auto-merge is now safe: the release branches (and main) require the
+      # `buildkite/ml-cpp-pr-builds` rollup status, which reflects the whole build/test
+      # matrix — including any triggered QA/PyTorch downstream (their trigger steps are
+      # `async: false`, so their result propagates into the parent build). `gh pr merge
+      # --auto` therefore waits for CI to go green (and the review requirement to be
+      # met) before merging, rather than merging as soon as the lightweight checks (CLA,
+      # snyk) pass. (Auto-merge was temporarily disabled in #3114 until this required
+      # status check existed; re-enabled here now that it does.)
+      - name: Approve and enable auto-merge on backport PRs
         if: >-
           steps.backport.outcome == 'success' &&
           contains(github.event.pull_request.labels.*.name, 'auto-backport')
@@ -157,13 +159,19 @@ jobs:
               # approval is from a distinct identity and satisfies the required review.
               echo "Approving backport PR #$pr as github-actions[bot]"
               gh pr review "$pr" --repo "$REPO" --approve \
-                --body "Automated approval: clean backport of an already-reviewed change. Auto-merge is disabled — a maintainer should merge once this PR's CI build is green." || \
+                --body "Automated approval: clean backport of an already-reviewed change. Auto-merge is armed and will merge once the required CI checks are green." || \
                 echo "::warning::Could not approve #$pr"
             else
-              echo "::warning::Ephemeral token was unavailable (is the backport Token Policy registered in elastic/catalog-info?); #$pr was authored by github-actions[bot], so it cannot be auto-approved and will need a manual approval to merge."
+              echo "::warning::Ephemeral token was unavailable (is the backport Token Policy registered in elastic/catalog-info?); #$pr was authored by github-actions[bot], so it cannot be auto-approved and needs a manual approval. Auto-merge is still armed and will merge once approved and CI is green."
             fi
 
-            echo "Auto-merge is disabled; leaving PR #$pr for a maintainer to merge once CI is green."
+            # Arm auto-merge (squash). This does NOT merge immediately: GitHub merges only
+            # once every required status check (including buildkite/ml-cpp-pr-builds) is
+            # green and the review requirement is satisfied. If CI never runs or fails, the
+            # PR simply stays open — fail-safe.
+            echo "Enabling auto-merge (squash) on backport PR #$pr"
+            gh pr merge "$pr" --repo "$REPO" --auto --squash || \
+              echo "::warning::Could not enable auto-merge on #$pr"
           done
 
   remove-backport-pending:


### PR DESCRIPTION
## Summary

Re-enables auto-merge for auto-backport PRs, reverting the temporary disable in #3114.

#3114 disabled `gh pr merge --auto` because, at the time, the release branches did **not** require the ml-cpp build/test checks — so auto-merge would merge a backport as soon as the lightweight checks (CLA, snyk) passed, before the C++ matrix finished (this actually happened with #3106–#3111).

That gap is now closed:
- The pipeline publishes a single overall rollup status, `buildkite/ml-cpp-pr-builds` (`publish_commit_status=True`).
- `buildkite/ml-cpp-pr-builds` is now a **required** status check on `main` and on `9.5` / `9.4` / `8.19`.
- The rollup reflects the whole build/test matrix, including any triggered QA/PyTorch downstream — those `trigger` steps are `async: false`, so a downstream failure propagates into the parent build and hence the rollup.

So `gh pr merge --auto --squash` now waits for CI to be green (and the one-review requirement to be met) before merging. If CI never runs or fails, the PR just stays open — fail-safe.

Approval continues to be posted by `github-actions[bot]` (a distinct identity from the ephemeral-token PR author), satisfying the org "[org] Require a PR" ruleset on the release branches.

Related: #3099 (CI-trigger fix #3103), #3112 (set_commit_status), #3114 (temporary disable).

## Test plan
- [x] Merge a `>bug` PR carrying version + `auto-backport` labels.
- [x] Confirm each backport PR is approved by `github-actions[bot]` and has auto-merge armed.
- [x] Confirm a backport merges only **after** its `buildkite/ml-cpp-pr-builds` rollup goes green (not before).
- [ ] Confirm a backport whose CI fails does **not** auto-merge. _(Guaranteed by the required `buildkite/ml-cpp-pr-builds` check — GitHub auto-merge cannot complete unless it is `success`; gating proven on #3078/#3115. Not yet exercised by a naturally-failing backport build.)_