### PR TITLE
[ML] Auto-approve automated version-bump PRs

### DIFF
--- a/.github/workflows/auto-approve-version-bump.yml
+++ b/.github/workflows/auto-approve-version-bump.yml
@@ -50,8 +50,11 @@ jobs:
             exit 0
           fi
           # Reopened PRs re-trigger this workflow; don't stack duplicate reviews.
-          approved=$(gh api "repos/$REPO/pulls/$PR/reviews" \
-            --jq '[.[] | select(.user.login == "github-actions[bot]" and .state == "APPROVED")] | length')
+          # The reviews endpoint is paginated (30/page), so --paginate --slurp
+          # gathers every page into one array (of pages) before counting - a
+          # single count across all reviews rather than one per page.
+          approved=$(gh api --paginate --slurp "repos/$REPO/pulls/$PR/reviews" \
+            --jq '[.[][] | select(.user.login == "github-actions[bot]" and .state == "APPROVED")] | length')
           if [ "$approved" -gt 0 ]; then
             echo "PR #$PR already approved by github-actions[bot]; nothing to do."
             exit 0

--- a/.github/workflows/auto-approve-version-bump.yml
+++ b/.github/workflows/auto-approve-version-bump.yml
@@ -1,0 +1,60 @@
+name: Auto-approve version-bump PRs
+
+# The automated patch/minor version-bump PRs (dev-tools/bump_version.sh) are
+# opened by the elastic-vault-github-plugin-prod[bot] app and already arm
+# auto-merge. The only thing left blocking an unattended merge is the single
+# required approving review. GitHub forbids a token/app from approving its own
+# PR, so github-actions[bot] (this workflow's GITHUB_TOKEN) is used as a
+# distinct identity whose approval counts - the same pattern the Backport
+# workflow uses for backport PRs. Auto-merge then merges once the required CI
+# checks (buildkite/ml-cpp-pr-builds) are green; CI still gates the merge.
+#
+# pull_request_target reads this workflow from the PR's *base* branch, and bump
+# PRs target release branches, so this file must live on each active release
+# branch as well as main (backport it like backport.yml).
+
+on:
+  pull_request_target:
+    types: ["opened", "reopened"]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    name: Auto-approve version bump
+    runs-on: ubuntu-latest
+    # Only the automated bump PRs: authored by the vault app and on the topic
+    # branch created by dev-tools/bump_version.sh (topic_branch_name). Both
+    # guards must hold, so an unrelated PR cannot be auto-approved even if it
+    # borrows one of the two traits.
+    if: >-
+      github.event.pull_request.user.login == 'elastic-vault-github-plugin-prod[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'ci/ml-cpp-version-bump-')
+    steps:
+      - name: Approve iff the diff is only the version bump
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Safety belt: an automated bump only edits elasticsearchVersion in
+          # gradle.properties. Refuse to auto-approve anything broader so a buggy
+          # or tampered bump job cannot land unreviewed changes to other files -
+          # such a PR falls back to needing a human review.
+          mapfile -t files < <(gh pr view "$PR" --repo "$REPO" --json files --jq '.files[].path')
+          if [ "${#files[@]}" -ne 1 ] || [ "${files[0]}" != "gradle.properties" ]; then
+            echo "::warning::PR #$PR changes [${files[*]:-<none>}]; expected only gradle.properties. Skipping auto-approval - a human should review."
+            exit 0
+          fi
+          # Reopened PRs re-trigger this workflow; don't stack duplicate reviews.
+          approved=$(gh api "repos/$REPO/pulls/$PR/reviews" \
+            --jq '[.[] | select(.user.login == "github-actions[bot]" and .state == "APPROVED")] | length')
+          if [ "$approved" -gt 0 ]; then
+            echo "PR #$PR already approved by github-actions[bot]; nothing to do."
+            exit 0
+          fi
+          gh pr review "$PR" --repo "$REPO" --approve \
+            --body "Automated approval: version-bump PR that only edits \`elasticsearchVersion\` in \`gradle.properties\`. Auto-merge is armed and will merge once the required CI checks are green."


### PR DESCRIPTION
## Summary

The automated version-bump PRs (`dev-tools/bump_version.sh`, e.g. #3135) already **arm auto-merge**, but stalled on the single **required approving review** — a human still had to click Approve. This adds a workflow that supplies that approval automatically.

`github-actions[bot]` (this workflow's `GITHUB_TOKEN`) approves the PR. Because the PR was authored by `elastic-vault-github-plugin-prod[bot]`, `github-actions[bot]` is a **distinct identity** and its approval counts — GitHub forbids self-approval. This is the same mechanism the [Backport workflow](.github/workflows/backport.yml) already uses, and the repo has "Allow GitHub Actions to approve pull requests" enabled. The armed auto-merge then lands the PR **once required CI (`buildkite/ml-cpp-pr-builds`) is green** — CI still gates the merge.

## Guards / safety

- Fires only when **both**: author is `elastic-vault-github-plugin-prod[bot]` **and** head branch matches `ci/ml-cpp-version-bump-*` (the topic branch from `bump_version.sh`).
- **Diff safety belt**: approves only if the PR's *sole* changed file is `gradle.properties`; anything broader is skipped and left for a human.
- Idempotent: skips if `github-actions[bot]` already approved (reopened PRs re-trigger).
- Read-only `contents`, `pull-requests: write`; does not check out or run PR code (safe under `pull_request_target`).

## Backport note

`pull_request_target` reads the workflow from the **PR's base branch**, and bump PRs target release branches — so this file must also live on each active release branch (`9.5`, `9.4`, `8.19`). Version labels will be added to backport it there. Until then, release-branch bump PRs still need a manual approval.

## Test plan

- [x] YAML parses; embedded bash `bash -n` clean
- [ ] On next automated bump PR into `main` (minor freeze) or a backported branch: `github-actions[bot]` approves automatically and auto-merge lands it on green CI _(pending next automated version bump — per the Elastic release schedule the next patch cycle is 8.19.21 / 9.4.6: Feature Freeze Tue 25 Aug 2026, GA Tue 01 Sep 2026; then 9.5.2 FF 8 Sep 2026)_
- [ ] A hand-crafted PR on a `ci/ml-cpp-version-bump-*` branch touching a file other than `gradle.properties` is **not** auto-approved _(not schedule-dependent — can be verified manually at any time)_

Made with [Cursor](https://cursor.com)