### PR TITLE
[ML] Remove 9.3 from snapshot build schedule

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -162,7 +162,7 @@ spec:
         build_branches: true
         build_pull_request_forks: false
         cancel_deleted_branch_builds: true
-        filter_condition: build.branch == "main" || build.branch == "9.5" || build.branch == "9.4" || build.branch == "9.3" || build.branch == "8.19"
+        filter_condition: build.branch == "main" || build.branch == "9.5" || build.branch == "9.4" || build.branch == "8.19"
         filter_enabled: true
         publish_blocked_as_pending: true
         publish_commit_status: false
@@ -174,10 +174,6 @@ spec:
           branch: '8.19'
           cronline: 30 03 * * *
           message: Daily SNAPSHOT build for 8.19
-        Daily 9.3:
-          branch: '9.3'
-          cronline: 30 02 * * *
-          message: Daily SNAPSHOT build for 9.3
         Daily 9.4:
           branch: '9.4'
           cronline: 30 01 * * *


### PR DESCRIPTION
## Summary

9.5.0 has been released, so **9.3 is now out of support**. Per the release-eng "remove unsupported version" notification, drop 9.3 from our snapshot build schedule:

- Remove the **`Daily 9.3`** cron schedule from the `ml-cpp-snapshot-builds` pipeline.
- Remove `9.3` from that pipeline's branch `filter_condition` (so a stray push to `9.3` no longer triggers a snapshot build).

`catalog-info.yaml` is the Backstage-synced source of truth for these pipeline settings, so merging to `main` updates the live schedule. **main-only, no backport.**

## Staging

The `ml-cpp-staging-builds` pipeline has no explicit `9.3` reference (its filter is a generic version-branch regex) and carries no schedules — staging DRA runs are triggered centrally. The staging-side 9.3 removal is handled by artifact-management in [unified-release#4732](https://github.com/elastic/unified-release/pull/4732), so there's nothing branch-specific to change here.

## Test plan

- [x] `catalog-info.yaml` parses (multi-doc); snapshot schedules now `main, 9.4, 9.5, 8.19`; filter no longer lists `9.3`
- [x] After merge + Backstage sync: `ml-cpp-snapshot-builds` no longer shows a `Daily 9.3` schedule _(verified 2026-08-10: live schedules are Daily main/9.5/9.4/8.19 only — no 9.3)_

Made with [Cursor](https://cursor.com)