### PR TITLE
[ML] Run QA and PyTorch suites concurrently in a single triggered build

### DIFF
--- a/.buildkite/pipeline.json.py
+++ b/.buildkite/pipeline.json.py
@@ -90,11 +90,20 @@ def main():
             if config.run_qa_tests or config.run_pytorch_tests:
                 qa_suites = []
                 if config.run_qa_tests:
-                    qa_suites.append(os.environ.get("QAF_TESTS_TO_RUN") or "ml_cpp_pr")
+                    # QAF_TESTS_TO_RUN may itself be a comma-separated override
+                    # (e.g. a subset of QA markers), so split it into individual
+                    # suites rather than appending the whole string verbatim.
+                    override = os.environ.get("QAF_TESTS_TO_RUN")
+                    if override:
+                        qa_suites.extend(s.strip() for s in override.split(",") if s.strip())
+                    else:
+                        qa_suites.append("ml_cpp_pr")
                 if config.run_pytorch_tests:
                     qa_suites.append("pytorch_tests")
-                env["QAF_TESTS_TO_RUN"] = ",".join(qa_suites)
-                pipeline_steps.append(pipeline_steps.generate_step("Upload QA tests runner pipeline",
+                # De-duplicate while preserving order so an override that already
+                # includes pytorch_tests does not produce a duplicate suite.
+                env["QAF_TESTS_TO_RUN"] = ",".join(dict.fromkeys(qa_suites))
+                pipeline_steps.append(pipeline_steps.generate_step("Upload QA/PyTorch tests runner pipeline",
                                                                    ".buildkite/pipelines/run_qa_tests.yml.sh"))
         if config.build_aarch64 and not config.skip_version_bump_pr_ci:
             pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests aarch64 runner pipeline",

--- a/.buildkite/pipeline.json.py
+++ b/.buildkite/pipeline.json.py
@@ -80,13 +80,22 @@ def main():
                                                                    ".buildkite/pipelines/run_es_tests_x86_64.yml.sh"))
                 pipeline_steps.append(pipeline_steps.generate_step("Upload ES inference tests x86_64 runner pipeline",
                                                                    ".buildkite/pipelines/run_es_inference_tests_x86_64.yml.sh"))
-            # We only use linux x86_64 builds for QA tests.
-            if config.run_qa_tests:
+            # We only use linux x86_64 builds for QA tests. When both the QA
+            # (ml_cpp_pr) and PyTorch suites are requested we trigger a SINGLE
+            # downstream build with a comma-separated QAF_TESTS_TO_RUN so the
+            # appex-qa generator fans them out into concurrent parallel jobs.
+            # A single trigger avoids the same-branch build de-duplication
+            # (skip_queued_branch_builds) on the appex pipeline that otherwise
+            # skipped one of two separately-triggered builds.
+            if config.run_qa_tests or config.run_pytorch_tests:
+                qa_suites = []
+                if config.run_qa_tests:
+                    qa_suites.append(os.environ.get("QAF_TESTS_TO_RUN") or "ml_cpp_pr")
+                if config.run_pytorch_tests:
+                    qa_suites.append("pytorch_tests")
+                env["QAF_TESTS_TO_RUN"] = ",".join(qa_suites)
                 pipeline_steps.append(pipeline_steps.generate_step("Upload QA tests runner pipeline",
                                                                    ".buildkite/pipelines/run_qa_tests.yml.sh"))
-            if config.run_pytorch_tests:
-                pipeline_steps.append(pipeline_steps.generate_step("Upload QA PyTorch tests runner pipeline",
-                                                                   ".buildkite/pipelines/run_pytorch_tests.yml.sh"))
         if config.build_aarch64 and not config.skip_version_bump_pr_ci:
             pipeline_steps.append(pipeline_steps.generate_step("Upload ES tests aarch64 runner pipeline",
                                                                ".buildkite/pipelines/run_es_tests_aarch64.yml.sh"))

--- a/.buildkite/pipelines/run_qa_tests.yml.sh
+++ b/.buildkite/pipelines/run_qa_tests.yml.sh
@@ -18,16 +18,34 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/derive_qa_stack_env.sh"
 
+# Derive a human-readable descriptor for the trigger step's label and GitHub
+# commit-status context from the requested suites. This single script now
+# handles QA-only, PyTorch-only and combined runs, so a fixed "QA Tests" label
+# would mislabel the other two. Substring matches (rather than exact tokens)
+# keep this correct for marker expressions such as "ml_cpp_pr and not slow".
+QAF_SUITES="${QAF_TESTS_TO_RUN:-ml_cpp_pr}"
+_has_qa=false
+_has_pytorch=false
+case "${QAF_SUITES}" in *ml_cpp_pr*) _has_qa=true ;; esac
+case "${QAF_SUITES}" in *pytorch_tests*) _has_pytorch=true ;; esac
+if [ "${_has_qa}" = true ] && [ "${_has_pytorch}" = true ]; then
+    QA_TESTS_DESC="QA + PyTorch"
+elif [ "${_has_pytorch}" = true ]; then
+    QA_TESTS_DESC="PyTorch"
+else
+    QA_TESTS_DESC="QA"
+fi
+
 cat <<EOL
 steps:
-  - label: "Trigger Appex QA Tests :test_tube:"
+  - label: "Trigger Appex ${QA_TESTS_DESC} Tests :test_tube:"
     command:
-      - echo 'Trigger QA Tests'
+      - echo 'Trigger ${QA_TESTS_DESC} Tests'
       - 'buildkite-agent artifact download "build/*" . --step build_test_linux-x86_64-RelWithDebInfo'
     depends_on: "test_linux-x86_64-RelWithDebInfo"
     notify:
       -  github_commit_status:
-           context: "Trigger Appex QA Tests"
+           context: "Trigger Appex ${QA_TESTS_DESC} Tests"
   - wait
   - trigger: appex-qa-stateful-custom-ml-cpp-build-testing
     async: false


### PR DESCRIPTION
## Summary

When both the QA (`ml_cpp_pr`) and PyTorch suites are requested on a PR, trigger a **single** downstream appex-qa build with a comma-separated `QAF_TESTS_TO_RUN` instead of two separate trigger steps.

Previously the two suites were triggered as independent downstream builds. Because the `appex-qa-stateful-custom-ml-cpp-build-testing` pipeline has `skip_queued_branch_builds=true`, two builds on the same branch collided and one suite was silently skipped. Emitting a single trigger with both markers lets the appex-qa generator fan them out into concurrent parallel jobs.

## Changes

- `.buildkite/pipeline.json.py`: merge the `run_qa_tests` / `run_pytorch_tests` trigger blocks into one. `QAF_TESTS_TO_RUN` is built from the requested suites:
  - QA only → `ml_cpp_pr`
  - PyTorch only → `pytorch_tests`
  - both → `ml_cpp_pr,pytorch_tests`

The separate PyTorch allowlist-validation step is unaffected.

## ⚠️ Ordering dependency

This is **Part B**. It depends on **Part A** — the appex-qa generator change in `elastic/qaf-tests#309` — which teaches the generator to split a comma-separated `QAF_TESTS_TO_RUN` into parallel jobs. **qaf-tests#309 must merge first.** Until then, requesting *both* labels would pass `ml_cpp_pr,pytorch_tests` to the old generator, which treats it as a single invalid pytest `-m` expression. Single-suite requests are unaffected.

## Testing

- [x]  Local dry-runs of the generator confirm valid pipeline JSON and correct `QAF_TESTS_TO_RUN` for QA-only, PyTorch-only, and both-labels cases.
- [x]  End-to-end validation of concurrent jobs performed on a qaf-tests feature branch build.
