### PR TITLE
[ML] Periodically report pytorch_inference RSS

### DIFF
--- a/bin/pytorch_inference/CResultWriter.cc
+++ b/bin/pytorch_inference/CResultWriter.cc
@@ -30,7 +30,9 @@ const std::string CResultWriter::ACK{"ack"};
 const std::string CResultWriter::ACKNOWLEDGED{"acknowledged"};
 const std::string CResultWriter::NUM_ALLOCATIONS{"num_allocations"};
 const std::string CResultWriter::NUM_THREADS_PER_ALLOCATION{"num_threads_per_allocation"};
-const std::string CResultWriter::PROCESS_STATS{"process_stats"};
+// This key must match the field name the Elasticsearch PyTorchResult parser expects
+// for process stats (see InferenceProcessStats / PyTorchResult on the Java side).
+const std::string CResultWriter::PROCESS_STATS{"stats"};
 const std::string CResultWriter::MEMORY_RESIDENT_SET_SIZE{"memory_rss"};
 const std::string CResultWriter::MEMORY_MAX_RESIDENT_SET_SIZE{"memory_max_rss"};
 

--- a/bin/pytorch_inference/CResultWriter.h
+++ b/bin/pytorch_inference/CResultWriter.h
@@ -73,6 +73,12 @@ public:
     void writeSimpleAck(const std::string_view& requestId);
 
     //! Write memory usage information to the output stream.
+    //!
+    //! Emits both the current resident set size (\c memory_rss) and the peak
+    //! resident set size (\c memory_max_rss, the OS high-water mark). The peak is
+    //! transmitted explicitly rather than derived on the Elasticsearch side from
+    //! the stream of samples, so transient spikes between reports are not lost;
+    //! this is the memory signal used to keep model assignment OOM-safe.
     void writeProcessStats(const std::string_view& requestId,
                            const std::size_t residentSetSize,
                            const std::size_t maxResidentSetSize);

--- a/bin/pytorch_inference/Main.cc
+++ b/bin/pytorch_inference/Main.cc
@@ -36,13 +36,24 @@
 #include <torch/csrc/api/include/torch/types.h>
 #include <torch/script.h>
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <exception>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
+#include <thread>
 
 namespace {
+//! How often the periodic memory reporter emits the process resident set size.
+//! Elasticsearch aggregates these samples over a longer window, so a short
+//! interval gives several samples per window at negligible cost (a single
+//! resident-set-size read).
+constexpr std::chrono::seconds MEMORY_REPORT_INTERVAL{10};
+
 void verifySafeModel(const torch::jit::script::Module& module_) {
     try {
         auto result = ml::torch::CModelGraphValidator::validate(module_);
@@ -377,6 +388,33 @@ int main(int argc, char** argv) {
         LOG_DEBUG(<< "Using a single allocation");
     }
 
+    // Periodically report the resident set size so Elasticsearch can track the
+    // process's actual (OS-reported) memory use and bound model assignment and
+    // adaptive scaling by real memory rather than an a priori estimate. The
+    // command loop below blocks on input (a getline in CCommandParser::ioLoop),
+    // so the report is emitted from a dedicated timer thread. The concurrent
+    // line writer is safe to use from this thread alongside the inference-result
+    // threads. Shutdown is prompt: the condition variable is signalled the
+    // moment the command loop returns.
+    std::atomic_bool stopMemoryReporter{false};
+    std::mutex memoryReporterMutex;
+    std::condition_variable memoryReporterCondition;
+    std::thread memoryReporterThread{[&] {
+        std::unique_lock<std::mutex> lock{memoryReporterMutex};
+        while (stopMemoryReporter.load() == false) {
+            memoryReporterCondition.wait_for(lock, MEMORY_REPORT_INTERVAL, [&] {
+                return stopMemoryReporter.load();
+            });
+            if (stopMemoryReporter.load()) {
+                break;
+            }
+            resultWriter.writeProcessStats(
+                ml::torch::CCommandParser::RESERVED_REQUEST_ID,
+                ml::core::CProcessStats::residentSetSize(),
+                ml::core::CProcessStats::maxResidentSetSize());
+        }
+    }};
+
     commandParser.ioLoop(
         [&module_, &resultWriter](ml::torch::CCommandParser::CRequestCacheInterface& cache,
                                   ml::torch::CCommandParser::SRequest request) -> bool {
@@ -390,6 +428,17 @@ int main(int argc, char** argv) {
         [&resultWriter](const std::string_view& requestId, const std::string& message) {
             resultWriter.writeError(requestId, message);
         });
+
+    // Stop the periodic memory reporter before tearing down the rest of the
+    // process so it cannot write to a closing output stream.
+    {
+        std::lock_guard<std::mutex> lock{memoryReporterMutex};
+        stopMemoryReporter.store(true);
+    }
+    memoryReporterCondition.notify_all();
+    if (memoryReporterThread.joinable()) {
+        memoryReporterThread.join();
+    }
 
     // Stopping the executor forces this to block until all work is done
     if (useImmediateExecutor == false) {

--- a/bin/pytorch_inference/evaluate.py
+++ b/bin/pytorch_inference/evaluate.py
@@ -440,15 +440,16 @@ def memory_usage(args):
         # first get memory request
         request_sizes.insert(0, 0)
 
-        print(f"num items in request, memory_max_rss, inference time (ms)")
+        print(f"num items in request, memory_rss, memory_max_rss, inference time (ms)")
         for result in result_docs:            
             if 'result' in result:
                 inference_count = inference_count +1
                 last_time = result['time_ms']                
                 continue
 
-            if 'process_stats' in result:
-                print(f"{request_sizes[stats_count]},{result['process_stats']['memory_max_rss']},{last_time}")
+            if 'stats' in result:
+                stats = result['stats']
+                print(f"{request_sizes[stats_count]},{stats['memory_rss']},{stats.get('memory_max_rss')},{last_time}")
                 stats_count = stats_count +1
                 continue
 

--- a/bin/pytorch_inference/unittest/CResultWriterTest.cc
+++ b/bin/pytorch_inference/unittest/CResultWriterTest.cc
@@ -51,10 +51,10 @@ BOOST_AUTO_TEST_CASE(testWriteProcessStats) {
     std::ostringstream output;
     {
         ml::torch::CResultWriter resultWriter{output};
-        resultWriter.writeProcessStats("req3", 42, 54);
+        resultWriter.writeProcessStats("req3", 42, 64);
     }
-    BOOST_REQUIRE_EQUAL("[{\"request_id\":\"req3\",\"process_stats\":"
-                        "{\"memory_rss\":42,\"memory_max_rss\":54}}\n]",
+    BOOST_REQUIRE_EQUAL("[{\"request_id\":\"req3\",\"stats\":"
+                        "{\"memory_rss\":42,\"memory_max_rss\":64}}\n]",
                         output.str());
 }
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,6 +28,12 @@
 
 //=== Regressions
 
+== {es} version 9.6.0
+
+=== Enhancements
+
+* Periodically report the pytorch_inference process resident set size, including the peak (OS high-water mark), so Elasticsearch can track real native memory use per trained model deployment. (See {ml-pull}3160[#3160].)
+
 == {es} version 9.4.0
 
 === Bug Fixes

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -28,12 +28,6 @@
 
 //=== Regressions
 
-== {es} version 9.6.0
-
-=== Enhancements
-
-* Periodically report the pytorch_inference process resident set size, including the peak (OS high-water mark), so Elasticsearch can track real native memory use per trained model deployment. (See {ml-pull}3160[#3160].)
-
 == {es} version 9.4.0
 
 === Bug Fixes

--- a/docs/changelog/3160.yaml
+++ b/docs/changelog/3160.yaml
@@ -1,0 +1,5 @@
+area: Machine Learning
+issues: []
+pr: 3160
+summary: Periodically report `pytorch_inference` RSS
+type: enhancement


### PR DESCRIPTION
## Summary

Adds a periodic memory reporter to `pytorch_inference` so Elasticsearch can track the process's real resident set size (RSS) for a trained model deployment, independent of inference traffic.

- A dedicated timer thread emits process stats every 10s (a single RSS read; negligible cost), so memory is observed even when a deployment is idle or between requests.
- Each report carries both the current RSS (`memory_rss`) and the OS peak / high-water mark (`memory_max_rss`). The peak is transmitted explicitly rather than derived on the ES side from the sample stream, so transient spikes between reports are not lost — this is the signal used to keep model assignment and adaptive scaling OOM-safe.
- The process-stats document key is renamed from `process_stats` to `stats` to match the Elasticsearch `PyTorchResult` / `InferenceProcessStats` parser.
- The reporter thread is shut down promptly (condition-variable signalled) before the rest of the process tears down, so it can never write to a closing stream.

Closes https://github.com/elastic/ml-cpp/issues/2885
Relates https://github.com/elastic/elasticsearch/pull/156891

## Release-ordering note (important)

ES's `InferenceProcessStats` parser is strict and treats an unknown field as a fatal parse error for the result stream. Because this PR (re)introduces `memory_max_rss`, **the Elasticsearch-side change that accepts `memory_max_rss` as an optional field must be merged before this PR is merged into ml-cpp.** See the companion Elasticsearch PR.

Merging this PR before the ES-side fix is not simply "safe with the constraint on the version bump" — once this PR lands, the nightly ml-cpp snapshot will start emitting `memory_max_rss`. The automatic ES version bump PR will pick up that snapshot and run ES integration tests and QAF tests against an ES parser that still rejects unknown fields, causing those tests to fail with a fatal parse error. The version bump PR will be stuck until the ES-side fix lands. To avoid that: merge the ES-side PR first, then merge this one.

## Test plan

- [x] `CResultWriterTest.testWriteProcessStats` updated for the `stats` schema + `memory_max_rss`; passes (all 7 `CResultWriterTest` cases pass).
- [x] Manual: run `pytorch_inference` with a model and confirm periodic `stats` docs are emitted ~every 10s with `memory_rss` and `memory_max_rss`. Observed `{"request_id":"ignore","stats":{"memory_rss":0,"memory_max_rss":93339648}}` after one 10s tick on macOS (`memory_rss` is 0 on macOS — platform-specific; both fields will be non-zero on Linux).
- [x] Confirm prompt shutdown (no stray writes / hangs on exit). Process exits with code 0 cleanly after stdin closes.

Made with [Cursor](https://cursor.com)