### PR TITLE
[ML] Prefetch Docker image with retry before running aarch64 tests

### DIFF
--- a/.buildkite/scripts/steps/run_tests.sh
+++ b/.buildkite/scripts/steps/run_tests.sh
@@ -51,7 +51,7 @@ if [[ "$HARDWARE_ARCH" = aarch64 && -z "${CPP_CROSS_COMPILE:-}" && "$(uname)" = 
     # --- Linux aarch64: run tests inside Docker container from base image ---
     BASE_IMAGE="docker.elastic.co/ml-dev/ml-linux-aarch64-native-build:17"
 
-    source dev-tools/docker/prefetch_docker_image.sh
+. ./dev-tools/docker/prefetch_docker_image.sh
     prefetch_docker_image "$BASE_IMAGE"
 
     echo "--- Running tests (Docker)"

--- a/.buildkite/scripts/steps/run_tests.sh
+++ b/.buildkite/scripts/steps/run_tests.sh
@@ -51,6 +51,9 @@ if [[ "$HARDWARE_ARCH" = aarch64 && -z "${CPP_CROSS_COMPILE:-}" && "$(uname)" = 
     # --- Linux aarch64: run tests inside Docker container from base image ---
     BASE_IMAGE="docker.elastic.co/ml-dev/ml-linux-aarch64-native-build:17"
 
+    source dev-tools/docker/prefetch_docker_image.sh
+    prefetch_docker_image "$BASE_IMAGE"
+
     echo "--- Running tests (Docker)"
     docker run --rm \
         -v "$(pwd)/${BUILD_DIR}:/ml-cpp/${BUILD_DIR}" \


### PR DESCRIPTION
## Summary

The Linux aarch64 test step in CI pulls `docker.elastic.co/ml-dev/ml-linux-aarch64-native-build` implicitly via `docker run`. A transient 503 from the Docker registry causes the step to fail immediately with exit code 125, requiring a full manual retry — including re-downloading the 458MB test bundle.

This PR reuses the existing `prefetch_docker_image` function from `dev-tools/docker/prefetch_docker_image.sh`, which retries `docker pull` up to 5 times before giving up. The build step (`build.sh`) already uses this function (via `prefetch_docker_base_image`) — this brings the test step into line.

All other CI scripts that use `docker run` with registry-pulled images already call `prefetch_docker_image` (via `dev-tools/docker_build.sh`, `docker_test.sh`, `docker_check_style.sh`). `run_tests.sh` was the only gap.

## Test plan

- [x] Snapshot build CI passes

Relates to: https://buildkite.com/elastic/ml-cpp-snapshot-builds/builds/7014#01a05d5a-cf70-4c7a-b556-ae172e0a2bd7