### PR TITLE
[ML] Apply required team and type labels to automated version-bump PRs

### DIFF
--- a/dev-tools/bump_main_minor_freeze.sh
+++ b/dev-tools/bump_main_minor_freeze.sh
@@ -179,6 +179,11 @@ pr_cmd=(
     --body "$pr_body"
     --label "ci:skip-es-tests"
     --label "no-backport"
+    # Repo policy requires a team label and a type label on every PR. :ml is
+    # the team label; >build marks this as a no-changelog build change. Keeping
+    # the automated freeze bump PR compliant on open, same as bump_version.sh.
+    --label ":ml"
+    --label ">build"
 )
 if [[ "${VERSION_BUMP_NO_MERGE:-}" != "true" ]]; then
     if [[ "${VERSION_BUMP_MERGE_AUTO:-}" == "true" ]]; then

--- a/dev-tools/bump_version.sh
+++ b/dev-tools/bump_version.sh
@@ -179,12 +179,11 @@ EOF
         --body "$pr_body"
         --label "ci:skip-es-tests"
         # Repo policy requires a team label and a type label on every PR. :ml is
-        # the team label; >build and >non-issue mark this as a no-changelog build
-        # change. Applying them here means the automated bump PRs open compliant
-        # rather than needing a human to add them by hand (e.g. #3135).
+        # the team label; >build marks this as a no-changelog build change.
+        # Applying them here means the automated bump PRs open compliant rather
+        # than needing a human to add them by hand (e.g. #3135).
         --label ":ml"
         --label ">build"
-        --label ">non-issue"
     )
     if [[ "${VERSION_BUMP_NO_MERGE:-}" != "true" ]]; then
         if [[ "${VERSION_BUMP_MERGE_AUTO:-}" == "true" ]]; then

--- a/dev-tools/bump_version.sh
+++ b/dev-tools/bump_version.sh
@@ -178,6 +178,13 @@ EOF
         --title "[ML] Bump version to ${target_version}"
         --body "$pr_body"
         --label "ci:skip-es-tests"
+        # Repo policy requires a team label and a type label on every PR. :ml is
+        # the team label; >build and >non-issue mark this as a no-changelog build
+        # change. Applying them here means the automated bump PRs open compliant
+        # rather than needing a human to add them by hand (e.g. #3135).
+        --label ":ml"
+        --label ">build"
+        --label ">non-issue"
     )
     if [[ "${VERSION_BUMP_NO_MERGE:-}" != "true" ]]; then
         if [[ "${VERSION_BUMP_MERGE_AUTO:-}" == "true" ]]; then

--- a/dev-tools/unittest/test_job_version_bump_pipeline.py
+++ b/dev-tools/unittest/test_job_version_bump_pipeline.py
@@ -197,6 +197,19 @@ def test_create_pr_script_requires_body() -> None:
     assert "--body" in proc.stderr
 
 
+def test_bump_version_pr_applies_required_labels() -> None:
+    """Automated bump PRs must open with the labels repo policy requires.
+
+    :ml is the team label, >build and >non-issue are the type labels marking a
+    no-changelog build change, and ci:skip-es-tests keeps the ES test suite off
+    a pure version bump. Wiring them into bump_version.sh means the PRs open
+    compliant instead of needing a human to add them by hand (e.g. #3135).
+    """
+    script = (_REPO_ROOT / "dev-tools" / "bump_version.sh").read_text()
+    for label in ("ci:skip-es-tests", ":ml", ">build", ">non-issue"):
+        assert f'--label "{label}"' in script, f"missing --label {label}"
+
+
 def test_phase2_minor_has_parallel_freeze_group() -> None:
     pipeline = _run_phase2_minor()
     group = pipeline["steps"][0]

--- a/dev-tools/unittest/test_job_version_bump_pipeline.py
+++ b/dev-tools/unittest/test_job_version_bump_pipeline.py
@@ -200,13 +200,13 @@ def test_create_pr_script_requires_body() -> None:
 def test_bump_version_pr_applies_required_labels() -> None:
     """Automated bump PRs must open with the labels repo policy requires.
 
-    :ml is the team label, >build and >non-issue are the type labels marking a
-    no-changelog build change, and ci:skip-es-tests keeps the ES test suite off
-    a pure version bump. Wiring them into bump_version.sh means the PRs open
-    compliant instead of needing a human to add them by hand (e.g. #3135).
+    :ml is the team label, >build is the type label marking a no-changelog
+    build change, and ci:skip-es-tests keeps the ES test suite off a pure
+    version bump. Wiring them into bump_version.sh means the PRs open compliant
+    instead of needing a human to add them by hand (e.g. #3135).
     """
     script = (_REPO_ROOT / "dev-tools" / "bump_version.sh").read_text()
-    for label in ("ci:skip-es-tests", ":ml", ">build", ">non-issue"):
+    for label in ("ci:skip-es-tests", ":ml", ">build"):
         assert f'--label "{label}"' in script, f"missing --label {label}"
 
 

--- a/dev-tools/unittest/test_job_version_bump_pipeline.py
+++ b/dev-tools/unittest/test_job_version_bump_pipeline.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -197,17 +198,29 @@ def test_create_pr_script_requires_body() -> None:
     assert "--body" in proc.stderr
 
 
+def _asserts_label(script: str, label: str) -> bool:
+    """True if the script passes ``--label <label>`` in any common quoting style.
+
+    Tolerates double quotes, single quotes, or no quotes so a harmless requote
+    of the argument doesn't fail the guard while the behaviour is unchanged.
+    """
+    pattern = rf"--label\s+(?:\"{re.escape(label)}\"|'{re.escape(label)}'|{re.escape(label)})(?:\s|\))"
+    return re.search(pattern, script) is not None
+
+
 def test_bump_version_pr_applies_required_labels() -> None:
     """Automated bump PRs must open with the labels repo policy requires.
 
     :ml is the team label, >build is the type label marking a no-changelog
     build change, and ci:skip-es-tests keeps the ES test suite off a pure
-    version bump. Wiring them into bump_version.sh means the PRs open compliant
-    instead of needing a human to add them by hand (e.g. #3135).
+    version bump. Both automated PR creators (patch bump and main minor-freeze
+    bump) must open compliant instead of needing a human to add them by hand
+    (e.g. #3135).
     """
-    script = (_REPO_ROOT / "dev-tools" / "bump_version.sh").read_text()
-    for label in ("ci:skip-es-tests", ":ml", ">build"):
-        assert f'--label "{label}"' in script, f"missing --label {label}"
+    for name in ("bump_version.sh", "bump_main_minor_freeze.sh"):
+        script = (_REPO_ROOT / "dev-tools" / name).read_text()
+        for label in ("ci:skip-es-tests", ":ml", ">build"):
+            assert _asserts_label(script, label), f"{name}: missing --label {label}"
 
 
 def test_phase2_minor_has_parallel_freeze_group() -> None:


### PR DESCRIPTION
## Summary

The automated patch version-bump PRs (e.g. #3135) were opened with only the `ci:skip-es-tests` label, so a human still had to hand-apply the mandatory **team** label (`:ml`) and a **type** label (`>build`) before the PR was policy-compliant.

This wires those labels into the `gh pr create` call in `dev-tools/bump_version.sh` (alongside the existing `ci:skip-es-tests`), so the bump PRs open compliant with no manual step.

## Why main-only (no backport)

The version-bump pipeline **starts from `main`**, snapshots the helper scripts (`create_github_pull_request.sh` et al.) via `version_bump_snapshot_helpers`, and only then checks out the target release-branch tip. The running `bump_version.sh` is `main`'s copy (its open file descriptor survives the checkout) and it invokes the snapshotted `main` helper. So the label list here runs for **every** release-branch patch bump regardless of what that branch's own `dev-tools/` contains — this is exactly the design #3083 introduced. No backport labels required.

## Test plan

- [x] `bash -n dev-tools/bump_version.sh` passes
- [x] New guard test `test_bump_version_pr_applies_required_labels` asserts the `--label` values are wired in; `test_job_version_bump_pipeline.py` green (15 passed)
- [ ] Next automated patch bump opens its PR carrying `:ml`, `>build`, `ci:skip-es-tests` _(pending next automated version bump — per the Elastic release schedule the next patch cycle is 8.19.21 / 9.4.6: Feature Freeze Tue 25 Aug 2026, GA Tue 01 Sep 2026; then 9.5.2 FF 8 Sep 2026)_