### PR TITLE
Fail CMake configure if 3rd-party git clone fails (#3164) (#9.5)

### DIFF
--- a/3rd_party/pull-eigen.cmake
+++ b/3rd_party/pull-eigen.cmake
@@ -42,5 +42,9 @@ if(PULL_EIGEN)
   execute_process(
     COMMAND git -c advice.detachedHead=false clone --depth=1 --branch=3.4.0 https://gitlab.com/libeigen/eigen.git
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    RESULT_VARIABLE GIT_RESULT
     )
+  if(NOT GIT_RESULT EQUAL 0)
+    message(FATAL_ERROR "Failed to clone Eigen: git exited with ${GIT_RESULT}. Check network access to gitlab.com.")
+  endif()
 endif()

--- a/3rd_party/pull-valijson.cmake
+++ b/3rd_party/pull-valijson.cmake
@@ -16,5 +16,12 @@
 # This cmake script is expected to be called from a target or custom command with WORKING_DIRECTORY set to this file's location
 
 if ( NOT EXISTS valijson )
-  execute_process( COMMAND git -c advice.detachedHead=false clone --depth=1 --branch=v1.0.2 https://github.com/tristanpenman/valijson.git WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
+  execute_process(
+    COMMAND git -c advice.detachedHead=false clone --depth=1 --branch=v1.0.2 https://github.com/tristanpenman/valijson.git
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    RESULT_VARIABLE GIT_RESULT
+    )
+  if(NOT GIT_RESULT EQUAL 0)
+    message(FATAL_ERROR "Failed to clone Valijson: git exited with ${GIT_RESULT}. Check network access to github.com.")
+  endif()
 endif()


### PR DESCRIPTION
Backport of #3164 to 9.5.

Adds `RESULT_VARIABLE` checking to both `pull-eigen.cmake` and `pull-valijson.cmake`. On 9.5, both Eigen and Valijson are cloned at CMake configure time; the 9.5 and 9.4 snapshot builds on 2026-08-30 failed because GitLab was overloaded when Eigen was being cloned, and CMake continued silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)