### PR TITLE
[ML] Fix backport-pending label handling for auto-backports

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -15,7 +15,7 @@
     "^v9.6.0$": "main",
     "^v(\\d+).(\\d+).\\d+(?:-(?:alpha|beta|rc)\\d+)?$": "$1.$2"
   },
-  "copySourcePRLabels": "^(?!backport$)(?!v\\d).*$",
+  "copySourcePRLabels": "^(?!backport(?:-pending)?$)(?!auto-backport$)(?!v\\d).*$",
   "sourcePRLabels": [
     "backport-pending"
   ]

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -162,9 +162,9 @@ jobs:
           # If we armed auto-merge with GITHUB_TOKEN, the merge would never fire the
           # remove-backport-pending job, so backport-pending would stay stuck on the source
           # PR (it had to be cleared by hand). Arming with the ephemeral App identity makes
-          # the eventual merge trigger that job normally. This is the same reason we author
-          # the PRs with the ephemeral token: so downstream workflows (CI here, cleanup on
-          # merge) actually run. Falls back to GITHUB_TOKEN when the ephemeral token is
+          # the eventual merge trigger that job normally. This is the same reason we don't
+          # arm auto-merge with GITHUB_TOKEN: events attributed to github-actions[bot] won't
+          # start this workflow on merge. Falls back to GITHUB_TOKEN when the ephemeral token is
           # unavailable (Token Policy not registered) — in that degraded case cleanup still
           # needs doing manually, but backports at least open and can be merged by a human.
           MERGE_TOKEN="${EPHEMERAL_TOKEN:-$GH_TOKEN}"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -139,11 +139,13 @@ jobs:
           steps.backport.outcome == 'success' &&
           contains(github.event.pull_request.labels.*.name, 'auto-backport')
         env:
+          # github-actions[bot] token: used to APPROVE the backport PRs (a distinct
+          # identity from the ephemeral-token author, so the approval counts).
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # 'true' only when the ephemeral token was minted (Token Policy registered),
-          # i.e. the backport PRs were authored by the ephemeral-token app identity and
-          # can therefore be approved by github-actions[bot].
-          EPHEMERAL_AUTHORED: ${{ steps.ephemeral_token.outputs.token != '' }}
+          # The ephemeral App token (elastic-vault-github-plugin-prod[bot]) that authored
+          # the backport PRs, when it was minted (Token Policy registered). Empty on the
+          # fallback path. Used to ARM auto-merge — see the note below.
+          EPHEMERAL_TOKEN: ${{ steps.ephemeral_token.outputs.token }}
           REPO: ${{ github.repository }}
         run: |
           # Extract created PR numbers from the backport info log.
@@ -153,10 +155,25 @@ jobs:
             echo "No backport PRs found in log. Skipping approval."
             exit 0
           fi
+
+          # Choose the token that ARMS auto-merge. GitHub attributes a deferred auto-merge
+          # to whichever identity enabled it, and merges attributed to github-actions[bot]
+          # (i.e. GITHUB_TOKEN) do NOT trigger further workflows — GitHub's recursion guard.
+          # If we armed auto-merge with GITHUB_TOKEN, the merge would never fire the
+          # remove-backport-pending job, so backport-pending would stay stuck on the source
+          # PR (it had to be cleared by hand). Arming with the ephemeral App identity makes
+          # the eventual merge trigger that job normally. This is the same reason we author
+          # the PRs with the ephemeral token: so downstream workflows (CI here, cleanup on
+          # merge) actually run. Falls back to GITHUB_TOKEN when the ephemeral token is
+          # unavailable (Token Policy not registered) — in that degraded case cleanup still
+          # needs doing manually, but backports at least open and can be merged by a human.
+          MERGE_TOKEN="${EPHEMERAL_TOKEN:-$GH_TOKEN}"
+
           for pr in $PR_NUMBERS; do
-            if [ "$EPHEMERAL_AUTHORED" = "true" ]; then
+            if [ -n "$EPHEMERAL_TOKEN" ]; then
               # Authored by the ephemeral-token identity, so this github-actions[bot]
-              # approval is from a distinct identity and satisfies the required review.
+              # approval (via the step-level GH_TOKEN) is from a distinct identity and
+              # satisfies the required review.
               echo "Approving backport PR #$pr as github-actions[bot]"
               gh pr review "$pr" --repo "$REPO" --approve \
                 --body "Automated approval: clean backport of an already-reviewed change. Auto-merge is armed and will merge once the required CI checks are green." || \
@@ -165,12 +182,12 @@ jobs:
               echo "::warning::Ephemeral token was unavailable (is the backport Token Policy registered in elastic/catalog-info?); #$pr was authored by github-actions[bot], so it cannot be auto-approved and needs a manual approval. Auto-merge is still armed and will merge once approved and CI is green."
             fi
 
-            # Arm auto-merge (squash). This does NOT merge immediately: GitHub merges only
-            # once every required status check (including buildkite/ml-cpp-pr-builds) is
-            # green and the review requirement is satisfied. If CI never runs or fails, the
-            # PR simply stays open — fail-safe.
+            # Arm auto-merge (squash) as MERGE_TOKEN. This does NOT merge immediately:
+            # GitHub merges only once every required status check (including
+            # buildkite/ml-cpp-pr-builds) is green and the review requirement is satisfied.
+            # If CI never runs or fails, the PR simply stays open — fail-safe.
             echo "Enabling auto-merge (squash) on backport PR #$pr"
-            gh pr merge "$pr" --repo "$REPO" --auto --squash || \
+            GH_TOKEN="$MERGE_TOKEN" gh pr merge "$pr" --repo "$REPO" --auto --squash || \
               echo "::warning::Could not enable auto-merge on #$pr"
           done
 

--- a/docs/changelog/3128.yaml
+++ b/docs/changelog/3128.yaml
@@ -1,0 +1,5 @@
+area: Machine Learning
+issues: []
+pr: 3128
+summary: Fix backport-pending never clearing on auto-merged backports
+type: bug

--- a/docs/changelog/3128.yaml
+++ b/docs/changelog/3128.yaml
@@ -1,5 +1,0 @@
-area: Machine Learning
-issues: []
-pr: 3128
-summary: Fix backport-pending never clearing on auto-merged backports
-type: bug


### PR DESCRIPTION
## Summary

The `remove-backport-pending` job clears `backport-pending` from a source PR once all of its backports have merged. It never runs for **auto-merged** backports: auto-merge was armed with `GITHUB_TOKEN`, so GitHub attributes the deferred merge to `github-actions[bot]`, and **merges attributed to `github-actions[bot]` do not trigger workflows** — GitHub's built-in recursion guard ([docs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow): *"events triggered by the `GITHUB_TOKEN` will not create a new workflow run"*). So `backport-pending` got stuck on the source PR and had to be removed by hand (seen on #3078 and #3115).

## Fix (direct, not a workaround)

Arm auto-merge with the **ephemeral App token** (`elastic-vault-github-plugin-prod[bot]`) that already authors the backport PRs, instead of `GITHUB_TOKEN`. GitHub attributes a deferred auto-merge to whichever identity *enabled* it, and merges by a GitHub App identity **do** trigger downstream workflows — so `remove-backport-pending` fires normally on merge.

- The **approval** still comes from `github-actions[bot]` (step-level `GITHUB_TOKEN`), a distinct identity from the ephemeral-token author, so it satisfies the required review (a token can't approve its own PR).
- Falls back to `GITHUB_TOKEN` only when the ephemeral token is unavailable (Token Policy not registered); in that degraded case cleanup still needs a manual touch, but backports still open and can be merged by a human.

This is the GitHub-recommended remedy (use an App/PAT identity for the merge, per the docs above) and reuses the *exact* infrastructure we already rely on to make CI trigger on backport PRs. It's the same thing `elastic/kibana` gets for free by authoring/merging backports as the `kibanamachine` user rather than `github-actions[bot]`.

Supersedes #3127 (scheduled-sweep backstop), which treated the symptom rather than the cause.

## Test plan
- [x] Merge to `main`.
- [x] Merge a `>bug`/`auto-backport` PR with version labels; confirm backports open (ephemeral-authored), are approved by `github-actions[bot]`, and auto-merge on green. <!-- Verified via the #3131 round (2026-07-31): #3132 (9.4) and #3133 (9.5) were authored by `elastic-vault-github-plugin-prod[bot]` (ephemeral App), approved by `github-actions`, and auto-merged on green. -->
- [x] Confirm that when the backports auto-merge, `remove-backport-pending` runs (check the Actions tab for the backport PR's merged event) and `backport-pending` is cleared from the source PR **without** manual intervention. <!-- Verified: the job fired on the auto-merged #3132/#3133 (Actions runs 30603558275 / 30603446061) - previously suppressed under GITHUB_TOKEN - and on the final backport merge it logged "Open backport PRs remaining: 0 ... Removing backport-pending label from #3131" (run 30768113953). #3131 no longer carries backport-pending; no manual step. -->
- [ ] Confirm the fallback path (no ephemeral token) still opens backports and arms auto-merge.

Fixes the `GITHUB_TOKEN`-suppression cleanup gap from the auto-backport-and-merge work (#3094, #3103, #3122).


---

## Implications for the auto-backport-and-merge workflow — no change to the merge gate

This is **strictly additive** to the auto-backport-and-merge flow validated in #3122/#3115. The "merge only when CI is green" guarantee is enforced by **branch protection**, not by the token that arms auto-merge, so it is untouched:

- All release branches (`9.5`/`9.4`/`8.19`) require the `buildkite/ml-cpp-pr-builds` rollup + `CLA` status checks and **1 approving review**, with **no push restrictions** (`restrictions: none`). `gh pr merge --auto` honours these regardless of which identity enabled it — GitHub still holds the merge until CI is green *and* the review is satisfied.
- What changes is only *who is recorded as enabling* auto-merge (ephemeral App identity vs `github-actions[bot]`), which is what un-suppresses the on-merge `remove-backport-pending` run. Timing/behaviour of the merge itself is identical.

Nothing new is triggered that shouldn't be:
- The `backport` job on a backport PR's merge event stays skipped (`!contains(labels,'backport')`), so **no recursive backporting**.
- Buildkite branch/snapshot builds already fire on any merge commit (Buildkite webhooks aren't subject to GitHub's Actions recursion guard) — unchanged.
- Only `remove-backport-pending` newly fires, which is the goal.

Permissions: release branches have `restrictions: none`, and the TokenPolicy (elastic/catalog-info #4297) grants the ephemeral identity `contents: write` + `pull_requests: write`, so it can complete the merge once the gate passes. If it ever couldn't, `gh pr merge` errors are swallowed (`|| echo ::warning`) and the PR simply stays open — **fail-safe: the worst case is a stuck-open PR, never a premature or unreviewed merge**.

Fallback path unchanged: if the ephemeral token isn't minted, `MERGE_TOKEN` falls back to `GITHUB_TOKEN`, exactly matching today's behaviour (backports open, auto-merge armed, cleanup needs a manual touch).

> Note: backports created *before* this merges (e.g. #3125/#3126/#3118) were armed under the old GITHUB_TOKEN path, so that round still needs one manual `backport-pending` clear on the source PR. This fix applies to backport rounds created after it merges.


---

## Also: stop copying `backport-pending` / `auto-backport` onto the backport PRs

`.backportrc.json`'s `copySourcePRLabels` copied every source label except `backport` and version labels onto the backports the action creates, so `backport-pending` and `auto-backport` leaked onto them (observed on #3125/#3126). `backport-pending` on a backport is misleading (it isn't itself awaiting backports) and pollutes "pending backports" queries; `auto-backport` is meaningless there (the `backport` label already guards against re-backporting).

Fix: exclude both from the copy regex —
```
-  "copySourcePRLabels": "^(?!backport$)(?!v\\d).*$",
+  "copySourcePRLabels": "^(?!backport(?:-pending)?$)(?!auto-backport$)(?!v\\d).*$",
```
`:ml`, `>type` and other labels still propagate. `main`-only, same as the merge-identity change (the backport action runs from `main`'s config when a source PR merges to `main`).

### Test plan (label copy)
- [x] After the next auto-backport round, confirm the created backport PRs carry `backport` + `:ml` + `>type` + their version label, but **not** `backport-pending` or `auto-backport`. _(verified 2026-08-10: #3137 auto-backports #3140/#3141/#3142 each carried `backport, :ml, >build, v…` only — no `backport-pending`/`auto-backport`)_
