### PR TITLE
[ML] Fix auto-approve version-bump workflow for current gh CLI

### DIFF
--- a/.github/workflows/auto-approve-version-bump.yml
+++ b/.github/workflows/auto-approve-version-bump.yml
@@ -50,11 +50,12 @@ jobs:
             exit 0
           fi
           # Reopened PRs re-trigger this workflow; don't stack duplicate reviews.
-          # The reviews endpoint is paginated (30/page), so --paginate --slurp
-          # gathers every page into one array (of pages) before counting - a
-          # single count across all reviews rather than one per page.
-          approved=$(gh api --paginate --slurp "repos/$REPO/pulls/$PR/reviews" \
-            --jq '[.[][] | select(.user.login == "github-actions[bot]" and .state == "APPROVED")] | length')
+          # The reviews endpoint is paginated (30/page). Current gh rejects
+          # combining --paginate --slurp with --jq, so count approvals per page
+          # and sum (awk). That matches the GHA ubuntu-latest gh CLI.
+          approved=$(gh api --paginate "repos/$REPO/pulls/$PR/reviews" \
+            --jq '[.[] | select(.user.login == "github-actions[bot]" and .state == "APPROVED")] | length' \
+            | awk '{s+=$1} END {print s+0}')
           if [ "$approved" -gt 0 ]; then
             echo "PR #$PR already approved by github-actions[bot]; nothing to do."
             exit 0


### PR DESCRIPTION
## Summary
- The Auto-approve version-bump workflow failed on recent patch bumps (`#3146` / `#3147` / `#3148`) because `gh api --paginate --slurp … --jq …` is rejected by current `gh` (`the --slurp option is not supported with --jq or --template`).
- Count github-actions approvals per page with `--paginate --jq` and sum with `awk` instead.
- Needs backport to release branches that run `pull_request_target` for bump PRs (`8.19`, `9.4`, `9.5`).

## Test plan
- [x] Locally: old `gh api --paginate --slurp … --jq …` still fails as on CI
- [x] Locally: fixed command returns `0` for `#3148` and `1` for `#3150` (bot-approved backport)
- [x] YAML still parses
- [ ] Next automated patch bump auto-approves without a human review


Made with [Cursor](https://cursor.com)